### PR TITLE
[snap/frontend]: Added account list component

### DIFF
--- a/snap/frontend/components/AccountInfo/AccountInfo.spec.jsx
+++ b/snap/frontend/components/AccountInfo/AccountInfo.spec.jsx
@@ -1,6 +1,6 @@
 import AccountInfo from '.';
 import testHelper from '../testHelper';
-import { screen } from '@testing-library/react';
+import { act, fireEvent,screen } from '@testing-library/react';
 
 const context = {
 	dispatch: jest.fn(),
@@ -8,7 +8,8 @@ const context = {
 		selectedAccount: {
 			address: 'address 1',
 			label: 'wallet 1'
-		}
+		},
+		accounts: {}
 	}
 };
 
@@ -37,5 +38,18 @@ describe('components/AccountInfo', () => {
 		expect(address).toBeInTheDocument();
 		expect(label).toBeInTheDocument();
 		expect(copyIcon).toBeInTheDocument();
+	});
+
+	it('opens account list modal box when click on profile image', async () => {
+		// Arrange:
+		testHelper.customRender(<AccountInfo />, context);
+		const image = screen.getByRole('profile-image');
+
+		// Act:
+		await act(async () => fireEvent.click(image));
+
+		// Assert:
+		const modalBox = screen.getByRole('modal');
+		expect(modalBox).toBeInTheDocument();
 	});
 });

--- a/snap/frontend/components/AccountInfo/AccountInfo.spec.jsx
+++ b/snap/frontend/components/AccountInfo/AccountInfo.spec.jsx
@@ -1,6 +1,6 @@
 import AccountInfo from '.';
 import testHelper from '../testHelper';
