### PR TITLE
[lightapi/python]: treat all HTTP statuses less than 400 as success

### DIFF
--- a/lightapi/python/symbollightapi/connector/BasicConnector.py
+++ b/lightapi/python/symbollightapi/connector/BasicConnector.py
@@ -25,7 +25,7 @@ class BasicConnector:
 					except (client_exceptions.ContentTypeError, json.decoder.JSONDecodeError) as ex:
 						raise NodeException from ex
 
-					if response.status not in (200, 404):
+					if 400 <= response.status and 404 != response.status:
 						error_message = f'HTTP request failed with code {response.status}'
 						for key in ('code', 'message'):
 							if key in response_json:


### PR DESCRIPTION
 problem: only HTTP statuses 200 and 404 are treated as non-error
solution: treate all statuses less than 400 and 404 as non-error

fixes: #867