### PR TITLE
[tools/shoestring] fix: add support for Ubuntu 20.04

### DIFF
--- a/tools/shoestring/pyproject.toml
+++ b/tools/shoestring/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'symbol-shoestring'
-version = '0.0.1'
+version = '0.0.2'
 description = 'Symbol Shoestring Deployment Tool'
 authors = ['Symbol Contributors <contributors@symbol.dev>']
 maintainers = ['Symbol Contributors <contributors@symbol.dev>']

--- a/tools/shoestring/shoestring/healthagents/rest_https_certificate.py
+++ b/tools/shoestring/shoestring/healthagents/rest_https_certificate.py
@@ -30,9 +30,6 @@ def _openssl_run_sclient_verify(hostname, test_args):
 	for line in lines:
 		line = line.strip()
 		if line.startswith('verify error:'):
-			# normalize error message
-			if '1.1.1' in openssl_executor.version():
-				line = line.replace('self signed', 'self-signed')
 			return False, line
 
 	with tempfile.TemporaryDirectory() as temp_directory:

--- a/tools/shoestring/shoestring/healthagents/rest_https_certificate.py
+++ b/tools/shoestring/shoestring/healthagents/rest_https_certificate.py
@@ -37,29 +37,27 @@ def _openssl_run_sclient_verify(hostname, test_args):
 
 	with tempfile.TemporaryDirectory() as temp_directory:
 		temp_file = Path(temp_directory) / 'cert.txt'
-		with open(temp_file, 'w', encoding='utf-8') as cert_file:
-			cert_file.writelines(lines)
+		with open(temp_file, 'wt', encoding='utf-8') as cert_outfile:
+			cert_outfile.writelines(lines)
 
 		lines = openssl_executor.dispatch([
 			'x509',
-			'-inform',
-			'pem',
+			'-inform', 'pem',
 			'-noout',
 			'-text',
-			'-in',
-			temp_file
+			'-in', temp_file
 		], command_input='Q', show_output=False)
 
-	searching_for_date = [r'Not Before: (.*)', r'Not After : (.*)']
+	date_patterns = [r'Not Before: (.*)', r'Not After : (.*)']
 	collect_dates = False
 	collected_dates = []
 	for line in lines:
 		line = line.strip()
-		if collect_dates and searching_for_date:
-			res = re.search(searching_for_date[0], line)
+		if collect_dates and date_patterns:
+			res = re.search(date_patterns[0], line)
 			if res:
 				collected_dates.append(parsedate_to_datetime(res.group(1)))
-				searching_for_date.pop(0)
+				date_patterns.pop(0)
 
 		if line == 'Certificate:':
 			collect_dates = True

--- a/tools/shoestring/shoestring/internal/OpensslExecutor.py
+++ b/tools/shoestring/shoestring/internal/OpensslExecutor.py
@@ -37,6 +37,6 @@ class OpensslExecutor:
 
 			if 0 != process.returncode:
 				formatted_command_line = ' '.join(command_line)
-				raise RuntimeError(f'{formatted_command_line} exited with {process.returncode}, stdout:\n {stdout_lines}')
+				raise RuntimeError(f'{formatted_command_line} exited with {process.returncode}, stdout:\n{stdout_lines}')
 
 		return all_lines

--- a/tools/shoestring/shoestring/internal/OpensslExecutor.py
+++ b/tools/shoestring/shoestring/internal/OpensslExecutor.py
@@ -19,15 +19,12 @@ class OpensslExecutor:
 		match = self.version_regex.match(version_output)
 		return match.group(1)
 
-	def dispatch(self, args, command_input=None, show_output=True, use_shell=False):
+	def dispatch(self, args, command_input=None, show_output=True):
 		"""Dispatches an openssl command, optionally showing output."""
 
 		command_line = [self.executable_path] + [str(arg) for arg in args]
-		if use_shell:
-			formatted_command_line = ' '.join(command_line)
-
 		all_lines = []
-		with Popen(formatted_command_line if use_shell else command_line, stdout=PIPE, stderr=STDOUT, stdin=PIPE, shell=use_shell) as process:
+		with Popen(command_line, stdout=PIPE, stderr=STDOUT, stdin=PIPE) as process:
 			stdout_lines, _ = process.communicate(input=command_input.encode('ascii') if command_input else None, timeout=10)
 
 			for line_bin in stdout_lines.splitlines(keepends=True):
@@ -40,6 +37,6 @@ class OpensslExecutor:
 
 			if 0 != process.returncode:
 				formatted_command_line = ' '.join(command_line)
-				raise RuntimeError(f'{formatted_command_line} exited with {process.returncode}')
+				raise RuntimeError(f'{formatted_command_line} exited with {process.returncode}, stdout: {stdout_lines}')
 
 		return all_lines

--- a/tools/shoestring/shoestring/internal/OpensslExecutor.py
+++ b/tools/shoestring/shoestring/internal/OpensslExecutor.py
@@ -37,6 +37,6 @@ class OpensslExecutor:
 
 			if 0 != process.returncode:
 				formatted_command_line = ' '.join(command_line)
-				raise RuntimeError(f'{formatted_command_line} exited with {process.returncode}, stdout: {stdout_lines}')
+				raise RuntimeError(f'{formatted_command_line} exited with {process.returncode}, stdout:\n {stdout_lines}')
 
 		return all_lines

--- a/tools/shoestring/shoestring/internal/OpensslExecutor.py
+++ b/tools/shoestring/shoestring/internal/OpensslExecutor.py
@@ -19,12 +19,15 @@ class OpensslExecutor:
 		match = self.version_regex.match(version_output)
 		return match.group(1)
 
