### PR TITLE
[monorepo] task: enable weekly build for Lightapi and Shoestring

### DIFF
--- a/.github/buildConfiguration.yaml
+++ b/.github/buildConfiguration.yaml
@@ -30,3 +30,10 @@ customBuilds:
     triggers:
       - type: cron
         schedule: '@midnight'
+
+  - name: Weekly Job
+    jobName: weeklyJob
+    scriptPath: .github/jenkinsfile/weeklyBuild.groovy
+    triggers:
+      - type: cron
+        schedule: '@weekly'

--- a/.github/jenkinsfile/weeklyBuild.groovy
+++ b/.github/jenkinsfile/weeklyBuild.groovy
@@ -1,0 +1,3 @@
+weeklyBuildPipeline {
+	projectNames = ['Light API Python', 'Shoestring']
+}

--- a/lightapi/python/Jenkinsfile
+++ b/lightapi/python/Jenkinsfile
@@ -1,8 +1,9 @@
 defaultCiPipeline {
-	operatingSystem = ['ubuntu']
+	operatingSystem = ['ubuntu', 'windows']
 	instanceSize = 'medium'
 
-	ciBuildDockerfile = 'python.Dockerfile'
+	environment = 'python'
+	otherEnvironments = ['python-ubuntu-base', 'python-ubuntu-latest', 'python-windows-lts']
 
 	packageId = 'lightapi-python'
 

--- a/tools/shoestring/Jenkinsfile
+++ b/tools/shoestring/Jenkinsfile
@@ -2,7 +2,8 @@ defaultCiPipeline {
 	operatingSystem = ['ubuntu']
 	instanceSize = 'medium'
 
-	ciBuildDockerfile = 'python.Dockerfile'
+	environment = 'python'
+	otherEnvironments = ['python-ubuntu-base', 'python-ubuntu-latest']
 
 	packageId = 'tools-shoestring'
 


### PR DESCRIPTION
problem: Lightapi and Shoestring are not able to run tests in different Python environments
solution: Lightapi has a Windows and Python base and the latest weekly runs
              Shoestring has a Python base and the latest weekly runs