### PR TITLE
[tools/shoestring]: fix health check failure on nodes with https REST

### DIFF
--- a/tools/shoestring/shoestring/commands/health.py
+++ b/tools/shoestring/shoestring/commands/health.py
@@ -23,8 +23,9 @@ class HealthAgentContext:
 	def peer_endpoint(self):
 		"""Peer endpoint."""
 
+		host = self._load_hostname()
 		port = int(self.config_manager.lookup('config-node.properties', [('node', 'port')])[0])
-		return ('localhost', port)
+		return (host, port)
 
 	@property
 	def rest_endpoint(self):
@@ -45,10 +46,8 @@ class HealthAgentContext:
 		return f'{scheme}://{hostname}:{port}/ws'
 
 	def _load_hostname(self):
-		if self.config.node.api_https:
-			return self.config_manager.lookup('config-node.properties', [('localnode', 'host')])[0]
-
-		return 'localhost'
+		host = self.config_manager.lookup('config-node.properties', [('localnode', 'host')])[0]
+		return host or 'localhost'
 
 	def _load_rest_port(self):
 		if self.config.node.api_https:

--- a/tools/shoestring/shoestring/healthagents/peer_api.py
+++ b/tools/shoestring/shoestring/healthagents/peer_api.py
@@ -10,7 +10,13 @@ def should_run(_):
 
 
 async def validate(context):
-	(host, port) = context.peer_endpoint
+	# this agent runs on the node (re)using the node's certificate (and identity key)
+	# in order to prevent the connection from being rejected due to an 'in use identity key' error,
+	# use 'localhost' so that the node treats the connection as local and allows the reuse of its identity key
+	host = 'localhost'
+
+	(_host, port) = context.peer_endpoint
+
 	try:
 		connector = SymbolPeerConnector(host, port, context.directories.certificates)
 		chain_statistics = await connector.chain_statistics()

--- a/tools/shoestring/shoestring/healthagents/rest_https_certificate.py
+++ b/tools/shoestring/shoestring/healthagents/rest_https_certificate.py
@@ -15,13 +15,13 @@ def should_run(node_config):
 	return node_config.api_https
 
 
-def _openssl_run_sclient_verify(hostname, test_args):
+def _openssl_run_sclient_verify(servername, test_args):
 	# some other commands are listed here https://www.cyberciti.biz/faq/terminate-close-openssl-s_client-command-connection-linux-unix/
 	# note: adding '-quiet' flag seems to change behavior and s_client stops reacting to commands, so DON'T
 	openssl_executor = OpensslExecutor(os.environ.get('OPENSSL_EXECUTABLE', 'openssl'))
 	lines = openssl_executor.dispatch([
 		's_client',
-		'-servername', hostname,
+		'-servername', servername,
 		'-connect',
 		'localhost:3001'
 	] + test_args, command_input='Q', show_output=False)
@@ -87,10 +87,10 @@ def _openssl_run_sclient_verify(hostname, test_args):
 
 
 async def validate(context):
-	hostname = context.hostname
+	(host, _port) = context.peer_endpoint
 	test_args = getattr(context, 'test_args', [])
 
-	result, dates_or_error = _openssl_run_sclient_verify(hostname, test_args)
+	result, dates_or_error = _openssl_run_sclient_verify(host, test_args)
 
 	if not result:
 		log.warning(_('health-rest-https-certificate-invalid').format(error_message=dates_or_error))

--- a/tools/shoestring/tests/commands/test_health.py
+++ b/tools/shoestring/tests/commands/test_health.py
@@ -38,6 +38,21 @@ def _create_configuration(api_https):
 
 # pylint: disable=invalid-name
 
