### PR TITLE
[snap/frontend]: implement wallet connection

### DIFF
--- a/snap/frontend/app/page.jsx
+++ b/snap/frontend/app/page.jsx
@@ -1,14 +1,19 @@
 'use client';
 
 import HomeComponent from '../components/Home';
-import React from 'react';
+import { WalletContext, initialState, reducer } from '../context';
+import React, { useReducer } from 'react';
 
 /**
  * Renders the home page.
  * @returns {React.JSX} The home page component.
  */
 export default function Home() {
+	const [walletState, dispatch] = useReducer(reducer, initialState);
+
 	return (
-		<HomeComponent />
+		<WalletContext.Provider value={{ walletState, dispatch: dispatch }}>
+			<HomeComponent />
+		</WalletContext.Provider>
 	);
 }

--- a/snap/frontend/app/page.jsx
+++ b/snap/frontend/app/page.jsx
@@ -1,7 +1,7 @@
 'use client';
 
 import HomeComponent from '../components/Home';
-import { WalletContext, initialState, reducer } from '../context';
+import { WalletContextProvider, initialState, reducer } from '../context';
 import React, { useReducer } from 'react';
 
 /**
@@ -12,8 +12,8 @@ export default function Home() {
 	const [walletState, dispatch] = useReducer(reducer, initialState);
 
 	return (
-		<WalletContext.Provider value={{ walletState, dispatch: dispatch }}>
+		<WalletContextProvider value={{ walletState, dispatch: dispatch }}>
 			<HomeComponent />
-		</WalletContext.Provider>
+		</WalletContextProvider>
 	);
 }

--- a/snap/frontend/components/ConnectMetamask/ConnectMetamask.spec.jsx
+++ b/snap/frontend/components/ConnectMetamask/ConnectMetamask.spec.jsx
@@ -79,7 +79,7 @@ describe('components/ConnectMetamask', () => {
 	describe('handleConnectClick', () => {
 		const assertSnapIsConnected = async (isConnected, expectedResult) => {
 			// Arrange:
-			jest.spyOn(symbolSnap, 'connectSnap').mockResolvedValue(isConnected);
+			jest.spyOn(symbolSnap(), 'connectSnap').mockResolvedValue(isConnected);
 			customRender(<ConnectMetamask isOpen={true} onRequestClose={() => { }} />);
 			const element = screen.getByText('Connect MetaMask');
 

--- a/snap/frontend/components/ConnectMetamask/index.jsx
+++ b/snap/frontend/components/ConnectMetamask/index.jsx
@@ -1,8 +1,21 @@
+import { actionTypes, useWalletContext } from '../../context';
+import symbolSnap from '../../utils/snap';
 import WarningModalBox from '../WarningModalBox';
 
 const ConnectMetamask = ({ isOpen, onRequestClose }) => {
+	const { dispatch } = useWalletContext();
+
 	const title = 'Connect to MetaMask Symbol Snap';
 	const description = 'If you do not have the Symbol snap installed you will be prompted to install it.';
+
+	const handleConnectClick = async () => {
+		const isConnected = await symbolSnap.connectSnap();
+
+		if (isConnected)
+			dispatch({ type: actionTypes.SET_SNAP_INSTALLED, payload: true });
+		else
+			dispatch({ type: actionTypes.SET_SNAP_INSTALLED, payload: false });
+	};
 
 	return (
 		<WarningModalBox
@@ -11,7 +24,7 @@ const ConnectMetamask = ({ isOpen, onRequestClose }) => {
 			title={title}
 			description={description}
 		>
-			<div>Connect MetaMask</div>
+			<div onClick={handleConnectClick}>Connect MetaMask</div>
 		</WarningModalBox>
 	);
 };

--- a/snap/frontend/components/ConnectMetamask/index.jsx
+++ b/snap/frontend/components/ConnectMetamask/index.jsx
@@ -11,10 +11,7 @@ const ConnectMetamask = ({ isOpen, onRequestClose }) => {
 	const handleConnectClick = async () => {
 		const isConnected = await symbolSnap().connectSnap();
 
-		if (isConnected)
-			dispatch({ type: actionTypes.SET_SNAP_INSTALLED, payload: true });
-		else
-			dispatch({ type: actionTypes.SET_SNAP_INSTALLED, payload: false });
+		dispatch({ type: actionTypes.SET_SNAP_INSTALLED, payload: isConnected });
 	};
 
 	return (

--- a/snap/frontend/components/ConnectMetamask/index.jsx
+++ b/snap/frontend/components/ConnectMetamask/index.jsx
@@ -9,7 +9,7 @@ const ConnectMetamask = ({ isOpen, onRequestClose }) => {
 	const description = 'If you do not have the Symbol snap installed you will be prompted to install it.';
 
 	const handleConnectClick = async () => {
-		const isConnected = await symbolSnap.connectSnap();
+		const isConnected = await symbolSnap().connectSnap();
 
 		if (isConnected)
 			dispatch({ type: actionTypes.SET_SNAP_INSTALLED, payload: true });

--- a/snap/frontend/components/Home/Home.spec.jsx
+++ b/snap/frontend/components/Home/Home.spec.jsx
@@ -1,13 +1,35 @@
 import Home from '.';
+import WalletContextProvider from '../../context/store';
 import { render, screen } from '@testing-library/react';
 
 describe('components/Home', () => {
-	it('renders home page', async () => {
+	const assertModalScreen = async (walletState, expectedModal) => {
+		// Arrange:
+		const context = {
+			walletState,
+			dispatch: jest.fn()
+		};
+
 		// Act:
-		render(<Home />);
-		const textElement = await screen.findByText('Symbol Snap');
+		render(<WalletContextProvider value={context}>
+			<Home />
+		</WalletContextProvider>);
+
+		const textElement = await screen.findByText(expectedModal);
 
 		// Assert:
 		expect(textElement).toBeInTheDocument();
+	};
+
+	it('renders DetectMetamask modal when metamask is not install', async () => {
+		await assertModalScreen({ isMetamaskInstalled: false, isSnapInstalled: false }, 'Download MetaMask');
+	});
+
+	it('renders ConnectMetamask modal when metamask is installed but snap is not installed', async () => {
+		await assertModalScreen({ isMetamaskInstalled: true, isSnapInstalled: false }, 'Connect MetaMask');
+	});
+
+	it('renders connected when metamask and snap are installed', async () => {
+		await assertModalScreen({ isMetamaskInstalled: true, isSnapInstalled: true }, 'connected');
 	});
 });

--- a/snap/frontend/components/Home/index.jsx
+++ b/snap/frontend/components/Home/index.jsx
@@ -1,7 +1,20 @@
+import useWalletInstallation from '../../hooks/useWalletInstallation';
+import ConnectMetamask from '../ConnectMetamask';
+import DetectMetamask from '../DetectMetamask';
+
 const Home = () => {
+	const { isMetamaskInstalled, isSnapInstalled } = useWalletInstallation();
+
 	return (
 		<div className='m-auto max-w-screen-xl max-h-min'>
 			Symbol Snap
+			{
+				!isMetamaskInstalled ?
+					<DetectMetamask isOpen={!isMetamaskInstalled} onRequestClose={() => false} /> :
+					!isSnapInstalled ?
+						<ConnectMetamask isOpen={!isSnapInstalled} onRequestClose={() => false} /> :
+						<div>connected</div>
+			}
 		</div>
 	);
 };

--- a/snap/frontend/config/index.js
+++ b/snap/frontend/config/index.js
@@ -1,0 +1,3 @@
+export const defaultSnapOrigin =
+// eslint-disable-next-line no-restricted-globals
+    process.env.SNAP_ORIGIN ?? 'local:http://localhost:8080';

--- a/snap/frontend/context/index.js
+++ b/snap/frontend/context/index.js
@@ -1,0 +1,2 @@
+export { default as WalletContext } from './store';
+export * from './reducer';

--- a/snap/frontend/context/index.js
+++ b/snap/frontend/context/index.js
@@ -1,2 +1,2 @@
-export { default as WalletContext } from './store';
+export { default as WalletContextProvider, useWalletContext } from './store';
 export * from './reducer';

--- a/snap/frontend/context/reducer.js
+++ b/snap/frontend/context/reducer.js
@@ -1,0 +1,21 @@
+export const initialState = {
+	isMetamaskInstalled: false,
+	isSnapInstalled: false
+};
+
+export const actionTypes = {
+	SET_METAMASK_INSTALLED: 'setMetamaskInstalled',
+	SET_SNAP_INSTALLED: 'setSnapInstalled',
+	SET_CONNECTED: 'setConnected'
+};
+
+export const reducer = (state, action) => {
+	switch (action.type) {
+	case actionTypes.SET_METAMASK_INSTALLED:
+		return { ...state, isMetamaskInstalled: action.payload };
+	case actionTypes.SET_SNAP_INSTALLED:
+		return { ...state, isSnapInstalled: action.payload };
+	default:
+		return state;
+	}
+};

--- a/snap/frontend/context/reducer.js
+++ b/snap/frontend/context/reducer.js
@@ -5,8 +5,7 @@ export const initialState = {
 
 export const actionTypes = {
 	SET_METAMASK_INSTALLED: 'setMetamaskInstalled',
-	SET_SNAP_INSTALLED: 'setSnapInstalled',
-	SET_CONNECTED: 'setConnected'
+	SET_SNAP_INSTALLED: 'setSnapInstalled'
 };
 
 export const reducer = (state, action) => {

--- a/snap/frontend/context/store.js
+++ b/snap/frontend/context/store.js
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+const WalletContext = createContext();
+
+export default WalletContext;

--- a/snap/frontend/context/store.js
+++ b/snap/frontend/context/store.js
@@ -1,5 +1,10 @@
-import { createContext } from 'react';
+import { createContext, useContext } from 'react';
 
 const WalletContext = createContext();
 
-export default WalletContext;
+export const useWalletContext = () => {
+	const context = useContext(WalletContext);
+	return context;
+};
+
+export default WalletContext.Provider;

--- a/snap/frontend/context/store.js
+++ b/snap/frontend/context/store.js
@@ -2,9 +2,6 @@ import { createContext, useContext } from 'react';
 
 const WalletContext = createContext();
 
-export const useWalletContext = () => {
-	const context = useContext(WalletContext);
-	return context;
-};
+export const useWalletContext = () => useContext(WalletContext);
 
 export default WalletContext.Provider;

--- a/snap/frontend/hooks/useWalletInstallation.jsx
+++ b/snap/frontend/hooks/useWalletInstallation.jsx
@@ -1,26 +1,25 @@
-import { getSnap } from '../utils/snap';
-import { useEffect, useState } from 'react';
+import { actionTypes, useWalletContext } from '../context';
+import symbolSnap from '../utils/snap';
+import { useEffect } from 'react';
 
 const useWalletInstallation = () => {
-	const [isMetamaskInstalled, setIsMetamaskInstalled] = useState(false);
-	const [isSnapInstalled, setIsSnapInstalled] = useState(false);
+	const { walletState, dispatch } = useWalletContext();
+	const { isMetamaskInstalled, isSnapInstalled } = walletState;
 
 	useEffect(() => {
 		const checkInstallationStatus = async () => {
 			if (window.ethereum && window.ethereum.isMetaMask) {
-				setIsMetamaskInstalled(true);
+				dispatch({ type: actionTypes.SET_METAMASK_INSTALLED, payload: true });
 
-				const installedSnap = await getSnap();
+				const installedSnap = await symbolSnap().getSnap();
 
 				if (installedSnap && installedSnap.enabled)
-					setIsSnapInstalled(true);
-				else
-					throw new Error('Please connect snap and enable it in MetaMask');
+					dispatch({ type: actionTypes.SET_SNAP_INSTALLED, payload: true });
 			}
 		};
 
 		checkInstallationStatus();
-	}, [isSnapInstalled]);
+	}, [isSnapInstalled, dispatch]);
 
 	return { isMetamaskInstalled, isSnapInstalled };
 };

--- a/snap/frontend/hooks/useWalletInstallation.jsx
+++ b/snap/frontend/hooks/useWalletInstallation.jsx
@@ -1,0 +1,28 @@
+import { getSnap } from '../utils/snap';
+import { useEffect, useState } from 'react';
+
+const useWalletInstallation = () => {
+	const [isMetamaskInstalled, setIsMetamaskInstalled] = useState(false);
+	const [isSnapInstalled, setIsSnapInstalled] = useState(false);
+
+	useEffect(() => {
+		const checkInstallationStatus = async () => {
+			if (window.ethereum && window.ethereum.isMetaMask) {
+				setIsMetamaskInstalled(true);
+
+				const installedSnap = await getSnap();
+
+				if (installedSnap && installedSnap.enabled)
+					setIsSnapInstalled(true);
+				else
+					throw new Error('Please connect snap and enable it in MetaMask');
+			}
+		};
+
+		checkInstallationStatus();
+	}, [isSnapInstalled]);
+
+	return { isMetamaskInstalled, isSnapInstalled };
+};
+
+export default useWalletInstallation;

--- a/snap/frontend/hooks/useWalletInstallation.jsx
+++ b/snap/frontend/hooks/useWalletInstallation.jsx
@@ -19,7 +19,7 @@ const useWalletInstallation = () => {
 		};
 
 		checkInstallationStatus();
-	}, [isSnapInstalled, dispatch]);
+	}, [dispatch]);
 
 	return { isMetamaskInstalled, isSnapInstalled };
 };

--- a/snap/frontend/hooks/useWalletInstallation.spec.jsx
+++ b/snap/frontend/hooks/useWalletInstallation.spec.jsx
@@ -1,0 +1,30 @@
+import useWalletInstallation from './useWalletInstallation';
+import { WalletContextProvider } from '../context';
+import { renderHook } from '@testing-library/react';
+
+describe('hooks/useWalletInstallation', () => {
+	beforeEach(() => {
+		window.ethereum = {
+			isMetaMask: true
+		};
+	});
+
+	it('dispatch setMetamaskInstalled if metamask install in browser', async () => {
+		// Arrange:
+		const dispatch = jest.fn();
+		const walletState = { isMetamaskInstalled: false, isSnapInstalled: false };
+		const context = { walletState, dispatch };
+
+		// Act:
+		renderHook(() => useWalletInstallation(), {
+			wrapper: ({ children }) => (
+				<WalletContextProvider value={context}>
+					{children}
+				</WalletContextProvider>
+			)
+		});
+
+		// Assert:
+		expect(dispatch).toHaveBeenCalledWith({ type: 'setMetamaskInstalled', payload: true });
+	});
+});

--- a/snap/frontend/utils/snap.js
+++ b/snap/frontend/utils/snap.js
@@ -21,14 +21,10 @@ const symbolSnap = (provider = window.ethereum) =>({
 	 * @returns {object} The snap object returned by the extension.
 	 */
 	async getSnap(version) {
-		try {
-			const snaps = await this.getSnaps();
+		const snaps = await this.getSnaps();
 
-			return Object.values(snaps).find(snap =>
-				snap.id === defaultSnapOrigin && (!version || snap.version === version));
-		} catch {
-			return undefined;
-		}
+		return Object.values(snaps).find(snap =>
+			snap.id === defaultSnapOrigin && (!version || snap.version === version));
 	},
 	/**
 	 * Connect a snap to MetaMask.

--- a/snap/frontend/utils/snap.js
+++ b/snap/frontend/utils/snap.js
@@ -1,0 +1,54 @@
+import { defaultSnapOrigin } from '../config';
+
+const symbolSnap = (provider = window.ethereum) =>({
+	provider: provider,
+	/**
+	 * Get the installed snaps in MetaMask.
+	 * @returns {object} The snaps installed in MetaMask.
+	 */
+	async getSnaps() {
+		try {
+			return await this.provider.request({
+				method: 'wallet_getSnaps'
+			});
+		} catch {
+			return {};
+		}
+	},
+	/**
+	 * Get the snap from MetaMask.
+	 * @param {string} version - The version of the snap to install (optional).
+	 * @returns {object} The snap object returned by the extension.
+	 */
+	async getSnap(version) {
+		try {
+			const snaps = await this.getSnaps();
+
+			return Object.values(snaps).find(snap =>
+				snap.id === defaultSnapOrigin && (!version || snap.version === version));
+		} catch {
+			return undefined;
+		}
+	},
+	/**
+	 * Connect a snap to MetaMask.
+	 * @param {string} snapId - The ID of the snap.
+	 * @param {object} params - The params to pass with the snap to connect.
+	 * @returns {boolean} A boolean indicating if the snap was connected.
+	 */
+	async connectSnap(snapId = defaultSnapOrigin, params = {}) {
+		try {
+			await provider.request({
+				method: 'wallet_requestSnaps',
+				params: {
+					[snapId]: params
+				}
+			});
+			return true;
+		} catch {
+			return false;
+		}
+	}
+});
+
+export default symbolSnap;

