### PR TITLE
[explorer/nodewatch]: estimate network wide finalized heights

### DIFF
--- a/explorer/nodewatch/nodewatch/NetworkRepository.py
+++ b/explorer/nodewatch/nodewatch/NetworkRepository.py
@@ -107,9 +107,9 @@ class NetworkRepository:
 		self._network = network
 		self.blockchain_name = blockchain_name
 
-		self.node_descriptors = None
-		self.harvester_descriptors = None
-		self.voter_descriptors = None
+		self.node_descriptors = []
+		self.harvester_descriptors = []
+		self.voter_descriptors = []
 
 	@property
 	def is_nem(self):
@@ -120,9 +120,22 @@ class NetworkRepository:
 	def estimate_height(self):
 		"""Estimates the network height by returning the median height of all nodes."""
 
+		if not self.node_descriptors:
+			return 1
+
 		heights = [descriptor.height for descriptor in self.node_descriptors]
 		heights.sort()
-		return heights[round(len(heights) / 2)]
+		return heights[len(heights) // 2]
+
+	def estimate_finalized_height(self):
+		"""Estimates the network finalized height by returning the median finalized height of all nodes."""
+
+		if self.is_nem:
+			return max(1, self.estimate_height() - 360)
+
+		heights = [descriptor.finalized_height for descriptor in self.node_descriptors if descriptor.finalized_height]
+		heights.sort()
+		return 1 if not heights else heights[len(heights) // 2]
 
 	def load_node_descriptors(self, nodes_data_filepath):
 		"""Loads node descriptors."""

--- a/explorer/nodewatch/nodewatch/RoutesFacade.py
+++ b/explorer/nodewatch/nodewatch/RoutesFacade.py
@@ -95,7 +95,10 @@ class BasicRoutesFacade:
 	def json_height(self):
 		"""Gets the estimated network height."""
 
-		return {'height': self.repository.estimate_height()}
+		return {
+			'height': self.repository.estimate_height(),
+			'finalizedHeight': self.repository.estimate_finalized_height()
+		}
 
 	def reload_all(self, resources_path, force=False):
 		"""Reloads all descriptor files."""

--- a/explorer/nodewatch/tests/resources/symbol_nodes.json
+++ b/explorer/nodewatch/tests/resources/symbol_nodes.json
@@ -29,7 +29,7 @@
   {
     "extraData": {
       "balance": 28083310.571743,
-      "finalizedHeight": 1486740,
+      "finalizedHeight": 1486742,
       "height": 1486761
     },
     "friendlyName": "jaguar",

--- a/explorer/nodewatch/tests/test_NetworkRepository.py
+++ b/explorer/nodewatch/tests/test_NetworkRepository.py
@@ -20,6 +20,16 @@ class NetworkRepositoryTest(unittest.TestCase):
 		for name in property_names:
 			self.assertEqual(kwargs[name], getattr(descriptor, name))
 
+	def test_can_load_zero_nem_node_descriptors(self):
+		# Act:
+		repository = NetworkRepository(NemNetwork.MAINNET, 'nem')
+
+		# Assert:
+		self.assertTrue(repository.is_nem)
+		self.assertEqual(0, len(repository.node_descriptors))
+		self.assertEqual(1, repository.estimate_height())
+		self.assertEqual(1, repository.estimate_finalized_height())
+
 	def test_can_load_nem_node_descriptors(self):
 		# Arrange:
 		repository = NetworkRepository(NemNetwork.MAINNET, 'nem')
@@ -31,6 +41,7 @@ class NetworkRepositoryTest(unittest.TestCase):
 		self.assertTrue(repository.is_nem)
 		self.assertEqual(4, len(repository.node_descriptors))
 		self.assertEqual(3850057, repository.estimate_height())  # median
+		self.assertEqual(3850057 - 360, repository.estimate_finalized_height())
 		self._assert_node_descriptor(
 			repository.node_descriptors[0],
 			main_address=NemAddress('NA32LQUMJBADX2XMKJ5QEIQBCF2ZIW5SZDXVGPOL'),
@@ -84,6 +95,16 @@ class NetworkRepositoryTest(unittest.TestCase):
 			roles=0xFF,
 			has_api=True)  # simulates incomplete extraData
 
+	def test_can_load_zero_symbol_node_descriptors(self):
+		# Act:
+		repository = NetworkRepository(SymbolNetwork.MAINNET, 'symbol')
+
+		# Assert:
+		self.assertFalse(repository.is_nem)
+		self.assertEqual(0, len(repository.node_descriptors))
+		self.assertEqual(1, repository.estimate_height())
+		self.assertEqual(1, repository.estimate_finalized_height())
+
 	def test_can_load_symbol_node_descriptors(self):
 		# Arrange:
 		repository = NetworkRepository(SymbolNetwork.MAINNET, 'symbol')
@@ -95,6 +116,7 @@ class NetworkRepositoryTest(unittest.TestCase):
 		self.assertFalse(repository.is_nem)
 		self.assertEqual(6, len(repository.node_descriptors))
 		self.assertEqual(1486760, repository.estimate_height())  # median
+		self.assertEqual(1486740, repository.estimate_finalized_height())  # median (nonzero)
 		self._assert_node_descriptor(
 			repository.node_descriptors[0],
 			main_address=SymbolAddress('NDZOZPTDVCFFLDCNJL7NZGDQDNBB7TY3V6SZNGI'),
@@ -155,7 +177,7 @@ class NetworkRepositoryTest(unittest.TestCase):
 			endpoint='http://jaguar.catapult.ninja:7900',
 			name='jaguar',
 			height=1486761,
-			finalized_height=1486740,
+			finalized_height=1486742,
 			version='1.0.3.5',
 			balance=28083310.571743,
 			roles=5,
@@ -189,7 +211,7 @@ class NetworkRepositoryTest(unittest.TestCase):
 			'endpoint': 'http://jaguar.catapult.ninja:7900',
 			'name': 'jaguar',
 			'height': 1486761,
-			'finalizedHeight': 1486740,
+			'finalizedHeight': 1486742,
 			'version': '1.0.3.5',
 			'balance': 28083310.571743,
 			'roles': 5,

--- a/explorer/nodewatch/tests/test_RoutesFacade.py
+++ b/explorer/nodewatch/tests/test_RoutesFacade.py
@@ -38,7 +38,7 @@ class NemRoutesFacadeTest(unittest.TestCase):
 
 		self.assertEqual(4, len(facade.repository.node_descriptors))
 		self.assertEqual(4, len(facade.repository.harvester_descriptors))
-		self.assertEqual(None, facade.repository.voter_descriptors)
+		self.assertEqual(0, len(facade.repository.voter_descriptors))
 
 	def test_can_skip_reload_when_noop(self):
 		# Arrange:
@@ -55,7 +55,7 @@ class NemRoutesFacadeTest(unittest.TestCase):
 
 		self.assertEqual(4, len(facade.repository.node_descriptors))
 		self.assertEqual(4, len(facade.repository.harvester_descriptors))
-		self.assertEqual(None, facade.repository.voter_descriptors)
+		self.assertEqual(0, len(facade.repository.voter_descriptors))
 
 	def test_can_reset_refresh_time(self):
 		# Arrange:
@@ -195,8 +195,9 @@ class NemRoutesFacadeTest(unittest.TestCase):
 		height_json = facade.json_height()
 
 		# Assert:
-		self.assertEqual(1, len(height_json))
+		self.assertEqual(2, len(height_json))
 		self.assertEqual(3850057, height_json['height'])
+		self.assertEqual(3850057 - 360, height_json['finalizedHeight'])
 
 	# endregion
 
@@ -439,8 +440,9 @@ class SymbolRoutesFacadeTest(unittest.TestCase):
 		height_json = facade.json_height()
 
 		# Assert:
-		self.assertEqual(1, len(height_json))
+		self.assertEqual(2, len(height_json))
 		self.assertEqual(1486760, height_json['height'])
+		self.assertEqual(1486740, height_json['finalizedHeight'])
 
 	# endregion
 

--- a/explorer/nodewatch/tests/test_app.py
+++ b/explorer/nodewatch/tests/test_app.py
@@ -145,7 +145,7 @@ def test_get_api_nem_network_height(client):  # pylint: disable=redefined-outer-
 	# Assert:
 	assert 200 == response.status_code
 	assert 'application/json' == response.headers['Content-Type']
-	assert {'height': 3850057} == response_json
+	assert {'height': 3850057, 'finalizedHeight': 3850057 - 360} == response_json
 
 
 def test_get_api_nem_network_height_chart(client):  # pylint: disable=redefined-outer-name
@@ -198,7 +198,7 @@ def test_get_api_symbol_network_height(client):  # pylint: disable=redefined-out
 	# Assert:
 	assert 200 == response.status_code
 	assert 'application/json' == response.headers['Content-Type']
-	assert {'height': 1486760} == response_json
+	assert {'height': 1486760, 'finalizedHeight': 1486740} == response_json
 
 
 def test_get_api_symbol_network_height_chart(client):  # pylint: disable=redefined-outer-name


### PR DESCRIPTION
 problem: nodewatch should estimate network wide finalized height
solution: add 'finalizedHeight' to /api/xyz/height apis