### PR TITLE
[optin/reporting/client] fix: lint failure due to incorrectly sorted imports

### DIFF
--- a/optin/reporting/client/src/pages/Completed/Completed.jsx
+++ b/optin/reporting/client/src/pages/Completed/Completed.jsx
@@ -6,7 +6,7 @@ import { addressTemplate, balanceTemplate, dateTransactionHashTemplate } from '.
 import { Column } from 'primereact/column';
 import { InputText } from 'primereact/inputtext';
 import { SelectButton } from 'primereact/selectbutton';
-import React, { useState, useEffect, useRef} from 'react';
+import React, { useEffect, useRef, useState} from 'react';
 const { NemFacade, SymbolFacade } = require('symbol-sdk').facade;
 const { Hash256 } = require('symbol-sdk').nem;
 

--- a/optin/reporting/client/src/pages/Requests/Requests.jsx
+++ b/optin/reporting/client/src/pages/Requests/Requests.jsx
@@ -5,7 +5,7 @@ import { addressTemplate, dateTransactionHashTemplate } from '../../utils/pageUt
 import { Column } from 'primereact/column';
 import { InputText } from 'primereact/inputtext';
 import { SelectButton } from 'primereact/selectbutton';
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 const { NemFacade } = require('symbol-sdk').facade;
 const { Hash256 } = require('symbol-sdk').nem;
 


### PR DESCRIPTION
problem: new rules were added to default.eslintrc for sorted imports
solution: sort the failing imports correctly