### PR TITLE
[snap/frontend]: Refactor symbolSnap

### DIFF
--- a/snap/frontend/app/page.jsx
+++ b/snap/frontend/app/page.jsx
@@ -1,5 +1,6 @@
 'use client';
 
+import DetectMetamask from '../components/DetectMetamask';
 import HomeComponent from '../components/Home';
 import { WalletContextProvider, initialState, reducer } from '../context';
 import symbolSnapFactory from '../utils/snap';
@@ -7,10 +8,10 @@ import detectEthereumProvider from '@metamask/detect-provider';
 import React, { useEffect, useMemo, useReducer, useState } from 'react';
 
 /**
- * Renders the home page.
+ * Renders the main page.
  * @returns {React.JSX} The home page component.
  */
-export default function Home() {
+export default function Main() {
 	const [walletState, dispatch] = useReducer(reducer, initialState);
 	const [provider, setProvider] = useState(null);
 
@@ -18,7 +19,6 @@ export default function Home() {
 		const detectedProvider = await detectEthereumProvider();
 		if (detectedProvider)
 			setProvider(detectedProvider);
-
 	};
 
 	useEffect(() => {
@@ -26,14 +26,15 @@ export default function Home() {
 	}, []);
 
 	const symbolSnap = useMemo(() => {
-		if (provider && provider.isMetaMask)
+		if (provider && provider.isMetaMask) 
 			return symbolSnapFactory.create(provider);
+		
 
 		return null;
 	}, [provider]);
 
 	if (!symbolSnap)
-		return null;
+		return (<DetectMetamask isOpen={true} onRequestClose={() => false} />);;
 
 	return (
 		<WalletContextProvider value={{ walletState, dispatch, symbolSnap }}>

--- a/snap/frontend/app/page.jsx
+++ b/snap/frontend/app/page.jsx
@@ -2,7 +2,9 @@
 
 import HomeComponent from '../components/Home';
 import { WalletContextProvider, initialState, reducer } from '../context';
-import React, { useReducer } from 'react';
+import symbolSnapFactory from '../utils/snap';
+import detectEthereumProvider from '@metamask/detect-provider';
+import React, { useEffect, useMemo, useReducer, useState } from 'react';
 
 /**
  * Renders the home page.
@@ -10,9 +12,31 @@ import React, { useReducer } from 'react';
  */
 export default function Home() {
 	const [walletState, dispatch] = useReducer(reducer, initialState);
+	const [provider, setProvider] = useState(null);
+
+	const detectProvider = async () => {
+		const detectedProvider = await detectEthereumProvider();
+		if (detectedProvider)
+			setProvider(detectedProvider);
+
+	};
+
+	useEffect(() => {
+		detectProvider();
+	}, []);
+
+	const symbolSnap = useMemo(() => {
+		if (provider && provider.isMetaMask)
+			return symbolSnapFactory.create(provider);
+
+		return null;
+	}, [provider]);
+
+	if (!symbolSnap)
+		return null;
 
 	return (
-		<WalletContextProvider value={{ walletState, dispatch: dispatch }}>
+		<WalletContextProvider value={{ walletState, dispatch, symbolSnap }}>
 			<HomeComponent />
 		</WalletContextProvider>
 	);

--- a/snap/frontend/app/page.spec.jsx
+++ b/snap/frontend/app/page.spec.jsx
@@ -1,0 +1,44 @@
+import Main from './page';
+import symbolSnapFactory from '../utils/snap';
+import detectEthereumProvider from '@metamask/detect-provider';
+import { act, render } from '@testing-library/react';
+import React from 'react';
+
+describe('Main', () => {
+	it('renders the HomeComponent when a provider is detected and symbolSnapFactory is created', async () => {
+		// Arrange:
+		const mockProvider = { isMetaMask: true };
+		detectEthereumProvider.mockResolvedValue(mockProvider);
+		jest.spyOn(symbolSnapFactory, 'create').mockReturnValue({
+			getSnap: () => ({
+				'enabled': true
+			})
+		});
+
+		// Act:
+		let component;
+		await act(async () => {
+			component = render(<Main />);
+		});
+
+		// Assert:
+		const connectionStatus = component.queryByRole('connection-status');
+		expect(connectionStatus).toBeInTheDocument();
+	});
+
+	it('renders the DetectMetamask component when provider is detected but symbolSnap is not created', async () => {
+		// Arrange:
+		const mockProvider = { isMetaMask: false };
+		detectEthereumProvider.mockResolvedValue(mockProvider);
+
+		// Act:
+		let component;
+		await act(async () => {
+			component = render(<Main />);
+		});
+
+		// Assert:
+		const text = component.queryByText('Download MetaMask');
+		expect(text).toBeInTheDocument();
+	});
+});

--- a/snap/frontend/components/ConnectMetamask/ConnectMetamask.spec.jsx
+++ b/snap/frontend/components/ConnectMetamask/ConnectMetamask.spec.jsx
@@ -1,21 +1,19 @@
 import ConnectMetamask from '.';
-import * as WalletContext from '../../context/store';
-import symbolSnap from '../../utils/snap';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import testHelper from '../testHelper';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 
 const context = {
-	dispatch: jest.fn()
+	dispatch: jest.fn(),
+	symbolSnap: {
+		connectSnap: jest.fn()
+	}
 };
 
 describe('components/ConnectMetamask', () => {
 	afterEach(() => {
 		jest.clearAllMocks();
 	});
-
-	const customRender = ui => render(<WalletContext.default value={context}>
-		{ui}
-	</WalletContext.default>);
 
 	it('renders title, description and children with isOpen is true', async () => {
 		// Arrange:
@@ -24,7 +22,7 @@ describe('components/ConnectMetamask', () => {
 		const children = 'Connect MetaMask';
 
 		// Act:
-		customRender(<ConnectMetamask isOpen={true} onRequestClose={() => { }} />);
+		testHelper.customRender(<ConnectMetamask isOpen={true} onRequestClose={() => {}} />, context);
 
 		// Assert:
 		const titleElement = screen.getByText(title);
@@ -38,7 +36,7 @@ describe('components/ConnectMetamask', () => {
 
 	it('does not render when isOpen is false', () => {
 		// Arrange + Act:
-		customRender(<ConnectMetamask isOpen={false} />);
+		testHelper.customRender(<ConnectMetamask isOpen={false} />, context);
 
 		// Assert:
 		const modalElement = screen.queryByRole('modal');
@@ -51,7 +49,7 @@ describe('components/ConnectMetamask', () => {
 			it('does not called when clicked in modal box', () => {
 				// Arrange:
 				const onRequestClose = jest.fn();
-				customRender(<ConnectMetamask isOpen={true} onRequestClose={onRequestClose} />);
+				testHelper.customRender(<ConnectMetamask isOpen={true} onRequestClose={onRequestClose} />, context);
 				const element = screen.getByRole('modal');
 
 				// Act:
@@ -64,7 +62,7 @@ describe('components/ConnectMetamask', () => {
 			it('called when overlay is clicked', () => {
 				// Arrange:
 				const onRequestClose = jest.fn();
-				customRender(<ConnectMetamask isOpen={true} onRequestClose={onRequestClose} />);
+				testHelper.customRender(<ConnectMetamask isOpen={true} onRequestClose={onRequestClose} />, context);
 				const element = screen.getByRole('overlay');
 
 				// Act:
@@ -79,8 +77,9 @@ describe('components/ConnectMetamask', () => {
 	describe('handleConnectClick', () => {
 		const assertSnapIsConnected = async (isConnected, expectedResult) => {
 			// Arrange:
-			jest.spyOn(symbolSnap(), 'connectSnap').mockResolvedValue(isConnected);
-			customRender(<ConnectMetamask isOpen={true} onRequestClose={() => { }} />);
+			jest.spyOn(context.symbolSnap, 'connectSnap').mockResolvedValue(isConnected);
+
+			testHelper.customRender(<ConnectMetamask isOpen={true} onRequestClose={() => {}} />, context);
 			const element = screen.getByText('Connect MetaMask');
 
 			// Act:

--- a/snap/frontend/components/ConnectMetamask/index.jsx
+++ b/snap/frontend/components/ConnectMetamask/index.jsx
@@ -1,15 +1,14 @@
 import { actionTypes, useWalletContext } from '../../context';
-import symbolSnap from '../../utils/snap';
 import WarningModalBox from '../WarningModalBox';
 
 const ConnectMetamask = ({ isOpen, onRequestClose }) => {
-	const { dispatch } = useWalletContext();
+	const { dispatch, symbolSnap } = useWalletContext();
 
 	const title = 'Connect to MetaMask Symbol Snap';
 	const description = 'If you do not have the Symbol snap installed you will be prompted to install it.';
 
 	const handleConnectClick = async () => {
-		const isConnected = await symbolSnap().connectSnap();
+		const isConnected = await symbolSnap.connectSnap();
 
 		dispatch({ type: actionTypes.SET_SNAP_INSTALLED, payload: isConnected });
 	};

--- a/snap/frontend/components/Home/Home.spec.jsx
+++ b/snap/frontend/components/Home/Home.spec.jsx
@@ -42,11 +42,7 @@ describe('components/Home', () => {
 		expect(textElement).toBeInTheDocument();
 	};
 
-	it('renders DetectMetamask modal when metamask is not install', async () => {
-		await assertModalScreen({ isMetamaskInstalled: false, isSnapInstalled: false }, 'Download MetaMask');
-	});
-
 	it('renders ConnectMetamask modal when metamask is installed but snap is not installed', async () => {
-		await assertModalScreen({ isMetamaskInstalled: true, isSnapInstalled: false }, 'Connect MetaMask');
+		await assertModalScreen({ isSnapInstalled: false }, 'Connect MetaMask');
 	});
 });

--- a/snap/frontend/components/Home/Home.spec.jsx
+++ b/snap/frontend/components/Home/Home.spec.jsx
@@ -19,6 +19,9 @@ const context = {
 			symbol: 'usd',
 			currencyPerXYM: 0.25
 		}
+	},
+	symbolSnap: {
+		getSnap: jest.fn()
 	}
 };
 

--- a/snap/frontend/components/Home/index.jsx
+++ b/snap/frontend/components/Home/index.jsx
@@ -3,22 +3,19 @@ import AccountBalance from '../AccountBalance';
 import AccountInfo from '../AccountInfo';
 import AssetList from '../AssetList';
 import ConnectMetamask from '../ConnectMetamask';
-import DetectMetamask from '../DetectMetamask';
 import LoadingScreen from '../LoadingScreen';
 import Navbar from '../Navbar';
 import TransactionTable from '../TransactionTable';
 
 const Home = () => {
-	const { isMetamaskInstalled, isSnapInstalled } = useWalletInstallation();
+	const { isSnapInstalled } = useWalletInstallation();
 
 	return (
 		<div className='m-auto max-w-screen-xl min-w-[910px] max-h-min p-5'>
 			{
-				!isMetamaskInstalled ?
-					<DetectMetamask isOpen={!isMetamaskInstalled} onRequestClose={() => false} /> :
-					!isSnapInstalled ?
-						<ConnectMetamask isOpen={!isSnapInstalled} onRequestClose={() => false} /> :
-						null
+				!isSnapInstalled ?
+					<ConnectMetamask isOpen={!isSnapInstalled} onRequestClose={() => false} /> :
+					null
 			}
 
 			<Navbar />

--- a/snap/frontend/components/Navbar/Navbar.spec.jsx
+++ b/snap/frontend/components/Navbar/Navbar.spec.jsx
@@ -104,17 +104,15 @@ describe('components/Navbar', () => {
 			expect(connectionStatus).toHaveClass(expectedResult);
 		};
 
-		it('renders green when isConnected is true', () => {
+		it('renders green when isSnapInstalled is true', () => {
 			// Arrange:
-			context.walletState.isMetamaskInstalled = true;
 			context.walletState.isSnapInstalled = true;
 
 			assertConnectionStatus(context, 'bg-green');
 		});
 
-		it('renders red when isConnected is false', () => {
+		it('renders red when isSnapInstalled is false', () => {
 			// Arrange:
-			context.walletState.isMetamaskInstalled = false;
 			context.walletState.isSnapInstalled = false;
 
 			assertConnectionStatus(context, 'bg-red-500');

--- a/snap/frontend/components/Navbar/index.jsx
+++ b/snap/frontend/components/Navbar/index.jsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 
 const Navbar = () => {
 	const { walletState } = useWalletContext();
-	const { isMetamaskInstalled, isSnapInstalled } = walletState;
+	const { isSnapInstalled } = walletState;
 
 	const networks = [
 		{ label: 'Mainnet', value: 'mainnet' },
@@ -19,7 +19,6 @@ const Navbar = () => {
 
 	const [selectedNetwork, setSelectedNetwork] = useState('Network');
 	const [selectedCurrency, setSelectedCurrency] = useState('Currency');
-	const isConnected = isMetamaskInstalled && isSnapInstalled;
 
 	const handleSelectNetwork = option => {
 		setSelectedNetwork(option.label);
@@ -43,7 +42,7 @@ const Navbar = () => {
 			<div className='flex items-center'>
 				<Dropdown label={selectedNetwork} options={networks} onSelect={handleSelectNetwork}/>
 				<Dropdown label={selectedCurrency} options={currencies} onSelect={handleSelectCurrency} />
-				<div role='connection-status' className={`rounded-full w-5 h-5 ml-2 ${isConnected ? 'bg-green' :'bg-red-500'}`}></div>
+				<div role='connection-status' className={`rounded-full w-5 h-5 ml-2 ${isSnapInstalled ? 'bg-green' :'bg-red-500'}`}></div>
 			</div>
 		</div>
 	);

--- a/snap/frontend/context/reducer.js
+++ b/snap/frontend/context/reducer.js
@@ -1,5 +1,4 @@
 export const initialState = {
-	isMetamaskInstalled: false,
 	isSnapInstalled: false,
 	loadingStatus: {
 		isLoading: false,
@@ -19,15 +18,12 @@ export const initialState = {
 };
 
 export const actionTypes = {
-	SET_METAMASK_INSTALLED: 'setMetamaskInstalled',
 	SET_SNAP_INSTALLED: 'setSnapInstalled',
 	SET_LOADING_STATUS: 'setLoadingStatus'
 };
 
 export const reducer = (state, action) => {
 	switch (action.type) {
-	case actionTypes.SET_METAMASK_INSTALLED:
-		return { ...state, isMetamaskInstalled: action.payload };
 	case actionTypes.SET_SNAP_INSTALLED:
 		return { ...state, isSnapInstalled: action.payload };
 	case actionTypes.SET_LOADING_STATUS:

--- a/snap/frontend/hooks/useWalletInstallation.jsx
+++ b/snap/frontend/hooks/useWalletInstallation.jsx
@@ -1,25 +1,24 @@
 import { actionTypes, useWalletContext } from '../context';
-import symbolSnap from '../utils/snap';
 import { useEffect } from 'react';
 
 const useWalletInstallation = () => {
-	const { walletState, dispatch } = useWalletContext();
+	const { walletState, dispatch, symbolSnap } = useWalletContext();
 	const { isMetamaskInstalled, isSnapInstalled } = walletState;
 
 	useEffect(() => {
 		const checkInstallationStatus = async () => {
-			if (window.ethereum && window.ethereum.isMetaMask) {
+			if (window.ethereum && window.ethereum.isMetaMask)
 				dispatch({ type: actionTypes.SET_METAMASK_INSTALLED, payload: true });
 
-				const installedSnap = await symbolSnap().getSnap();
+			const installedSnap = await symbolSnap.getSnap();
 
-				if (installedSnap && installedSnap.enabled)
-					dispatch({ type: actionTypes.SET_SNAP_INSTALLED, payload: true });
-			}
+			if (installedSnap && installedSnap.enabled)
+				dispatch({ type: actionTypes.SET_SNAP_INSTALLED, payload: true });
+
 		};
 
 		checkInstallationStatus();
-	}, [dispatch]);
+	}, [dispatch, symbolSnap]);
 
 	return { isMetamaskInstalled, isSnapInstalled };
 };

--- a/snap/frontend/hooks/useWalletInstallation.jsx
+++ b/snap/frontend/hooks/useWalletInstallation.jsx
@@ -3,24 +3,20 @@ import { useEffect } from 'react';
 
 const useWalletInstallation = () => {
 	const { walletState, dispatch, symbolSnap } = useWalletContext();
-	const { isMetamaskInstalled, isSnapInstalled } = walletState;
+	const { isSnapInstalled } = walletState;
 
 	useEffect(() => {
 		const checkInstallationStatus = async () => {
-			if (window.ethereum && window.ethereum.isMetaMask)
-				dispatch({ type: actionTypes.SET_METAMASK_INSTALLED, payload: true });
-
 			const installedSnap = await symbolSnap.getSnap();
 
 			if (installedSnap && installedSnap.enabled)
 				dispatch({ type: actionTypes.SET_SNAP_INSTALLED, payload: true });
-
 		};
 
 		checkInstallationStatus();
 	}, [dispatch, symbolSnap]);
 
-	return { isMetamaskInstalled, isSnapInstalled };
+	return { isSnapInstalled };
 };
 
 export default useWalletInstallation;

--- a/snap/frontend/hooks/useWalletInstallation.spec.jsx
+++ b/snap/frontend/hooks/useWalletInstallation.spec.jsx
@@ -13,7 +13,8 @@ describe('hooks/useWalletInstallation', () => {
 		// Arrange:
 		const dispatch = jest.fn();
 		const walletState = { isMetamaskInstalled: false, isSnapInstalled: false };
-		const context = { walletState, dispatch };
+		const symbolSnap = { getSnap: jest.fn() };
+		const context = { walletState, dispatch, symbolSnap };
 
 		// Act:
 		renderHook(() => useWalletInstallation(), {

--- a/snap/frontend/package-lock.json
+++ b/snap/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
+        "@metamask/detect-provider": "^2.0.0",
         "next": "14.1.3",
         "react": "^18",
         "react-dom": "^18"
@@ -1328,6 +1329,14 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@metamask/detect-provider": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@metamask/detect-provider/-/detect-provider-2.0.0.tgz",
+      "integrity": "sha512-sFpN+TX13E9fdBDh9lvQeZdJn4qYoRb/6QF2oZZK/Pn559IhCFacPMU1rMuqyXoFQF3JSJfii2l98B87QDPeCQ==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@next/env": {

--- a/snap/frontend/package.json
+++ b/snap/frontend/package.json
@@ -20,6 +20,7 @@
     "lint:fix": "eslint --ext js,jsx,cjs --fix ."
   },
   "dependencies": {
+    "@metamask/detect-provider": "^2.0.0",
     "next": "14.1.3",
     "react": "^18",
     "react-dom": "^18"

--- a/snap/frontend/setupTests.js
+++ b/snap/frontend/setupTests.js
@@ -9,3 +9,8 @@ jest.mock('next/image', () => {
 	const mockImage = ({...props}) => <img {...props} />;
 	return mockImage;
 });
+
+jest.mock('@metamask/detect-provider', () => {
+	const detectEthereumProvider = jest.fn();
+	return detectEthereumProvider;
+});

--- a/snap/frontend/utils/snap.js
+++ b/snap/frontend/utils/snap.js
@@ -1,50 +1,54 @@
 import { defaultSnapOrigin } from '../config';
 
-const symbolSnap = (provider = window.ethereum) =>({
-	provider: provider,
-	/**
-	 * Get the installed snaps in MetaMask.
-	 * @returns {object} The snaps installed in MetaMask.
-	 */
-	async getSnaps() {
-		try {
-			return await this.provider.request({
-				method: 'wallet_getSnaps'
-			});
-		} catch {
-			return {};
-		}
-	},
-	/**
-	 * Get the snap from MetaMask.
-	 * @param {string} version - The version of the snap to install (optional).
-	 * @returns {object} The snap object returned by the extension.
-	 */
-	async getSnap(version) {
-		const snaps = await this.getSnaps();
-
-		return Object.values(snaps).find(snap =>
-			snap.id === defaultSnapOrigin && (!version || snap.version === version));
-	},
-	/**
-	 * Connect a snap to MetaMask.
-	 * @param {string} snapId - The ID of the snap.
-	 * @param {object} params - The params to pass with the snap to connect.
-	 * @returns {boolean} A boolean indicating if the snap was connected.
-	 */
-	async connectSnap(snapId = defaultSnapOrigin, params = {}) {
-		try {
-			await provider.request({
-				method: 'wallet_requestSnaps',
-				params: {
-					[snapId]: params
+const symbolSnapFactory = {
+	create(provider) {
+		return {
+			provider: provider,
+			/**
+			 * Get the installed snaps in MetaMask.
+			 * @returns {object} The snaps installed in MetaMask.
+			 */
+			async getSnaps() {
+				try {
+					return await this.provider.request({
+						method: 'wallet_getSnaps'
+					});
+				} catch {
+					return {};
 				}
-			});
-			return true;
-		} catch {
-			return false;
-		}
-	}
-});
+			},
+			/**
+			 * Get the snap from MetaMask.
+			 * @param {string} version - The version of the snap to install (optional).
+			 * @returns {object} The snap object returned by the extension.
+			 */
+			async getSnap(version) {
+				const snaps = await this.getSnaps();
 
-export default symbolSnap;
+				return Object.values(snaps).find(snap =>
+					snap.id === defaultSnapOrigin && (!version || snap.version === version));
+			},
+			/**
+			 * Connect a snap to MetaMask.
+			 * @param {string} snapId - The ID of the snap.
+			 * @param {object} params - The params to pass with the snap to connect.
+			 * @returns {boolean} A boolean indicating if the snap was connected.
+			 */
+			async connectSnap(snapId = defaultSnapOrigin, params = {}) {
+				try {
+					await provider.request({
+						method: 'wallet_requestSnaps',
+						params: {
+							[snapId]: params
+						}
+					});
+					return true;
+				} catch {
+					return false;
+				}
+			}
+		};
+	}
+};
+
+export default symbolSnapFactory;

--- a/snap/frontend/utils/snap.spec.js
+++ b/snap/frontend/utils/snap.spec.js
@@ -1,7 +1,8 @@
-import symbolSnap from './snap';
+import symbolSnapFactory from './snap';
 
-describe('symbolSnap', () => {
+describe('symbolSnapFactory', () => {
 	let mockProvider;
+	let symbolSnap;
 
 	const mockSnaps = { snap1: {
 		blocked: false,
@@ -23,11 +24,22 @@ describe('symbolSnap', () => {
 			request: jest.fn()
 		};
 
-		window.ethereum = mockProvider;
+		symbolSnap = symbolSnapFactory.create(mockProvider);
 	});
 
 	afterEach(() => {
 		jest.clearAllMocks();
+	});
+
+	describe('create', () => {
+		it('returns an object with provider and methods', () => {
+
+			// Assert:
+			expect(symbolSnap.provider).toBe(mockProvider);
+			expect(symbolSnap.getSnaps).toBeInstanceOf(Function);
+			expect(symbolSnap.getSnap).toBeInstanceOf(Function);
+			expect(symbolSnap.connectSnap).toBeInstanceOf(Function);
+		});
 	});
 
 	describe('getSnaps', () => {
@@ -36,7 +48,7 @@ describe('symbolSnap', () => {
 			mockProvider.request.mockResolvedValue(mockSnaps);
 
 			// Act:
-			const result = await symbolSnap().getSnaps();
+			const result = await symbolSnap.getSnaps();
 
 			// Assert:
 			expect(result).toEqual(mockSnaps);
@@ -48,7 +60,7 @@ describe('symbolSnap', () => {
 			mockProvider.request.mockRejectedValue();
 
 			// Act:
-			const result = await symbolSnap().getSnaps();
+			const result = await symbolSnap.getSnaps();
 
 			// Assert:
 			expect(result).toEqual({});
@@ -62,7 +74,7 @@ describe('symbolSnap', () => {
 			mockProvider.request.mockResolvedValue(mockSnaps);
 
 			// Act:
-			const result = await symbolSnap().getSnap(version);
+			const result = await symbolSnap.getSnap(version);
 
 			// Assert:
 			expect(result).toEqual(expectedSnap);
@@ -89,7 +101,7 @@ describe('symbolSnap', () => {
 
 			mockProvider.request.mockResolvedValue(mockSnaps.snap1);
 
-			const result = await symbolSnap().connectSnap(snapId, params);
+			const result = await symbolSnap.connectSnap(snapId, params);
 
 			expect(result).toBe(true);
 			expect(mockProvider.request).toHaveBeenCalledWith({
@@ -103,7 +115,7 @@ describe('symbolSnap', () => {
 			mockProvider.request.mockRejectedValueOnce();
 
 			// Act:
-			const result = await symbolSnap().connectSnap();
+			const result = await symbolSnap.connectSnap();
 
 			expect(result).toBe(false);
 		});


### PR DESCRIPTION
## What was the issue?
- Having issues with mock `symbolSnap` in the unit test.

## What's the fix?
- Refactor `symbolSnap` -> `symbolSnapFactory` with `create` method returns an object.
- Move `symbolSnap` in the top of the component, shared global context.
- Added `@metamask/detect-provider` to detect isMetamask installed in the browser.
- Removed `isMetamaskInstalled`, It will replaced by @metamask/detect-provider library.
- Rename component `Home` -> `Main`