### PR TITLE
[monorepo] fix: move nightly builds to bulid configuration file

### DIFF
--- a/.github/buildConfiguration.yaml
+++ b/.github/buildConfiguration.yaml
@@ -10,3 +10,11 @@ builds:
 
   - name: Vanity Address Generator
     path: tools/vanity
+
+customBuilds:
+  - name: Nightly Job
+    jobName: nightlyJob
+    scriptPath: .github/jenkinsfile/nightlyBuild.groovy
+    triggers:
+      - type: cron
+        schedule: '@midnight'


### PR DESCRIPTION
problem: nightly build properties was in the code.
solution: move nightly job to the buildconfiguration file.