### PR TITLE
[monorepo] fix: remove duplicate ecosystem entry

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -123,12 +123,3 @@ updates:
     labels: ['Vanity']
     commit-message:
       prefix: '[dependency]'
-
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: weekly
-      day: sunday
-    target-branch: dev
-    commit-message:
-      prefix: '[dependency]'


### PR DESCRIPTION
problem: there are two entries for github-action in the dependabot.yaml file
solution: remove the last entry for github-action