-import { act, fireEvent,screen } from '@testing-library/react';
+import { act, fireEvent, screen } from '@testing-library/react';
 
 const context = {
 	dispatch: jest.fn(),

--- a/snap/frontend/components/AccountInfo/index.jsx
+++ b/snap/frontend/components/AccountInfo/index.jsx
@@ -7,15 +7,15 @@ const AccountInfo = () => {
 	const { walletState } = useWalletContext();
 	const { accounts, selectedAccount } = walletState;
 
-	const [ isOpenAccountListModalBox, setOpenAccountListModalBox ] = useState(false);
+	const [ accountListModalBoxVisible, setAccountListModalBoxVisible ] = useState(false);
 
 	const handleAccountListModalBox = () => {
-		setOpenAccountListModalBox(!isOpenAccountListModalBox);
+		setAccountListModalBoxVisible(!accountListModalBoxVisible);
 	};
 
 	return (
 		<>
-			<AccountListModalBox accounts={accounts} isOpen={isOpenAccountListModalBox} onRequestClose={setOpenAccountListModalBox} />
+			<AccountListModalBox accounts={accounts} isOpen={accountListModalBoxVisible} onRequestClose={setAccountListModalBoxVisible} />
 
 			<div className='flex flex-col items-center justify-center p-2'>
 				<div role='profile-image' className="rounded-full w-16 h-16 bg-gray-300" onClick={handleAccountListModalBox}/>

--- a/snap/frontend/components/AccountInfo/index.jsx
+++ b/snap/frontend/components/AccountInfo/index.jsx
@@ -1,16 +1,28 @@
 import { useWalletContext } from '../../context';
+import AccountListModalBox from '../AccountListModalBox';
 import Address from '../Address';
+import { useState } from 'react';
 
 const AccountInfo = () => {
 	const { walletState } = useWalletContext();
-	const { selectedAccount } = walletState;
+	const { accounts, selectedAccount } = walletState;
+
+	const [ isOpenAccountListModalBox, setOpenAccountListModalBox ] = useState(false);
+
+	const handleAccountListModalBox = () => {
+		setOpenAccountListModalBox(!isOpenAccountListModalBox);
+	};
 
 	return (
-		selectedAccount && <div className='flex flex-col items-center justify-center p-2'>
-			<div role='profile-image' className="rounded-full w-16 h-16 bg-gray-300" />
-			{/* Text Address and wallet label */}
-			<Address account={selectedAccount} />
-		</div>
+		<>
+			<AccountListModalBox accounts={accounts} isOpen={isOpenAccountListModalBox} onRequestClose={setOpenAccountListModalBox} />
+
+			<div className='flex flex-col items-center justify-center p-2'>
+				<div role='profile-image' className="rounded-full w-16 h-16 bg-gray-300" onClick={handleAccountListModalBox}/>
+				{/* Text Address and wallet label */}
+				<Address account={selectedAccount} />
+			</div>
+		</>
 	);
 };
 

--- a/snap/frontend/components/AccountListModalBox/AccountListModalBox.spec.jsx
+++ b/snap/frontend/components/AccountListModalBox/AccountListModalBox.spec.jsx
@@ -3,29 +3,10 @@ import testHelper from '../testHelper';
 import { screen } from '@testing-library/react';
 
 describe('components/AccountListModalBox', () => {
-	const generateAccountsState = numberOfAccounts => {
-		const accounts = {};
-
-		for (let index = 0; index < numberOfAccounts; index++) {
-			const accountId = `accountId ${index}`;
-			accounts[accountId] = {
-				id: accountId,
-				addressIndex: index,
-				type: 'metamask',
-				networkName: 'network',
-				label: `Wallet ${index}`,
-				address: `Address ${index}`,
-				publicKey: `publicKey ${index}`
-			};
-		}
-
-		return accounts;
-	};
-
 	it('renders account list', () => {
 		// Arrange:
 		const numberOfAccounts = 2;
-		const accounts = generateAccountsState(numberOfAccounts);
+		const accounts = testHelper.generateAccountsState(numberOfAccounts);
 
 		testHelper.customRender(<AccountListModalBox accounts={accounts} isOpen={true} onRequestClose={jest.fn()} />, {});
 

--- a/snap/frontend/components/AccountListModalBox/AccountListModalBox.spec.jsx
+++ b/snap/frontend/components/AccountListModalBox/AccountListModalBox.spec.jsx
@@ -1,0 +1,42 @@
+import AccountListModalBox from '.';
+import testHelper from '../testHelper';
+import { screen } from '@testing-library/react';
+
+describe('components/AccountListModalBox', () => {
+	const generateAccountsState = numberOfAccounts => {
+		const accounts = {};
+
+		for (let index = 0; index < numberOfAccounts; index++) {
+			const accountId = `accountId ${index}`;
+			accounts[accountId] = {
+				id: accountId,
+				addressIndex: index,
+				type: 'metamask',
+				networkName: 'network',
+				label: `Wallet ${index}`,
+				address: `Address ${index}`,
+				publicKey: `publicKey ${index}`
+			};
+		}
+
+		return accounts;
+	};
+
+	it('renders account list', () => {
+		// Arrange:
+		const numberOfAccounts = 2;
+		const accounts = generateAccountsState(numberOfAccounts);
+
+		testHelper.customRender(<AccountListModalBox accounts={accounts} isOpen={true} onRequestClose={jest.fn()} />, {});
+
+		for (let index = 0; index < numberOfAccounts; index++) {
+			// Act:
+			const accountLabel = screen.getByText('Wallet 0');
+			const accountAddress = screen.getByText('Address 0');
+
+			// Assert:
+			expect(accountLabel).toBeInTheDocument();
+			expect(accountAddress).toBeInTheDocument();
+		}
+	});
+});

--- a/snap/frontend/components/AccountListModalBox/index.jsx
+++ b/snap/frontend/components/AccountListModalBox/index.jsx
@@ -1,0 +1,43 @@
+import Button from '../Button';
+import ModalBox from '../ModalBox';
+
+const AccountListModalBox = ({ accounts, isOpen, onRequestClose }) => {
+	const renderAccount = account => {
+		return (
+			<div key={`wallet_${account.id}`} className='flex items-center'>
+				<div className="rounded-full w-10 h-10 bg-gray-300"/>
+				<div className='flex flex-col items-start justify-center p-2'>
+					<div className='font-bold'>{account.label}</div>
+					<div className='truncate w-[180px]'>{account.address}</div>
+				</div>
+			</div>
+		);
+
+	};
+	return (
+		<ModalBox isOpen={isOpen} onRequestClose={onRequestClose}>
+			<div className='flex flex-col px-5 text-center'>
+				<div className='text-2xl font-bold mb-6'>
+                    Wallet
+				</div>
+
+				<div className='flex items-center justify-start mb-6 text-xs'>
+					{
+						Object.keys(accounts).map(key => renderAccount(accounts[key]))
+					}
+				</div>
+
+				<div className='flex justify-center font-bold pt-2'>
+					<Button className='uppercase w-40 h-10 bg-secondary m-2'>
+                        Create
+					</Button>
+					<Button className='uppercase w-40 h-10 bg-secondary m-2'>
+                        Import
+					</Button>
+				</div>
+			</div>
+		</ModalBox>
+	);
+};
+
+export default AccountListModalBox;

--- a/snap/frontend/components/Home/Home.spec.jsx
+++ b/snap/frontend/components/Home/Home.spec.jsx
@@ -7,7 +7,8 @@ const context = {
 	dispatch: {
 		setLoadingStatus: jest.fn(),
 		setNetwork: jest.fn(),
-		setSelectedAccount: jest.fn()
+		setSelectedAccount: jest.fn(),
+		setAccounts: jest.fn()
 	},
 	walletState: {
 		loadingStatus: {
@@ -15,6 +16,7 @@ const context = {
 			message: ''
 		},
 		selectedAccount: {},
+		accounts: {},
 		mosaics: [],
 		transactions: [],
 		currency: {
@@ -65,6 +67,10 @@ describe('components/Home', () => {
 		context.symbolSnap.initialSnap.mockResolvedValue({
 			network: mockNetwork,
 			accounts: {}
+		});
+
+		context.symbolSnap.createAccount.mockResolvedValue({
+			...Object.values(testHelper.generateAccountsState(1))[0]
 		});
 
 		// Act:

--- a/snap/frontend/components/Input/index.jsx
+++ b/snap/frontend/components/Input/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const Input = ({ label, placeholder, value, onChange, type = 'text', className, ...props }) => {
+const Input = ({ label, placeholder, value, onChange, type = 'text', className, disabled = false, ...props }) => {
 	const combinedClassName = `flex flex-col ${className || ''}`;
 
 	return (
@@ -11,7 +11,8 @@ const Input = ({ label, placeholder, value, onChange, type = 'text', className, 
 				value={value}
 				placeholder={placeholder}
 				onChange={e => onChange(e.target.value)}
-				className="px-4 py-2 text-black bg-[#D9D9D9] rounded-xl"
+				className="w-full px-4 py-2 text-black bg-[#D9D9D9] rounded-xl"
+				disabled={disabled}
 			/>
 		</div>
 	);

--- a/snap/frontend/components/testHelper.js
+++ b/snap/frontend/components/testHelper.js
@@ -6,6 +6,23 @@ const testHelper = {
 		return render(<WalletContext.default value={context}>
 			{ui}
 		</WalletContext.default>);
+	},
+	generateAccountsState: numberOfAccounts => {
+		const accounts = {};
+
+		for (let index = 0; index < numberOfAccounts; index++) {
+			const accountId = `accountId ${index}`;
+			accounts[accountId] = {
+				id: accountId,
+				addressIndex: index,
+				type: 'metamask',
+				networkName: 'network',
+				label: `Wallet ${index}`,
+				address: `Address ${index}`,
+				publicKey: `publicKey ${index}`
+			};
+		}
+		return accounts;
 	}
 };
 

--- a/snap/frontend/context/reducer.js
+++ b/snap/frontend/context/reducer.js
@@ -11,6 +11,7 @@ export const initialState = {
 	},
 	network: {},
 	selectedAccount: {},
+	accounts: {},
 	mosaics: [],
 	transactions: []
 };
@@ -19,7 +20,8 @@ export const actionTypes = {
 	SET_SNAP_INSTALLED: 'setSnapInstalled',
 	SET_LOADING_STATUS: 'setLoadingStatus',
 	SET_NETWORK: 'setNetwork',
-	SET_SELECTED_ACCOUNT: 'setSelectedAccount'
+	SET_SELECTED_ACCOUNT: 'setSelectedAccount',
+	SET_ACCOUNTS: 'setAccounts'
 };
 
 export const reducer = (state, action) => {
@@ -32,6 +34,8 @@ export const reducer = (state, action) => {
 		return { ...state, network: action.payload };
 	case actionTypes.SET_SELECTED_ACCOUNT:
 		return { ...state, selectedAccount: action.payload };
+	case actionTypes.SET_ACCOUNTS:
+		return { ...state, accounts: action.payload };
 	default:
 		return state;
 	}

--- a/snap/frontend/utils/dispatchUtils.js
+++ b/snap/frontend/utils/dispatchUtils.js
@@ -28,6 +28,13 @@ const dispatchUtils = dispatch => ({
 	 */
 	setSelectedAccount: account => {
 		dispatch({ type: actionTypes.SET_SELECTED_ACCOUNT, payload: account });
+	},
+	/**
+	 * Set accounts
+	 * @param {Accounts} accounts - The accounts object.
+	 */
+	setAccounts: accounts => {
+		dispatch({ type: actionTypes.SET_ACCOUNTS, payload: accounts });
 	}
 });
 

--- a/snap/frontend/utils/dispatchUtils.spec.js
+++ b/snap/frontend/utils/dispatchUtils.spec.js
@@ -81,4 +81,27 @@ describe('dispatchUtils', () => {
 			expect(dispatchState).toHaveBeenCalledWith({ type: 'setSelectedAccount', payload: account });
 		});
 	});
+
+	describe('setAccounts', () => {
+		it('dispatches SET_ACCOUNTS action with accounts', () => {
+			// Arrange:
+			const accounts = {
+				'account1': {
+					id: 'account1',
+					addressIndex: 1,
+					type: 'metamask',
+					networkName: 'network',
+					label: 'label',
+					address: 'address',
+					publicKey: 'publicKey'
+				}
+			};
+
+			// Act:
+			dispatch.setAccounts(accounts);
+
+			// Assert:
+			expect(dispatchState).toHaveBeenCalledWith({ type: 'setAccounts', payload: accounts });
+		});
+	});
 });

--- a/snap/frontend/utils/helper.js
+++ b/snap/frontend/utils/helper.js
@@ -14,9 +14,13 @@ const helper = {
 		if (0 < Object.keys(snapState.accounts).length) {
 			// set first account as selected account
 			account = Object.values(snapState.accounts)[0];
+			dispatch.setAccounts(snapState.accounts);
 		} else {
 			// create account from snap
 			account = await symbolSnap.createAccount('Wallet 1');
+			dispatch.setAccounts({
+				[account.id]: account
+			});
 		}
 
 		dispatch.setSelectedAccount(account);

--- a/snap/frontend/utils/helper.spec.js
+++ b/snap/frontend/utils/helper.spec.js
@@ -9,7 +9,8 @@ describe('helper', () => {
 		const dispatch = {
 			setLoadingStatus: jest.fn(),
 			setNetwork: jest.fn(),
-			setSelectedAccount: jest.fn()
+			setSelectedAccount: jest.fn(),
+			setAccounts: jest.fn()
 		};
 
 		const symbolSnap = {
@@ -68,6 +69,7 @@ describe('helper', () => {
 			assertSetupSnap(mockSnapState, networkName);
 			expect(symbolSnap.createAccount).not.toHaveBeenCalled();
 			expect(dispatch.setSelectedAccount).toHaveBeenCalledWith(Object.values(mockSnapState.accounts)[0]);
+			expect(dispatch.setAccounts).toHaveBeenCalledWith(mockSnapState.accounts);
 		});
 
 		it('initializes snap and creates account when no accounts are found', async () => {
@@ -89,6 +91,9 @@ describe('helper', () => {
 			assertSetupSnap(mockSnapState, networkName);
 			expect(symbolSnap.createAccount).toHaveBeenCalledWith('Wallet 1');
 			expect(dispatch.setSelectedAccount).toHaveBeenCalledWith(mockAccount);
+			expect(dispatch.setAccounts).toHaveBeenCalledWith({
+				[mockAccount.id]: mockAccount
+			});
 		});
 	});
 });


### PR DESCRIPTION
## What was the issue?
- Display all Symbol accounts from the snap.

## What's the fix?
- Added account list modal box
- click on the profile image, and the modal box pops up.

<img width="1229" alt="image" src="https://github.com/symbol/product/assets/5649156/d94ee499-0e4b-43fe-a766-da751618113c">
