### PR TITLE
[monorepo]: enable controller job for CI

### DIFF
--- a/.github/jenkinsfile/controller.groovy
+++ b/.github/jenkinsfile/controller.groovy
@@ -1,0 +1,4 @@
+monorepoControllerPipeline {
+	operatingSystem = ['ubuntu']
+	instanceSize = 'small'
+}


### PR DESCRIPTION
problem: currently all jobs are run for each checkin
solution: enable controller job which will only run the
          required jobs for the commit.