### PR TITLE
[snap/frontend]: create multiple account

### DIFF
--- a/snap/backend/src/utils/accountUtils.js
+++ b/snap/backend/src/utils/accountUtils.js
@@ -4,7 +4,7 @@ import { PrivateKey } from 'symbol-sdk';
 import { SymbolFacade } from 'symbol-sdk/symbol';
 import { v4 as uuidv4 } from 'uuid';
 
-const WalletType = {
+const AccountType = {
 	METAMASK: 'metamask'
 };
 
@@ -41,7 +41,7 @@ const accountUtils = {
 	getLatestAccountIndex(accounts, networkName) {
 		return Object.values(accounts)
 			.filter(walletAccount =>
-				WalletType.METAMASK === walletAccount.account.type
+				AccountType.METAMASK === walletAccount.account.type
 				&& networkName === walletAccount.account.networkName)
 			.reduce((maxIndex, walletAccount) => Math.max(maxIndex, walletAccount.account.addressIndex), -1);
 	},
@@ -63,7 +63,7 @@ const accountUtils = {
 	},
 	async createAccount({ state, requestParams }) {
 		try {
-			const { walletLabel } = requestParams;
+			const { accountLabel } = requestParams;
 			const { network, accounts } = state;
 
 			const facade = new SymbolFacade(network.networkName);
@@ -74,12 +74,12 @@ const accountUtils = {
 			const newKeyPair = await this.deriveKeyPair(network.networkName, newAddressIndex);
 			const accountId = uuidv4();
 
-			const wallet = {
+			const newAccount = {
 				account: {
 					id: accountId,
 					addressIndex: newAddressIndex,
-					type: WalletType.METAMASK,
-					label: walletLabel,
+					type: AccountType.METAMASK,
+					label: accountLabel,
 					address: facade.network.publicKeyToAddress(newKeyPair.publicKey).toString(),
 					publicKey: newKeyPair.publicKey.toString(),
 					networkName: network.networkName
@@ -89,12 +89,12 @@ const accountUtils = {
 
 			state.accounts = {
 				...state.accounts,
-				[accountId]: wallet
+				[accountId]: newAccount
 			};
 
 			await stateManager.update(state);
 
-			return wallet.account;
+			return newAccount.account;
 		} catch (error) {
 			throw new Error(`Failed to create account: ${error.message}`);
 		}

--- a/snap/backend/test/utils/accountUtils_spec.js
+++ b/snap/backend/test/utils/accountUtils_spec.js
@@ -207,7 +207,7 @@ describe('accountUtils', () => {
 				addressIndex: expectedAddressIndex,
 				type: 'metamask',
 				networkName: 'testnet',
-				label: requestParams.walletLabel,
+				label: requestParams.accountLabel,
 				address: 'TDCYZ45MX4IZ7SKEL5UL4ZA7O6KDDUAZZALCA6Y',
 				publicKey: 'FABAD1271A72816961B95CCCAAE1FD1E356F26A6AD3E0A91A25F703C1312F73D'
 			});
@@ -223,7 +223,7 @@ describe('accountUtils', () => {
 			};
 
 			const requestParams = {
-				walletLabel: 'my first wallet'
+				accountLabel: 'my first wallet'
 			};
 
 			await assertCreateAccount(state, requestParams, 0);
@@ -242,7 +242,7 @@ describe('accountUtils', () => {
 			};
 
 			const requestParams = {
-				walletLabel: 'invest wallet'
+				accountLabel: 'invest wallet'
 			};
 
 			await assertCreateAccount(state, requestParams, 3);
@@ -258,7 +258,7 @@ describe('accountUtils', () => {
 			};
 
 			const requestParams = {
-				walletLabel: 'my first wallet'
+				accountLabel: 'my first wallet'
 			};
 
 			// Act + Assert:
@@ -276,7 +276,7 @@ describe('accountUtils', () => {
 			};
 
 			const requestParams = {
-				walletLabel: 'my first wallet'
+				accountLabel: 'my first wallet'
 			};
 
 			jest.spyOn(accountUtils, 'deriveKeyPair').mockRejectedValue(new Error('error'));

--- a/snap/frontend/components/AccountCreateModalBox/AccountCreateModalBox.spec.jsx
+++ b/snap/frontend/components/AccountCreateModalBox/AccountCreateModalBox.spec.jsx
@@ -1,0 +1,130 @@
+import AccountCreateModalBox from '.';
+import helper from '../../utils/helper';
+import testHelper from '../testHelper';
+import { act, fireEvent, screen } from '@testing-library/react';
+
+const context = {
+	dispatch: {
+		setAccounts: jest.fn(),
+		setSelectedAccount: jest.fn()
+	},
+	symbolSnap: {
+		createAccount: jest.fn()
+	},
+	walletState: {
+		accounts: {}
+	}
+};
+
+describe('components/AccountCreateModalBox', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('renders AccountCreateModalBox', () => {
+		// Arrange:
+		testHelper.customRender(<AccountCreateModalBox isOpen={true} onRequestClose={jest.fn()} />, context);
+
+		// Act:
+		const createWalletTitle = screen.getByText('Create Wallet');
+		const createButton = screen.getByText('Create');
+
+		// Assert:
+		expect(createWalletTitle).toBeInTheDocument();
+		expect(createButton).toBeInTheDocument();
+	});
+
+	it('can creates new account', async () => {
+		// Arrange:
+		const onRequestClose = jest.fn();
+
+		testHelper.customRender(<AccountCreateModalBox isOpen={true} onRequestClose={onRequestClose} />, context);
+
+		const createButton = screen.getByText('Create');
+		const inputElement = screen.getByPlaceholderText('Wallet Name');
+
+		const mockNewAccount = Object.values(testHelper.generateAccountsState(1))[0];
+		fireEvent.change(inputElement, { target: { value: mockNewAccount.label } });
+
+		context.symbolSnap.createAccount.mockResolvedValue(mockNewAccount);
+		jest.spyOn(helper, 'createNewAccount');
+
+		// Act:
+		await act(async () => fireEvent.click(createButton));
+
+		// Assert:
+		expect(helper.createNewAccount).toHaveBeenCalledWith(
+			context.dispatch,
+			context.symbolSnap,
+			context.walletState.accounts,
+			mockNewAccount.label
+		);
+		expect(inputElement.value).toBe('');
+		expect(onRequestClose).toHaveBeenCalledWith(false);
+	});
+
+	it('can not creates new account when wallet name is empty', async () => {
+		// Arrange:
+		testHelper.customRender(<AccountCreateModalBox isOpen={true} onRequestClose={jest.fn()} />, context);
+
+		const createButton = screen.getByText('Create');
+		const inputElement = screen.getByPlaceholderText('Wallet Name');
+
+		jest.spyOn(helper, 'createNewAccount');
+
+		fireEvent.change(inputElement, { target: { value: '' } });
+
+		// Act:
+		await act(async () => fireEvent.click(createButton));
+
+		// Assert:
+		expect(helper.createNewAccount).not.toHaveBeenCalled();
+	});
+
+	it('can not creates new account when wallet name already exist', async () => {
+		// Arrange:
+		context.walletState.accounts = testHelper.generateAccountsState(1);
+
+		testHelper.customRender(<AccountCreateModalBox isOpen={true} onRequestClose={jest.fn()} />, context);
+
+		const createButton = screen.getByText('Create');
+		const inputElement = screen.getByPlaceholderText('Wallet Name');
+
+		jest.spyOn(helper, 'createNewAccount');
+
+		fireEvent.change(inputElement, { target: { value: 'Wallet 0' } });
+
+		// Act:
+		await act(async () => fireEvent.click(createButton));
+
+		// Assert:
+		expect(helper.createNewAccount).not.toHaveBeenCalled();
+	});
+
+	const assertValidationError = async (input, context, expectedError) => {
+		// Arrange:
+		testHelper.customRender(<AccountCreateModalBox isOpen={true} onRequestClose={jest.fn()} />, context);
+
+		const createButton = screen.getByText('Create');
+		const inputElement = screen.getByPlaceholderText('Wallet Name');
+
+		fireEvent.change(inputElement, { target: { value: input } });
+
+		// Act:
+		await act(async () => fireEvent.click(createButton));
+
+		// Assert:
+		const errorElement = screen.getByText(expectedError);
+		expect(errorElement).toBeInTheDocument();
+	};
+
+	it('input box can validates wallet name already exists', async () => {
+		// create default wallet
+		context.walletState.accounts = testHelper.generateAccountsState(1);
+		await assertValidationError('Wallet 0', context, 'Wallet name already exists');
+	});
+
+	it('input box can validates wallet name when empty', async () => {
+		await assertValidationError(' ', context, 'Wallet name is required');
+	});
+});

--- a/snap/frontend/components/AccountCreateModalBox/AccountCreateModalBox.spec.jsx
+++ b/snap/frontend/components/AccountCreateModalBox/AccountCreateModalBox.spec.jsx
@@ -26,11 +26,11 @@ describe('components/AccountCreateModalBox', () => {
 		testHelper.customRender(<AccountCreateModalBox isOpen={true} onRequestClose={jest.fn()} />, context);
 
 		// Act:
-		const createWalletTitle = screen.getByText('Create Wallet');
+		const createAccountTitle = screen.getByText('Create Account');
 		const createButton = screen.getByText('Create');
 
 		// Assert:
-		expect(createWalletTitle).toBeInTheDocument();
+		expect(createAccountTitle).toBeInTheDocument();
 		expect(createButton).toBeInTheDocument();
 	});
 
@@ -41,7 +41,7 @@ describe('components/AccountCreateModalBox', () => {
 		testHelper.customRender(<AccountCreateModalBox isOpen={true} onRequestClose={onRequestClose} />, context);
 
 		const createButton = screen.getByText('Create');
-		const inputElement = screen.getByPlaceholderText('Wallet Name');
+		const inputElement = screen.getByPlaceholderText('Account Name');
 
 		const mockNewAccount = Object.values(testHelper.generateAccountsState(1))[0];
 		fireEvent.change(inputElement, { target: { value: mockNewAccount.label } });
@@ -63,12 +63,12 @@ describe('components/AccountCreateModalBox', () => {
 		expect(onRequestClose).toHaveBeenCalledWith(false);
 	});
 
-	it('can not creates new account when wallet name is empty', async () => {
+	it('can not creates new account when account name is empty', async () => {
 		// Arrange:
 		testHelper.customRender(<AccountCreateModalBox isOpen={true} onRequestClose={jest.fn()} />, context);
 
 		const createButton = screen.getByText('Create');
-		const inputElement = screen.getByPlaceholderText('Wallet Name');
+		const inputElement = screen.getByPlaceholderText('Account Name');
 
 		jest.spyOn(helper, 'createNewAccount');
 
@@ -81,18 +81,18 @@ describe('components/AccountCreateModalBox', () => {
 		expect(helper.createNewAccount).not.toHaveBeenCalled();
 	});
 
-	it('can not creates new account when wallet name already exist', async () => {
+	it('can not creates new account when account name already exist', async () => {
 		// Arrange:
 		context.walletState.accounts = testHelper.generateAccountsState(1);
 
 		testHelper.customRender(<AccountCreateModalBox isOpen={true} onRequestClose={jest.fn()} />, context);
 
 		const createButton = screen.getByText('Create');
-		const inputElement = screen.getByPlaceholderText('Wallet Name');
+		const inputElement = screen.getByPlaceholderText('Account Name');
 
 		jest.spyOn(helper, 'createNewAccount');
 
-		fireEvent.change(inputElement, { target: { value: 'Wallet 0' } });
+		fireEvent.change(inputElement, { target: { value: 'Account 0' } });
 
 		// Act:
 		await act(async () => fireEvent.click(createButton));
@@ -106,7 +106,7 @@ describe('components/AccountCreateModalBox', () => {
 		testHelper.customRender(<AccountCreateModalBox isOpen={true} onRequestClose={jest.fn()} />, context);
 
 		const createButton = screen.getByText('Create');
-		const inputElement = screen.getByPlaceholderText('Wallet Name');
+		const inputElement = screen.getByPlaceholderText('Account Name');
 
 		fireEvent.change(inputElement, { target: { value: input } });
 
@@ -118,13 +118,13 @@ describe('components/AccountCreateModalBox', () => {
 		expect(errorElement).toBeInTheDocument();
 	};
 
-	it('input box can validates wallet name already exists', async () => {
-		// create default wallet
+	it('input box can validates account name already exists', async () => {
+		// create default account
 		context.walletState.accounts = testHelper.generateAccountsState(1);
-		await assertValidationError('Wallet 0', context, 'Wallet name already exists');
+		await assertValidationError('Account 0', context, 'Account name already exists');
 	});
 
-	it('input box can validates wallet name when empty', async () => {
-		await assertValidationError(' ', context, 'Wallet name is required');
+	it('input box can validates account name when empty', async () => {
+		await assertValidationError(' ', context, 'Account name is required');
 	});
 });

--- a/snap/frontend/components/AccountCreateModalBox/index.jsx
+++ b/snap/frontend/components/AccountCreateModalBox/index.jsx
@@ -1,0 +1,61 @@
+import { useWalletContext } from '../../context';
+import dispatchHelper from '../../utils/dispatchHelper';
+import helper from '../../utils/helper';
+import Button from '../Button';
+import Input from '../Input';
+import ModalBox from '../ModalBox';
+import { useCallback, useState } from 'react';
+
+const AccountCreateModalBox = ({ isOpen, onRequestClose }) => {
+	const { walletState, dispatch } = useWalletContext();
+	const { accounts } = walletState;
+	const actionDispatchers = dispatchHelper(dispatch);
+
+	const [walletName, setWalletName] = useState('');
+	const [isError, setError] = useState(false);
+
+	const isWalletNameExist = useCallback(
+		newWalletName => Object.values(accounts).some(account => account.label.toUpperCase() === newWalletName.toUpperCase()),
+		[accounts]
+	);
+
+	const handleCreateNewAccount = useCallback(async () => {
+		if (isError)
+			return;
+
+		const newAccountId = await helper.createAccount(actionDispatchers, accounts, walletName);
+		actionDispatchers.setSelectedAccount(newAccountId);
+		setWalletName('');
+		onRequestClose(false);
+	}, [isError, accounts, walletName, actionDispatchers, onRequestClose]);
+
+	const handleOnChangeWalletName = useCallback(event => {
+		const newWalletName = event.target.value;
+		setWalletName(newWalletName);
+		setError(isWalletNameExist(newWalletName));
+	}, [isWalletNameExist]);
+
+	const defaultLabel = `Wallet ${helper.getNewMetamaskWalletIndex(accounts) + 1}`;
+
+	return (
+		<ModalBox isOpen={isOpen} onRequestClose={onRequestClose}>
+			<div className='flex flex-col px-5 text-center'>
+				<div className='text-2xl font-bold mb-6'>
+                        Create Wallet
+				</div>
+
+				<Input label='Wallet Name:' placeholder={defaultLabel} value={walletName} onChange={handleOnChangeWalletName} />
+
+				{
+					isError && <p className='text-red-500 text-xs'>This account name already exists</p>
+				}
+
+				<Button className='uppercase bg-secondary m-2' onClick={handleCreateNewAccount}>
+                    Create
+				</Button>
+			</div>
+		</ModalBox>
+	);
+};
+
+export default AccountCreateModalBox;

--- a/snap/frontend/components/AccountCreateModalBox/index.jsx
+++ b/snap/frontend/components/AccountCreateModalBox/index.jsx
@@ -9,43 +9,43 @@ const AccountCreateModalBox = ({ isOpen, onRequestClose }) => {
 	const { walletState, dispatch, symbolSnap } = useWalletContext();
 	const { accounts } = walletState;
 
-	const [walletName, setWalletName] = useState('');
+	const [accountName, setAccountName] = useState('');
 	const [error, setError] = useState('');
 
-	const isWalletNameExist = newWalletName => {
-		return Object.values(accounts).some(account => account.label.toUpperCase() === newWalletName.toUpperCase());
+	const isAccountNameExist = newAccountName => {
+		return Object.values(accounts).some(account => account.label.toUpperCase() === newAccountName.toUpperCase());
 	};
 
-	const validateWalletName = walletName => {
-		if ('' === walletName.trim())
-			return 'Wallet name is required';
-		if (isWalletNameExist(walletName))
-			return 'Wallet name already exists';
+	const validateAccountName = accountName => {
+		if ('' === accountName.trim())
+			return 'Account name is required';
+		if (isAccountNameExist(accountName))
+			return 'Account name already exists';
 	};
 
 	const handleCreateNewAccount = async () => {
-		if (error || '' === walletName)
+		if (error || '' === accountName)
 			return;
 
-		await helper.createNewAccount(dispatch, symbolSnap, accounts, walletName);
+		await helper.createNewAccount(dispatch, symbolSnap, accounts, accountName);
 
-		setWalletName('');
+		setAccountName('');
 		onRequestClose(false);
 	};
 
-	const handleOnChangeWalletName = newWalletName => {
-		setWalletName(newWalletName);
-		setError(validateWalletName(newWalletName));
+	const handleOnChangeAccountName = newAccountName => {
+		setAccountName(newAccountName);
+		setError(validateAccountName(newAccountName));
 	};
 
 	return (
 		<ModalBox isOpen={isOpen} onRequestClose={onRequestClose}>
 			<div className='flex flex-col px-5 text-center'>
 				<div className='text-2xl font-bold mb-6'>
-                        Create Wallet
+                        Create Account
 				</div>
 
-				<Input label='Wallet Name:' placeholder='Wallet Name' value={walletName} onChange={handleOnChangeWalletName} />
+				<Input label='Account Name:' placeholder='Account Name' value={accountName} onChange={handleOnChangeAccountName} />
 
 				{
 					error && <p className='text-red-500 text-xs'>{error}</p>

--- a/snap/frontend/components/AccountInfo/index.jsx
+++ b/snap/frontend/components/AccountInfo/index.jsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 
 const AccountInfo = () => {
 	const { walletState } = useWalletContext();
-	const { accounts, selectedAccount } = walletState;
+	const { selectedAccount } = walletState;
 
 	const [ accountListModalBoxVisible, setAccountListModalBoxVisible ] = useState(false);
 
@@ -15,7 +15,7 @@ const AccountInfo = () => {
 
 	return (
 		<>
-			<AccountListModalBox accounts={accounts} isOpen={accountListModalBoxVisible} onRequestClose={setAccountListModalBoxVisible} />
+			<AccountListModalBox isOpen={accountListModalBoxVisible} onRequestClose={setAccountListModalBoxVisible} />
 
 			<div className='flex flex-col items-center justify-center p-2'>
 				<div role='profile-image' className="rounded-full w-16 h-16 bg-gray-300" onClick={handleAccountListModalBox}/>

--- a/snap/frontend/components/AccountListModalBox/AccountListModalBox.spec.jsx
+++ b/snap/frontend/components/AccountListModalBox/AccountListModalBox.spec.jsx
@@ -1,14 +1,27 @@
 import AccountListModalBox from '.';
 import testHelper from '../testHelper';
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
+
+const context = {
+	dispatch: {
+		setSelectedAccount: jest.fn()
+	},
+	walletState: {
+		selectedAccount: {
+			address: 'address 1',
+			label: 'wallet 1'
+		},
+		accounts: {}
+	}
+};
 
 describe('components/AccountListModalBox', () => {
 	it('renders account list', () => {
 		// Arrange:
 		const numberOfAccounts = 2;
-		const accounts = testHelper.generateAccountsState(numberOfAccounts);
+		context.walletState.accounts = testHelper.generateAccountsState(numberOfAccounts);
 
-		testHelper.customRender(<AccountListModalBox accounts={accounts} isOpen={true} onRequestClose={jest.fn()} />, {});
+		testHelper.customRender(<AccountListModalBox isOpen={true} onRequestClose={jest.fn()} />, context);
 
 		for (let index = 0; index < numberOfAccounts; index++) {
 			// Act:
@@ -19,5 +32,34 @@ describe('components/AccountListModalBox', () => {
 			expect(accountLabel).toBeInTheDocument();
 			expect(accountAddress).toBeInTheDocument();
 		}
+	});
+
+	it('dispatch selects account when click on address', () => {
+		// Arrange:
+		const numberOfAccounts = 2;
+		context.walletState.accounts = testHelper.generateAccountsState(numberOfAccounts);
+
+		testHelper.customRender(<AccountListModalBox isOpen={true} onRequestClose={jest.fn()} />, context);
+
+		// Act:
+		const accountAddress = screen.getByText('Address 1');
+		fireEvent.click(accountAddress);
+
+		// Assert:
+		expect(context.dispatch.setSelectedAccount).toHaveBeenCalledWith(Object.values(context.walletState.accounts)[1]);
+	});
+
+	it('renders account create modal box when click on create button', () => {
+		// Arrange:
+		testHelper.customRender(<AccountListModalBox isOpen={true} onRequestClose={jest.fn()} />, context);
+
+		const createButton = screen.getByText('Create');
+
+		// Act:
+		fireEvent.click(createButton);
+
+		// Assert:
+		const createWalletScreen = screen.getByText('Create Wallet');
+		expect(createWalletScreen).toBeInTheDocument();
 	});
 });

--- a/snap/frontend/components/AccountListModalBox/AccountListModalBox.spec.jsx
+++ b/snap/frontend/components/AccountListModalBox/AccountListModalBox.spec.jsx
@@ -25,7 +25,7 @@ describe('components/AccountListModalBox', () => {
 
 		for (let index = 0; index < numberOfAccounts; index++) {
 			// Act:
-			const accountLabel = screen.getByText('Wallet 0');
+			const accountLabel = screen.getByText('Account 0');
 			const accountAddress = screen.getByText('Address 0');
 
 			// Assert:
@@ -59,7 +59,7 @@ describe('components/AccountListModalBox', () => {
 		fireEvent.click(createButton);
 
 		// Assert:
-		const createWalletScreen = screen.getByText('Create Wallet');
-		expect(createWalletScreen).toBeInTheDocument();
+		const createAccountScreen = screen.getByText('Create Account');
+		expect(createAccountScreen).toBeInTheDocument();
 	});
 });

--- a/snap/frontend/components/AccountListModalBox/index.jsx
+++ b/snap/frontend/components/AccountListModalBox/index.jsx
@@ -1,10 +1,28 @@
+import { useWalletContext } from '../../context';
+import AccountCreateModalBox from '../AccountCreateModalBox';
 import Button from '../Button';
 import ModalBox from '../ModalBox';
+import { useState } from 'react';
 
-const AccountListModalBox = ({ accounts, isOpen, onRequestClose }) => {
+const AccountListModalBox = ({ isOpen, onRequestClose }) => {
+	const { walletState, dispatch } = useWalletContext();
+	const { accounts } = walletState;
+	const [ accountCreateModalBoxVisible, setAccountCreateModalBoxVisible ] = useState(false);
+
+	const handleOpenAccountCreateModalBox = () => {
+		setAccountCreateModalBoxVisible(!accountCreateModalBoxVisible);
+		onRequestClose(false);
+	};
+
+	const handleSelectAccount = account => {
+		dispatch.setSelectedAccount(account);
+		onRequestClose(false);
+	};
+
 	const renderAccount = account => {
 		return (
-			<div key={`wallet_${account.id}`} className='flex items-center'>
+			<div key={`wallet_${account.id}`} className='flex items-center cursor-pointer'
+				onClick={() => handleSelectAccount(account)}>
 				<div className="rounded-full w-10 h-10 bg-gray-300"/>
 				<div className='flex flex-col items-start justify-center p-2'>
 					<div className='font-bold'>{account.label}</div>
@@ -15,28 +33,32 @@ const AccountListModalBox = ({ accounts, isOpen, onRequestClose }) => {
 
 	};
 	return (
-		<ModalBox isOpen={isOpen} onRequestClose={onRequestClose}>
-			<div className='flex flex-col px-5 text-center'>
-				<div className='text-2xl font-bold mb-6'>
+		<>
+			<ModalBox isOpen={isOpen} onRequestClose={onRequestClose}>
+				<div className='flex flex-col px-5 text-center'>
+					<div className='text-2xl font-bold mb-6'>
                     Wallet
-				</div>
+					</div>
 
-				<div className='flex items-center justify-start mb-6 text-xs'>
-					{
-						Object.keys(accounts).map(key => renderAccount(accounts[key]))
-					}
-				</div>
+					<div className='flex flex-col overflow-y-auto h-72 items-center justify-start mb-6 text-xs'>
+						{
+							Object.keys(accounts).map(key => renderAccount(accounts[key]))
+						}
+					</div>
 
-				<div className='flex justify-center font-bold pt-2'>
-					<Button className='uppercase w-40 h-10 bg-secondary m-2'>
+					<div className='flex justify-center font-bold pt-2'>
+						<Button className='uppercase w-40 h-10 bg-secondary m-2' onClick={handleOpenAccountCreateModalBox}>
                         Create
-					</Button>
-					<Button className='uppercase w-40 h-10 bg-secondary m-2'>
+						</Button>
+						<Button className='uppercase w-40 h-10 bg-secondary m-2'>
                         Import
-					</Button>
+						</Button>
+					</div>
 				</div>
-			</div>
-		</ModalBox>
+			</ModalBox>
+
+			<AccountCreateModalBox isOpen={accountCreateModalBoxVisible} onRequestClose={setAccountCreateModalBoxVisible} />
+		</>
 	);
 };
 

--- a/snap/frontend/components/testHelper.js
+++ b/snap/frontend/components/testHelper.js
@@ -17,7 +17,7 @@ const testHelper = {
 				addressIndex: index,
 				type: 'metamask',
 				networkName: 'network',
-				label: `Wallet ${index}`,
+				label: `Account ${index}`,
 				address: `Address ${index}`,
 				publicKey: `publicKey ${index}`
 			};

--- a/snap/frontend/utils/helper.js
+++ b/snap/frontend/utils/helper.js
@@ -29,6 +29,13 @@ const helper = {
 			isLoading: false,
 			message: ''
 		});
+	},
+	async createNewAccount (dispatch, symbolSnap, accounts, walletName) {
+		const newAccount = await symbolSnap.createAccount(walletName);
+
+		// update account state
+		dispatch.setAccounts({ ...accounts, [newAccount.id]: newAccount });
+		dispatch.setSelectedAccount(newAccount);
 	}
 };
 

--- a/snap/frontend/utils/helper.spec.js
+++ b/snap/frontend/utils/helper.spec.js
@@ -1,22 +1,23 @@
 import helper from './helper';
+import testHelper from '../components/testHelper';
 
 describe('helper', () => {
+	const dispatch = {
+		setLoadingStatus: jest.fn(),
+		setNetwork: jest.fn(),
+		setSelectedAccount: jest.fn(),
+		setAccounts: jest.fn()
+	};
+
+	const symbolSnap = {
+		initialSnap: jest.fn(),
+		createAccount: jest.fn()
+	};
+
 	describe('setupSnap', () => {
 		beforeEach(() => {
 			jest.clearAllMocks();
 		});
-
-		const dispatch = {
-			setLoadingStatus: jest.fn(),
-			setNetwork: jest.fn(),
-			setSelectedAccount: jest.fn(),
-			setAccounts: jest.fn()
-		};
-
-		const symbolSnap = {
-			initialSnap: jest.fn(),
-			createAccount: jest.fn()
-		};
 
 		const mockSnapState = {
 			network: {
@@ -94,6 +95,26 @@ describe('helper', () => {
 			expect(dispatch.setAccounts).toHaveBeenCalledWith({
 				[mockAccount.id]: mockAccount
 			});
+		});
+	});
+
+	describe('createNewAccount', () => {
+		it('should create new account and updates account state', async () => {
+			// Arrange:
+			const accounts = {};
+
+			const walletName = 'new Wallet';
+			const newAccount = Object.values(testHelper.generateAccountsState(1))[0];
+
+			symbolSnap.createAccount.mockResolvedValue(newAccount);
+
+			// Act:
+			await helper.createNewAccount(dispatch, symbolSnap, accounts, walletName);
+
+			// Assert:
+			expect(symbolSnap.createAccount).toHaveBeenCalledWith(walletName);
+			expect(dispatch.setAccounts).toHaveBeenCalledWith({ ...accounts, [newAccount.id]: newAccount });
+			expect(dispatch.setSelectedAccount).toHaveBeenCalledWith(newAccount);
 		});
 	});
 });

--- a/snap/frontend/utils/snap.js
+++ b/snap/frontend/utils/snap.js
@@ -108,10 +108,10 @@ const symbolSnapFactory = {
 			},
 			/**
 			 * Create an account in snap MetaMask.
-			 * @param {string} walletLabel - The label of the wallet.
+			 * @param {string} accountLabel - The label of the account.
 			 * @returns {Account} The account object returned by the snap.
 			 */
-			async createAccount(walletLabel) {
+			async createAccount(accountLabel) {
 				const account = await provider.request({
 					method: 'wallet_invokeSnap',
 					params: {
@@ -119,7 +119,7 @@ const symbolSnapFactory = {
 						request: {
 							method: 'createAccount',
 							params: {
-								walletLabel
+								accountLabel
 							}
 						}
 					}

--- a/snap/frontend/utils/snap.spec.js
+++ b/snap/frontend/utils/snap.spec.js
@@ -218,12 +218,12 @@ describe('symbolSnapFactory', () => {
 	describe('createAccount', () => {
 		it('returns account data when provider request is successful', async () => {
 			// Arrange:
-			const walletLabel = 'Test Wallet';
+			const accountLabel = 'Test Wallet';
 			const mockAccountData = {
 				id: '1234',
 				addressIndex: 0,
 				address: 'TBZ6JU7K5Y3W4H3XJ7XJ5JQW6X3J5JQW6X3J5JQW',
-				label: walletLabel,
+				label: accountLabel,
 				networkName: 'testnet',
 				publicKey: '1234',
 				type: 'metamask'
@@ -232,7 +232,7 @@ describe('symbolSnapFactory', () => {
 			mockProvider.request.mockResolvedValue(mockAccountData);
 
 			// Act:
-			const result = await symbolSnap.createAccount(walletLabel);
+			const result = await symbolSnap.createAccount(accountLabel);
 
 			// Assert:
 			expect(result).toEqual(mockAccountData);
@@ -243,7 +243,7 @@ describe('symbolSnapFactory', () => {
 					request: {
 						method: 'createAccount',
 						params: {
-							walletLabel
+							accountLabel
 						}
 					}
 				}


### PR DESCRIPTION
## What was the issue?
- it does not allow create multiple accounts

## What's the fix?
- Added AccountCreateModalBox components containing an input box for the wallet name.
- When a new account is created, it will update the account list and selected account state.
- Validation of wallet name

## Screeshot
![image](https://github.com/symbol/product/assets/5649156/2b656807-3e6c-48e8-85ff-1a39553b2af3)
Validation Input box

![image](https://github.com/symbol/product/assets/5649156/4ccdd58b-0cb2-4e82-bf92-45303151df0e)
Success created new account
