### PR TITLE
[optin/reporting] fix: set docker image name and increased coverage to 95 in jenkinsfile

### DIFF
--- a/optin/reporting/Jenkinsfile
+++ b/optin/reporting/Jenkinsfile
@@ -2,9 +2,11 @@ defaultCiPipeline {
 	platform = ['ubuntu']
 	ciBuildDockerfile = 'javascript.Dockerfile'
 
-	publisher = 'docker'
 	packageId = 'optin-reporting'
 
+	publisher = 'docker'
+	dockerImageName = 'symbolplatform/optin-reporting'
+
 	codeCoverageTool = 'nyc'
-	minimumCodeCoverage = 75
+	minimumCodeCoverage = 95
 }


### PR DESCRIPTION
## What was the issue?
The manual private release build(in Jenkins) cannot produce the expected image. `dockerImageName` field in the Jenkinsfile needs to be set explicitly.

## What's the fix?
* `dockerImageName` is set to `symbolplatform/optin-reporting`
* minimumCodeCoverage is now increased to 95%