### PR TITLE
[faucet/fronted]: fix dynamic docker run on image

### DIFF
--- a/faucet/frontend/Dockerfile
+++ b/faucet/frontend/Dockerfile
@@ -3,5 +3,8 @@ WORKDIR /app
 COPY . .
 RUN npm install && npm install -g serve
 
+# Build the app to cache the dependencies
+RUN npm run build
+
 EXPOSE 3000
 CMD ["/bin/sh", "-c", "./scripts/docker/startup.sh"]

--- a/faucet/frontend/Dockerfile
+++ b/faucet/frontend/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:lts-alpine AS builder
 WORKDIR /app
 COPY . .
-RUN npm install && npm run build
-RUN npm install -g serve
+RUN npm install && npm install -g serve
+
 EXPOSE 3000
-CMD ["serve", "-s", "build"]
+CMD ["/bin/sh", "-c", "./scripts/docker/startup.sh"]

--- a/faucet/frontend/Dockerfile
+++ b/faucet/frontend/Dockerfile
@@ -1,10 +1,7 @@
 FROM node:lts-alpine AS builder
 WORKDIR /app
 COPY . .
-RUN npm install && npm install -g serve
-
-# Build the app to cache the dependencies
-RUN npm run build
+RUN npm install && npm install -g serve && npm run build
 
 EXPOSE 3000
 CMD ["/bin/sh", "-c", "./scripts/docker/startup.sh"]

--- a/faucet/frontend/next.config.js
+++ b/faucet/frontend/next.config.js
@@ -7,6 +7,9 @@ const nextConfig = {
 	experimental: {
 		appDir: true
 	},
+	eslint: {
+		ignoreDuringBuilds: true
+	},
 	webpack: (config, { isServer }) => {
 		// use a browser-optimized wasm for Ed25519 crypto operations
 		config.plugins.push(new webpack.NormalModuleReplacementPlugin(

--- a/faucet/frontend/scripts/docker/startup.sh
+++ b/faucet/frontend/scripts/docker/startup.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+npm run build
+serve -s build


### PR DESCRIPTION
## What was the issue?
- Faucet frontend docker image is not able to assign dynamic env params, which it needs to separate build different images to run NEM / Symbol website.

## What's the fix?
- instead of building a website inside the images, I move the build logic in the docker run time.
- the docker run will accept env params, and build different website

```
docker run -e NEXT_PUBLIC_BUILD_TARGET="nem" \
    -e NEXT_PUBLIC_META_TITLE="The XEM Faucet" \
    -e NEXT_PUBLIC_META_DESCRIPTION="NEM Faucet" \
    -e NEXT_PUBLIC_AUTH_URL=https://faucet-auth.url.io \
    -e NEXT_PUBLIC_BACKEND_URL=https://faucet-backend.url.io \
    -e NEXT_PUBLIC_AES_SECRET="secret" \
    -p 3000:3000 \
    --name nem-frontend \
   frontend:latest
```