### PR TITLE
[snap/backend]: Added derive key pair from metamask

### DIFF
--- a/snap/backend/package-lock.json
+++ b/snap/backend/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.1.0",
 			"license": "ISC",
 			"dependencies": {
+				"@metamask/key-tree": "^9.1.1",
 				"@metamask/snaps-cli": "^6.0.2",
 				"@metamask/snaps-sdk": "^3.1.0",
 				"crypto-js": "^4.2.0",
@@ -2688,32 +2689,15 @@
 			}
 		},
 		"node_modules/@metamask/key-tree": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/@metamask/key-tree/-/key-tree-9.0.0.tgz",
-			"integrity": "sha512-Fma7twGR7PK0QLby0ZCI2q4VDiSlZM0iIUYvmExDtiS6TIGQBu4br0rMWgfgMBz+arFFw8FriQxRrNBv4hb8SA==",
+			"version": "9.1.1",
+			"resolved": "https://registry.npmjs.org/@metamask/key-tree/-/key-tree-9.1.1.tgz",
+			"integrity": "sha512-Z/KEbNlNvLeaBIjw+ibtC8gfLAm7X152JPcLo2KJgw8wMxKjwq/OjkI3XIqn7hFRA2HWCm3MWJPcABQsXWPQcQ==",
 			"dependencies": {
-				"@metamask/scure-bip39": "^2.1.0",
-				"@metamask/utils": "^6.0.1",
-				"@noble/ed25519": "^1.6.0",
-				"@noble/hashes": "^1.0.0",
-				"@noble/secp256k1": "^1.5.5",
+				"@metamask/scure-bip39": "^2.1.1",
+				"@metamask/utils": "^8.3.0",
+				"@noble/curves": "^1.2.0",
+				"@noble/hashes": "^1.3.2",
 				"@scure/base": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@metamask/key-tree/node_modules/@metamask/utils": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-6.2.0.tgz",
-			"integrity": "sha512-nM5CujDd4STfwx4ic/gim9G1W9oZcWUGKN4WbAT4waEkqNSIluVmZeHgxUKvdajZ7iCFDnjDLajkD4sP7c/ClQ==",
-			"dependencies": {
-				"@ethereumjs/tx": "^4.1.2",
-				"@noble/hashes": "^1.3.1",
-				"@types/debug": "^4.1.7",
-				"debug": "^4.3.4",
-				"semver": "^7.3.8",
-				"superstruct": "^1.0.3"
 			},
 			"engines": {
 				"node": ">=16.0.0"
@@ -3336,17 +3320,6 @@
 				"url": "https://paulmillr.com/funding/"
 			}
 		},
-		"node_modules/@noble/ed25519": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.3.tgz",
-			"integrity": "sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://paulmillr.com/funding/"
-				}
-			]
-		},
 		"node_modules/@noble/hashes": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
@@ -3357,17 +3330,6 @@
 			"funding": {
 				"url": "https://paulmillr.com/funding/"
 			}
-		},
-		"node_modules/@noble/secp256k1": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
-			"integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://paulmillr.com/funding/"
-				}
-			]
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",

--- a/snap/backend/package.json
+++ b/snap/backend/package.json
@@ -28,6 +28,7 @@
 		"test:jenkins:cov": "NODE_OPTIONS=--experimental-vm-modules npx jest --coverage"
 	},
 	"dependencies": {
+		"@metamask/key-tree": "^9.1.1",
 		"@metamask/snaps-cli": "^6.0.2",
 		"@metamask/snaps-sdk": "^3.1.0",
 		"crypto-js": "^4.2.0",

--- a/snap/backend/snap.manifest.json
+++ b/snap/backend/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/symbol/product.git"
   },
   "source": {
-    "shasum": "r9BK/WRHSBTR90A0WUgqH0l0G+6k+JMRlN7Pty+C9aY=",
+    "shasum": "rRtt2/Ee0L2qrqOznyiOFI55h/xul8Pwz02NoTfFhNk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -24,7 +24,15 @@
     "endowment:rpc": {
       "dapps": true,
       "snaps": false
-    }
+    },
+    "snap_getBip44Entropy": [
+      {
+        "coinType": 1
+      },
+      {
+        "coinType": 4343
+      }
+    ]
   },
   "manifestVersion": "0.1"
 }

