### PR TITLE
[tools/shoestring]: fixes for openssl 3.2.0 support

### DIFF
--- a/tools/shoestring/shoestring/internal/CertificateFactory.py
+++ b/tools/shoestring/shoestring/internal/CertificateFactory.py
@@ -87,9 +87,15 @@ class CertificateFactory:
 				'[req]',
 				'prompt = no',
 				'distinguished_name = dn',
+				'x509_extensions = x509_v3',
 				'',
 				'[dn]',
 				f'CN = {ca_cn}'
+				'',
+				'[x509_v3]',
+				'basicConstraints = critical,CA:TRUE',
+				'subjectKeyIdentifier = hash',
+				'authorityKeyIdentifier = keyid:always,issuer'
 			]))
 
 		# create new certs directory
@@ -123,9 +129,15 @@ class CertificateFactory:
 				'[req]',
 				'prompt = no',
 				'distinguished_name = dn',
+				'x509_extensions = x509_v3',
 				'',
 				'[dn]',
-				f'CN = {node_cn}'
+				f'CN = {node_cn}',
+				'',
+				'[x509_v3]',
+				'basicConstraints = CA:FALSE',
+				'subjectKeyIdentifier = hash',
+				'authorityKeyIdentifier = keyid,issuer'
 			]))
 
 		# prepare node certificate signing request

--- a/tools/shoestring/tests/internal/test_CertificateFactory.py
+++ b/tools/shoestring/tests/internal/test_CertificateFactory.py
@@ -125,8 +125,8 @@ class CertificateFactoryTest(unittest.TestCase):
 	# region certificates
 
 	def _assert_certificate_issuer_and_subject(self, x509_output, expected_issuer, expected_subject):
-		self.assertEqual(expected_issuer, re.search(r'Issuer: CN = (.*)\n', x509_output).group(1))
-		self.assertEqual(expected_subject, re.search(r'Subject: CN = (.*)\n', x509_output).group(1))
+		self.assertEqual(expected_issuer, re.search(r'Issuer: CN ?= ?(.*)\n', x509_output).group(1))
+		self.assertEqual(expected_subject, re.search(r'Subject: CN ?= ?(.*)\n', x509_output).group(1))
 
 	def _assert_certificate_duration(self, x509_output, test_start_time, expected_days, has_explicit_start_date=False):
 		time_format = '%b %d %H:%M:%S %Y %Z'

--- a/tools/shoestring/tests/internal/test_OpensslExecutor.py
+++ b/tools/shoestring/tests/internal/test_OpensslExecutor.py
@@ -61,10 +61,11 @@ def test_can_dispatch_openssl_command_with_additional_command_input(capfd):
 	# Act:
 	output_lines = executor.dispatch(['s_client', '-connect', 'jenkins.symboldev.com:443'], command_input='Q')
 	standard_output, standard_error = capfd.readouterr()
+	subject_line = next(line for line in output_lines if line.startswith('subject='))
 
 	# Assert:
 	assert 0 != len(output_lines)
-	assert 'subject=CN = jenkins.symboldev.com\n' in output_lines
+	assert re.fullmatch(r'subject=CN ?= ?jenkins\.symboldev\.com\n', subject_line)
 	assert standard_output
 	assert not standard_error
 

--- a/tools/shoestring/tests/internal/test_OpensslExecutor.py
+++ b/tools/shoestring/tests/internal/test_OpensslExecutor.py
@@ -21,7 +21,7 @@ def test_can_retrieve_openssl_version():
 	version = executor.version()
 
 	# Assert:
-	assert re.match(r'3\.[0-1]\.*|1\.1\.1', version)
+	assert re.match(r'3\.[0-2]\.*|1\.1\.1', version)
 
 
 def test_can_dispatch_openssl_command_with_reflected_output(capfd):

--- a/tools/shoestring/tests/test/CertificateTestUtils.py
+++ b/tools/shoestring/tests/test/CertificateTestUtils.py
@@ -12,8 +12,8 @@ def create_openssl_executor():
 def assert_certificate_properties(certificate_path, expected_issuer, expected_subject, expected_days):
 	x509_output = ''.join(create_openssl_executor().dispatch(['x509', '-noout', '-text', '-in', certificate_path], False))
 
-	assert expected_issuer == re.search(r'Issuer: CN = (.*)\n', x509_output).group(1)
-	assert expected_subject == re.search(r'Subject: CN = (.*)\n', x509_output).group(1)
+	assert expected_issuer == re.search(r'Issuer: CN ?= ?(.*)\n', x509_output).group(1)
+	assert expected_subject == re.search(r'Subject: CN ?= ?(.*)\n', x509_output).group(1)
 
 	time_format = '%b %d %H:%M:%S %Y %Z'
 	cert_start_time = datetime.datetime.strptime(re.search(r'Not Before: (.*)\n', x509_output).group(1), time_format)


### PR DESCRIPTION
* allow openssl version 3.2.x
* ignore unimportant whitespace in openssl output
* generate x509 v3 certificates