### PR TITLE
[monorepo] fix: update git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "_symbol"]
 	path = _symbol
-	url = git@github.com:symbol/symbol.git
+	url = https://github.com/symbol/symbol.git

--- a/optin/puller/Jenkinsfile
+++ b/optin/puller/Jenkinsfile
@@ -1,0 +1,6 @@
+defaultCiPipeline {
+	platform = ['ubuntu']
+	ciBuildDockerfile = 'python.Dockerfile'
+
+	packageId = 'optin-puller'
+}

--- a/seed-job/Jenkinsfile
+++ b/seed-job/Jenkinsfile
@@ -1,0 +1,5 @@
+monorepoSeedPipeline {
+	platform = ['ubuntu']
+	organizationName = 'Symbol'
+	gitHubId = 'Symbol-Github-app'
+}

--- a/seed-job/buildConfiguration.yaml
+++ b/seed-job/buildConfiguration.yaml
@@ -1,0 +1,4 @@
+builds:
+  - name: Optin Puller
+    path: optin/puller
+


### PR DESCRIPTION
Update the git submodule to use https instead ssh so that an ssh key is not required to clone.