### PR TITLE
[tools/shoestring]: update shoestring to support python 3.11

### DIFF
--- a/tools/shoestring/shoestring/internal/NodeFeatures.py
+++ b/tools/shoestring/shoestring/internal/NodeFeatures.py
@@ -17,9 +17,33 @@ class NodeFeatures(IntFlag):
 	# Node that is able to participate in voting.
 	VOTER = 4
 
+	def to_formatted_string(self):
+		"""Constructs a string representation of these Node features."""
+
+		if not self.value:
+			return 'PEER'
+
+		value_name_tuples = [
+			(self.API, 'API'),
+			(self.HARVESTER, 'HARVESTER'),
+			(self.VOTER, 'VOTER')
+		]
+
+		str_values = []
+		for (value, str_value) in value_name_tuples:
+			if value in self:
+				str_values.append(str_value)
+
+		return '|'.join(str_values)
+
 	@staticmethod
 	def parse(node_features_str):
 		"""Parses a string composed of Node features."""
 
-		values = [NodeFeatures[name.strip()] for name in node_features_str.split(',') if name]
+		try:
+			values = [NodeFeatures[name.strip()] for name in node_features_str.split('|') if name]
+		except KeyError as ex:
+			# rethrow KeyError as ValueError for consistency with other value parsing errors
+			raise ValueError(ex) from ex
+
 		return reduce(lambda rhs, lhs: rhs | lhs, values, NodeFeatures.PEER)

--- a/tools/shoestring/shoestring/internal/ShoestringConfiguration.py
+++ b/tools/shoestring/shoestring/internal/ShoestringConfiguration.py
@@ -69,14 +69,7 @@ def parse_imports_configuration(config):
 def parse_node_configuration(config):
 	"""Parses node configuration."""
 
-	features = NodeFeatures(0)
-	for feature in config['features'].split('|'):
-		try:
-			features |= NodeFeatures[feature.strip()]
-		except KeyError as ex:
-			# rethrow KeyError as ValueError for consistency with other value parsing errors
-			raise ValueError(ex) from ex
-
+	features = NodeFeatures.parse(config['features'])
 	user_id = int(config['userId'])
 	group_id = int(config['groupId'])
 	ca_password = config['caPassword']

--- a/tools/shoestring/shoestring/wizard/setup_file_generator.py
+++ b/tools/shoestring/shoestring/wizard/setup_file_generator.py
@@ -93,7 +93,7 @@ async def prepare_shoestring_files(screens, directory):
 		('node', 'apiHttps', _to_bool_string(node_settings.api_https)),
 		('node', 'caCommonName', certificates.ca_common_name),
 		('node', 'nodeCommonName', certificates.node_common_name),
-		('node', 'features', ','.join(node_feature[len('NodeFeatures.'):] for node_feature in str(node_features).split(',')))
+		('node', 'features', node_features.to_formatted_string())
 	]
 
 	if harvesting.active:

--- a/tools/shoestring/tests/internal/test_NodeFeatures.py
+++ b/tools/shoestring/tests/internal/test_NodeFeatures.py
@@ -4,6 +4,26 @@ from shoestring.internal.NodeFeatures import NodeFeatures
 
 
 class NodeFeaturesTest(unittest.TestCase):
+	# region to_formatted_string
+
+	def test_can_format_zero_values(self):
+		self.assertEqual('PEER', NodeFeatures(0).to_formatted_string())
+
+	def test_can_format_single_value(self):
+		for name in ('PEER', 'API', 'HARVESTER', 'VOTER'):
+			self.assertEqual(name, NodeFeatures[name].to_formatted_string())
+
+	def test_can_format_multiple_values(self):
+		self.assertEqual('API|VOTER', NodeFeatures(NodeFeatures.API | NodeFeatures.VOTER).to_formatted_string())
+		self.assertEqual('HARVESTER', NodeFeatures(NodeFeatures.PEER | NodeFeatures.HARVESTER).to_formatted_string())
+		self.assertEqual(
+			'API|HARVESTER|VOTER',
+			NodeFeatures(NodeFeatures.API | NodeFeatures.VOTER | NodeFeatures.HARVESTER).to_formatted_string())
+
+	# endregion
+
+	# region parse
+
 	def test_can_parse_zero_values(self):
 		self.assertEqual(NodeFeatures.PEER, NodeFeatures.parse(''))
 
@@ -12,11 +32,17 @@ class NodeFeaturesTest(unittest.TestCase):
 			self.assertEqual(NodeFeatures[name], NodeFeatures.parse(name))
 
 	def test_can_parse_multiple_values(self):
-		self.assertEqual(NodeFeatures.API | NodeFeatures.VOTER, NodeFeatures.parse('API,VOTER'))
-		self.assertEqual(NodeFeatures.HARVESTER, NodeFeatures.parse('PEER,HARVESTER'))
-		self.assertEqual(NodeFeatures.API | NodeFeatures.VOTER | NodeFeatures.HARVESTER, NodeFeatures.parse('API,VOTER,HARVESTER'))
+		self.assertEqual(NodeFeatures.API | NodeFeatures.VOTER, NodeFeatures.parse('API|VOTER'))
+		self.assertEqual(NodeFeatures.HARVESTER, NodeFeatures.parse('PEER|HARVESTER'))
+		self.assertEqual(NodeFeatures.API | NodeFeatures.VOTER | NodeFeatures.HARVESTER, NodeFeatures.parse('API|VOTER|HARVESTER'))
 
 	def test_can_parse_multiple_values_with_whitespace(self):
-		self.assertEqual(NodeFeatures.API | NodeFeatures.VOTER, NodeFeatures.parse('API, VOTER'))
-		self.assertEqual(NodeFeatures.HARVESTER, NodeFeatures.parse('  PEER  ,  HARVESTER  '))
-		self.assertEqual(NodeFeatures.API | NodeFeatures.VOTER | NodeFeatures.HARVESTER, NodeFeatures.parse(' API, VOTER,HARVESTER '))
+		self.assertEqual(NodeFeatures.API | NodeFeatures.VOTER, NodeFeatures.parse('API| VOTER'))
+		self.assertEqual(NodeFeatures.HARVESTER, NodeFeatures.parse('  PEER  |  HARVESTER  '))
+		self.assertEqual(NodeFeatures.API | NodeFeatures.VOTER | NodeFeatures.HARVESTER, NodeFeatures.parse(' API| VOTER|HARVESTER '))
+
+	def test_cannot_parse_unknown_value(self):
+		with self.assertRaises(ValueError):
+			NodeFeatures.parse('API|OTHER|HARVESTER')
+
+	# endregion

--- a/tools/shoestring/tests/test/ConfigurationTestUtils.py
+++ b/tools/shoestring/tests/test/ConfigurationTestUtils.py
@@ -10,9 +10,7 @@ def prepare_shoestring_configuration(directory, node_features, services_nodewatc
 	parser.read(Path('tests/resources/sai.shoestring.ini').absolute())
 
 	parser['services']['nodewatch'] = str(services_nodewatch)
-
-	node_features_str = str(node_features)
-	parser['node']['features'] = node_features_str[node_features_str.index('.') + 1:]
+	parser['node']['features'] = node_features.to_formatted_string()
 
 	ca_password = node_kwargs.get('ca_password', None)
 	if ca_password:


### PR DESCRIPTION
 problem: python 3.11 changed Enum.__str__ to use int.__str__
solution: add NodeFeatures.to_formatted_string and use as appropriate