### PR TITLE
[lightapi/python]: add custom publishing for lightapi

### DIFF
--- a/lightapi/python/scripts/ci/build.sh
+++ b/lightapi/python/scripts/ci/build.sh
@@ -2,4 +2,4 @@
 
 set -ex
 
-python3 -m build --wheel
+python3 -m build --sdist

--- a/lightapi/python/scripts/ci/publish.sh
+++ b/lightapi/python/scripts/ci/publish.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -ex
+
+export TWINE_USERNAME='__token__'
+export TWINE_PASSWORD="${PYPI_TOKEN}"
+
+if [ "$(git rev-parse --abbrev-ref HEAD)" == "main" ]; then
+	twine upload dist/*
+else
+	twine upload --repository testpypi dist/*
+fi


### PR DESCRIPTION
problem: lightapi does not use poetry for publishing its artifact
solution: create a custom script for publishing