### PR TITLE
[optin/reporting/client] fix: table row height

### DIFF
--- a/optin/reporting/client/src/styles/globals.scss
+++ b/optin/reporting/client/src/styles/globals.scss
@@ -46,6 +46,10 @@ p-tabview,
   z-index: 10 !important;
 }
 
+tr {
+  height: 0;
+}
+
 .pagination {
   display: flex;
   justify-content: center;


### PR DESCRIPTION
### What was the issue?
- Single table row fills the table body height.
![image](https://user-images.githubusercontent.com/33131259/163990815-09d279ee-b1df-4312-8a50-cc3684f3adb8.png)

### What's the fix?
- Keep row height depending on its content.
![image](https://user-images.githubusercontent.com/33131259/163990682-7c25a28c-9578-4cda-83fa-a5da41de10a1.png)
