### PR TITLE
[optin/puller]: completed db changes

### DIFF
--- a/optin/puller/puller/client/NemClient.py
+++ b/optin/puller/puller/client/NemClient.py
@@ -10,9 +10,8 @@ class NemClient(BasicClient):
 		"""Determines if specified address is known to the network."""
 
 		# NEM API returns empty account for unknown accounts, so do balance check
-		url_path = f'account/get?address={address}'
-		account = await self.get(url_path, 'account')
-		return bool(account['balance'])
+		transactions = await self.incoming_transactions(address)
+		return bool(transactions)
 
 	async def height(self):
 		"""Gets current blockchain height."""

--- a/optin/puller/puller/db/CompletedOptinDatabase.py
+++ b/optin/puller/puller/db/CompletedOptinDatabase.py
@@ -20,7 +20,8 @@ class CompletedOptinDatabase:
 		cursor = self.connection.cursor()
 		cursor.execute('''CREATE TABLE IF NOT EXISTS optin_id (
 			id integer PRIMARY KEY,
-			attribute_flags integer
+			attribute_flags integer,
+			label text
 		)''')
 		cursor.execute('''CREATE TABLE IF NOT EXISTS nem_source (
 			address blob UNIQUE,
@@ -49,8 +50,8 @@ class CompletedOptinDatabase:
 			raise ValueError(f'NEM source balance {nem_balance} does not match Symbol destination balance {symbol_balance}')
 
 	@staticmethod
-	def _insert_mapping(cursor, nem_address_dict, symbol_address_dict, nem_transactions_dict=None, is_postoptin=True):
-		cursor.execute('''INSERT INTO optin_id VALUES (NULL, ?)''', (is_postoptin,))
+	def _insert_mapping(cursor, nem_address_dict, symbol_address_dict, nem_transactions_dict=None, optin_label=None, is_postoptin=True):
+		cursor.execute('''INSERT INTO optin_id VALUES (NULL, ?, ?)''', (is_postoptin, optin_label))
 		optin_id = cursor.lastrowid
 
 		cursor.executemany(
@@ -101,7 +102,8 @@ class CompletedOptinDatabase:
 				}
 
 				self._assert_balances(nem_address_dict, symbol_address_dict)
-				self._insert_mapping(cursor, nem_address_dict, symbol_address_dict, nem_transactions_dict, is_postoptin)
+				self._insert_mapping(
+					cursor, nem_address_dict, symbol_address_dict, nem_transactions_dict, mapping_json.get('label', None), is_postoptin)
 
 				yield mapping_json
 

--- a/optin/puller/puller/db/CompletedOptinDatabase.py
+++ b/optin/puller/puller/db/CompletedOptinDatabase.py
@@ -20,7 +20,7 @@ class CompletedOptinDatabase:
 		cursor = self.connection.cursor()
 		cursor.execute('''CREATE TABLE IF NOT EXISTS optin_id (
 			id integer PRIMARY KEY,
-			attribute_flags integer,
+			is_postoptin boolean,
 			label text
 		)''')
 		cursor.execute('''CREATE TABLE IF NOT EXISTS nem_source (

--- a/optin/puller/puller/db/CompletedOptinDatabase.py
+++ b/optin/puller/puller/db/CompletedOptinDatabase.py
@@ -31,12 +31,14 @@ class CompletedOptinDatabase:
 		)''')
 		cursor.execute('''CREATE TABLE IF NOT EXISTS nem_transactions (
 			address blob,
-			nem_tx_hash blob,
-			nem_tx_height integer
+			hash blob,
+			height integer
 		)''')
 		cursor.execute('''CREATE TABLE IF NOT EXISTS symbol_destination (
 			address blob,
 			balance integer,
+			hash blob,
+			height integer,
 			optin_id integer,
 			FOREIGN KEY (optin_id) REFERENCES optin_id(id)
 		)''')  # address cannot be unique because merges are supported
@@ -44,13 +46,25 @@ class CompletedOptinDatabase:
 	@staticmethod
 	def _assert_balances(nem_address_dict, symbol_address_dict):
 		nem_balance = reduce(lambda x, y: x + y, nem_address_dict.values())
-		symbol_balance = reduce(lambda x, y: x + y, symbol_address_dict.values())
+		symbol_balance = reduce(lambda x, y: x + y, map(lambda info: info['sym-balance'], symbol_address_dict.values()))
 
 		if nem_balance != symbol_balance:
 			raise ValueError(f'NEM source balance {nem_balance} does not match Symbol destination balance {symbol_balance}')
 
 	@staticmethod
-	def _insert_mapping(cursor, nem_address_dict, symbol_address_dict, nem_transactions_dict=None, optin_label=None, is_postoptin=True):
+	def _insert_transactions(cursor, nem_transactions_dict):
+		if not nem_transactions_dict:
+			return
+
+		items = []
+		for address, transactions in nem_transactions_dict.items():
+			for transaction in transactions:
+				items.append((NemAddress(address).bytes, Hash256(transaction['hash']).bytes, transaction['height']))
+
+		cursor.executemany('''INSERT INTO nem_transactions VALUES (?, ?, ?)''', items)
+
+	@staticmethod
+	def _insert_mapping(cursor, nem_address_dict, symbol_address_dict, optin_label=None, is_postoptin=True):
 		cursor.execute('''INSERT INTO optin_id VALUES (NULL, ?, ?)''', (is_postoptin, optin_label))
 		optin_id = cursor.lastrowid
 
@@ -58,17 +72,10 @@ class CompletedOptinDatabase:
 			'''INSERT INTO nem_source VALUES (?, ?, ?)''',
 			[(NemAddress(address).bytes, balance, optin_id) for address, balance in nem_address_dict.items()])
 
-		if nem_transactions_dict:
-			items = []
-			for address, transactions in nem_transactions_dict.items():
-				for transaction in transactions:
-					items.append((NemAddress(address).bytes, Hash256(transaction['hash']).bytes, transaction['height']))
-
-			cursor.executemany('''INSERT INTO nem_transactions VALUES (?, ?, ?)''', items)
-
 		cursor.executemany(
-			'''INSERT INTO symbol_destination VALUES (?, ?, ?)''',
-			[(SymbolAddress(address).bytes, balance, optin_id) for address, balance in symbol_address_dict.items()])
+			'''INSERT INTO symbol_destination VALUES (?, ?, ?, ?, ?)''',
+			[(SymbolAddress(address).bytes, entry['sym-balance'], entry.get('hash', None), entry.get('height', 1), optin_id)
+				for address, entry in symbol_address_dict.items()])
 
 	def insert_mapping(self, nem_address_dict, symbol_address_dict):
 		"""Adds a NEM to Symbol mapping to the database."""
@@ -95,15 +102,17 @@ class CompletedOptinDatabase:
 					source_json['nis-address']: int(source_json['nis-balance']) for source_json in mapping_json['source']
 				}
 				symbol_address_dict = {
-					destination_json['sym-address']: destination_json['sym-balance'] for destination_json in mapping_json['destination']
-				}
-				nem_transactions_dict = {
-					source_json['nis-address']: source_json.get('transactions', []) for source_json in mapping_json['source']
+					destination_json['sym-address']: destination_json for destination_json in mapping_json['destination']
 				}
 
 				self._assert_balances(nem_address_dict, symbol_address_dict)
 				self._insert_mapping(
-					cursor, nem_address_dict, symbol_address_dict, nem_transactions_dict, mapping_json.get('label', None), is_postoptin)
+					cursor, nem_address_dict, symbol_address_dict, mapping_json.get('label', None), is_postoptin)
+
+				nem_transactions_dict = {
+					source_json['nis-address']: source_json.get('transactions', []) for source_json in mapping_json['source']
+				}
+				self._insert_transactions(cursor, nem_transactions_dict)
 
 				yield mapping_json
 

--- a/optin/puller/scripts/setup.sh
+++ b/optin/puller/scripts/setup.sh
@@ -12,7 +12,7 @@ echo
 
 PYTHONPATH=. python3 workflows/populate_db.py \
 	--database-directory "${DATABASE_DIRECTORY}" \
-	--preoptin "${PREOPTIN_JSON}"
+	--optin "${PREOPTIN_JSON}"
 
 echo
 echo "[GENERATE_POSTOPTIN] generating post optin json file '${POSTOPTIN_JSON}'"
@@ -29,7 +29,8 @@ echo
 
 PYTHONPATH=. python3 workflows/populate_db.py \
 	--database-directory "${DATABASE_DIRECTORY}" \
-	--preoptin "${POSTOPTIN_JSON}"
+	--optin "${POSTOPTIN_JSON}" \
+	--post
 
 echo
 echo "[DOWNLOAD_POSTOPTIN] downloading post optin data from optin address '${OPTIN_ADDRESS}'"

--- a/optin/puller/tests/db/test_CompletedOptinDatabase.py
+++ b/optin/puller/tests/db/test_CompletedOptinDatabase.py
@@ -37,8 +37,8 @@ class CompletedOptinDatabaseTest(unittest.TestCase):
 		cursor.execute('''SELECT COUNT(*) FROM optin_id''')
 		optin_count = cursor.fetchone()[0]
 
-		cursor.execute('''SELECT attribute_flags, label FROM optin_id ORDER BY id''')
-		flags_and_label = cursor.fetchall()
+		cursor.execute('''SELECT is_postoptin, label FROM optin_id ORDER BY id''')
+		postoptin_and_label = cursor.fetchall()
 
 		cursor.execute('''SELECT * FROM nem_source ORDER BY balance DESC''')
 		nem_sources = cursor.fetchall()
@@ -51,12 +51,12 @@ class CompletedOptinDatabaseTest(unittest.TestCase):
 
 		# Assert:
 		self.assertEqual(expected_optin_count, optin_count)
-		self.assertEqual(expected_data['flags_labels'], flags_and_label)
+		self.assertEqual(expected_data['postoptin_labels'], postoptin_and_label)
 		self.assertEqual(expected_data['nem_sources'], nem_sources)
 		self.assertEqual(expected_data['nem_transactions'], nem_transactions)
 		self.assertEqual(expected_data['symbol_destinations'], symbol_destinations)
 
-	def _assert_can_insert_mappings(self, one_or_more_mappings, expected_nem_sources, expected_flags_labels, expected_symbol_destinations):
+	def _assert_can_insert_mappings(self, one_or_more_mappings, expected_nem_sources, expected_postoptin_labels, expected_symbol_destinations):
 		# Arrange:
 		with sqlite3.connect(':memory:') as connection:
 			mappings = one_or_more_mappings if isinstance(one_or_more_mappings, list) else [one_or_more_mappings]
@@ -70,7 +70,7 @@ class CompletedOptinDatabaseTest(unittest.TestCase):
 
 			# Assert:
 			self._assert_db_contents(connection, len(mappings), {
-				'flags_labels': expected_flags_labels,
+				'postoptin_labels': expected_postoptin_labels,
 				'nem_sources': expected_nem_sources,
 				'nem_transactions': [],
 				'symbol_destinations': expected_symbol_destinations
@@ -83,7 +83,7 @@ class CompletedOptinDatabaseTest(unittest.TestCase):
 		), [
 			(NemAddress(NEM_ADDRESSES[0]).bytes, 558668349881393, 1)
 		], [
-			(1, None)
+			(True, None)
 		], [
 			(SymbolAddress(SYMBOL_ADDRESSES[0]).bytes, 558668349881393, None, 1, 1)
 		])
@@ -96,7 +96,7 @@ class CompletedOptinDatabaseTest(unittest.TestCase):
 			(NemAddress(NEM_ADDRESSES[0]).bytes, 43686866144523, 1),
 			(NemAddress(NEM_ADDRESSES[1]).bytes, 16108065258303, 1)
 		], [
-			(1, None)
+			(True, None)
 		], [
 			(SymbolAddress(SYMBOL_ADDRESSES[0]).bytes, 59794931402826, None, 1, 1)
 		])
@@ -113,7 +113,7 @@ class CompletedOptinDatabaseTest(unittest.TestCase):
 			(NemAddress(NEM_ADDRESSES[0]).bytes, 43686866144523, 1),
 			(NemAddress(NEM_ADDRESSES[1]).bytes, 16108065258303, 1)
 		], [
-			(1, None)
+			(True, None)
 		], [
 			(SymbolAddress(SYMBOL_ADDRESSES[0]).bytes, 33686866144523, None, 1, 1),
 			(SymbolAddress(SYMBOL_ADDRESSES[1]).bytes, 26108065200000, None, 1, 1),
@@ -139,8 +139,8 @@ class CompletedOptinDatabaseTest(unittest.TestCase):
 			(NemAddress(NEM_ADDRESSES[1]).bytes, 43686866144523, 2),
 			(NemAddress(NEM_ADDRESSES[2]).bytes, 16108065258303, 2)
 		], [
-			(1, None),
-			(1, None)
+			(True, None),
+			(True, None)
 		], [
 			(SymbolAddress(SYMBOL_ADDRESSES[0]).bytes, 558668349881393, None, 1, 1),
 			(SymbolAddress(SYMBOL_ADDRESSES[1]).bytes, 33686866144523, None, 1, 2),
@@ -214,8 +214,8 @@ class CompletedOptinDatabaseTest(unittest.TestCase):
 			(NemAddress(NEM_ADDRESSES[0]).bytes, 43686866144523, 1),
 			(NemAddress(NEM_ADDRESSES[1]).bytes, 16108065258303, 2)
 		], [
-			(1, None),
-			(1, None)
+			(True, None),
+			(True, None)
 		], [
 			(SymbolAddress(SYMBOL_ADDRESSES[0]).bytes, 43686866144523, None, 1, 1),
 			(SymbolAddress(SYMBOL_ADDRESSES[0]).bytes, 16108065258303, None, 1, 2)
@@ -338,9 +338,9 @@ class CompletedOptinDatabaseTest(unittest.TestCase):
 
 			# Assert:
 			self._assert_db_contents(connection, 2, {
-				'flags_labels': [
-					(0, 'test-label'),
-					(0, None)
+				'postoptin_labels': [
+					(False, 'test-label'),
+					(False, None)
 				],
 				'nem_sources': [
 					(NemAddress(NEM_ADDRESSES[0]).bytes, 558668349881393, 1),
@@ -365,9 +365,9 @@ class CompletedOptinDatabaseTest(unittest.TestCase):
 
 			# Assert:
 			self._assert_db_contents(connection, 2, {
-				'flags_labels': [
-					(0, 'test-label'),
-					(0, None)
+				'postoptin_labels': [
+					(False, 'test-label'),
+					(False, None)
 				],
 				'nem_sources': [
 					(NemAddress(NEM_ADDRESSES[0]).bytes, 558668349881393, 1),

--- a/optin/puller/workflows/populate_db.py
+++ b/optin/puller/workflows/populate_db.py
@@ -18,9 +18,8 @@ def main():
 
 		with open(args.preoptin, 'rt', encoding='utf8') as infile:
 			data = json.load(infile)
-
-			for _ in database.insert_mappings_from_json(data):
-				print('.', end='', flush=True)
+			count = sum(1 for _ in database.insert_mappings_from_json(data))
+			print(f'inserted {count} mappings')
 
 
 if '__main__' == __name__:

--- a/optin/puller/workflows/populate_db.py
+++ b/optin/puller/workflows/populate_db.py
@@ -9,16 +9,17 @@ from puller.db.CompletedOptinDatabase import CompletedOptinDatabase
 def main():
 	parser = argparse.ArgumentParser(description='populate db with pre optin data')
 	parser.add_argument('--database-directory', help='output database directory', default='_temp')
-	parser.add_argument('--preoptin', help='pre optin json data', default='./resources/preoptin.json')
+	parser.add_argument('--optin', help='optin json data', default='./resources/preoptin.json')
+	parser.add_argument('--post', help='specify if file contains post optin data', action='store_true')
 	args = parser.parse_args()
 
 	with sqlite3.connect(Path(args.database_directory) / 'completed.db') as connection:
 		database = CompletedOptinDatabase(connection)
 		database.create_tables()
 
-		with open(args.preoptin, 'rt', encoding='utf8') as infile:
+		with open(args.optin, 'rt', encoding='utf8') as infile:
 			data = json.load(infile)
-			count = sum(1 for _ in database.insert_mappings_from_json(data))
+			count = sum(1 for _ in database.insert_mappings_from_json(data, args.post))
 			print(f'inserted {count} mappings')
 
 


### PR DESCRIPTION
 * add postoptin flag - in `optin_id` table (per operation) and label
 * add `nem_transactions` table (given that there are multiple txes per address not sure if it should be singular `nem_transaction` or not)
 * add symbol transaction hash and height (since there can be only one, it's directly in `symbol_destination` table)
 * finally, add `--post` flag to `workflows/populate`
 
 **NOTE** this change does not contain "special" flag - imo if there is no transactions in `nem_transactions` it should be treated as special already...