### PR TITLE
[Snap]: Implementation of navbar dropdown (network)

### DIFF
--- a/snap/backend/snap.manifest.json
+++ b/snap/backend/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/symbol/product.git"
   },
   "source": {
-    "shasum": "vTkPsF6V824DRPlFe3gx/OM0hl/bk+G74M8NlYD4uR4=",
+    "shasum": "r9BK/WRHSBTR90A0WUgqH0l0G+6k+JMRlN7Pty+C9aY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -20,6 +20,7 @@
   "initialPermissions": {
     "snap_dialog": {},
     "snap_manageState": {},
+    "endowment:network-access": {},
     "endowment:rpc": {
       "dapps": true,
       "snaps": false

--- a/snap/backend/src/config.js
+++ b/snap/backend/src/config.js
@@ -1,0 +1,8 @@
+const config = {
+	statisticsServiceURL: {
+		mainnet: 'https://symbol.services',
+		testnet: 'https://testnet.symbol.services'
+	}
+};
+
+export default config;

--- a/snap/backend/src/index.js
+++ b/snap/backend/src/index.js
@@ -1,7 +1,5 @@
-import statisticsClient from './services/statisticsClient.js';
 import stateManager from './stateManager.js';
 import networkUtils from './utils/networkUtils.js';
-import { SymbolFacade } from 'symbol-sdk/symbol';
 
 // eslint-disable-next-line import/prefer-default-export
 export const onRpcRequest = async ({ request }) => {
@@ -10,29 +8,21 @@ export const onRpcRequest = async ({ request }) => {
 	let state = await stateManager.getState();
 
 	if (!state) {
-		// initialize state if empty and set default data
-		const nodeInfo = await statisticsClient.getNodeInfo('mainnet');
-
 		state = {
-			network: {
-				...nodeInfo
-			}
+			network: {}
 		};
-
-		await stateManager.update(state);
 	}
-
-	const facade = new SymbolFacade(state.network.networkName);
 
 	const apiParams = {
 		state,
-		requestParams,
-		snap,
-		facade
+		requestParams
 	};
 
 	// handle request
 	switch (request.method) {
+	case 'initialSnap':
+		await networkUtils.switchNetwork(apiParams);
+		return state;
 	case 'getNetwork':
 		return state.network;
 	case 'switchNetwork':

--- a/snap/backend/src/index.js
+++ b/snap/backend/src/index.js
@@ -1,18 +1,42 @@
-import { panel, text } from '@metamask/snaps-sdk';
+import statisticsClient from './services/statisticsClient.js';
+import stateManager from './stateManager.js';
+import networkUtils from './utils/networkUtils.js';
+import { SymbolFacade } from 'symbol-sdk/symbol';
 
 // eslint-disable-next-line import/prefer-default-export
-export const onRpcRequest = async ({ origin, request }) => {
-	switch (request.method) {
-	case 'hello':
-		return snap.request({
-			method: 'snap_dialog',
-			params: {
-				type: 'confirmation',
-				content: panel([
-					text(`Hello, **${origin}**!`)
-				])
+export const onRpcRequest = async ({ request }) => {
+	const requestParams = request?.params || {};
+
+	let state = await stateManager.getState();
+
+	if (!state) {
+		// initialize state if empty and set default data
+		const nodeInfo = await statisticsClient.getNodeInfo('mainnet');
+
+		state = {
+			network: {
+				...nodeInfo
 			}
-		});
+		};
+
+		await stateManager.update(state);
+	}
+
+	const facade = new SymbolFacade(state.network.networkName);
+
+	const apiParams = {
+		state,
+		requestParams,
+		snap,
+		facade
+	};
+
+	// handle request
+	switch (request.method) {
+	case 'getNetwork':
+		return state.network;
+	case 'switchNetwork':
+		return networkUtils.switchNetwork(apiParams);
 	default:
 		throw new Error('Method not found.');
 	}

--- a/snap/backend/src/services/statisticsClient.js
+++ b/snap/backend/src/services/statisticsClient.js
@@ -1,0 +1,41 @@
+import config from '../config.js';
+import fetchUtils from '../utils/fetchUtils.js';
+
+const statisticsClient = {
+	/**
+     * Get the nodes from the network.
+     * @param {'mainnet' | 'testnet'} networkName - The network name identifier.
+     * @returns {Promise<NodeInfo>} The node information.
+     */
+	getNodeInfo: async networkName => {
+		if (!networkName)
+			throw new Error('Network is required');
+
+		try {
+			const queryString = '?filter=suggested&limit=1&ssl=true';
+			const nodes = await fetchUtils.fetchData(`${config.statisticsServiceURL[networkName]}/nodes?${queryString}`, 'GET');
+
+			return {
+				identifier: nodes[0].networkIdentifier,
+				networkName,
+				url: nodes[0].apiStatus.restGatewayUrl
+			};
+		} catch (error) {
+			throw new Error(`Failed to fetch nodes from statistics service: ${error.message}`);
+		}
+	}
+};
+
+export default statisticsClient;
+
+// region type declarations
+
+/**
+ * Result of a node request.
+ * @typedef {object} NodeInfo
+ * @property {number} identifier - The network identifier.
+ * @property {string} networkName - The network name.
+ * @property {string} url - The node URL.
+ */
+
+// endregion

--- a/snap/backend/src/utils/fetchUtils.js
+++ b/snap/backend/src/utils/fetchUtils.js
@@ -1,0 +1,22 @@
+const fetchUtils = {
+	async fetchData(url, method = 'GET', body = null) {
+		const options = {
+			method,
+			headers: {
+				'Content-Type': 'application/json'
+			}
+		};
+
+		if (body)
+			options.body = JSON.stringify(body);
+
+		const response = await fetch(url, options);
+
+		if (!response.ok)
+			throw new Error(`Failed to fetch: ${response.statusText}`);
+
+		return response.json();
+	}
+};
+
+export default fetchUtils;

--- a/snap/backend/src/utils/networkUtils.js
+++ b/snap/backend/src/utils/networkUtils.js
@@ -1,0 +1,19 @@
+import statisticsClient from '../services/statisticsClient.js';
+import stateManager from '../stateManager.js';
+
+const networkUtils = {
+	async switchNetwork({ state, requestParams }) {
+		const { networkName } = requestParams;
+		const nodeInfo = await statisticsClient.getNodeInfo(networkName);
+
+		state.network = {
+			...nodeInfo
+		};
+
+		await stateManager.update(state);
+
+		return state.network;
+	}
+};
+
+export default networkUtils;

--- a/snap/backend/test/index_spec.js
+++ b/snap/backend/test/index_spec.js
@@ -27,39 +27,26 @@ describe('onRpcRequest', () => {
 		});
 	});
 
-	describe('initialize state', () => {
-		it('set default network (mainnet) if state is empty', async () => {
+	describe('initialSnap', () => {
+		it('returns snap states', async () => {
 			// Arrange:
 			stateManager.getState.mockResolvedValue(null);
 			statisticsClient.getNodeInfo.mockResolvedValue(mockNodeInfo);
 
 			// Act:
-			await onRpcRequest({
+			const response = await onRpcRequest({
 				request: {
-					method: 'getNetwork'
+					method: 'initialSnap',
+					params: {
+						networkName: 'mainnet'
+					}
 				}
 			});
 
 			// Assert:
-			expect(statisticsClient.getNodeInfo).toHaveBeenCalledWith('mainnet');
-			expect(stateManager.update).toHaveBeenCalledWith({
-				network: {
-					...mockNodeInfo
-				}
+			expect(response).toStrictEqual({
+				network: mockNodeInfo
 			});
-		});
-
-		it('does not set default network if state is not empty', async () => {
-			// Act:
-			await onRpcRequest({
-				request: {
-					method: 'getNetwork'
-				}
-			});
-
-			// Assert:
-			expect(statisticsClient.getNodeInfo).not.toHaveBeenCalled();
-			expect(stateManager.update).not.toHaveBeenCalled();
 		});
 	});
 

--- a/snap/backend/test/index_spec.js
+++ b/snap/backend/test/index_spec.js
@@ -1,43 +1,114 @@
-import { expect } from '@jest/globals';
-import snapsJest from '@metamask/snaps-jest';
-import { panel, text } from '@metamask/snaps-sdk';
+import { onRpcRequest } from '../src/index.js';
+import statisticsClient from '../src/services/statisticsClient.js';
+import stateManager from '../src/stateManager.js';
+import {
+	describe, expect, it, jest
+} from '@jest/globals';
 
-const { installSnap } = snapsJest;
+jest.spyOn(stateManager, 'getState').mockResolvedValue();
+jest.spyOn(stateManager, 'update').mockResolvedValue();
+jest.spyOn(statisticsClient, 'getNodeInfo').mockResolvedValue();
+global.snap = {
+	request: jest.fn()
+};
 
 describe('onRpcRequest', () => {
-	describe('hello', () => {
-		it('shows a confirmation dialog', async () => {
-			const { request } = await installSnap();
+	const mockNodeInfo = {
+		identifier: 104,
+		networkName: 'mainnet',
+		url: 'http://localhost:3000'
+	};
 
-			const origin = 'Jest';
-			const response = request({
-				method: 'hello',
-				origin
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		stateManager.getState.mockResolvedValue({
+			network: mockNodeInfo
+		});
+	});
+
+	describe('initialize state', () => {
+		it('set default network (mainnet) if state is empty', async () => {
+			// Arrange:
+			stateManager.getState.mockResolvedValue(null);
+			statisticsClient.getNodeInfo.mockResolvedValue(mockNodeInfo);
+
+			// Act:
+			await onRpcRequest({
+				request: {
+					method: 'getNetwork'
+				}
 			});
 
-			const ui = await response.getInterface();
-			expect(ui.type).toBe('confirmation');
-			expect(ui).toRender(panel([text(`Hello, **${origin}**!`)]));
+			// Assert:
+			expect(statisticsClient.getNodeInfo).toHaveBeenCalledWith('mainnet');
+			expect(stateManager.update).toHaveBeenCalledWith({
+				network: {
+					...mockNodeInfo
+				}
+			});
+		});
 
-			await ui.ok();
+		it('does not set default network if state is not empty', async () => {
+			// Act:
+			await onRpcRequest({
+				request: {
+					method: 'getNetwork'
+				}
+			});
 
-			expect(await response).toRespondWith(true);
+			// Assert:
+			expect(statisticsClient.getNodeInfo).not.toHaveBeenCalled();
+			expect(stateManager.update).not.toHaveBeenCalled();
 		});
 	});
 
 	it('throws an error if the requested method does not exist', async () => {
-		const { request, close } = await installSnap();
+		// Act + Assert:
+		await expect(onRpcRequest({
+			request: {
+				method: 'unknownMethod'
+			}
+		})).rejects.toThrow('Method not found.');
+	});
 
-		const response = await request({
-			method: 'foo'
+	describe('getNetwork', () => {
+		it('returns the current network', async () => {
+			// Act:
+			const response = await onRpcRequest({
+				request: {
+					method: 'getNetwork'
+				}
+			});
+
+			// Assert:
+			expect(response).toStrictEqual(mockNodeInfo);
 		});
+	});
 
-		expect(response).toRespondWithError({
-			code: -32603,
-			message: 'Method not found.',
-			stack: expect.any(String)
+	describe('switchNetwork', () => {
+		it('switches the network', async () => {
+			// Arrange:
+			const mockExpectedNodeInfo = {
+				identifier: 152,
+				networkName: 'testnet',
+				url: 'http://localhost:3000'
+			};
+
+			statisticsClient.getNodeInfo.mockResolvedValue(mockExpectedNodeInfo);
+
+			// Act:
+			const response = await onRpcRequest({
+				request: {
+					method: 'switchNetwork',
+					params: {
+						networkName: 'testnet'
+					}
+				}
+			});
+
+			// Assert:
+			expect(response).toStrictEqual(mockExpectedNodeInfo);
 		});
-
-		await close();
 	});
 });

--- a/snap/backend/test/services/statisticsClient_spec.js
+++ b/snap/backend/test/services/statisticsClient_spec.js
@@ -10,7 +10,7 @@ describe('statisticsClient', () => {
 	});
 
 	describe('getNodeInfo', () => {
-		it('should fetch node info successfully', async () => {
+		it('can fetch node info successfully', async () => {
 			// Arrange:
 			const networkName = 'mainnet';
 			const nodes = [{

--- a/snap/backend/test/services/statisticsClient_spec.js
+++ b/snap/backend/test/services/statisticsClient_spec.js
@@ -1,0 +1,50 @@
+import statisticsClient from '../../src/services/statisticsClient.js';
+import fetchUtils from '../../src/utils/fetchUtils.js';
+import { describe, expect, jest } from '@jest/globals';
+
+jest.spyOn(fetchUtils, 'fetchData').mockImplementation();
+
+describe('statisticsClient', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('getNodeInfo', () => {
+		it('should fetch node info successfully', async () => {
+			// Arrange:
+			const networkName = 'mainnet';
+			const nodes = [{
+				networkIdentifier: 1,
+				apiStatus: {
+					restGatewayUrl: 'http://localhost:3000'
+				}
+			}];
+
+			fetchUtils.fetchData.mockResolvedValue(nodes);
+
+			// Act:
+			const result = await statisticsClient.getNodeInfo(networkName);
+
+			// Assert:
+			expect(result).toStrictEqual({
+				identifier: nodes[0].networkIdentifier,
+				networkName,
+				url: nodes[0].apiStatus.restGatewayUrl
+			});
+			expect(fetchUtils.fetchData).toHaveBeenCalledWith('https://symbol.services/nodes??filter=suggested&limit=1&ssl=true', 'GET');
+		});
+
+		it('should throw an error when network is not provided', async () => {
+			await expect(statisticsClient.getNodeInfo()).rejects.toThrow('Network is required');
+		});
+
+		it('should throw an error when fetch fails', async () => {
+			// Arrange:
+			fetchUtils.fetchData.mockRejectedValue(new Error('Failed to fetch'));
+
+			// Assert:
+			const errorMessage = 'Failed to fetch nodes from statistics service: Failed to fetch';
+			await expect(statisticsClient.getNodeInfo('mainnet')).rejects.toThrow(errorMessage);
+		});
+	});
+});

--- a/snap/backend/test/utils/fetchUtils_spec.js
+++ b/snap/backend/test/utils/fetchUtils_spec.js
@@ -1,0 +1,98 @@
+import fetchUtils from '../../src/utils/fetchUtils.js';
+import { describe, jest } from '@jest/globals';
+
+jest.spyOn(global, 'fetch').mockImplementation();
+
+describe('fetchUtils', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	const runBasicFetchDataTest = async method => {
+		it(`should fetch data successfully with ${method} method`, async () => {
+			// Arrange:
+			const url = 'https://example.com';
+			const data = 'result data';
+			fetch.mockResolvedValueOnce({
+				ok: true,
+				json: jest.fn().mockResolvedValueOnce(data)
+			});
+
+			// Act:
+			const result = await fetchUtils.fetchData(url, method);
+
+			// Assert:
+			expect(fetch).toHaveBeenCalledWith(url, {
+				method: `${method}`,
+				headers: {
+					'Content-Type': 'application/json'
+				}
+			});
+			expect(result).toStrictEqual(data);
+		});
+
+		it(`should throw an error if the response is not ok with ${method} method`, async () => {
+			// Arrange:
+			const url = 'https://example.com';
+			fetch.mockResolvedValueOnce({
+				ok: false,
+				statusText: 'Not Found'
+			});
+
+			// Assert:
+			await expect(fetchUtils.fetchData(url, method)).rejects.toThrow('Failed to fetch: Not Found');
+			expect(fetch).toHaveBeenCalledWith(url, {
+				method: `${method}`,
+				headers: {
+					'Content-Type': 'application/json'
+				}
+			});
+		});
+	};
+
+	describe('fetchData', () => {
+		runBasicFetchDataTest('GET');
+
+		runBasicFetchDataTest('POST');
+
+		it('should fetch data successfully with default GET method', async () => {
+			// Arrange:
+			const url = 'https://example.com';
+			const data = { key: 'value' };
+			fetch.mockResolvedValueOnce({
+				ok: true,
+				json: jest.fn().mockResolvedValueOnce(data)
+			});
+
+			// Act:
+			const result = await fetchUtils.fetchData(url);
+
+			// Assert:
+			expect(fetch).toHaveBeenCalledWith(url, {
+				method: 'GET',
+				headers: {
+					'Content-Type': 'application/json'
+				}
+			});
+			expect(result).toStrictEqual(data);
+		});
+
+		it('should throw an error if the response is not ok with default GET method', async () => {
+			// Arrange:
+			const url = 'https://example.com';
+			fetch.mockResolvedValueOnce({
+				ok: false,
+				statusText: 'Not Found'
+			});
+
+			// Assert:
+			await expect(fetchUtils.fetchData(url)).rejects.toThrow('Failed to fetch: Not Found');
+			expect(fetch).toHaveBeenCalledWith(url, {
+				method: 'GET',
+				headers: {
+					'Content-Type': 'application/json'
+				}
+			});
+		});
+	});
+});

--- a/snap/backend/test/utils/networkUtils_spec.js
+++ b/snap/backend/test/utils/networkUtils_spec.js
@@ -1,0 +1,42 @@
+import statisticsClient from '../../src/services/statisticsClient.js';
+import stateManager from '../../src/stateManager.js';
+import networkUtils from '../../src/utils/networkUtils.js';
+import { describe, jest } from '@jest/globals';
+
+jest.spyOn(statisticsClient, 'getNodeInfo').mockResolvedValue();
+jest.spyOn(stateManager, 'update').mockResolvedValue();
+
+describe('networkUtils', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('switchNetwork', () => {
+		it('should switch network when giving network name', async () => {
+			// Arrange:
+			const state = {
+				network: {}
+			};
+
+			const requestParams = {
+				networkName: 'testnet'
+			};
+
+			const mockNodeInfo = {
+				identifier: 1,
+				networkName: requestParams.networkName,
+				url: 'http://localhost:3000'
+			};
+
+			statisticsClient.getNodeInfo.mockResolvedValue(mockNodeInfo);
+
+			// Act:
+			const result = await networkUtils.switchNetwork({ state, requestParams });
+
+			// Assert:
+			expect(statisticsClient.getNodeInfo).toHaveBeenCalledWith(requestParams.networkName);
+			expect(stateManager.update).toHaveBeenCalledWith({ network: mockNodeInfo });
+			expect(result).toStrictEqual(mockNodeInfo);
+		});
+	});
+});

--- a/snap/frontend/components/Navbar/Navbar.spec.jsx
+++ b/snap/frontend/components/Navbar/Navbar.spec.jsx
@@ -1,10 +1,13 @@
 import Navbar from '.';
 import testHelper from '../testHelper';
-import { fireEvent, screen } from '@testing-library/react';
+import { act, fireEvent, screen } from '@testing-library/react';
 
 const context = {
 	dispatch: jest.fn(),
-	walletState: {}
+	walletState: {},
+	symbolSnap: {
+		switchNetwork: jest.fn()
+	}
 };
 
 describe('components/Navbar', () => {
@@ -70,9 +73,59 @@ describe('components/Navbar', () => {
 				assertOptions('Network', ['Mainnet', 'Testnet']);
 			});
 
-			it('sets selected network when clicked on item', () => {
-				assertSelectedOption('Network', 'Mainnet');
-				assertSelectedOption('Network', 'Testnet');
+			it('renders nothing when selected same network', async () => {
+				// Arrange:
+				const mockNetworkData = {
+					identifier: 152,
+					networkName: 'testnet',
+					url: 'http://localhost:3000'
+				};
+
+				jest.spyOn(context.symbolSnap, 'switchNetwork').mockReturnValue(mockNetworkData);
+
+				testHelper.customRender(<Navbar />, context);
+				const dropdown = screen.getByText('Network');
+				fireEvent.click(dropdown);
+				const item = screen.getByText('Testnet');
+
+				await act(async () => fireEvent.click(item));
+
+				// Act:
+				// Click on the same network
+				await act(async () => fireEvent.click(item));
+
+				// Assert:
+				const selectedOption = screen.getByText('Testnet');
+
+				expect(selectedOption).toBeInTheDocument();
+				expect(context.symbolSnap.switchNetwork).toHaveBeenCalledTimes(1);
+				expect(context.dispatch).toHaveBeenCalledTimes(1);
+			});
+
+			it('sets selected network when clicked on item', async () => {
+				// Arrange:
+				const mockNetworkData = {
+					identifier: 152,
+					networkName: 'testnet',
+					url: 'http://localhost:3000'
+				};
+
+				jest.spyOn(context.symbolSnap, 'switchNetwork').mockReturnValue(mockNetworkData);
+
+				testHelper.customRender(<Navbar />, context);
+				const dropdown = screen.getByText('Network');
+				fireEvent.click(dropdown);
+				const item = screen.getByText('Testnet');
+
+				// Act:
+				await act(async () => fireEvent.click(item));
+
+				// Assert:
+				const selectedOption = screen.getByText('Testnet');
+
+				expect(selectedOption).toBeInTheDocument();
+				expect(context.symbolSnap.switchNetwork).toHaveBeenCalledWith('testnet');
+				expect(context.dispatch).toHaveBeenCalledWith({ type: 'setNetwork', payload: mockNetworkData });
 			});
 		});
 

--- a/snap/frontend/components/Navbar/index.jsx
+++ b/snap/frontend/components/Navbar/index.jsx
@@ -1,10 +1,10 @@
-import { useWalletContext } from '../../context';
+import { actionTypes, useWalletContext } from '../../context';
 import Dropdown from '../Dropdown';
 import Image from 'next/image';
 import { useState } from 'react';
 
 const Navbar = () => {
-	const { walletState } = useWalletContext();
+	const { walletState, dispatch, symbolSnap } = useWalletContext();
 	const { isSnapInstalled } = walletState;
 
 	const networks = [
@@ -20,8 +20,16 @@ const Navbar = () => {
 	const [selectedNetwork, setSelectedNetwork] = useState('Network');
 	const [selectedCurrency, setSelectedCurrency] = useState('Currency');
 
-	const handleSelectNetwork = option => {
+	const handleSelectNetwork = async option => {
+		if (option.label === selectedNetwork)
+			return;
+
+		// switch network
+		const networkData = await symbolSnap.switchNetwork(option.value);
+
 		setSelectedNetwork(option.label);
+
+		dispatch({ type: actionTypes.SET_NETWORK, payload: networkData });
 	};
 
 	const handleSelectCurrency = option => {

--- a/snap/frontend/context/reducer.js
+++ b/snap/frontend/context/reducer.js
@@ -9,6 +9,7 @@ export const initialState = {
 		symbol: 'usd',
 		currencyPerXYM: 0
 	},
+	network: {},
 	selectedAccount: {
 		address: '',
 		label: ''
@@ -19,7 +20,8 @@ export const initialState = {
 
 export const actionTypes = {
 	SET_SNAP_INSTALLED: 'setSnapInstalled',
-	SET_LOADING_STATUS: 'setLoadingStatus'
+	SET_LOADING_STATUS: 'setLoadingStatus',
+	SET_NETWORK: 'setNetwork'
 };
 
 export const reducer = (state, action) => {
@@ -28,6 +30,8 @@ export const reducer = (state, action) => {
 		return { ...state, isSnapInstalled: action.payload };
 	case actionTypes.SET_LOADING_STATUS:
 		return { ...state, loadingStatus: action.payload };
+	case actionTypes.SET_NETWORK:
+		return { ...state, network: action.payload };
 	default:
 		return state;
 	}

--- a/snap/frontend/utils/snap.js
+++ b/snap/frontend/utils/snap.js
@@ -46,6 +46,45 @@ const symbolSnapFactory = {
 				} catch {
 					return false;
 				}
+			},
+			/**
+			 * Get current selected network from snap MetaMask.
+			 * @returns {object} The network object returned by the snap.
+			 */
+			async getNetwork() {
+				const networkData = await provider.request({
+					method: 'wallet_invokeSnap',
+					params: {
+						snapId: defaultSnapOrigin,
+						request: {
+							method: 'getNetwork'
+						}
+					}
+				});
+
+				return networkData;
+			},
+			/**
+			 * Switch network in snap MetaMask.
+			 * @typedef {'mainnet' | 'testnet'} NetworkName
+			 * @param {NetworkName} networkName - The name of the network to switch to.
+			 * @returns {object} The network object returned by the snap.
+			 */
+			async switchNetwork(networkName) {
+				const network = await provider.request({
+					method: 'wallet_invokeSnap',
+					params: {
+						snapId: defaultSnapOrigin,
+						request: {
+							method: 'switchNetwork',
+							params: {
+								networkName
+							}
+						}
+					}
+				});
+
+				return network;
 			}
 		};
 	}

--- a/snap/frontend/utils/snap.spec.js
+++ b/snap/frontend/utils/snap.spec.js
@@ -120,4 +120,64 @@ describe('symbolSnapFactory', () => {
 			expect(result).toBe(false);
 		});
 	});
+
+	describe('getNetwork', () => {
+		it('returns network data when provider request is successful', async () => {
+			// Arrange:
+			const mockNetworkData = {
+				identifier: 104,
+				networkName: 'mainnet',
+				url: 'http://localhost:3000'
+			};
+
+			mockProvider.request.mockResolvedValue(mockNetworkData);
+
+			// Act:
+			const result = await symbolSnap.getNetwork();
+
+			// Assert:
+			expect(result).toEqual(mockNetworkData);
+			expect(mockProvider.request).toHaveBeenCalledWith({
+				method: 'wallet_invokeSnap',
+				params: {
+					snapId: 'local:http://localhost:8080',
+					request: {
+						method: 'getNetwork'
+					}
+				}
+			});
+		});
+	});
+
+	describe('switchNetwork', () => {
+		it('returns network data when provider request is successful', async () => {
+			// Arrange:
+			const networkName = 'testnet';
+			const mockNetworkData = {
+				identifier: 152,
+				networkName: 'testnet',
+				url: 'http://localhost:3000'
+			};
+
+			mockProvider.request.mockResolvedValue(mockNetworkData);
+
+			// Act:
+			const result = await symbolSnap.switchNetwork(networkName);
+
+			// Assert:
+			expect(result).toEqual(mockNetworkData);
+			expect(mockProvider.request).toHaveBeenCalledWith({
+				method: 'wallet_invokeSnap',
+				params: {
+					snapId: 'local:http://localhost:8080',
+					request: {
+						method: 'switchNetwork',
+						params: {
+							networkName
+						}
+					}
+				}
+			});
+		});
+	});
 });


### PR DESCRIPTION
## What was the issue?
- Implement navbar network dropdown 

## What's the fix?
- Backend
  - Added fetch data utils.
  - Added statistic client which is used to query network nodes
  - Added switch network method
  - Added `getNetowork` and `switchNetwork`, refactor snap onRpcRequest,

- Frontend 
  - Implement on click network dropdown switch network


