### PR TITLE
[connectors/python] fix: bump python connectors version to 0.0.2

### DIFF
--- a/.gitlintmodules
+++ b/.gitlintmodules
@@ -1,1 +1,1 @@
-optin/puller|optin/reporting|optin/reporting/client|tools/vanity|monorepo|explorer/nodewatch
+optin/puller|optin/reporting|optin/reporting/client|tools/vanity|monorepo|explorer/nodewatch|connectors/python

--- a/connectors/python/pyproject.toml
+++ b/connectors/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'symbol-connectors'
-version = '0.0.1'
+version = '0.0.2'
 description = 'Symbol Connectors'
 authors = ['Symbol Contributors <contributors@symbol.dev>']
 maintainers = ['Symbol Contributors <contributors@symbol.dev>']


### PR DESCRIPTION
problem: in preparation for release need to bump version.
solution: bump the  python connectors to 0.0.2 for release