### PR TITLE
[tools/vanity]: max-offset argument is not coerced to int

### DIFF
--- a/tools/vanity/scripts/ci/test_examples.sh
+++ b/tools/vanity/scripts/ci/test_examples.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -ex
+
+python -m vanity --patterns AAA,BBB
+python -m vanity --blockchain symbol --network testnet --patterns AXE,AXA --max-offset=100 --format pretty
+python -m vanity --blockchain nem --network mainnet --patterns AXE,AXA --format csv --suppress-console --out "${TMPDIR}/foo.txt"
+cat "${TMPDIR}/foo.txt"
+rm "${TMPDIR}/foo.txt"

--- a/tools/vanity/vanity/__main__.py
+++ b/tools/vanity/vanity/__main__.py
@@ -31,7 +31,7 @@ def main(args):
 	parser.add_argument('--blockchain', help='blockchain to target', choices=('symbol', 'nem'), default='symbol')
 	parser.add_argument('--network', help='network to target', choices=('testnet', 'mainnet'), default='mainnet')
 	parser.add_argument('--patterns', help='patterns to match (comma delimited)', required=True)
-	parser.add_argument('--max-offset', help='maximum offset of match start', default=2)
+	parser.add_argument('--max-offset', help='maximum offset of match start', default=2, type=int)
 	parser.add_argument('--format', help='output format', choices=('pretty', 'csv'), default='pretty')
 	parser.add_argument('--suppress-console', help='suppress printing matches to console', action='store_true')
 	parser.add_argument('--out', help='output file')


### PR DESCRIPTION
```
     problem: when specified, max-offset argument is treated as string
    solution: coerce max-offset to int
              add a few test examples to detect future regressions

```