### PR TITLE
[tools/shoestring]: Python 3.11 IntFlag returns enum value instead of enum name

### DIFF
--- a/tools/shoestring/shoestring/internal/NodeFeatures.py
+++ b/tools/shoestring/shoestring/internal/NodeFeatures.py
@@ -1,4 +1,4 @@
-from enum import IntFlag
+from enum import Enum, IntFlag
 from functools import reduce
 
 
@@ -23,3 +23,31 @@ class NodeFeatures(IntFlag):
 
 		values = [NodeFeatures[name.strip()] for name in node_features_str.split(',') if name]
 		return reduce(lambda rhs, lhs: rhs | lhs, values, NodeFeatures.PEER)
+
+	@staticmethod
+	def _iter_bits_lsb(num):
+		# num must be a positive integer
+		original = num
+		if isinstance(num, Enum):
+			num = num.value
+
+		if num < 0:
+			raise ValueError(f'{original} is not a positive integer')
+
+		while num:
+			value = num & (~num + 1)
+			yield value
+			num ^= value
+
+	def get_flag_values(self, value):
+		return list(self._iter_bits_lsb(value))
+
+	def get_flags(self, value):
+		flag_values = self.get_flag_values(value)
+		return [NodeFeatures(flag_value) for flag_value in flag_values]
+
+	def __str__(self):
+		if self.name is None:
+			return f'{self.__class__.__name__}.{"|".join([str(m.name) for m in self.get_flags(self.value)])}'
+
+		return f'{self.__class__.__name__}.{self.name}'

--- a/tools/shoestring/shoestring/internal/NodeFeatures.py
+++ b/tools/shoestring/shoestring/internal/NodeFeatures.py
@@ -39,15 +39,15 @@ class NodeFeatures(IntFlag):
 			yield value
 			num ^= value
 
-	def get_flag_values(self, value):
+	def _get_flag_values(self, value):
 		return list(self._iter_bits_lsb(value))
 
-	def get_flags(self, value):
-		flag_values = self.get_flag_values(value)
+	def _get_flags(self, value):
+		flag_values = self._get_flag_values(value)
 		return [NodeFeatures(flag_value) for flag_value in flag_values]
 
 	def __str__(self):
 		if self.name is None:
-			return f'{self.__class__.__name__}.{"|".join([str(m.name) for m in self.get_flags(self.value)])}'
+			return f'{self.__class__.__name__}.{"|".join([str(m.name) for m in self._get_flags(self.value)])}'
 
 		return f'{self.__class__.__name__}.{self.name}'

--- a/tools/shoestring/tests/internal/test_NodeFeatures.py
+++ b/tools/shoestring/tests/internal/test_NodeFeatures.py
@@ -20,3 +20,51 @@ class NodeFeaturesTest(unittest.TestCase):
 		self.assertEqual(NodeFeatures.API | NodeFeatures.VOTER, NodeFeatures.parse('API, VOTER'))
 		self.assertEqual(NodeFeatures.HARVESTER, NodeFeatures.parse('  PEER  ,  HARVESTER  '))
 		self.assertEqual(NodeFeatures.API | NodeFeatures.VOTER | NodeFeatures.HARVESTER, NodeFeatures.parse(' API, VOTER,HARVESTER '))
+
+	def test_can_convert_single_value_to_string(self):
+		# Arrange:
+		node_features = NodeFeatures.API
+
+		# Act:
+		node_features_str = str(node_features)
+
+		# Assert:
+		self.assertEqual('NodeFeatures.API', node_features_str)
+
+	def test_can_convert_multiple_values_to_string(self):
+		# Arrange:
+		node_features = NodeFeatures.API | NodeFeatures.VOTER
+
+		# Act:
+		node_features_str = str(node_features)
+
+		# Assert:
+		self.assertEqual('NodeFeatures.API|VOTER', node_features_str)
+
+	def test_can_convert_single_zero_value_to_string(self):
+		# Arrange:
+		node_features = NodeFeatures.PEER
+
+		# Act:
+		node_features_str = str(node_features)
+
+		# Assert:
+		self.assertEqual('NodeFeatures.PEER', node_features_str)
+
+	def test_can_convert_multiple_values_with_peer_to_string(self):
+		# Arrange:
+		node_features = NodeFeatures.API | NodeFeatures.PEER | NodeFeatures.VOTER
+
+		# Act:
+		node_features_str = str(node_features)
+
+		# Assert:
+		self.assertEqual('NodeFeatures.API|VOTER', node_features_str)
+
+	def test_cannot_parse_negative_value(self):
+		# Arrange:
+		node_features_value = -1
+
+		# Act + Assert:
+		with self.assertRaises(ValueError):
+			list(NodeFeatures._iter_bits_lsb(node_features_value))

--- a/tools/shoestring/tests/internal/test_NodeFeatures.py
+++ b/tools/shoestring/tests/internal/test_NodeFeatures.py
@@ -67,4 +67,4 @@ class NodeFeaturesTest(unittest.TestCase):
 
 		# Act + Assert:
 		with self.assertRaises(ValueError):
-			list(NodeFeatures._iter_bits_lsb(node_features_value))
+			str(NodeFeatures(node_features_value))


### PR DESCRIPTION
problem: In python 3.11, IntFlag __str__ change to return enum value instead of the enum name.
               This broke parsing logic for NodeFeatures.
solution: to support python 3.11, override the default __str__ to always return enum names for all python versions