### PR TITLE
[explorer/rest]: added sort block by height filter in blocks endpoints

### DIFF
--- a/explorer/rest/rest/__init__.py
+++ b/explorer/rest/rest/__init__.py
@@ -65,14 +65,15 @@ def setup_nem_routes(app, nem_api_facade):
 			limit = int(request.args.get('limit', 10))
 			offset = int(request.args.get('offset', 0))
 			min_height = int(request.args.get('min_height', 1))
+			sort = request.args.get('sort', 'DESC')
 
-			if limit < 0 or offset < 0 or min_height < 1:
+			if limit < 0 or offset < 0 or min_height < 1 or sort.upper() not in ['ASC', 'DESC']:
 				raise ValueError()
 
 		except ValueError:
 			abort(400)
 
-		return jsonify(nem_api_facade.get_blocks(limit=limit, offset=offset, min_height=min_height))
+		return jsonify(nem_api_facade.get_blocks(limit=limit, offset=offset, min_height=min_height, sort=sort))
 
 
 def setup_error_handlers(app):

--- a/explorer/rest/rest/db/NemDatabase.py
+++ b/explorer/rest/rest/db/NemDatabase.py
@@ -39,15 +39,16 @@ class NemDatabase(DatabaseConnectionPool):
 
 			return self._create_block_view(result) if result else None
 
-	def get_blocks(self, limit, offset, min_height):
+	def get_blocks(self, limit, offset, min_height, sort):
 		"""Gets blocks pagination in database."""
 
 		with self.connection() as connection:
 			cursor = connection.cursor()
-			cursor.execute('''
+			cursor.execute(f'''
 				SELECT *
 				FROM blocks
 				WHERE height >= %s
+				ORDER BY height {sort}
 				LIMIT %s OFFSET %s
 			''', (min_height, limit, offset,))
 			results = cursor.fetchall()

--- a/explorer/rest/rest/db/NemDatabase.py
+++ b/explorer/rest/rest/db/NemDatabase.py
@@ -15,14 +15,14 @@ class NemDatabase(DatabaseConnectionPool):
 	@staticmethod
 	def _create_block_view(result):
 		return BlockView(
-			height=result[0],
-			timestamp=str(result[1]),
-			total_fees=result[2],
-			total_transactions=result[3],
-			difficulty=result[4],
-			block_hash=_format_bytes(result[5]),
-			signer=_format_bytes(result[6]),
-			signature=_format_bytes(result[7])
+			height=result[1],
+			timestamp=str(result[2]),
+			total_fees=result[3],
+			total_transactions=result[4],
+			difficulty=result[5],
+			block_hash=_format_bytes(result[6]),
+			signer=_format_bytes(result[7]),
+			signature=_format_bytes(result[8])
 		)
 
 	def get_block(self, height):
@@ -48,7 +48,7 @@ class NemDatabase(DatabaseConnectionPool):
 				SELECT *
 				FROM blocks
 				WHERE height >= %s
-				ORDER BY height {sort}
+				ORDER BY id {sort}
 				LIMIT %s OFFSET %s
 			''', (min_height, limit, offset,))
 			results = cursor.fetchall()

--- a/explorer/rest/rest/facade/NemRestFacade.py
+++ b/explorer/rest/rest/facade/NemRestFacade.py
@@ -16,9 +16,9 @@ class NemRestFacade:
 
 		return block.to_dict() if block else None
 
-	def get_blocks(self, limit, offset, min_height):
+	def get_blocks(self, limit, offset, min_height, sort):
 		"""Gets blocks pagination."""
 
-		blocks = self.nem_db.get_blocks(limit, offset, min_height)
+		blocks = self.nem_db.get_blocks(limit, offset, min_height, sort)
 
 		return [block.to_dict() for block in blocks]

--- a/explorer/rest/tests/db/test_NemDatabase.py
+++ b/explorer/rest/tests/db/test_NemDatabase.py
@@ -8,7 +8,7 @@ from rest.model.Block import BlockView
 
 from ..test.DatabaseTestUtils import BLOCKS, DatabaseConfig, initialize_database
 
