### PR TITLE
[snap/backend]: Added snap state

### DIFF
--- a/snap/backend/snap.manifest.json
+++ b/snap/backend/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/symbol/product.git"
   },
   "source": {
-    "shasum": "uhRryYWrO1D7U9yyDo8OIw41DbiV/tE1UAw89wuhxT8=",
+    "shasum": "vTkPsF6V824DRPlFe3gx/OM0hl/bk+G74M8NlYD4uR4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/snap/backend/src/stateManager.js
+++ b/snap/backend/src/stateManager.js
@@ -1,27 +1,22 @@
-const manageStateSnapRequest = async (operation, newState) => {
-	try {
-		return await snap.request({
+const stateManager = {
+	async manageStateSnapRequest(operation, newState) {
+		return snap.request({
 			method: 'snap_manageState',
 			params: {
 				operation,
 				newState
 			}
 		});
-	} catch (error) {
-		throw new Error('Error in manageStateSnapRequest:', error);
-	}
-};
-
-const stateManager = {
+	},
 	async update(state) {
-		await manageStateSnapRequest('update', state);
+		await this.manageStateSnapRequest('update', state);
 	},
 	async getState() {
-		const state = await manageStateSnapRequest('get');
+		const state = await this.manageStateSnapRequest('get');
 		return state;
 	},
 	async clear() {
-		await manageStateSnapRequest('clear');
+		await this.manageStateSnapRequest('clear');
 	}
 };
 

--- a/snap/backend/test/stateManager_spec.js
+++ b/snap/backend/test/stateManager_spec.js
@@ -1,0 +1,44 @@
+import stateManager from '../src/stateManager.js';
+import { describe, jest } from '@jest/globals';
+
+global.snap = {
+	request: jest.fn()
+};
+
+describe('stateManager', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should update state', async () => {
+		const mockState = { key: 'value' };
+		await stateManager.update(mockState);
+		expect(snap.request).toHaveBeenCalledWith({
+			method: 'snap_manageState',
+			params: {
+				operation: 'update',
+				newState: mockState
+			}
+		});
+	});
+
+	it('should get state', async () => {
+		await stateManager.getState();
+		expect(snap.request).toHaveBeenCalledWith({
+			method: 'snap_manageState',
+			params: {
+				operation: 'get'
+			}
+		});
+	});
+
+	it('should clear state', async () => {
+		await stateManager.clear();
+		expect(snap.request).toHaveBeenCalledWith({
+			method: 'snap_manageState',
+			params: {
+				operation: 'clear'
+			}
+		});
+	});
+});


### PR DESCRIPTION
## What was the issue?
- Implement snap_manageState, which allows the Snap to persist data to disk and retrieve it.

## What's the fix?
- Added get, update, and clear state method.

