### PR TITLE
[faucet/frontend]: enhancement of error message

### DIFF
--- a/faucet/frontend/components/common/FaucetForm/FaucetForm.spec.jsx
+++ b/faucet/frontend/components/common/FaucetForm/FaucetForm.spec.jsx
@@ -295,7 +295,10 @@ describe('components/FaucetForm', () => {
 				const toastElement = await screen.findByRole('alert');
 				const toastProgressbar = await screen.findByRole('progressbar');
 
-				assertToast(toastElement, toastProgressbar, $t('notification_error_unqualified_twitter_account'), 'error');
+				assertToast(toastElement, toastProgressbar, $t('notification_error_unqualified_twitter_account', {
+					minFollowers: config.minFollowers,
+					minAccountAge: config.minAccountAge
+				}), 'error');
 			};
 
 			it('renders error toast when twitter account followersCount less than 10', async () => {

--- a/faucet/frontend/components/common/FaucetForm/index.jsx
+++ b/faucet/frontend/components/common/FaucetForm/index.jsx
@@ -52,7 +52,7 @@ const FaucetForm = function ({ config, addressValidation }) {
 		return isTwitterVerify;
 	};
 
-	const showErrorToast = errorMessage => toast.error($t(errorMessage), toastConfig);
+	const showErrorToast = (errorMessage, params) => toast.error($t(errorMessage, params), toastConfig);
 
 	const handleAddressOnChange = value => {
 		const formattedAddress = value.replace(/-/g, '').replace(/\s/g, '');
@@ -129,7 +129,10 @@ const FaucetForm = function ({ config, addressValidation }) {
 			return;
 		}
 		else if (!isTwitterVerify) {
-			showErrorToast('notification_error_unqualified_twitter_account');
+			showErrorToast('notification_error_unqualified_twitter_account', {
+				minFollowers: config.minFollowers,
+				minAccountAge: config.minAccountAge
+			});
 			return;
 		}
 

--- a/faucet/frontend/components/nem/locales/en.json
+++ b/faucet/frontend/components/nem/locales/en.json
@@ -25,7 +25,7 @@
     "notification_info_requested": "Requested %amount %currency for %address.",
     "notification_error_address_invalid": "Incorrect address format.",
     "notification_error_amount_invalid": "Incorrect amount.",
-    "notification_error_unqualified_twitter_account": "Twitter account is unqualified.",
+    "notification_error_unqualified_twitter_account": "Twitter account does not meet the requirements, must have a minimum of %minFollowers followers and be registered for at least %minAccountAge days.",
     "notification_error_amount_max_request": "Transfer amount excess limit.",
     "notification_error_account_high_balance": "Your account balance is too high.",
     "notification_error_fund_drains": "Faucet balance not enough to pay out.",

--- a/faucet/frontend/components/symbol/locales/en.json
+++ b/faucet/frontend/components/symbol/locales/en.json
@@ -25,7 +25,7 @@
     "notification_info_requested": "Requested %amount %currency for %address.",
     "notification_error_address_invalid": "Incorrect address format.",
     "notification_error_amount_invalid": "Incorrect amount.",
-    "notification_error_unqualified_twitter_account": "Twitter account is unqualified.",
+    "notification_error_unqualified_twitter_account": "Twitter account does not meet the requirements, must have a minimum of %minFollowers followers and be registered for at least %minAccountAge days.",
     "notification_error_amount_max_request": "Transfer amount excess limit.",
     "notification_error_account_high_balance": "Your account balance is too high.",
     "notification_error_fund_drains": "Faucet balance not enough to pay out.",


### PR DESCRIPTION
## What was the issue?
- the message of `notification_error_unqualified_twitter_account` is not clear enough.

## What's the fix?
- update the requirement message in the error notification