+def test_can_detect_endpoints_without_host():
+	# Arrange:
+	with tempfile.TemporaryDirectory() as output_directory:
+		with Preparer(output_directory, _create_configuration(False)) as preparer:
+			preparer.create_subdirectories()
+			_write_resources(preparer.directories, '', 1111, 2345)
+
+			# Act:
+			context = HealthAgentContext(preparer.directories, preparer.config)
+
+			# Assert:
+			assert ('localhost', 1111) == context.peer_endpoint
+			assert 'http://localhost:2345' == context.rest_endpoint
+			assert 'ws://localhost:2345/ws' == context.websocket_endpoint
+
 
 def test_can_detect_endpoints_without_https():
 	# Arrange:
@@ -50,9 +65,9 @@ def test_can_detect_endpoints_without_https():
 			context = HealthAgentContext(preparer.directories, preparer.config)
 
 			# Assert:
-			assert ('localhost', 1111) == context.peer_endpoint
-			assert 'http://localhost:2345' == context.rest_endpoint
-			assert 'ws://localhost:2345/ws' == context.websocket_endpoint
+			assert ('symbol.fyi', 1111) == context.peer_endpoint
+			assert 'http://symbol.fyi:2345' == context.rest_endpoint
+			assert 'ws://symbol.fyi:2345/ws' == context.websocket_endpoint
 
 
 def test_can_detect_endpoints_with_https():
@@ -66,7 +81,7 @@ def test_can_detect_endpoints_with_https():
 			context = HealthAgentContext(preparer.directories, preparer.config)
 
 			# Assert:
-			assert ('localhost', 1111) == context.peer_endpoint
+			assert ('symbol.fyi', 1111) == context.peer_endpoint
 			assert 'https://symbol.fyi:3001' == context.rest_endpoint
 			assert 'wss://symbol.fyi:3001/ws' == context.websocket_endpoint
 

--- a/tools/shoestring/tests/healthagents/test_peer_api.py
+++ b/tools/shoestring/tests/healthagents/test_peer_api.py
@@ -93,7 +93,7 @@ def test_should_run_for_all_roles():
 async def _dispatch_validate(port, preparer):
 	# Arrange:
 	HealthAgentContext = namedtuple('HealthAgentContext', ['peer_endpoint', 'directories'])
-	context = HealthAgentContext(('localhost', port), preparer.directories)
+	context = HealthAgentContext(('symbol.fyi', port), preparer.directories)
 
 	# Act:
 	await validate(context)

--- a/tools/shoestring/tests/healthagents/test_rest_https_certificate.py
+++ b/tools/shoestring/tests/healthagents/test_rest_https_certificate.py
@@ -52,8 +52,8 @@ def _validate_thread(context):
 
 
 async def _dispatch_validate(test_args=None):
-	HealthAgentContext = namedtuple('HealthAgentContext', ['hostname', 'test_args'])
-	context = HealthAgentContext('localhost', test_args or [])
+	HealthAgentContext = namedtuple('HealthAgentContext', ['peer_endpoint', 'test_args'])
+	context = HealthAgentContext(('localhost', 7890), test_args or [])
 
 	await asyncio.get_running_loop().run_in_executor(None, _validate_thread, context)
 

--- a/tools/shoestring/tests/internal/test_ConfigurationManager.py
+++ b/tools/shoestring/tests/internal/test_ConfigurationManager.py
@@ -73,6 +73,17 @@ class ConfigurationManagerTest(unittest.TestCase):
 		# Act + Assert:
 		self._assert_lookup(self.CONFIG_LINES_WITH_DISTINCT_KEYS, search_identifiers, expected_values)
 
+	def test_can_lookup_empty_value(self):
+		# Arrange:
+		search_identifiers = [
+			('operating_systems', ''),
+			('build_tools', '')
+		]
+		expected_values = [None, None]
+
+		# Act + Assert:
+		self._assert_lookup(self.CONFIG_LINES_WITH_DISTINCT_KEYS, search_identifiers, expected_values)
+
 	def test_can_lookup_value_with_shared_cross_section_key(self):
 		# Arrange:
 		search_identifiers = [


### PR DESCRIPTION
 problem: health agent is accessing wrong property from context
solution: fix access and update agents to use domainname when specified