-BlockQueryParams = namedtuple('BlockQueryParams', ['limit', 'offset', 'min_height'])
+BlockQueryParams = namedtuple('BlockQueryParams', ['limit', 'offset', 'min_height', 'sort'])
 
 # region test data
 
@@ -46,7 +46,7 @@ class NemDatabaseTest(unittest.TestCase):
 		nem_db = NemDatabase(self.db_config)
 
 		# Act:
-		blocks_view = nem_db.get_blocks(query_params.limit, query_params.offset, query_params.min_height)
+		blocks_view = nem_db.get_blocks(query_params.limit, query_params.offset, query_params.min_height, query_params.sort)
 
 		# Assert:
 		self.assertEqual(expected_blocks, blocks_view)
@@ -58,19 +58,25 @@ class NemDatabaseTest(unittest.TestCase):
 		self._assert_can_query_block_by_height(3, None)
 
 	def test_can_query_blocks_filtered_limit(self):
-		self._assert_can_query_blocks_with_filter(BlockQueryParams(1, 0, 1), [EXPECTED_BLOCK_VIEW_1])
+		self._assert_can_query_blocks_with_filter(BlockQueryParams(1, 0, 1, 'desc'), [EXPECTED_BLOCK_VIEW_2])
 
 	def test_can_query_blocks_filtered_offset_0(self):
-		self._assert_can_query_blocks_with_filter(BlockQueryParams(1, 0, 0), [EXPECTED_BLOCK_VIEW_1])
+		self._assert_can_query_blocks_with_filter(BlockQueryParams(1, 0, 0, 'desc'), [EXPECTED_BLOCK_VIEW_2])
 
 	def test_can_query_blocks_filtered_offset_1(self):
-		self._assert_can_query_blocks_with_filter(BlockQueryParams(1, 1, 0), [EXPECTED_BLOCK_VIEW_2])
+		self._assert_can_query_blocks_with_filter(BlockQueryParams(1, 1, 0, 'desc'), [EXPECTED_BLOCK_VIEW_1])
 
 	def test_can_query_blocks_filtered_min_height_1(self):
-		self._assert_can_query_blocks_with_filter(BlockQueryParams(10, 0, 1), [EXPECTED_BLOCK_VIEW_1, EXPECTED_BLOCK_VIEW_2])
+		self._assert_can_query_blocks_with_filter(BlockQueryParams(10, 0, 1, 'desc'), [EXPECTED_BLOCK_VIEW_2, EXPECTED_BLOCK_VIEW_1])
 
 	def test_can_query_blocks_filtered_min_height_2(self):
-		self._assert_can_query_blocks_with_filter(BlockQueryParams(10, 0, 2), [EXPECTED_BLOCK_VIEW_2])
+		self._assert_can_query_blocks_with_filter(BlockQueryParams(10, 0, 2, 'desc'), [EXPECTED_BLOCK_VIEW_2])
 
 	def test_can_query_blocks_filtered_min_height_3(self):
-		self._assert_can_query_blocks_with_filter(BlockQueryParams(10, 0, 3), [])
+		self._assert_can_query_blocks_with_filter(BlockQueryParams(10, 0, 3, 'desc'), [])
+
+	def test_can_query_blocks_sorted_by_height_asc(self):
+		self._assert_can_query_blocks_with_filter(BlockQueryParams(10, 0, 0, 'asc'), [EXPECTED_BLOCK_VIEW_1, EXPECTED_BLOCK_VIEW_2])
+
+	def test_can_query_blocks_sorted_by_height_desc(self):
+		self._assert_can_query_blocks_with_filter(BlockQueryParams(10, 0, 0, 'desc'), [EXPECTED_BLOCK_VIEW_2, EXPECTED_BLOCK_VIEW_1])

--- a/explorer/rest/tests/facade/test_NemRestFacade.py
+++ b/explorer/rest/tests/facade/test_NemRestFacade.py
@@ -4,6 +4,7 @@ import testing.postgresql
 
 from rest.facade.NemRestFacade import NemRestFacade
 
+from ..db.test_NemDatabase import BlockQueryParams
 from ..test.DatabaseTestUtils import DatabaseConfig, initialize_database
 
 # region test data