--- a/snap/frontend/utils/snap.spec.js
+++ b/snap/frontend/utils/snap.spec.js
@@ -79,10 +79,6 @@ describe('symbolSnap', () => {
 		it('returns undefined when no matching snap found', async () => {
 			await assertSnap('0.3.0', undefined);
 		});
-
-		it('returns undefined when request fails', async () => {
-			await assertSnap('1.0.0', undefined);
-		});
 	});
 
 	describe('connectSnap', () => {

--- a/snap/frontend/utils/snap.spec.js
+++ b/snap/frontend/utils/snap.spec.js
@@ -1,0 +1,115 @@
+import symbolSnap from './snap';
+
+describe('symbolSnap', () => {
+	let mockProvider;
+
+	const mockSnaps = { snap1: {
+		blocked: false,
+		enabled: true,
+		id: 'local:http://localhost:8080',
+		version: '0.1.0',
+		initialPermissions: []
+	}, snap2: {
+		blocked: false,
+		enabled: true,
+		id: 'local:http://localhost:8080',
+		version: '0.2.0',
+		initialPermissions: []
+	} };
+
+	beforeAll(() => {
+		// Mock window.ethereum for testing
+		mockProvider = {
+			request: jest.fn()
+		};
+
+		window.ethereum = mockProvider;
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('getSnaps', () => {
+		it('returns snaps when provider request is successful', async () => {
+			// Arrange:
+			mockProvider.request.mockResolvedValue(mockSnaps);
+
+			// Act:
+			const result = await symbolSnap().getSnaps();
+
+			// Assert:
+			expect(result).toEqual(mockSnaps);
+			expect(mockProvider.request).toHaveBeenCalledWith({ method: 'wallet_getSnaps' });
+		});
+
+		it('returns empty object when provider request fails', async () => {
+			// Arrange:
+			mockProvider.request.mockRejectedValue();
+
+			// Act:
+			const result = await symbolSnap().getSnaps();
+
+			// Assert:
+			expect(result).toEqual({});
+			expect(mockProvider.request).toHaveBeenCalledWith({ method: 'wallet_getSnaps' });
+		});
+	});
+
+	describe('getSnap', () => {
+		const assertSnap = async (version, expectedSnap) => {
+			// Arrange:
+			mockProvider.request.mockResolvedValue(mockSnaps);
+
+			// Act:
+			const result = await symbolSnap().getSnap(version);
+
+			// Assert:
+			expect(result).toEqual(expectedSnap);
+		};
+
+		it('returns the matching snap when version is provided', async () => {
+			await assertSnap('0.2.0', mockSnaps.snap2);
+		});
+
+		it('returns first snap when no version is provided', async () => {
+			await assertSnap('', mockSnaps.snap1);
+		});
+
+		it('returns undefined when no matching snap found', async () => {
+			await assertSnap('0.3.0', undefined);
+		});
+
+		it('returns undefined when request fails', async () => {
+			await assertSnap('1.0.0', undefined);
+		});
+	});
+
+	describe('connectSnap', () => {
+		it('returns true when connect snap request success', async () => {
+			const snapId = mockSnaps.snap1.id;
+			const params = { param1: 'value1', param2: 'value2' };
+			const expectedParams = { [snapId]: params };
+
+			mockProvider.request.mockResolvedValue(mockSnaps.snap1);
+
+			const result = await symbolSnap().connectSnap(snapId, params);
+
+			expect(result).toBe(true);
+			expect(mockProvider.request).toHaveBeenCalledWith({
+				method: 'wallet_requestSnaps',
+				params: expectedParams
+			});
+		});
+
+		it('returns false when connect snap request fails', async () => {
+			// Arrange:
+			mockProvider.request.mockRejectedValueOnce();
+
+			// Act:
+			const result = await symbolSnap().connectSnap();
+
+			expect(result).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
## What was the issue?
- wallet connected to snap is not implemented.

## What's the fix?
- added snap utils: which are used for request active to metamask snap.
- added hook: to check metamask installation status in the browser.
- added context (state, reducer)
- DetectMetamask modal will pop up if the browser doesn't install metamask.
- ConnectMetamask modal will pop up if symbol snap doesn't install in metamask.
- Click on the Connect button, and Metamask should pop up and ask you to install Symbol Snap. 

note: If you like to test on a browser, it required to install [Flask](https://docs.metamask.io/snaps/get-started/install-flask/)

## Screenshot
<img width="533" alt="Screenshot 2024-04-21 at 3 43 47 AM" src="https://github.com/symbol/product/assets/5649156/8dcff96e-3b69-4401-a88f-5eb8f49d5568">

<img width="537" alt="Screenshot 2024-04-21 at 3 43 37 AM" src="https://github.com/symbol/product/assets/5649156/1fed56dd-476d-4be0-822d-0f610b805e38">

<img width="183" alt="Screenshot 2024-04-21 at 3 46 09 AM" src="https://github.com/symbol/product/assets/5649156/f4ac24f1-c595-4558-a87f-985c848dcb78">