-	def dispatch(self, args, command_input=None, show_output=True):
+	def dispatch(self, args, command_input=None, show_output=True, use_shell=False):
 		"""Dispatches an openssl command, optionally showing output."""
 
 		command_line = [self.executable_path] + [str(arg) for arg in args]
+		if use_shell:
+			formatted_command_line = ' '.join(command_line)
+
 		all_lines = []
-		with Popen(command_line, stdout=PIPE, stderr=STDOUT, stdin=PIPE) as process:
+		with Popen(formatted_command_line if use_shell else command_line, stdout=PIPE, stderr=STDOUT, stdin=PIPE, shell=use_shell) as process:
 			stdout_lines, _ = process.communicate(input=command_input.encode('ascii') if command_input else None, timeout=10)
 
 			for line_bin in stdout_lines.splitlines(keepends=True):

--- a/tools/shoestring/shoestring/internal/PackageResolver.py
+++ b/tools/shoestring/shoestring/internal/PackageResolver.py
@@ -88,7 +88,7 @@ def _move_to_parent(destination_directory):
 			continue
 
 		for file in subdir.glob('*'):
-			shutil.move(file, destination_directory)
+			shutil.move(str(file), str(destination_directory))
 
 		subdir.rmdir()
 

--- a/tools/shoestring/tests/commands/test_renew_certificates.py
+++ b/tools/shoestring/tests/commands/test_renew_certificates.py
@@ -82,7 +82,7 @@ async def test_can_renew_node_certificate():
 
 
 async def test_can_renew_node_certificate_with_ca_password():
-	await _assert_can_renew_node_certificate('abc')
+	await _assert_can_renew_node_certificate('abcd')
 
 # endregion
 
@@ -143,7 +143,7 @@ async def test_can_renew_ca_and_node_certificates():
 
 
 async def test_can_renew_ca_and_node_certificates_with_ca_password():
-	await _assert_can_renew_ca_and_node_certificates('abc')
+	await _assert_can_renew_ca_and_node_certificates('abcd')
 
 # endregion
 

--- a/tools/shoestring/tests/commands/test_setup.py
+++ b/tools/shoestring/tests/commands/test_setup.py
@@ -150,7 +150,7 @@ async def _assert_can_prepare_node(
 	# Arrange:
 	with tempfile.TemporaryDirectory() as output_directory:
 		with tempfile.TemporaryDirectory() as package_directory:
-			ca_password = 'abc' if CaMode.WITH_PASSWORD == ca_mode else ''
+			ca_password = 'abcd' if CaMode.WITH_PASSWORD == ca_mode else ''
 			prepare_shoestring_configuration(
 				package_directory,
 				node_features,

--- a/tools/shoestring/tests/healthagents/test_rest_https_certificate.py
+++ b/tools/shoestring/tests/healthagents/test_rest_https_certificate.py
@@ -53,7 +53,7 @@ async def _dispatch_validate(test_args=None):
 	HealthAgentContext = namedtuple('HealthAgentContext', ['hostname', 'test_args'])
 	context = HealthAgentContext('localhost', test_args or [])
 
-	await asyncio.to_thread(_validate_thread, context)
+	await asyncio.get_running_loop().run_in_executor(None, _validate_thread, context)
 
 
 async def test_validate_fails_when_certificate_is_self_signed(server, caplog):  # pylint: disable=redefined-outer-name, unused-argument
@@ -61,7 +61,7 @@ async def test_validate_fails_when_certificate_is_self_signed(server, caplog):  
 	await _dispatch_validate()
 
 	# Assert:
-	assert_message_is_logged('HTTPS certificate looks invalid: Verify return code: 18 (self-signed certificate)', caplog)
+	assert_message_is_logged('HTTPS certificate looks invalid: verify error:num=18:self-signed certificate', caplog)
 	assert_max_log_level(LogLevel.WARNING, caplog)
 
 

--- a/tools/shoestring/tests/healthagents/test_rest_https_certificate.py
+++ b/tools/shoestring/tests/healthagents/test_rest_https_certificate.py
@@ -60,18 +60,18 @@ async def _dispatch_validate(test_args=None):
 
 async def test_validate_fails_when_certificate_is_self_signed(server, caplog):  # pylint: disable=redefined-outer-name, unused-argument
 	# Arrange:
-	error_message = 'HTTPS certificate looks invalid: verify error:num=18:self-signed certificate'
+	expected_error_message = 'HTTPS certificate looks invalid: verify error:num=18:self-signed certificate'
 
 	# normalize error message
 	openssl_executor = OpensslExecutor(os.environ.get('OPENSSL_EXECUTABLE', 'openssl'))
 	if '1.1.1' in openssl_executor.version():
-		error_message = error_message.replace('self-signed', 'self signed')
+		expected_error_message = expected_error_message.replace('self-signed', 'self signed')
 
 	# Act:
 	await _dispatch_validate()
 
 	# Assert:
-	assert_message_is_logged(error_message, caplog)
+	assert_message_is_logged(expected_error_message, caplog)
 	assert_max_log_level(LogLevel.WARNING, caplog)
 
 

--- a/tools/shoestring/tests/internal/test_Preparer.py
+++ b/tools/shoestring/tests/internal/test_Preparer.py
@@ -206,7 +206,7 @@ class PreparerTest(unittest.TestCase):
 				continue
 
 			for file in subdir.glob('**/*'):
-				shutil.move(file, preparer.directories.temp)
+				shutil.move(str(file), str(preparer.directories.temp))
 
 			subdir.rmdir()
 			break


### PR DESCRIPTION
problem: Ubuntu 20.04 ships with an older version of Python and Openssl which caused failures when running shoestring.
               1. Openssl 1.1.x output is different from Openssl 3.x
               2. Python 3.8, ``shutil.move`` does not support a path object.
solution: 1. Normalize the Openssl output so it works for both version
               2. Python 3.8 convert the path objects to string.