--- a/snap/backend/src/utils/accountUtils.js
+++ b/snap/backend/src/utils/accountUtils.js
@@ -1,0 +1,30 @@
+import { getBIP44AddressKeyDeriver } from '@metamask/key-tree';
+import { PrivateKey } from 'symbol-sdk';
+import { Network, SymbolFacade } from 'symbol-sdk/symbol';
+
+const accountUtils = {
+	/**
+	 * * Derives a key pair from a mnemonic and an address index.
+	 * @param {104 | 152} identifier - The network identifier.
+	 * @param {number} addressIndex - The address index.
+	 * @returns {Promise<SymbolFacade.KeyPair>} - The derived key pair.
+	 */
+	async deriveKeyPair(identifier, addressIndex) {
+		const coinType = Network.MAINNET.identifier === identifier ? 4343 : 1;
+
+		const rootNode = await snap.request({
+			method: 'snap_getBip44Entropy',
+			params: {
+				coinType
+			}
+		});
+
+		const derivePrivateKey = await getBIP44AddressKeyDeriver(rootNode);
+		const key = await derivePrivateKey(addressIndex);
+
+		const privateKey = new PrivateKey(key.privateKeyBytes);
+		return new SymbolFacade.KeyPair(privateKey);
+	}
+};
+
+export default accountUtils;

--- a/snap/backend/src/utils/accountUtils.js
+++ b/snap/backend/src/utils/accountUtils.js
@@ -1,16 +1,17 @@
 import { getBIP44AddressKeyDeriver } from '@metamask/key-tree';
 import { PrivateKey } from 'symbol-sdk';
