### PR TITLE
[dependency] fix: linting failures due to pylint update

### DIFF
--- a/explorer/nodewatch/nodewatch/VersionChartBuilder.py
+++ b/explorer/nodewatch/nodewatch/VersionChartBuilder.py
@@ -62,7 +62,7 @@ class VersionChartBuilder:
 
 	@staticmethod
 	def _append_bar_sections(sections, version_data_point_map, measure, group):
-		total_value = sum([getattr(data_point, measure) for _, data_point in version_data_point_map.items()])
+		total_value = sum(getattr(data_point, measure) for _, data_point in version_data_point_map.items())
 
 		for version in version_data_point_map:
 			friendly_version_name = version if version else 'delegating / updating'

--- a/optin/reporting/client/package-lock.json
+++ b/optin/reporting/client/package-lock.json
@@ -29,7 +29,7 @@
         "assert": "^2.0.0",
         "buffer": "^6.0.3",
         "crypto-browserify": "^3.12.0",
-        "eslint": "^8.17.0",
+        "eslint": "^8.18.0",
         "eslint-config-airbnb": "^19.0.4",
         "https-browserify": "^1.0.0",
         "jest-fetch-mock": "^3.0.3",
@@ -6979,9 +6979,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.17.0.tgz",
-      "integrity": "sha512-gq0m0BTJfci60Fz4nczYxNAlED+sMcihltndR8t9t1evnU/azx53x3t2UHXC/uRjcbvRw/XctpaNygSTcQD+Iw==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.18.0.tgz",
+      "integrity": "sha512-As1EfFMVk7Xc6/CvhssHUjsAQSkpfXvUGMFC3ce8JDe6WvqCgRrLOBQbVpsBFr1X1V+RACOadnzVvcUS5ni2bA==",
       "dependencies": {
         "@eslint/eslintrc": "^1.3.0",
         "@humanwhocodes/config-array": "^0.9.2",
@@ -22242,9 +22242,9 @@
       }
     },
     "eslint": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.17.0.tgz",
-      "integrity": "sha512-gq0m0BTJfci60Fz4nczYxNAlED+sMcihltndR8t9t1evnU/azx53x3t2UHXC/uRjcbvRw/XctpaNygSTcQD+Iw==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.18.0.tgz",
+      "integrity": "sha512-As1EfFMVk7Xc6/CvhssHUjsAQSkpfXvUGMFC3ce8JDe6WvqCgRrLOBQbVpsBFr1X1V+RACOadnzVvcUS5ni2bA==",
       "requires": {
         "@eslint/eslintrc": "^1.3.0",
         "@humanwhocodes/config-array": "^0.9.2",

--- a/optin/reporting/client/package.json
+++ b/optin/reporting/client/package.json
@@ -6,7 +6,7 @@
     "assert": "^2.0.0",
     "buffer": "^6.0.3",
     "crypto-browserify": "^3.12.0",
-    "eslint": "^8.17.0",
+    "eslint": "^8.18.0",
     "eslint-config-airbnb": "^19.0.4",
     "https-browserify": "^1.0.0",
     "jest-fetch-mock": "^3.0.3",

--- a/optin/reporting/package-lock.json
+++ b/optin/reporting/package-lock.json
@@ -11,17 +11,17 @@
       "dependencies": {
         "dotenv": "^16.0.1",
         "express": "^4.18.1",
-        "express-validator": "^6.14.1",
+        "express-validator": "^6.14.2",
         "json2csv": "^5.0.7",
         "moment-timezone": "^0.5.34",
-        "sequelize": "^6.20.1",
+        "sequelize": "^6.21.0",
         "sqlite3": "^5.0.8",
         "symbol-sdk": "^3.0.0"
       },
       "devDependencies": {
         "chai": "^4.3.6",
         "chai-as-promised": "^7.1.1",
-        "eslint": "^8.16.0",
+        "eslint": "^8.18.0",
         "eslint-config-airbnb": "^19.0.4",
         "mocha": "^9.2.2",
         "mocha-jenkins-reporter": "^0.4.7",
@@ -2035,9 +2035,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.17.0.tgz",
-      "integrity": "sha512-gq0m0BTJfci60Fz4nczYxNAlED+sMcihltndR8t9t1evnU/azx53x3t2UHXC/uRjcbvRw/XctpaNygSTcQD+Iw==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.18.0.tgz",
+      "integrity": "sha512-As1EfFMVk7Xc6/CvhssHUjsAQSkpfXvUGMFC3ce8JDe6WvqCgRrLOBQbVpsBFr1X1V+RACOadnzVvcUS5ni2bA==",
       "dev": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.3.0",
@@ -2493,9 +2493,9 @@
       }
     },
     "node_modules/express-validator": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.14.1.tgz",
