### PR TITLE
[jenkins] fix: store the package version needed by Jenkins to build docker image

### DIFF
--- a/faucet/authenticator/package.json
+++ b/faucet/authenticator/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint src/ test/",
     "lint:fix": "eslint src/ test/ --fix",
     "test": "mocha --full-trace --recursive test --exit -r dotenv/config dotenv_config_path=./.env.test",
-    "test:jenkins": "c8 --require mocha --no-clean --reporter=lcov npm run test"
+    "test:jenkins": "c8 --require mocha --no-clean --reporter=lcov npm run test",
+    "version": "echo $npm_package_version"
   },
   "author": "Symbol Contributors <contributors@symbol.dev>",
   "license": "ISC",

--- a/faucet/authenticator/scripts/ci/setup_build.sh
+++ b/faucet/authenticator/scripts/ci/setup_build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -ex
+
+# generate version.txt to be used in publishing
+echo $(npm run version --silent) > version.txt

--- a/faucet/backend/package.json
+++ b/faucet/backend/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint src/ test/",
     "lint:fix": "eslint src/ test/ --fix",
     "test": "TZ=utc mocha --full-trace --recursive test --exit -r dotenv/config dotenv_config_path=./.env.test",
-    "test:jenkins": "c8 --require mocha --no-clean --reporter=lcov npm run test"
+    "test:jenkins": "c8 --require mocha --no-clean --reporter=lcov npm run test",
+    "version": "echo $npm_package_version"
   },
   "author": "Symbol Contributors <contributors@symbol.dev>",
   "license": "ISC",

--- a/faucet/backend/scripts/ci/setup_build.sh
+++ b/faucet/backend/scripts/ci/setup_build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -ex
+
+# generate version.txt to be used in publishing
+echo $(npm run version --silent) > version.txt

--- a/faucet/frontend/package.json
+++ b/faucet/frontend/package.json
@@ -43,7 +43,8 @@
     "test:jenkins:cov": "NODE_OPTIONS=--experimental-vm-modules npx jest --coverage",
     "eject": "react-scripts eject",
     "lint": "eslint --ext js,jsx .",
-    "lint:fix": "eslint --ext js,jsx --fix ."
+    "lint:fix": "eslint --ext js,jsx --fix .",
+    "version": "echo $npm_package_version"
   },
   "browserslist": {
     "production": [

--- a/faucet/frontend/scripts/ci/setup_build.sh
+++ b/faucet/frontend/scripts/ci/setup_build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -ex
+
+# generate version.txt to be used in publishing
+echo $(npm run version --silent) > version.txt


### PR DESCRIPTION
problem: version.txt is not present when building the docker images for Faucet
solution: create the version.txt for each Faucet package during the build setup