### PR TITLE
[lightapi/python] fix: cffi fails to build on Windows

### DIFF
--- a/lightapi/python/cffi_src/openssl_build.py
+++ b/lightapi/python/cffi_src/openssl_build.py
@@ -22,7 +22,7 @@ ffi_builder.set_source(
 	''',
 	include_dirs=include_dirs,
 	library_dirs=library_dirs,
-	libraries=['crypto', 'ssl'])
+	libraries=['libcrypto', 'libssl'] if os.name == 'nt' else ['crypto', 'ssl'])
 
 # add all openssl constants, types and functions being used
 ffi_builder.cdef('''


### PR DESCRIPTION
problem: OpenSSL library names start with `lib` which caused MSVC to fail to find the file during linking.
solution: For Windows builds, prepend `lib` to the OpenSSL library names.