### PR TITLE
[lightapi, shoestring] fix: add fedora weekly jobs for lightapi and shoestring

### DIFF
--- a/lightapi/python/Jenkinsfile
+++ b/lightapi/python/Jenkinsfile
@@ -1,9 +1,10 @@
 defaultCiPipeline {
-	operatingSystem = ['ubuntu', 'windows']
+	// First OS is the default for CI
+	operatingSystem = ['ubuntu', 'fedora', 'windows']
 	instanceSize = 'medium'
 
 	environment = 'python'
-	otherEnvironments = ['python-ubuntu-base', 'python-ubuntu-latest', 'python-windows-lts']
+	otherEnvironments = ['python-fedora-lts', 'python-ubuntu-base', 'python-ubuntu-latest', 'python-windows-lts']
 
 	packageId = 'lightapi-python'
 

--- a/tools/shoestring/Jenkinsfile
+++ b/tools/shoestring/Jenkinsfile
@@ -1,9 +1,10 @@
 defaultCiPipeline {
-	operatingSystem = ['ubuntu']
+	// First OS is the default for CI
+	operatingSystem = ['ubuntu', 'fedora']
 	instanceSize = 'medium'
 
 	environment = 'python'
-	otherEnvironments = ['python-ubuntu-base', 'python-ubuntu-latest']
+	otherEnvironments = ['python-fedora-lts', 'python-ubuntu-base', 'python-ubuntu-latest']
 
 	packageId = 'tools-shoestring'
 


### PR DESCRIPTION
problem: tests are not run on Fedora
solution: add weekly jobs on Fedora