-import { Network, SymbolFacade } from 'symbol-sdk/symbol';
+import { SymbolFacade } from 'symbol-sdk/symbol';
 
 const accountUtils = {
 	/**
 	 * * Derives a key pair from a mnemonic and an address index.
-	 * @param {104 | 152} identifier - The network identifier.
+	 * @param {'mainnet' | 'testnet'} networkName - The network name.
 	 * @param {number} addressIndex - The address index.
 	 * @returns {Promise<SymbolFacade.KeyPair>} - The derived key pair.
 	 */
-	async deriveKeyPair(identifier, addressIndex) {
-		const coinType = Network.MAINNET.identifier === identifier ? 4343 : 1;
+	async deriveKeyPair(networkName, addressIndex) {
+		const facade = new SymbolFacade(networkName);
+		const coinType = facade.bip32Path(addressIndex)[1];
 
 		const rootNode = await snap.request({
 			method: 'snap_getBip44Entropy',

--- a/snap/backend/test/utils/accountUtils_spec.js
+++ b/snap/backend/test/utils/accountUtils_spec.js
@@ -2,12 +2,13 @@ import accountUtils from '../../src/utils/accountUtils.js';
 import {
 	describe, it, jest
 } from '@jest/globals';
-import { Network, SymbolFacade } from 'symbol-sdk/symbol';
+import { SymbolFacade } from 'symbol-sdk/symbol';
 
 describe('accountUtils', () => {
 	describe('deriveKeyPair', () => {
-		const generateMockBip44Entropy = identifier => {
-			const coinType = Network.MAINNET.identifier === identifier ? 4343 : 1;
+		const generateMockBip44Entropy = networkName => {
+			const facade = new SymbolFacade(networkName);
+			const coinType = facade.bip32Path(0)[1];
 
 			return {
 				chainCode: '0x90d3d16b776e542d7b1888e502292fc7b18e91f69be869f33a07f95068ae6e6a',
@@ -23,16 +24,16 @@ describe('accountUtils', () => {
 			};
 		};
 
-		const assertDeriveKeyPair = async (identifier, expectedCoinType) => {
+		const assertDeriveKeyPair = async (networkName, expectedCoinType) => {
 			// Arrange:
 			const mockRequest = jest.fn();
 
 			global.snap = { request: mockRequest };
 
-			global.snap.request.mockResolvedValue(generateMockBip44Entropy(identifier));
+			global.snap.request.mockResolvedValue(generateMockBip44Entropy(networkName));
 
 			// Act:
-			const keyPair = await accountUtils.deriveKeyPair(identifier, 0);
+			const keyPair = await accountUtils.deriveKeyPair(networkName, 0);
 
 			// Assert:
 			expect(mockRequest).toHaveBeenCalledWith({
@@ -45,11 +46,11 @@ describe('accountUtils', () => {
 		};
 
 		it('can derive key pair with mainnet network', async () => {
-			await assertDeriveKeyPair(104, 4343);
+			await assertDeriveKeyPair('mainnet', 4343);
 		});
 
 		it('can derive key pair with testnet network', async () => {
-			await assertDeriveKeyPair(152, 1);
+			await assertDeriveKeyPair('testnet', 1);
 		});
 	});
 });

--- a/snap/backend/test/utils/accountUtils_spec.js
+++ b/snap/backend/test/utils/accountUtils_spec.js
@@ -1,0 +1,55 @@
+import accountUtils from '../../src/utils/accountUtils.js';
+import {
+	describe, it, jest
+} from '@jest/globals';
+import { Network, SymbolFacade } from 'symbol-sdk/symbol';
+
+describe('accountUtils', () => {
+	describe('deriveKeyPair', () => {
+		const generateMockBip44Entropy = identifier => {
+			const coinType = Network.MAINNET.identifier === identifier ? 4343 : 1;
+
+			return {
+				chainCode: '0x90d3d16b776e542d7b1888e502292fc7b18e91f69be869f33a07f95068ae6e6a',
+				coin_type: coinType,
+				index: 1,
+				masterFingerprint: 0,
+				parentFingerprint: 1,
+				depth: 2,
+				path: `m / bip32:44' / bip32:${coinType}'`,
+				privateKey: '0x1f53ba3da42800d092a0c331a20a41acce81d2dd6f710106953ada277c502010',
+				publicKey: '0xf2195f2bce44400c76e4a03536e66d9b46840d042e6548e90a5f4d653d7aa133f6'
+                    + '2c18ca655eb4366e59088b3815867535e7ce6ca70baf6507c047a4b7637e5cc6'
+			};
+		};
+
+		const assertDeriveKeyPair = async (identifier, expectedCoinType) => {
+			// Arrange:
+			const mockRequest = jest.fn();
+
+			global.snap = { request: mockRequest };
+
+			global.snap.request.mockResolvedValue(generateMockBip44Entropy(identifier));
+
+			// Act:
+			const keyPair = await accountUtils.deriveKeyPair(identifier, 0);
+
+			// Assert:
+			expect(mockRequest).toHaveBeenCalledWith({
+				method: 'snap_getBip44Entropy',
+				params: {
+					coinType: expectedCoinType
+				}
+			});
+			expect(keyPair).toBeInstanceOf(SymbolFacade.KeyPair);
+		};
+
+		it('can derive key pair with mainnet network', async () => {
+			await assertDeriveKeyPair(104, 4343);
+		});
+
+		it('can derive key pair with testnet network', async () => {
+			await assertDeriveKeyPair(152, 1);
+		});
+	});
+});


### PR DESCRIPTION
## What was the issue?
- To generate a Symbol keypair, we need to derive the keypair from the metamask snap.

## What's the fix?
- Added `deriveKeyPair` to derive keypair from metamask snap.
- It supports coin-type: 4343 (mainnet) and 1 (testnet)