### PR TITLE
 [faucet/authenticator]: fix readme packageId

### DIFF
--- a/faucet/authenticator/Jenkinsfile
+++ b/faucet/authenticator/Jenkinsfile
@@ -4,10 +4,10 @@ defaultCiPipeline {
 
 	ciBuildDockerfile = 'javascript.Dockerfile'
 
-	packageId = 'authenticator'
+	packageId = 'faucet-authenticator'
 
 	publisher = 'docker'
-	dockerImageName = 'symbolplatform/authenticator'
+	dockerImageName = 'symbolplatform/faucet-authenticator'
 
 	codeCoverageTool = 'c8'
 	minimumCodeCoverage = 95

--- a/faucet/authenticator/package-lock.json
+++ b/faucet/authenticator/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "authenticator",
+  "name": "faucet-authenticator",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "authenticator",
+      "name": "faucet-authenticator",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/faucet/authenticator/package.json
+++ b/faucet/authenticator/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "authenticator",
+  "name": "faucet-authenticator",
   "version": "1.0.0",
   "description": "Twitter authenticator for faucet",
   "type": "commonjs",


### PR DESCRIPTION
## What was the issue?
- lint, test, and coverage status didn't show up in the readme.

## What's the fix?
- fix the wrong jenkins package id in readme 