### PR TITLE
[monorepo] fix: add threshold for code coverage drop

### DIFF
--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -8,11 +8,19 @@ coverage:
 
       optin-puller:
         target: auto
+        threshold: 1%
         flags:
           - optin-puller
 
+      optin-reporting:
+        target: auto
+        threshold: 1%
+        flags:
+          - optin-reporting
+
       tools-vanity:
         target: auto
+        threshold: 1%
         flags:
           - tools-vanity
 
@@ -26,6 +34,11 @@ flags:
   optin-puller:
     paths:
       - optin/puller
+    carryforward: true
+
+  optin-reporting:
+    paths:
+      - optin/reporting
     carryforward: true
 
   tools-vanity:


### PR DESCRIPTION
 problem: code coverage checks will fail due to a small drop in percentage.
solution: Allow a drop of up to 1% in code coverage.