### PR TITLE
[explorer/rest]: patch missing project name inside gitlintmodules

### DIFF
--- a/.gitlintmodules
+++ b/.gitlintmodules
@@ -1,1 +1,1 @@
-explorer/nodewatch|explorer/puller|faucet/authenticator|faucet/backend|faucet/frontend|lightapi/python|monorepo|optin/puller|optin/reporting|optin/reporting/client|tools/shoestring|tools/vanity
+explorer/nodewatch|explorer/puller|explorer/rest|faucet/authenticator|faucet/backend|faucet/frontend|lightapi/python|monorepo|optin/puller|optin/reporting|optin/reporting/client|tools/shoestring|tools/vanity


### PR DESCRIPTION
## What was the issue?
- Jenkins verify commit failed

## What's the fix?
- patch missing name inside gitlintmodules