-      "integrity": "sha512-4w7gn/jPW1a+r833xBqpu4pL7XiiScDwlbBIMtiqUEt/MVNqR94HOHyKLcCtnqCnEPiqrX1Mqt9l/SVN/iqeLA==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.14.2.tgz",
+      "integrity": "sha512-8XfAUrQ6Y7dIIuy9KcUPCfG/uCbvREctrxf5EeeME+ulanJ4iiW71lWmm9r4YcKKYOCBMan0WpVg7FtHu4Z4Wg==",
       "dependencies": {
         "lodash": "^4.17.21",
         "validator": "^13.7.0"
@@ -5388,9 +5388,9 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/sequelize": {
-      "version": "6.20.1",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.20.1.tgz",
-      "integrity": "sha512-1YBMv++Yy1JBFFiac1Xoa+Km5qV6YI1ckdkW0xyD7IpLMtE5JmjgZdZXGfwgRUNjhaKMxdzT+nkvJgeXO0rv/g==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.21.0.tgz",
+      "integrity": "sha512-QItP+QMoZL7KWaYtmRRb41sQ9Ua+dpWQbdREO4jYIUBg5hUfRiGq2i2/gAa25B84ft0EzDPY3UvCQS945ytNvA==",
       "funding": [
         {
           "type": "opencollective",
@@ -7979,9 +7979,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.17.0.tgz",
-      "integrity": "sha512-gq0m0BTJfci60Fz4nczYxNAlED+sMcihltndR8t9t1evnU/azx53x3t2UHXC/uRjcbvRw/XctpaNygSTcQD+Iw==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.18.0.tgz",
+      "integrity": "sha512-As1EfFMVk7Xc6/CvhssHUjsAQSkpfXvUGMFC3ce8JDe6WvqCgRrLOBQbVpsBFr1X1V+RACOadnzVvcUS5ni2bA==",
       "dev": true,
       "requires": {
         "@eslint/eslintrc": "^1.3.0",
@@ -8355,9 +8355,9 @@
       }
     },
     "express-validator": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.14.1.tgz",
-      "integrity": "sha512-4w7gn/jPW1a+r833xBqpu4pL7XiiScDwlbBIMtiqUEt/MVNqR94HOHyKLcCtnqCnEPiqrX1Mqt9l/SVN/iqeLA==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.14.2.tgz",
+      "integrity": "sha512-8XfAUrQ6Y7dIIuy9KcUPCfG/uCbvREctrxf5EeeME+ulanJ4iiW71lWmm9r4YcKKYOCBMan0WpVg7FtHu4Z4Wg==",
       "requires": {
         "lodash": "^4.17.21",
         "validator": "^13.7.0"
@@ -10508,9 +10508,9 @@
       }
     },
     "sequelize": {
-      "version": "6.20.1",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.20.1.tgz",
-      "integrity": "sha512-1YBMv++Yy1JBFFiac1Xoa+Km5qV6YI1ckdkW0xyD7IpLMtE5JmjgZdZXGfwgRUNjhaKMxdzT+nkvJgeXO0rv/g==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.21.0.tgz",
+      "integrity": "sha512-QItP+QMoZL7KWaYtmRRb41sQ9Ua+dpWQbdREO4jYIUBg5hUfRiGq2i2/gAa25B84ft0EzDPY3UvCQS945ytNvA==",
       "requires": {
         "@types/debug": "^4.1.7",
         "@types/validator": "^13.7.1",

--- a/optin/reporting/package.json
+++ b/optin/reporting/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",
-    "eslint": "^8.16.0",
+    "eslint": "^8.18.0",
     "eslint-config-airbnb": "^19.0.4",
     "mocha": "^9.2.2",
     "mocha-jenkins-reporter": "^0.4.7",
@@ -29,10 +29,10 @@
   "dependencies": {
     "dotenv": "^16.0.1",
     "express": "^4.18.1",
-    "express-validator": "^6.14.1",
+    "express-validator": "^6.14.2",
     "json2csv": "^5.0.7",
     "moment-timezone": "^0.5.34",
-    "sequelize": "^6.20.1",
+    "sequelize": "^6.21.0",
     "sqlite3": "^5.0.8",
     "symbol-sdk": "^3.0.0"
   }

--- a/tools/vanity/tests/test_AddressGenerator.py
+++ b/tools/vanity/tests/test_AddressGenerator.py
@@ -13,8 +13,7 @@ class AddressGeneratorTest(unittest.TestCase):
 	def _derive_public_key_at(facade, mnemonic, account_index):
 		coin_id = 1 if 'testnet' == facade.network.name else facade.BIP32_COIN_ID
 		bip32_root_node = Bip32(facade.BIP32_CURVE_NAME).from_mnemonic(mnemonic, '')
-		# pylint:disable=duplicate-value
-		return facade.KeyPair(bip32_root_node.derive_path({44, coin_id, account_index, 0, 0}).private_key).public_key
+		return facade.KeyPair(bip32_root_node.derive_path([44, coin_id, account_index, 0, 0]).private_key).public_key
 
 	def assert_derivable(self, facade, mnemonic, key_pair, max_wallet_accounts):
 		self.assertTrue(any(

--- a/tools/vanity/tests/test_AddressGenerator.py
+++ b/tools/vanity/tests/test_AddressGenerator.py
@@ -13,6 +13,7 @@ class AddressGeneratorTest(unittest.TestCase):
 	def _derive_public_key_at(facade, mnemonic, account_index):
 		coin_id = 1 if 'testnet' == facade.network.name else facade.BIP32_COIN_ID
 		bip32_root_node = Bip32(facade.BIP32_CURVE_NAME).from_mnemonic(mnemonic, '')
+		# pylint:disable=duplicate-value
 		return facade.KeyPair(bip32_root_node.derive_path({44, coin_id, account_index, 0, 0}).private_key).public_key
 
 	def assert_derivable(self, facade, mnemonic, key_pair, max_wallet_accounts):

--- a/tools/vanity/vanity/AddressGenerator.py
+++ b/tools/vanity/vanity/AddressGenerator.py
@@ -40,6 +40,7 @@ class AddressGenerator:
 			bip32_root_node = bip32.from_mnemonic(mnemonic, '')  # no password
 
 			for account_index in range(0, self.max_wallet_accounts):
+				# pylint:disable=duplicate-value
 				private_key = bip32_root_node.derive_path({44, coin_id, account_index, 0, 0}).private_key
 				key_pair = self.facade.KeyPair(private_key)
 

--- a/tools/vanity/vanity/AddressGenerator.py
+++ b/tools/vanity/vanity/AddressGenerator.py
@@ -40,8 +40,7 @@ class AddressGenerator:
 			bip32_root_node = bip32.from_mnemonic(mnemonic, '')  # no password
 
 			for account_index in range(0, self.max_wallet_accounts):
-				# pylint:disable=duplicate-value
-				private_key = bip32_root_node.derive_path({44, coin_id, account_index, 0, 0}).private_key
+				private_key = bip32_root_node.derive_path([44, coin_id, account_index, 0, 0]).private_key
 				key_pair = self.facade.KeyPair(private_key)
 
 				with self.lock:


### PR DESCRIPTION
With the latest pylint version, new issues were found and fix
1. nodewatch/VersionChartBuilder.py:65:16: R1728: Consider using a generator instead
2. vanity/AddressGenerator.py:43:46: W0130: Duplicate value 0 in set (duplicate-value)