### PR TITLE
[optin/reporting] fix: failing tests on dependency update

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -20,6 +20,9 @@ updates:
     labels: [Opt-In]
     commit-message:
       prefix: '[dependency]'
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: npm
     directory: /optin/reporting
@@ -31,6 +34,9 @@ updates:
     versioning-strategy: increase
     commit-message:
       prefix: '[dependency]'
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: npm
     directory: /optin/reporting/client
@@ -42,6 +48,9 @@ updates:
     versioning-strategy: increase
     commit-message:
       prefix: '[dependency]'
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: pip
     directory: /tools/vanity

--- a/optin/reporting/client/package-lock.json
+++ b/optin/reporting/client/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^12.1.5",
-        "@testing-library/user-event": "^13.0.5",
+        "@testing-library/user-event": "^14.4.3",
         "@trendmicro/react-paginations": "^0.6.1",
         "moment-timezone": "^0.5.37",
         "primeflex": "^3.2.1",
@@ -3408,14 +3408,11 @@
       }
     },
     "node_modules/@testing-library/user-event": {
-      "version": "13.5.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.5.0.tgz",
-      "integrity": "sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
+      "version": "14.4.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
+      "integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
       "engines": {
-        "node": ">=10",
+        "node": ">=12",
         "npm": ">=6"
       },
       "peerDependencies": {
@@ -19507,12 +19504,10 @@
       }
     },
     "@testing-library/user-event": {
-      "version": "13.5.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.5.0.tgz",
-      "integrity": "sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==",
-      "requires": {
-        "@babel/runtime": "^7.12.5"
-      }
+      "version": "14.4.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
+      "integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
+      "requires": {}
     },
     "@tootallnate/once": {
       "version": "1.1.2",

--- a/optin/reporting/client/package.json
+++ b/optin/reporting/client/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^12.1.5",
-    "@testing-library/user-event": "^13.0.5",
+    "@testing-library/user-event": "^14.4.3",
     "@trendmicro/react-paginations": "^0.6.1",
     "moment-timezone": "^0.5.37",
     "primeflex": "^3.2.1",

--- a/optin/reporting/client/src/pages/Completed/Completed.test.js
+++ b/optin/reporting/client/src/pages/Completed/Completed.test.js
@@ -158,7 +158,7 @@ describe('Completed', () => {
 				mockCompletedAPIFetch(completedAPIResponseFiltered);
 
 				// Act:
-				userEvent.type(filterSearchInput, `${expectedTextForFirstRow}{enter}`);
+				await userEvent.type(filterSearchInput, `${expectedTextForFirstRow}{enter}`);
 
 				// Assert:
 				expect(filterSearchInput).toHaveDisplayValue(expectedTextForFirstRow);
@@ -200,7 +200,7 @@ describe('Completed', () => {
 			const filterSearchInput = screen.getByPlaceholderText('NEM Address / Symbol Address / Tx Hash');
 
 			// Act:
-			userEvent.type(filterSearchInput, `${invalidFilterText}`);
+			await userEvent.type(filterSearchInput, `${invalidFilterText}`);
 
 			// Assert:
 			expect((await screen.findAllByText('Invalid NEM / Symbol Address or Transaction Hash.'))[0]).toBeInTheDocument();
@@ -251,7 +251,7 @@ describe('Completed', () => {
 				mockCompletedAPIFetch(completedAPIResponseFiltered);
 
 				// Act:
-				userEvent.click(filterOptinType);
+				await userEvent.click(filterOptinType);
 			};
 			await testFilterSort(
 				firstRowData, secondRowData, expectedTextForFirstRow, expectedTextForSecondRow,
@@ -287,7 +287,7 @@ describe('Completed', () => {
 				mockCompletedAPIFetch(completedAPIResponseSorted);
 
 				// Act:
-				userEvent.click(sortableColumnHeader);
+				await userEvent.click(sortableColumnHeader);
 			};
 			await testFilterSort(
 				firstRowData, secondRowData, expectedTextForFirstRow, expectedTextForSecondRow,

--- a/optin/reporting/client/src/pages/Requests/Requests.test.js
+++ b/optin/reporting/client/src/pages/Requests/Requests.test.js
@@ -130,7 +130,7 @@ describe('Requests', () => {
 				mockRequestsAPIFetch(requestsAPIResponseFiltered);
 
 				// Act:
-				userEvent.type(filterSearchInput, `${expectedTextForFirstRow}{enter}`);
+				await userEvent.type(filterSearchInput, `${expectedTextForFirstRow}{enter}`);
 
 				// Assert:
 				expect(filterSearchInput).toHaveDisplayValue(expectedTextForFirstRow);
@@ -165,7 +165,7 @@ describe('Requests', () => {
 			const filterSearchInput = screen.getByPlaceholderText('NEM Address / Tx Hash');
 
 			// Act:
-			userEvent.type(filterSearchInput, `${invalidFilterText}`);
+			await userEvent.type(filterSearchInput, `${invalidFilterText}`);
 
 			// Assert:
 			expect((await screen.findAllByText('Invalid NEM Address or Transaction Hash.'))[0]).toBeInTheDocument();
@@ -214,7 +214,7 @@ describe('Requests', () => {
 				mockRequestsAPIFetch(requestsAPIResponseFiltered);
 
 				// Act:
-				userEvent.click(filterStatus);
+				await userEvent.click(filterStatus);
 			};
 			await testFilterSort(
 				firstRowData, secondRowData, expectedTextForFirstRow, expectedTextForSecondRow,
@@ -263,7 +263,7 @@ describe('Requests', () => {
 				mockRequestsAPIFetch(requestsAPIResponseSorted);
 
 				// Act:
-				userEvent.click(sortableColumnHeader);
+				await userEvent.click(sortableColumnHeader);
 			};
 			await testFilterSort(
 				firstRowData, secondRowData, expectedTextForFirstRow, expectedTextForSecondRow,

--- a/optin/reporting/package-lock.json
+++ b/optin/reporting/package-lock.json
@@ -15,7 +15,7 @@
         "json2csv": "^5.0.7",
         "moment-timezone": "^0.5.37",
         "sequelize": "^6.21.6",
-        "sqlite3": "^5.0.8",
+        "sqlite3": "^5.1.1",
         "symbol-sdk": "^3.0.0"
       },
       "devDependencies": {
@@ -5941,9 +5941,9 @@
       "dev": true
     },
     "node_modules/sqlite3": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.0.8.tgz",
-      "integrity": "sha512-f2ACsbSyb2D1qFFcqIXPfFscLtPVOWJr5GmUzYxf4W+0qelu5MWrR+FAQE1d5IUArEltBrzSDxDORG8P/IkqyQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.1.tgz",
+      "integrity": "sha512-mMinkrQr/LKJqFiFF+AF7imPSzRCCpTCreusZO3D/ssJHVjZOrbu2Caz+zPH5KTmGGXBxXMGSRDssL+44CLxvg==",
       "hasInstallScript": true,
       "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.0",
@@ -11150,9 +11150,9 @@
       "dev": true
     },
     "sqlite3": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.0.8.tgz",
-      "integrity": "sha512-f2ACsbSyb2D1qFFcqIXPfFscLtPVOWJr5GmUzYxf4W+0qelu5MWrR+FAQE1d5IUArEltBrzSDxDORG8P/IkqyQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.1.tgz",
+      "integrity": "sha512-mMinkrQr/LKJqFiFF+AF7imPSzRCCpTCreusZO3D/ssJHVjZOrbu2Caz+zPH5KTmGGXBxXMGSRDssL+44CLxvg==",
       "requires": {
         "@mapbox/node-pre-gyp": "^1.0.0",
         "node-addon-api": "^4.2.0",

--- a/optin/reporting/package.json
+++ b/optin/reporting/package.json
@@ -33,7 +33,7 @@
     "json2csv": "^5.0.7",
     "moment-timezone": "^0.5.37",
     "sequelize": "^6.21.6",
-    "sqlite3": "^5.0.8",
+    "sqlite3": "^5.1.1",
     "symbol-sdk": "^3.0.0"
   }
 }

--- a/optin/reporting/test/models/completed.spec.js
+++ b/optin/reporting/test/models/completed.spec.js
@@ -345,7 +345,7 @@ describe('completed models', () => {
 
 			// Assert:
 			expect(result[0].nemSource.length).to.be.equal(1);
-			const nemSource = JSON.parse(result[0].nemSource[0])
+			const nemSource = JSON.parse(result[0].nemSource[0]);
 			expect(nemSource.address).to.be.equal(nemAddressHex);
 		});
 

--- a/optin/reporting/test/models/completed.spec.js
+++ b/optin/reporting/test/models/completed.spec.js
@@ -12,14 +12,14 @@ const mockCompletedRecordQuery = {
 		{
 			id: 26453,
 			isPostoptin: 1,
-			nemSource: [{
+			nemSource: [JSON.stringify({
 				address: '680B140819D8B6C734091637DA4B3B854BC2FD30D3FE42B0BA',
 				balance: 3007282359130,
 				hashes: '24C4DB714FB339905939D76665B3BB18AB0031938130C58546B8B0595593DDD8',
 				height: '3691432',
 				label: null,
 				timestamps: '1650982163'
-			}],
+			})],
 			symbolDestination: [{
 				address: '6854E15A45E973283640A12F90001251695C2295F496871F',
 				balance: 3007282359130,
@@ -33,14 +33,14 @@ const mockCompletedRecordQuery = {
 		{
 			id: 26452,
 			isPostoptin: 1,
-			nemSource: [{
+			nemSource: [JSON.stringify({
 				address: '688283016813AC29EE88053EFC62C8047773B7C085FC15AA51',
 				balance: 3001882177821,
 				hashes: 'E4AEE3D3D9507CC8818704D917C40F1FDBDD9E6FE84C143F5995C15DCAD4552F',
 				height: '3691446',
 				label: null,
 				timestamps: '1650983000'
-			}],
+			})],
 			symbolDestination: [{
 				address: '6854E15A45E973283640A12F90001251695C2295F496871F',
 				balance: 3001882177821,
@@ -54,14 +54,14 @@ const mockCompletedRecordQuery = {
 		{
 			id: 26451,
 			isPostoptin: 1,
-			nemSource: [{
+			nemSource: [JSON.stringify({
 				address: '6816811340FEC6BC4DFCDFBA6694548828FDDEA12BBF86E1D6',
 				balance: 3009039776345,
 				hashes: '03449973A061DB0B8D0207DBAF5301627A3E3ACB12BA4A9AC537CCC7C4B4CD62',
 				height: '3691452',
 				label: null,
 				timestamps: '1650983297'
-			}],
+			})],
 			symbolDestination: [{
 				address: '6854E15A45E973283640A12F90001251695C2295F496871F',
 				balance: 3009039776345,
@@ -75,14 +75,14 @@ const mockCompletedRecordQuery = {
 		{
 			id: 26450,
 			isPostoptin: 1,
-			nemSource: [{
+			nemSource: [JSON.stringify({
 				address: '6816811369BEDBFD1F3B4387713B47B411694C4F174B535BE8',
 				balance: 3008838713888,
 				hashes: 'CB5D980223A486CCA5C780C7E16A248052CF4DB7DC0D328D1E726CBBD30022E1',
 				height: '3691455',
 				label: null,
 				timestamps: '1650983483'
-			}],
+			})],
 			symbolDestination: [{
 				address: '6854E15A45E973283640A12F90001251695C2295F496871F',
 				balance: 3008838713888,
@@ -96,14 +96,14 @@ const mockCompletedRecordQuery = {
 		{
 			id: 26449,
 			isPostoptin: 1,
-			nemSource: [{
+			nemSource: [JSON.stringify({
 				address: '6816811396FACFE59582E9AE1DD5F5B209180DC24B48C373F4',
 				balance: 3008612385925,
 				hashes: 'F988C9EAE8BAA566B8273D934F55C5626281314588858994C3E8C160E2541918',
 				height: '3691462',
 				label: null,
 				timestamps: '1650983664'
-			}],
+			})],
 			symbolDestination: [{
 				address: '6854E15A45E973283640A12F90001251695C2295F496871F',
 				balance: 3008612385925,
@@ -118,14 +118,14 @@ const mockCompletedRecordQuery = {
 		{
 			id: 26453,
 			isPostoptin: 1,
-			nemSource: [{
+			nemSource: [JSON.stringify({
 				address: '680B140819D8B6C734091637DA4B3B854BC2FD30D3FE42B0BA',
 				balance: 3007282359130,
 				hashes: '24C4DB714FB339905939D76665B3BB18AB0031938130C58546B8B0595593DDD8',
 				height: '3691432',
 				label: null,
 				timestamps: '1650982163'
-			}],
+			})],
 			symbolDestination: [{
 				address: '6854E15A45E973283640A12F90001251695C2295F496871F',
 				balance: 3007282359130,
@@ -139,14 +139,14 @@ const mockCompletedRecordQuery = {
 		{
 			id: 26452,
 			isPostoptin: 1,
-			nemSource: [{
+			nemSource: [JSON.stringify({
 				address: '688283016813AC29EE88053EFC62C8047773B7C085FC15AA51',
 				balance: 3001882177821,
 				hashes: 'E4AEE3D3D9507CC8818704D917C40F1FDBDD9E6FE84C143F5995C15DCAD4552F',
 				height: '3691446',
 				label: null,
 				timestamps: '1650983000'
-			}],
+			})],
 			symbolDestination: [{
 				address: '6854E15A45E973283640A12F90001251695C2295F496871F',
 				balance: 3001882177821,
@@ -161,14 +161,14 @@ const mockCompletedRecordQuery = {
 		{
 			id: 10,
 			isPostoptin: 0,
-			nemSource: [{
+			nemSource: [JSON.stringify({
 				address: '68CBD6C5EF2B90A8167F5BCE2EBC495E755677916DEFEBC07E',
 				balance: 85657468724502,
 				hashes: '68FB3841FC1DFE77730A46DB4DB4E70B0EBC01ADF0096CA509E94E0A7EE56730',
 				height: '3092748',
 				label: null,
 				timestamps: '1614752283'
-			}],
+			})],
 			symbolDestination: [{
 				address: '68C364EF9573688F382BFEE13AA4DF68FB755CB02F11A08B',
 				balance: 85657468724502,
@@ -182,14 +182,14 @@ const mockCompletedRecordQuery = {
 		{
 			id: 9,
 			isPostoptin: 0,
-			nemSource: [{
+			nemSource: [JSON.stringify({
 				address: '68DE1E69EBF64ACDFEF5652E3B07AEBB211E75222CA334034D',
 				balance: 95300024600000,
 				hashes: '7E6CFC93B71E38F11B507777864F8EDF77753A5109036F321923D5C31CB4773B',
 				height: '2992634',
 				label: 'Bitflyer',
 				timestamps: '1608694362'
-			}],
+			})],
 			symbolDestination: [{
 				address: '6852D1DC6A57187644B3B8AD4806CE226B6E1B2D8A133D8B',
 				balance: 95300024600000,
@@ -345,7 +345,8 @@ describe('completed models', () => {
 
 			// Assert:
 			expect(result[0].nemSource.length).to.be.equal(1);
-			expect(result[0].nemSource[0].address).to.be.equal(nemAddressHex);
+			const nemSource = JSON.parse(result[0].nemSource[0])
+			expect(nemSource.address).to.be.equal(nemAddressHex);
 		});
 
 		it('returns search result provided symbol address', async () => {


### PR DESCRIPTION
problem: new release for sqlite3 and testing-library cause failure in tests 
solution: testing-library userevent functions are now async so added await
              the nemSource is now a string instead of object
              also disable dependabot major version updates for optin projects