### PR TITLE
[monorepo] fix: set the discord web hook url

### DIFF
--- a/explorer/nodewatch/Jenkinsfile
+++ b/explorer/nodewatch/Jenkinsfile
@@ -8,4 +8,6 @@ defaultCiPipeline {
 
 	codeCoverageTool = 'coverage'
 	minimumCodeCoverage = 95
+
+	discordWebHookUrlId = 'EXPLORER_DISCORD_WEB_HOOK_URL_ID'
 }

--- a/explorer/rest/Jenkinsfile
+++ b/explorer/rest/Jenkinsfile
@@ -8,4 +8,6 @@ defaultCiPipeline {
 
 	codeCoverageTool = 'coverage'
 	minimumCodeCoverage = 95
+
+	discordWebHookUrlId = 'EXPLORER_DISCORD_WEB_HOOK_URL_ID'
 }

--- a/faucet/authenticator/Jenkinsfile
+++ b/faucet/authenticator/Jenkinsfile
@@ -11,4 +11,6 @@ defaultCiPipeline {
 
 	codeCoverageTool = 'c8'
 	minimumCodeCoverage = 95
+
+	discordWebHookUrlId = 'WALLET_DISCORD_WEB_HOOK_URL_ID'
 }

--- a/faucet/backend/Jenkinsfile
+++ b/faucet/backend/Jenkinsfile
@@ -11,4 +11,6 @@ defaultCiPipeline {
 
 	codeCoverageTool = 'c8'
 	minimumCodeCoverage = 95
+
+	discordWebHookUrlId = 'WALLET_DISCORD_WEB_HOOK_URL_ID'
 }

--- a/faucet/frontend/Jenkinsfile
+++ b/faucet/frontend/Jenkinsfile
@@ -11,4 +11,6 @@ defaultCiPipeline {
 
 	codeCoverageTool = 'nyc'
 	minimumCodeCoverage = 95
+
+	discordWebHookUrlId = 'WALLET_DISCORD_WEB_HOOK_URL_ID'
 }

--- a/lightapi/python/Jenkinsfile
+++ b/lightapi/python/Jenkinsfile
@@ -10,4 +10,6 @@ defaultCiPipeline {
 
 	codeCoverageTool = 'coverage'
 	minimumCodeCoverage = 95
+
+	discordWebHookUrlId = 'SDK_DISCORD_WEB_HOOK_URL_ID'
 }

--- a/tools/shoestring/Jenkinsfile
+++ b/tools/shoestring/Jenkinsfile
@@ -10,4 +10,6 @@ defaultCiPipeline {
 
 	codeCoverageTool = 'coverage'
 	minimumCodeCoverage = 95
+
+	discordWebHookUrlId = 'CLIENT_DISCORD_WEB_HOOK_URL_ID'
 }

--- a/tools/vanity/Jenkinsfile
+++ b/tools/vanity/Jenkinsfile
@@ -8,4 +8,6 @@ defaultCiPipeline {
 
 	codeCoverageTool = 'coverage'
 	minimumCodeCoverage = 95
+
+	discordWebHookUrlId = 'CLIENT_DISCORD_WEB_HOOK_URL_ID'
 }


### PR DESCRIPTION
problem: project's build status messages goes to one discord channel
solution: set the discord channel id for each project to send build status message