### PR TITLE
[lightapi/python]: handle OSError raised by open_connection

### DIFF
--- a/lightapi/python/symbollightapi/connector/SymbolPeerConnector.py
+++ b/lightapi/python/symbollightapi/connector/SymbolPeerConnector.py
@@ -94,7 +94,7 @@ class SymbolPeerConnector:
 				ssl=self.ssl_context,
 				ssl_handshake_timeout=self.timeout_seconds)
 			return await asyncio.wait_for(self._process_write_read(reader, writer, packet_type, parser), timeout=self.timeout_seconds)
-		except (ConnectionRefusedError, asyncio.exceptions.IncompleteReadError, asyncio.exceptions.TimeoutError) as ex:
+		except (ConnectionRefusedError, OSError, asyncio.exceptions.IncompleteReadError, asyncio.exceptions.TimeoutError) as ex:
 			raise NodeException from ex
 		finally:
 			if writer:

--- a/lightapi/python/tests/connector/test_SymbolPeerConnector.py
+++ b/lightapi/python/tests/connector/test_SymbolPeerConnector.py
@@ -190,14 +190,22 @@ async def test_can_handle_corrupt_packet_type(server):  # pylint: disable=redefi
 		await connector.chain_height()
 
 
-async def test_can_handle_stopped_node():
+async def _assert_can_handle_stopped_node(host):
 	# Arrange:
-	connector = SymbolPeerConnector('127.0.0.1', 8888, locate_certificate_directory(2))
-	connector.timeout_seconds = 0.1
+	connector = SymbolPeerConnector(host, 8888, locate_certificate_directory(2))
 
 	# Act + Assert:
 	with pytest.raises(NodeException):
 		await connector.chain_height()
+
+
+async def test_can_handle_stopped_node():
+	await _assert_can_handle_stopped_node('127.0.0.1')
+
+
+async def test_can_handle_multiple_exceptions():
+	# Act + Assert: 'localhost' will raise a wrapped exception composed of two exceptions (failure to reach 127.0.0.1 and ::1)
+	await _assert_can_handle_stopped_node('localhost')
 
 # endregion
 


### PR DESCRIPTION
when there multiple component exceptions within open_connection, they are wrapped in a single OSError