### PR TITLE
[explorer/nodewatch] task: fix nodewatch layout issue

### DIFF
--- a/.gitlintmodules
+++ b/.gitlintmodules
@@ -1,1 +1,1 @@
-optin/puller|optin/reporting|optin/reporting/client|tools/vanity|monorepo|nodewatch
+optin/puller|optin/reporting|optin/reporting/client|tools/vanity|monorepo|explorer/nodewatch

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It includes our optin manager.
 | [@optin/puller](optin/puller) | [![lint][optin-puller-lint]][optin-puller-job] || [![test][optin-puller-test]][optin-puller-job]| [![][optin-puller-cov]][optin-puller-cov-link] |
 | [@optin/reporting](optin/reporting) | [![lint][optin-reporting-lint]][optin-reporting-job] || [![test][optin-reporting-test]][optin-reporting-job]| [![][optin-reporting-cov]][optin-reporting-cov-link] |
 | [@tools/vanity](tools/vanity) | [![lint][tools-vanity-lint]][tools-vanity-job] || [![test][tools-vanity-test]][tools-vanity-job]| [![][tools-vanity-cov]][tools-vanity-cov-link] |
-| [@explorer/nodewatch](explorer/nodewatch) | [![lint][nodewatch-lint]][nodewatch-job] ||||
+| [@explorer/nodewatch](explorer/nodewatch) | [![lint][explorer-nodewatch-lint]][explorer-nodewatch-job] ||||
 
 ## Full Coverage Report
 
@@ -37,5 +37,5 @@ Detailed version can be seen on [codecov.io][product-cov-link].
 [tools-vanity-cov]: https://codecov.io/gh/symbol/product/branch/dev/graph/badge.svg?token=SSYYBMK0M7&flag=tools-vanity
 [tools-vanity-cov-link]: https://codecov.io/gh/symbol/product/tree/dev/tools/vanity
 
-[nodewatch-job]: https://jenkins.symboldev.com/blue/organizations/jenkins/Symbol%2Fgenerated%2Fproduct%2Fnodewatch/activity?branch=dev
-[nodewatch-lint]: https://jenkins.symboldev.com/buildStatus/icon?job=Symbol%2Fgenerated%2Fproduct%2Fnodewatch%2Fdev%2F&config=explorer-nodewatch-lint
+[explorer-nodewatch-job]: https://jenkins.symboldev.com/blue/organizations/jenkins/Symbol%2Fgenerated%2Fproduct%2Fnodewatch/activity?branch=dev
+[explorer-nodewatch-lint]: https://jenkins.symboldev.com/buildStatus/icon?job=Symbol%2Fgenerated%2Fproduct%2Fnodewatch%2Fdev%2F&config=explorer-nodewatch-lint


### PR DESCRIPTION
### What was the issue?
- nodewatch should belong to `explorer` folder

### What's the fix?
- move `nodewatch` to `explorer`
- update readme and build config path