@@ -61,12 +62,12 @@ class TestNemRestFacade(unittest.TestCase):
 		# Assert:
 		self.assertEqual(expected_block, block)
 
-	def _assert_can_retrieve_blocks(self, limit, offset, min_height, expected_blocks):
+	def _assert_can_retrieve_blocks(self, query_params, expected_blocks):
 		# Arrange:
 		nem_rest_facade = NemRestFacade(self.db_config)
 
 		# Act:
-		blocks = nem_rest_facade.get_blocks(limit, offset, min_height)
+		blocks = nem_rest_facade.get_blocks(query_params.limit, query_params.offset, query_params.min_height, query_params.sort)
 
 		# Assert:
 		self.assertEqual(expected_blocks, blocks)
@@ -78,13 +79,19 @@ class TestNemRestFacade(unittest.TestCase):
 		self._assert_can_retrieve_block(3, None)
 
 	def test_blocks_filtered_by_limit(self):
-		self._assert_can_retrieve_blocks(1, 0, 0, [EXPECTED_BLOCK_1])
+		self._assert_can_retrieve_blocks(BlockQueryParams(1, 0, 0, 'desc'), [EXPECTED_BLOCK_2])
 
 	def test_blocks_filtered_by_offset(self):
-		self._assert_can_retrieve_blocks(1, 1, 0, [EXPECTED_BLOCK_2])
+		self._assert_can_retrieve_blocks(BlockQueryParams(1, 1, 0, 'desc'), [EXPECTED_BLOCK_1])
 
 	def test_blocks_filtered_by_min_height(self):
-		self._assert_can_retrieve_blocks(10, 0, 2, [EXPECTED_BLOCK_2])
+		self._assert_can_retrieve_blocks(BlockQueryParams(10, 0, 2, 'desc'), [EXPECTED_BLOCK_2])
 
 	def test_returns_empty_list_on_no_matches(self):
-		self._assert_can_retrieve_blocks(10, 0, 3, [])
+		self._assert_can_retrieve_blocks(BlockQueryParams(10, 0, 3, 'desc'), [])
+
+	def test_blocks_sorted_by_height_asc(self):
+		self._assert_can_retrieve_blocks(BlockQueryParams(10, 0, 0, 'asc'), [EXPECTED_BLOCK_1, EXPECTED_BLOCK_2])
+
+	def test_blocks_sorted_by_height_desc(self):
+		self._assert_can_retrieve_blocks(BlockQueryParams(10, 0, 0, 'desc'), [EXPECTED_BLOCK_2, EXPECTED_BLOCK_1])

--- a/explorer/rest/tests/test/DatabaseTestUtils.py
+++ b/explorer/rest/tests/test/DatabaseTestUtils.py
@@ -45,8 +45,8 @@ def initialize_database(db_config):
 				id serial NOT NULL PRIMARY KEY,
 				height bigint NOT NULL,
 				timestamp timestamp NOT NULL,
-				totalFees bigint DEFAULT 0,
-				totalTransactions int DEFAULT 0,
+				total_fees bigint DEFAULT 0,
+				total_transactions int DEFAULT 0,
 				difficulty bigInt NOT NULL,
 				hash bytea NOT NULL,
 				signer bytea NOT NULL,
