### PR TITLE
[nodewatch] fix: update to python sdk 3

### DIFF
--- a/explorer/nodewatch/README.md
+++ b/explorer/nodewatch/README.md
@@ -9,14 +9,10 @@ To produce certificates follow the instructions for generating keys and certs in
 git clone https://github.com/symbol/miscellaneous.git
 
 git clone https://github.com/symbol/symbol.git
-cd explorer/nodewatch/puller
+cd symbol/explorer/nodewatch/puller
 
 PYTHONPATH=../../../../miscellaneous ./pull.sh <resource folder> <timeout>
 cd ..
-```
 
-Create an app.config with the RESOURCES_PATH="<resource folder>"
-
-```sh
-NODEWATCH_SETTINGS=<path>/app.config FLASK_APP=nodewatch flask run
+python -m webapp.app --resources ./resources
 ```

--- a/explorer/nodewatch/README.md
+++ b/explorer/nodewatch/README.md
@@ -8,9 +8,15 @@ To produce certificates follow the instructions for generating keys and certs in
 ```sh
 git clone https://github.com/symbol/miscellaneous.git
 
-cd puller
-PYTHONPATH=../miscellaneous ./pull.sh
-cd ..
+git clone https://github.com/symbol/symbol.git
+cd explorer/nodewatch/puller
 
-python -m webapp.app --resources ./resources
+PYTHONPATH=../../../../miscellaneous ./pull.sh <resource folder> <timeout>
+cd ..
+```
+
+Create an app.config with the RESOURCES_PATH="<resource folder>"
+
+```sh
+NODEWATCH_SETTINGS=<path>/app.config FLASK_APP=nodewatch flask run
 ```

--- a/explorer/nodewatch/nodewatch/NetworkRepository.py
+++ b/explorer/nodewatch/nodewatch/NetworkRepository.py
@@ -1,11 +1,11 @@
 import csv
 import json
 
-from symbolchain.core.CryptoTypes import PublicKey
-from symbolchain.core.nem.Network import Address as NemAddress
-from symbolchain.core.nem.Network import Network as NemNetwork
-from symbolchain.core.symbol.Network import Address as SymbolAddress
-from symbolchain.core.symbol.Network import Network as SymbolNetwork
+from symbolchain.CryptoTypes import PublicKey
+from symbolchain.nem.Network import Address as NemAddress
+from symbolchain.nem.Network import Network as NemNetwork
+from symbolchain.symbol.Network import Address as SymbolAddress
+from symbolchain.symbol.Network import Network as SymbolNetwork
 from zenlog import log
 
 

--- a/explorer/nodewatch/requirements.txt
+++ b/explorer/nodewatch/requirements.txt
@@ -3,5 +3,5 @@ APScheduler==3.9.1
 Flask==2.1.2
 pandas==1.4.2
 plotly==5.8.0
-symbol-sdk-core-python==2.0.1
+symbol-sdk-python==3.0.3
 zenlog==1.1


### PR DESCRIPTION
1. Update the nodewatch to use symbol-sdk-python 3.0.3
2. Update readme to run nodewatch