### PR TITLE
[snap/frontend]: implement initial snap

### DIFF
--- a/snap/frontend/app/page.spec.jsx
+++ b/snap/frontend/app/page.spec.jsx
@@ -12,7 +12,8 @@ describe('Main', () => {
 		jest.spyOn(symbolSnapFactory, 'create').mockReturnValue({
 			getSnap: () => ({
 				'enabled': true
-			})
+			}),
+			initialSnap: () => jest.fn()
 		});
 
 		// Act:

--- a/snap/frontend/components/Home/Home.spec.jsx
+++ b/snap/frontend/components/Home/Home.spec.jsx
@@ -1,9 +1,12 @@
 import Home from '.';
 import testHelper from '../testHelper';
-import { screen } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 
 const context = {
-	dispatch: jest.fn(),
+	dispatch: {
+		setLoadingStatus: jest.fn(),
+		setNetwork: jest.fn()
+	},
 	walletState: {
 		loadingStatus: {
 			isLoading: false,
@@ -21,7 +24,8 @@ const context = {
 		}
 	},
 	symbolSnap: {
-		getSnap: jest.fn()
+		getSnap: jest.fn(),
+		initialSnap: jest.fn()
 	}
 };
 
@@ -44,5 +48,34 @@ describe('components/Home', () => {
 
 	it('renders ConnectMetamask modal when metamask is installed but snap is not installed', async () => {
 		await assertModalScreen({ isSnapInstalled: false }, 'Connect MetaMask');
+	});
+
+	it('calls initializeSnap when isSnapInstalled is true', async () => {
+		// Arrange:
+		const mockNetwork = {
+			identifier: 152,
+			networkName: 'testnet',
+			url: 'http://localhost:3000'
+		};
+
+		context.walletState.isSnapInstalled = true;
+
+		context.symbolSnap.initialSnap.mockResolvedValue({
+			network: mockNetwork
+		});
+
+		// Act:
+		await act(() => testHelper.customRender(<Home />, context));
+
+		// Assert:
+		expect(context.dispatch.setLoadingStatus).toHaveBeenCalledWith({
+			isLoading: true,
+			message: 'Initializing Snap...'
+		});
+		expect(context.dispatch.setNetwork).toHaveBeenCalledWith(mockNetwork);
+		expect(context.dispatch.setLoadingStatus).toHaveBeenCalledWith({
+			isLoading: false,
+			message: ''
+		});
 	});
 });

--- a/snap/frontend/components/Home/index.jsx
+++ b/snap/frontend/components/Home/index.jsx
@@ -1,3 +1,4 @@
+import { useWalletContext } from '../../context';
 import useWalletInstallation from '../../hooks/useWalletInstallation';
 import AccountBalance from '../AccountBalance';
 import AccountInfo from '../AccountInfo';
@@ -6,9 +7,34 @@ import ConnectMetamask from '../ConnectMetamask';
 import LoadingScreen from '../LoadingScreen';
 import Navbar from '../Navbar';
 import TransactionTable from '../TransactionTable';
+import { useEffect } from 'react';
 
 const Home = () => {
 	const { isSnapInstalled } = useWalletInstallation();
+	const { dispatch, symbolSnap } = useWalletContext();
+
+	useEffect(() => {
+		const initializeSnap = async () => {
+			if (isSnapInstalled) {
+				dispatch.setLoadingStatus({
+					isLoading: true,
+					message: 'Initializing Snap...'
+				});
+
+				const snapState = await symbolSnap.initialSnap();
+
+				dispatch.setNetwork(snapState.network);
+
+				dispatch.setLoadingStatus({
+					isLoading: false,
+					message: ''
+				});
+			}
+		};
+
+		initializeSnap();
+	}, [isSnapInstalled]); // eslint-disable-line react-hooks/exhaustive-deps
+
 
 	return (
 		<div className='m-auto max-w-screen-xl min-w-[910px] max-h-min p-5'>

--- a/snap/frontend/components/Navbar/Navbar.spec.jsx
+++ b/snap/frontend/components/Navbar/Navbar.spec.jsx
@@ -3,10 +3,13 @@ import testHelper from '../testHelper';
 import { act, fireEvent, screen } from '@testing-library/react';
 
 const context = {
-	dispatch: jest.fn(),
+	dispatch: {
+		setNetwork: jest.fn()
+	},
 	walletState: {},
 	symbolSnap: {
-		switchNetwork: jest.fn()
+		switchNetwork: jest.fn(),
+		initialSnap: jest.fn()
 	}
 };
 
@@ -99,7 +102,7 @@ describe('components/Navbar', () => {
 
 				expect(selectedOption).toBeInTheDocument();
 				expect(context.symbolSnap.switchNetwork).toHaveBeenCalledTimes(1);
-				expect(context.dispatch).toHaveBeenCalledTimes(1);
+				expect(context.dispatch.setNetwork).toHaveBeenCalledTimes(1);
 			});
 
 			it('sets selected network when clicked on item', async () => {
@@ -125,7 +128,7 @@ describe('components/Navbar', () => {
 
 				expect(selectedOption).toBeInTheDocument();
 				expect(context.symbolSnap.switchNetwork).toHaveBeenCalledWith('testnet');
-				expect(context.dispatch).toHaveBeenCalledWith({ type: 'setNetwork', payload: mockNetworkData });
+				expect(context.dispatch.setNetwork).toHaveBeenCalledWith(mockNetworkData);
 			});
 		});
 

--- a/snap/frontend/components/Navbar/Navbar.spec.jsx
+++ b/snap/frontend/components/Navbar/Navbar.spec.jsx
@@ -147,6 +147,10 @@ describe('components/Navbar', () => {
 				assertInitialNetwork('mainnet', 'Mainnet');
 				assertInitialNetwork('testnet', 'Testnet');
 			});
+
+			it('does not render network name when network is not set when initial', () => {
+				assertInitialNetwork(undefined, 'Network');
+			});
 		});
 
 		describe('currency', () => {

--- a/snap/frontend/components/Navbar/Navbar.spec.jsx
+++ b/snap/frontend/components/Navbar/Navbar.spec.jsx
@@ -68,6 +68,18 @@ describe('components/Navbar', () => {
 		};
 
 		describe('network', () => {
+			const assertInitialNetwork = (networkName, expectLabel) => {
+				// Arrange:
+				context.walletState.network = { networkName };
+
+				// Act:
+				testHelper.customRender(<Navbar />, context);
+
+				// Assert:
+				const label = screen.getByText(expectLabel);
+				expect(label).toBeInTheDocument();
+			};
+
 			it('renders dropdown', () => {
 				assertDropdown('Network');
 			});
@@ -129,6 +141,11 @@ describe('components/Navbar', () => {
 				expect(selectedOption).toBeInTheDocument();
 				expect(context.symbolSnap.switchNetwork).toHaveBeenCalledWith('testnet');
 				expect(context.dispatch.setNetwork).toHaveBeenCalledWith(mockNetworkData);
+			});
+
+			it('renders network name when network is set when initial', () => {
+				assertInitialNetwork('mainnet', 'Mainnet');
+				assertInitialNetwork('testnet', 'Testnet');
 			});
 		});
 

--- a/snap/frontend/components/Navbar/index.jsx
+++ b/snap/frontend/components/Navbar/index.jsx
@@ -1,11 +1,11 @@
 import { actionTypes, useWalletContext } from '../../context';
 import Dropdown from '../Dropdown';
 import Image from 'next/image';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 const Navbar = () => {
 	const { walletState, dispatch, symbolSnap } = useWalletContext();
-	const { isSnapInstalled } = walletState;
+	const { isSnapInstalled, network } = walletState;
 
 	const networks = [
 		{ label: 'Mainnet', value: 'mainnet' },
@@ -35,6 +35,14 @@ const Navbar = () => {
 	const handleSelectCurrency = option => {
 		setSelectedCurrency(option.label);
 	};
+
+	useEffect(() => {
+		// set selected network in dropdown label
+		if (network && network.hasOwnProperty('networkName')) {
+			const selected = networks.find(n => n.value === network.networkName);
+			setSelectedNetwork(selected.label);
+		}
+	}, [network]); // eslint-disable-line react-hooks/exhaustive-deps
 
 	return (
 		<div className='flex items-center justify-between'>

--- a/snap/frontend/components/Navbar/index.jsx
+++ b/snap/frontend/components/Navbar/index.jsx
@@ -40,7 +40,8 @@ const Navbar = () => {
 		// set selected network in dropdown label
 		if (network && network.hasOwnProperty('networkName')) {
 			const selected = networks.find(n => n.value === network.networkName);
-			setSelectedNetwork(selected.label);
+			if (selected)
+				setSelectedNetwork(selected.label);
 		}
 	}, [network]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/snap/frontend/components/Navbar/index.jsx
+++ b/snap/frontend/components/Navbar/index.jsx
@@ -29,7 +29,7 @@ const Navbar = () => {
 
 		setSelectedNetwork(option.label);
 
-		dispatch({ type: actionTypes.SET_NETWORK, payload: networkData });
+		dispatch.setNetwork(networkData);
 	};
 
 	const handleSelectCurrency = option => {

--- a/snap/frontend/utils/snap.js
+++ b/snap/frontend/utils/snap.js
@@ -85,6 +85,26 @@ const symbolSnapFactory = {
 				});
 
 				return network;
+			},
+			/**
+			 * Get the initial snap state.
+			 * @returns {object} The initial snap state.
+			 */
+			async initialSnap() {
+				const initialSnapState = await provider.request({
+					method: 'wallet_invokeSnap',
+					params: {
+						snapId: defaultSnapOrigin,
+						request: {
+							method: 'initialSnap',
+							params: {
+								networkName: 'mainnet'
+							}
+						}
+					}
+				});
+
+				return initialSnapState;
 			}
 		};
 	}

--- a/snap/frontend/utils/snap.spec.js
+++ b/snap/frontend/utils/snap.spec.js
@@ -180,4 +180,37 @@ describe('symbolSnapFactory', () => {
 			});
 		});
 	});
+
+	describe('initialSnap', () => {
+		it('returns initial snap state when provider request is successful', async () => {
+			// Arrange:
+			const mockInitialSnapState = {
+				network: {
+					identifier: 104,
+					networkName: 'mainnet',
+					url: 'http://localhost:3000'
+				}
+			};
+
+			mockProvider.request.mockResolvedValue(mockInitialSnapState);
+
+			// Act:
+			const result = await symbolSnap.initialSnap();
+
+			// Assert:
+			expect(result).toEqual(mockInitialSnapState);
+			expect(mockProvider.request).toHaveBeenCalledWith({
+				method: 'wallet_invokeSnap',
+				params: {
+					snapId: 'local:http://localhost:8080',
+					request: {
+						method: 'initialSnap',
+						params: {
+							networkName: 'mainnet'
+						}
+					}
+				}
+			});
+		});
+	});
 });


### PR DESCRIPTION
## What was the issue?
The page didn't load state when the page was first loaded.

## What's the fix?
- Call the `initialSnap` method when the page loads and snap is installed.
- Added loading status when waiting for initialSnap return.