@@ -58,7 +58,7 @@ def initialize_database(db_config):
 		for block in BLOCKS:
 			cursor.execute(
 				'''
-				INSERT INTO blocks (height, timestamp, totalFees, totalTransactions, difficulty, hash, signer, signature)
+				INSERT INTO blocks (height, timestamp, total_fees, total_transactions, difficulty, hash, signer, signature)
 				VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
 				''', (
 					block.height,

--- a/explorer/rest/tests/test/DatabaseTestUtils.py
+++ b/explorer/rest/tests/test/DatabaseTestUtils.py
@@ -42,7 +42,8 @@ def initialize_database(db_config):
 		# Create tables
 		cursor.execute('''
 			CREATE TABLE IF NOT EXISTS blocks (
-				height bigint NOT NULL PRIMARY KEY,
+				id serial NOT NULL PRIMARY KEY,
+				height bigint NOT NULL,
 				timestamp timestamp NOT NULL,
 				totalFees bigint DEFAULT 0,
 				totalTransactions int DEFAULT 0,
@@ -57,7 +58,7 @@ def initialize_database(db_config):
 		for block in BLOCKS:
 			cursor.execute(
 				'''
-				INSERT INTO blocks
+				INSERT INTO blocks (height, timestamp, totalFees, totalTransactions, difficulty, hash, signer, signature)
 				VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
 				''', (
 					block.height,

--- a/explorer/rest/tests/test_rest.py
+++ b/explorer/rest/tests/test_rest.py
@@ -124,23 +124,31 @@ def test_api_nem_blocks_without_params(client):  # pylint: disable=redefined-out
 
 	# Assert:
 	assert 200 == response.status_code
-	assert [BlockView(*block).to_dict() for block in BLOCKS] == response.json
+	assert [BlockView(*BLOCKS[1]).to_dict(), BlockView(*BLOCKS[0]).to_dict()] == response.json
 
 
 def test_api_nem_blocks_applies_limit(client):  # pylint: disable=redefined-outer-name
-	_assert_get_api_nem_blocks(client, 200, [BlockView(*BLOCKS[0]).to_dict()], limit=1)
+	_assert_get_api_nem_blocks(client, 200, [BlockView(*BLOCKS[1]).to_dict()], limit=1)
 
 
 def test_api_nem_blocks_applies_offset(client):  # pylint: disable=redefined-outer-name
-	_assert_get_api_nem_blocks(client, 200, [BlockView(*BLOCKS[1]).to_dict()], offset=1)
+	_assert_get_api_nem_blocks(client, 200, [BlockView(*BLOCKS[0]).to_dict()], offset=1)
 
 
 def test_api_nem_blocks_applies_min_height(client):  # pylint: disable=redefined-outer-name, invalid-name
 	_assert_get_api_nem_blocks(client, 200, [], min_height=10)
 
 
+def test_api_nem_blocks_applies_sorted_by_height_desc(client):  # pylint: disable=redefined-outer-name, invalid-name
+	_assert_get_api_nem_blocks(client, 200, [BlockView(*BLOCKS[1]).to_dict(), BlockView(*BLOCKS[0]).to_dict()], sort='desc')
+
+
+def test_api_nem_blocks_applies_sorted_by_height_asc(client):  # pylint: disable=redefined-outer-name, invalid-name
+	_assert_get_api_nem_blocks(client, 200, [BlockView(*BLOCKS[0]).to_dict(), BlockView(*BLOCKS[1]).to_dict()], sort='asc')
+
+
 def test_api_nem_blocks_with_all_params(client):  # pylint: disable=redefined-outer-name
-	_assert_get_api_nem_blocks(client, 200, [BlockView(*BLOCKS[1]).to_dict()], limit=1, offset=1, min_height=1)
+	_assert_get_api_nem_blocks(client, 200, [BlockView(*BLOCKS[1]).to_dict()], limit=1, offset=1, min_height=1, sort='asc')
 
 
 def test_api_nem_blocks_invalid_min_height(client):  # pylint: disable=redefined-outer-name, invalid-name
@@ -156,5 +164,11 @@ def test_api_nem_blocks_invalid_limit(client):  # pylint: disable=redefined-oute
 def test_api_nem_blocks_invalid_offset(client):  # pylint: disable=redefined-outer-name
 	_assert_get_api_nem_blocks_fail(client, offset=-1)
 	_assert_get_api_nem_blocks_fail(client, offset='invalid')
+
+
+def test_api_nem_blocks_invalid_sort(client):  # pylint: disable=redefined-outer-name
+	_assert_get_api_nem_blocks_fail(client, sort=-1)
+	_assert_get_api_nem_blocks_fail(client, sort='invalid')
+
 
 # endregion


### PR DESCRIPTION
## What was the issue?
- Currently, blocks are returned in ASC order by height, which is not user-friendly, In the explorer, we need the blocks to be sorted by default in DESC order of height.

## What's the fix?
- Added a sort filter to the blocks list.
- Set the default sorting of block height to DESC order.
