### PR TITLE
[optin/reporting/client] fix: table body overflow

### DIFF
--- a/optin/reporting/client/package.json
+++ b/optin/reporting/client/package.json
@@ -31,7 +31,6 @@
     "react-scripts": "5.0.0",
     "react-tabs": "^4.0.1",
     "react-transition-group": "^4.4.2",
-    "react-visibility-sensor": "^5.1.1",
     "sass": "^1.49.0",
     "symbol-sdk": "^3.0.0",
     "web-vitals": "^2.1.4"

--- a/optin/reporting/client/src/components/Table/Table.jsx
+++ b/optin/reporting/client/src/components/Table/Table.jsx
@@ -6,14 +6,14 @@ import React from 'react';
 const Table = props => {
 	const ref = React.useRef();
 
-	const allowLoadNextPage = !props.allPagesLoaded && props.rows <= props.value.length;
+	const allowLoadNextPage = !props.allPagesLoaded && props.rows <= props.value.length && !props.loading;
 
 	const infiniteLoaderHandler = React.useCallback(event => {
 		const bottom = Math.trunc(event.target.scrollHeight - event.target.scrollTop) <= event.target.clientHeight;
 				
 		if (bottom && allowLoadNextPage) 
 			props.onPage({});
-	}, [allowLoadNextPage]);
+	}, [allowLoadNextPage, props.onPage]);
 
 	React.useEffect(() => {
 		if (ref) {

--- a/optin/reporting/client/src/components/Table/Table.jsx
+++ b/optin/reporting/client/src/components/Table/Table.jsx
@@ -1,40 +1,70 @@
 import './Table.scss';
 import { DataTable } from 'primereact/datatable';
 import {ProgressSpinner} from 'primereact/progressspinner';
-import PropTypes from 'prop-types';
 import React from 'react';
-import VisibilitySensor from 'react-visibility-sensor';
 
 const Table = props => {
+	const ref = React.useRef();
 
-	const checkVisible = async visible => {
-		if (visible && !props.allPagesLoaded && props.rows <= props.value.length) 
-			await props.onPage({});
-	};
+	const allowLoadNextPage = !props.allPagesLoaded && props.rows <= props.value.length;
+
+	const infiniteLoaderHandler = React.useCallback(event => {
+		const bottom = Math.trunc(event.target.scrollHeight - event.target.scrollTop) <= event.target.clientHeight;
+				
+		if (bottom && allowLoadNextPage) 
+			props.onPage({});
+	}, [allowLoadNextPage]);
+
+	React.useEffect(() => {
+		if (ref) {
+			const scrollableElement = ref.current.el.lastChild;
+			scrollableElement.addEventListener('scroll', infiniteLoaderHandler);
+
+			return () => {
+				scrollableElement.removeEventListener('scroll', infiniteLoaderHandler);
+			};
+		}
+	}, [ref, infiniteLoaderHandler]);
 
 	const footer = (
 		<React.Fragment>
 			{props.footer}
 			{
-				!props.paginator && !props.allPagesLoaded && props.rows <= props.value.length && 
-				<VisibilitySensor onChange={checkVisible}>
-					<div class="grid flex align-items-center">
-						<div class="col-2"><ProgressSpinner className="w-6"/></div>
-						<div class="col-10">{props.loadingMessage}</div>
-					</div>
-				</VisibilitySensor>
+				props.loading && !props.paginator && 
+					<td colSpan={12}>
+						<div className="grid flex align-items-center w-100">
+							<div className="col-2"><ProgressSpinner className="w-6"/></div>
+							<div className="col-10">{props.loadingMessage}</div>
+						</div>
+					</td>
 			}
 		</React.Fragment>
 	);
 
 	return  (
-		<DataTable lazy={props.lazy} value={props.value} stripedRows showGridlines responsiveLayout="stack" 
-			breakpoint={props.breakpoint} paginator={props.paginator}
+		<DataTable 
+			lazy={props.lazy} 
+			value={props.value} 
+			stripedRows 
+			showGridlines 
+			responsiveLayout="stack" 
+			rowGroupMode="subheader" 
+			groupRowsBy="___all"
+			breakpoint={props.breakpoint} 
+			paginator={props.paginator}
 			paginatorTemplate="CurrentPageReport FirstPageLink PrevPageLink PageLinks NextPageLink LastPageLink RowsPerPageDropdown"
-			currentPageReportTemplate="Showing {first}-{last} of {totalRecords}" rows={props.rows} 
-			rowsPerPageOptions={props.rowsPerPageOptions}	onPage={props.onPage} 
-			loading={props.loading} totalRecords={props.totalRecords} first={props.first} header={props.header} 
-			emptyMessage={props.emptyMessage} footer={footer}>
+			currentPageReportTemplate="Showing {first}-{last} of {totalRecords}" 
+			rows={props.rows} 
+			rowsPerPageOptions={props.rowsPerPageOptions}
+			onPage={props.onPage} 
+			loading={props.loading} 
+			totalRecords={props.totalRecords} 
+			first={props.first} 
+			header={props.header} 
+			emptyMessage={props.emptyMessage} 
+			rowGroupFooterTemplate={footer} 
+			ref={ref}
+		>
 			{props.children}
 		</DataTable>
 	);

--- a/optin/reporting/client/src/pages/Home/Home.jsx
+++ b/optin/reporting/client/src/pages/Home/Home.jsx
@@ -20,7 +20,7 @@ const Home = function () {
 	const renderTabList = () => {
 		return Object.keys(tabConfig).map(key => {
 			return (
-				<TabPanel header={tabConfig[key].label}>
+				<TabPanel header={tabConfig[key].label} key={key}>
 					{tabConfig[key].table}
 				</TabPanel>
 			);
@@ -34,9 +34,11 @@ const Home = function () {
 				<div className='mainContainer'>
 					<h2>Opt-in Summary</h2>
 				</div>
-				<TabView>
-					{ renderTabList() }
-				</TabView>
+				<div className='tableContainer'>
+					<TabView>
+						{ renderTabList() }
+					</TabView>
+				</div>
 			</div>
 		</div>
 	);

--- a/optin/reporting/client/src/pages/Home/Home.scss
+++ b/optin/reporting/client/src/pages/Home/Home.scss
@@ -7,15 +7,25 @@
   background-position: center;
 }
 
+.mainContainerWrapper {
+  height: 100%;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: stretch;
+}
+
 .mainContainer {
   width: 100%;
   max-width: 600px;
-  padding: 20px 20px;
+  padding: 20px 0 0;
   margin: auto;
   position: relative;
   text-align: center;
 }
 
-.mainContainerWrapper {
-  position: relative;
+.tableContainer {
+  min-height: 0;
+  overflow-x: hidden;
+  flex: 1;
 }

--- a/optin/reporting/client/src/styles/globals.scss
+++ b/optin/reporting/client/src/styles/globals.scss
@@ -1,3 +1,51 @@
+html, body, #root, .App {
+  margin: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.p-tabview, 
+.p-tabview-panel, 
+.p-datatable, 
+.p-datatable-wrapper, 
+.p-datatable-table {
+  height: 100%;
+  flex: 1;
+}
+
+.p-tabview-panels {
+  padding: 0 !important;
+  height: calc(100% - 58px);
+}
+
+p-tabview, 
+.p-datatable {
+  display: flex;
+  flex-direction: column;
+}
+
+.p-datatable-wrapper {
+  overflow: auto;
+}
+
+.p-datatable-thead {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+
+  & > tr > th {
+    box-shadow: inset 0 1px 0 #dee2e6, inset 0 -1px 0 #dee2e6;
+  }
+}
+
+.p-rowgroup-header {
+  display: none;
+}
+
+.p-datatable-loading-overlay {
+  z-index: 10 !important;
+}
+
 .pagination {
   display: flex;
   justify-content: center;
@@ -20,7 +68,7 @@
   }
 }
 
- .sub-total-value {
+.sub-total-value {
   @extend .list-item;
   font-weight: bold;
   text-decoration: underline;


### PR DESCRIPTION
### What was the issue?
- The table body goes off of the viewport;
![image](https://user-images.githubusercontent.com/33131259/163829858-f5126c10-25a9-42e3-a111-b1c731488285.png)


### What's the fix?
- Changed the table width to match the width of a viewport;
- Changed the table height to fill the rest of remaining space (`flex: 1`);
- Added scrollbars to the table body instead of the viewport;
- Changed infinite-loader to trigger when the end of the table is reached. Removed 3rd party dependency;
- Added sticky table header;

![image](https://user-images.githubusercontent.com/33131259/163831041-4d5ec45a-cbe5-4c3d-8c6a-04d637636d88.png)
