### PR TITLE
[tools/vanity] fix: TMPDIR is not defined in Ubuntu

### DIFF
--- a/tools/vanity/scripts/ci/test_examples.sh
+++ b/tools/vanity/scripts/ci/test_examples.sh
@@ -2,8 +2,9 @@
 
 set -ex
 
+TMPFILE=$(mktemp -u)
 python -m vanity --patterns AAA,BBB
 python -m vanity --blockchain symbol --network testnet --patterns AXE,AXA --max-offset=100 --format pretty
-python -m vanity --blockchain nem --network mainnet --patterns AXE,AXA --format csv --suppress-console --out "${TMPDIR}/foo.txt"
-cat "${TMPDIR}/foo.txt"
-rm "${TMPDIR}/foo.txt"
+python -m vanity --blockchain nem --network mainnet --patterns AXE,AXA --format csv --suppress-console --out "${TMPFILE}"
+cat "${TMPFILE}"
+rm "${TMPFILE}"


### PR DESCRIPTION
problem: vanity example is failing due to TMPDIR is undefine on Ubuntu
solution: use the mktemp to generate a temp file name