### PR TITLE
[snap]: Implement currecny (USD/JPY) support in navbar

### DIFF
--- a/snap/backend/snap.manifest.json
+++ b/snap/backend/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/symbol/product.git"
   },
   "source": {
-    "shasum": "DdjQn/6vcAS1xj1zbAscvVZpcT0rX0+nbvVWOP7tlBk=",
+    "shasum": "RGSYTuioTQOf0MuhZPO3RRDOVHbVupuvF3Ibo932umw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/snap/backend/snap.manifest.json
+++ b/snap/backend/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/symbol/product.git"
   },
   "source": {
-    "shasum": "N38mDA7iqEkL58/y3QgO0SjmpaPa3zEzGOiNgjOlTi4=",
+    "shasum": "DdjQn/6vcAS1xj1zbAscvVZpcT0rX0+nbvVWOP7tlBk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -20,6 +20,16 @@
   "initialPermissions": {
     "snap_dialog": {},
     "snap_manageState": {},
+    "endowment:cronjob": {
+      "jobs": [
+        {
+          "expression": "* * * * *",
+          "request": {
+            "method": "fetchCurrencyPrice"
+          }
+        }
+      ]
+    },
     "endowment:network-access": {},
     "endowment:rpc": {
       "dapps": true,

--- a/snap/backend/src/config.js
+++ b/snap/backend/src/config.js
@@ -4,7 +4,7 @@ const config = {
 		testnet: 'https://testnet.symbol.services'
 	},
 	cryptoCompareURL: 'https://min-api.cryptocompare.com/data/price?fsym=xym&tsyms=',
-	supportCurrency: ['USD', 'JPY']
+	supportCurrency: ['usd', 'jpy']
 };
 
 export default config;

--- a/snap/backend/src/config.js
+++ b/snap/backend/src/config.js
@@ -2,7 +2,9 @@ const config = {
 	statisticsServiceURL: {
 		mainnet: 'https://symbol.services',
 		testnet: 'https://testnet.symbol.services'
-	}
+	},
+	cryptoCompareURL: 'https://min-api.cryptocompare.com/data/price?fsym=xym&tsyms=',
+	supportCurrency: ['USD', 'JPY']
 };
 
 export default config;

--- a/snap/backend/src/index.js
+++ b/snap/backend/src/index.js
@@ -1,6 +1,7 @@
 import stateManager from './stateManager.js';
 import accountUtils from './utils/accountUtils.js';
 import networkUtils from './utils/networkUtils.js';
+import priceUtils from './utils/priceUtils.js';
 
 // eslint-disable-next-line import/prefer-default-export
 export const onRpcRequest = async ({ request }) => {
@@ -10,6 +11,7 @@ export const onRpcRequest = async ({ request }) => {
 
 	if (!state) {
 		state = {
+			currencies: {},
 			accounts: {},
 			network: {}
 		};
@@ -24,10 +26,12 @@ export const onRpcRequest = async ({ request }) => {
 	switch (request.method) {
 	case 'initialSnap':
 		await networkUtils.switchNetwork(apiParams);
+		await priceUtils.getPrice(apiParams);
 
 		return {
 			...state,
-			accounts: accountUtils.getAccounts(apiParams)
+			accounts: accountUtils.getAccounts(apiParams),
+			currency: await priceUtils.getCurrencyPrice(apiParams)
 		};
 	case 'createAccount':
 		return accountUtils.createAccount(apiParams);
@@ -37,6 +41,19 @@ export const onRpcRequest = async ({ request }) => {
 		return state.network;
 	case 'switchNetwork':
 		return networkUtils.switchNetwork(apiParams);
+	case 'getCurrency':
+		return priceUtils.getCurrencyPrice(apiParams);
+	default:
+		throw new Error('Method not found.');
+	}
+};
+
+export const onCronjob = async ({ request }) => {
+	const state = await stateManager.getState();
+
+	switch (request.method) {
+	case 'fetchCurrencyPrice':
+		return priceUtils.getPrice({ state });
 	default:
 		throw new Error('Method not found.');
 	}

--- a/snap/backend/src/services/cryptocompareClient.js
+++ b/snap/backend/src/services/cryptocompareClient.js
@@ -1,0 +1,32 @@
+import config from '../config.js';
+import fetchUtils from '../utils/fetchUtils.js';
+
+const cryptoCompareClient = {
+	/**
+     * Fetch the price of the supported currencies.
+     * @returns {Promise<PriceInfo>} The price of the supported currencies.
+     */
+	fetchPrice: async () => {
+		try {
+			const currencies = config.supportCurrency.join(',');
+			const prices = await fetchUtils.fetchData(`${config.cryptoCompareURL}${currencies}`, 'GET');
+
+			return prices;
+		} catch (error) {
+			throw new Error(`Failed to fetch price from cryptoCompare service: ${error.message}`);
+		}
+	}
+};
+
+export default cryptoCompareClient;
+
+// region type declarations
+
+/**
+ * Result of a price request.
+ * @typedef {object} PriceInfo
+ * @property {number} USD - The conversion rate to US Dollars.
+ * @property {number} JPY - The conversion rate to Japanese Yen.
+ */
+
+// endregion

--- a/snap/backend/src/services/cryptocompareClient.js
+++ b/snap/backend/src/services/cryptocompareClient.js
@@ -11,7 +11,10 @@ const cryptoCompareClient = {
 			const currencies = config.supportCurrency.join(',');
 			const prices = await fetchUtils.fetchData(`${config.cryptoCompareURL}${currencies}`, 'GET');
 
-			return prices;
+			return {
+				usd: prices.USD,
+				jpy: prices.JPY
+			};
 		} catch (error) {
 			throw new Error(`Failed to fetch price from cryptoCompare service: ${error.message}`);
 		}
@@ -25,8 +28,8 @@ export default cryptoCompareClient;
 /**
  * Result of a price request.
  * @typedef {object} PriceInfo
- * @property {number} USD - The conversion rate to US Dollars.
- * @property {number} JPY - The conversion rate to Japanese Yen.
+ * @property {number} usd - The conversion rate to US Dollars.
+ * @property {number} jpy - The conversion rate to Japanese Yen.
  */
 
 // endregion

--- a/snap/backend/src/services/cryptocompareClient.js
+++ b/snap/backend/src/services/cryptocompareClient.js
@@ -3,9 +3,9 @@ import fetchUtils from '../utils/fetchUtils.js';
 
 const cryptoCompareClient = {
 	/**
-     * Fetch the price of the supported currencies.
-     * @returns {Promise<PriceInfo>} The price of the supported currencies.
-     */
+	 * Fetch the price of the supported currencies.
+	 * @returns {Promise<PriceInfo>} The price of the supported currencies.
+	 */
 	fetchPrice: async () => {
 		try {
 			const currencies = config.supportCurrency.join(',');

--- a/snap/backend/src/utils/priceUtils.js
+++ b/snap/backend/src/utils/priceUtils.js
@@ -13,7 +13,7 @@ const priceUtils = {
 	async getCurrencyPrice({ state, requestParams }) {
 		const { currency } = requestParams;
 
-		if (-1 === config.supportCurrency.indexOf(currency.toUpperCase()))
+		if (-1 === config.supportCurrency.indexOf(currency.toLowerCase()))
 			throw new Error('Currency not supported.');
 
 		return {

--- a/snap/backend/src/utils/priceUtils.js
+++ b/snap/backend/src/utils/priceUtils.js
@@ -1,0 +1,26 @@
+import config from '../config.js';
+import cryptoCompareClient from '../services/cryptocompareClient.js';
+import stateManager from '../stateManager.js';
+
+const priceUtils = {
+	async getPrice({ state }) {
+		const price = await cryptoCompareClient.fetchPrice();
+
+		state.currencies = price;
+
+		await stateManager.update(state);
+	},
+	async getCurrencyPrice({ state, requestParams }) {
+		const { currency } = requestParams;
+
+		if (-1 === config.supportCurrency.indexOf(currency.toUpperCase()))
+			throw new Error('Currency not supported.');
+
+		return {
+			symbol: currency,
+			price: state.currencies[currency]
+		};
+	}
+};
+
+export default priceUtils;

--- a/snap/backend/test/index_spec.js
+++ b/snap/backend/test/index_spec.js
@@ -15,265 +15,283 @@ global.snap = {
 	request: jest.fn()
 };
 
-describe('onRpcRequest', () => {
-	const mockNodeInfo = {
-		identifier: 104,
-		networkName: 'mainnet',
-		url: 'http://localhost:3000'
-	};
-
-	const mockCurrencies = {
-		USD: 0.25,
-		EUR: 0.20
-	};
-
-	beforeEach(() => {
-		jest.clearAllMocks();
-
-		stateManager.getState.mockResolvedValue({
-			accounts: {},
-			network: mockNodeInfo,
-			currencies: mockCurrencies
-		});
-	});
-
-	describe('initialSnap', () => {
-		const assertInitialSnap = async (state, expectedState) => {
-			// Arrange:
-			stateManager.getState.mockResolvedValue(state);
-			statisticsClient.getNodeInfo.mockResolvedValue(mockNodeInfo);
-			cryptoCompareClient.fetchPrice.mockResolvedValue(mockCurrencies);
-
-			// Act:
-			const response = await onRpcRequest({
+describe('index', () => {
+	const runBasicRequestThrowErrorTest = async RequestType => {
+		it('throws an error if the requested method does not exist', async () => {
+			// Act + Assert:
+			await expect(RequestType({
 				request: {
-					method: 'initialSnap',
-					params: {
-						networkName: 'mainnet',
-						currency: 'USD'
-					}
+					method: 'unknownMethod'
 				}
-			});
+			})).rejects.toThrow('Method not found.');
+		});
+	};
 
-			// Assert:
-			expect(response).toStrictEqual(expectedState);
+	describe('onRpcRequest', () => {
+		const mockNodeInfo = {
+			identifier: 104,
+			networkName: 'mainnet',
+			url: 'http://localhost:3000'
 		};
 
-		it('returns basic snap states', async () => {
-			await assertInitialSnap(null, {
+		const mockCurrencies = {
+			USD: 0.25,
+			EUR: 0.20
+		};
+
+		beforeEach(() => {
+			jest.clearAllMocks();
+
+			stateManager.getState.mockResolvedValue({
 				accounts: {},
-				currencies: mockCurrencies,
 				network: mockNodeInfo,
-				currency: {
-					symbol: 'USD',
-					price: 0.25
-				}
+				currencies: mockCurrencies
 			});
 		});
 
-		it('returns snap states with accounts', async () => {
-			// Arrange:
-			const state = {
-				accounts: {
-					'0x1': {
-						account: {
+		runBasicRequestThrowErrorTest(onRpcRequest);
+
+		describe('initialSnap', () => {
+			const assertInitialSnap = async (state, expectedState) => {
+				// Arrange:
+				stateManager.getState.mockResolvedValue(state);
+				statisticsClient.getNodeInfo.mockResolvedValue(mockNodeInfo);
+				cryptoCompareClient.fetchPrice.mockResolvedValue(mockCurrencies);
+
+				// Act:
+				const response = await onRpcRequest({
+					request: {
+						method: 'initialSnap',
+						params: {
+							networkName: 'mainnet',
+							currency: 'USD'
+						}
+					}
+				});
+
+				// Assert:
+				expect(response).toStrictEqual(expectedState);
+			};
+
+			it('returns basic snap states', async () => {
+				await assertInitialSnap(null, {
+					accounts: {},
+					currencies: mockCurrencies,
+					network: mockNodeInfo,
+					currency: {
+						symbol: 'USD',
+						price: 0.25
+					}
+				});
+			});
+
+			it('returns snap states with accounts', async () => {
+				// Arrange:
+				const state = {
+					accounts: {
+						'0x1': {
+							account: {
+								id: '0x1',
+								address: 'address',
+								label: 'Primary Account',
+								networkName: 'mainnet'
+							},
+							privateKey: 'private key'
+						},
+						'0x2': {
+							account: {
+								id: '0x2',
+								address: 'address',
+								label: 'Primary Account',
+								networkName: 'testnet'
+							},
+							privateKey: 'private key'
+						}
+					},
+					network: mockNodeInfo
+				};
+
+				await assertInitialSnap(state, {
+					accounts: {
+						'0x1': {
 							id: '0x1',
 							address: 'address',
 							label: 'Primary Account',
 							networkName: 'mainnet'
-						},
-						privateKey: 'private key'
+						}
 					},
-					'0x2': {
-						account: {
-							id: '0x2',
-							address: 'address',
-							label: 'Primary Account',
-							networkName: 'testnet'
-						},
-						privateKey: 'private key'
+					network: mockNodeInfo,
+					currencies: mockCurrencies,
+					currency: {
+						symbol: 'USD',
+						price: 0.25
 					}
-				},
-				network: mockNodeInfo
-			};
-
-			await assertInitialSnap(state, {
-				accounts: {
-					'0x1': {
-						id: '0x1',
-						address: 'address',
-						label: 'Primary Account',
-						networkName: 'mainnet'
-					}
-				},
-				network: mockNodeInfo,
-				currencies: mockCurrencies,
-				currency: {
-					symbol: 'USD',
-					price: 0.25
-				}
+				});
 			});
 		});
-	});
 
-	it('throws an error if the requested method does not exist', async () => {
-		// Act + Assert:
-		await expect(onRpcRequest({
-			request: {
-				method: 'unknownMethod'
-			}
-		})).rejects.toThrow('Method not found.');
-	});
+		describe('createAccount', () => {
+			it('returns new created account', async () => {
+				// Arrange:
+				jest.spyOn(accountUtils, 'createAccount').mockResolvedValue();
 
-	describe('createAccount', () => {
-		it('returns new created account', async () => {
-			// Arrange:
-			jest.spyOn(accountUtils, 'createAccount').mockResolvedValue();
+				// Act:
+				await onRpcRequest({
+					request: {
+						method: 'createAccount',
+						params: {
+							accountLabel: 'my wallet'
+						}
+					}
+				});
 
-			// Act:
-			await onRpcRequest({
-				request: {
-					method: 'createAccount',
-					params: {
+				// Assert:
+				expect(accountUtils.createAccount).toHaveBeenCalledWith({
+					state: {
+						accounts: {},
+						network: mockNodeInfo,
+						currencies: mockCurrencies
+					},
+					requestParams: {
 						accountLabel: 'my wallet'
 					}
-				}
-			});
-
-			// Assert:
-			expect(accountUtils.createAccount).toHaveBeenCalledWith({
-				state: {
-					accounts: {},
-					network: mockNodeInfo,
-					currencies: mockCurrencies
-				},
-				requestParams: {
-					accountLabel: 'my wallet'
-				}
+				});
 			});
 		});
-	});
 
-	describe('importAccount', () => {
-		it('returns new import account', async () => {
-			// Arrange:
-			jest.spyOn(accountUtils, 'importAccount').mockResolvedValue();
+		describe('importAccount', () => {
+			it('returns new import account', async () => {
+				// Arrange:
+				jest.spyOn(accountUtils, 'importAccount').mockResolvedValue();
 
-			// Act:
-			await onRpcRequest({
-				request: {
-					method: 'importAccount',
-					params: {
+				// Act:
+				await onRpcRequest({
+					request: {
+						method: 'importAccount',
+						params: {
+							accountLabel: 'my wallet',
+							privateKey: 'private key'
+						}
+					}
+				});
+
+				// Assert:
+				expect(accountUtils.importAccount).toHaveBeenCalledWith({
+					state: {
+						accounts: {},
+						currencies: mockCurrencies,
+						network: mockNodeInfo
+					},
+					requestParams: {
 						accountLabel: 'my wallet',
 						privateKey: 'private key'
 					}
-				}
-			});
-
-			// Assert:
-			expect(accountUtils.importAccount).toHaveBeenCalledWith({
-				state: {
-					accounts: {},
-					network: mockNodeInfo
-				},
-				requestParams: {
-					accountLabel: 'my wallet',
-					privateKey: 'private key'
-				}
+				});
 			});
 		});
-	});
 
-	describe('getNetwork', () => {
-		it('returns the current network', async () => {
-			// Act:
-			const response = await onRpcRequest({
-				request: {
-					method: 'getNetwork'
-				}
-			});
-
-			// Assert:
-			expect(response).toStrictEqual(mockNodeInfo);
-		});
-	});
-
-	describe('switchNetwork', () => {
-		it('switches the network', async () => {
-			// Arrange:
-			const mockExpectedNodeInfo = {
-				identifier: 152,
-				networkName: 'testnet',
-				url: 'http://localhost:3000'
-			};
-
-			statisticsClient.getNodeInfo.mockResolvedValue(mockExpectedNodeInfo);
-
-			// Act:
-			const response = await onRpcRequest({
-				request: {
-					method: 'switchNetwork',
-					params: {
-						networkName: 'testnet'
+		describe('getNetwork', () => {
+			it('returns the current network', async () => {
+				// Act:
+				const response = await onRpcRequest({
+					request: {
+						method: 'getNetwork'
 					}
-				}
+				});
+
+				// Assert:
+				expect(response).toStrictEqual(mockNodeInfo);
 			});
-
-			// Assert:
-			expect(response).toStrictEqual(mockExpectedNodeInfo);
 		});
-	});
 
-	describe('getCurrency', () => {
-		it('returns the currency given by symbol', async () => {
-			// Arrange + Act:
-			const response = await onRpcRequest({
-				request: {
-					method: 'getCurrency',
-					params: {
-						currency: 'USD'
+		describe('switchNetwork', () => {
+			it('switches the network', async () => {
+				// Arrange:
+				const mockExpectedNodeInfo = {
+					identifier: 152,
+					networkName: 'testnet',
+					url: 'http://localhost:3000'
+				};
+
+				statisticsClient.getNodeInfo.mockResolvedValue(mockExpectedNodeInfo);
+
+				// Act:
+				const response = await onRpcRequest({
+					request: {
+						method: 'switchNetwork',
+						params: {
+							networkName: 'testnet'
+						}
 					}
-				}
-			});
+				});
 
-			// Assert:
-			expect(response).toStrictEqual({
-				symbol: 'USD',
-				price: 0.25
+				// Assert:
+				expect(response).toStrictEqual(mockExpectedNodeInfo);
+			});
+		});
+
+		describe('getCurrency', () => {
+			it('returns the currency given by symbol', async () => {
+				// Arrange + Act:
+				const response = await onRpcRequest({
+					request: {
+						method: 'getCurrency',
+						params: {
+							currency: 'USD'
+						}
+					}
+				});
+
+				// Assert:
+				expect(response).toStrictEqual({
+					symbol: 'USD',
+					price: 0.25
+				});
 			});
 		});
 	});
-});
 
-describe('onCronjob', () => {
-	describe('fetchCurrencyPrice', () => {
-		it('fetches latest currency price and update state', async () => {
-			// Arrange:
-			const state = {
-				currencies: {
-					USD: 0.25,
-					JPY: 0.20
-				}
-			};
+	describe('onCronjob', () => {
+		runBasicRequestThrowErrorTest(onCronjob);
 
-			const mockLatestCurrencies = {
-				USD: 1.00,
-				JPY: 2.00
-			};
+		describe('fetchCurrencyPrice', () => {
+			it('fetches latest currency price and update state', async () => {
+				// Arrange:
+				const state = {
+					currencies: {
+						USD: 0.25,
+						JPY: 0.20
+					}
+				};
 
-			stateManager.getState.mockResolvedValue(state);
-			cryptoCompareClient.fetchPrice.mockResolvedValue(mockLatestCurrencies);
+				const mockLatestCurrencies = {
+					USD: 1.00,
+					JPY: 2.00
+				};
 
-			// Act:
-			await onCronjob({
-				request: {
-					method: 'fetchCurrencyPrice'
-				}
+				stateManager.getState.mockResolvedValue(state);
+				cryptoCompareClient.fetchPrice.mockResolvedValue(mockLatestCurrencies);
+
+				// Act:
+				await onCronjob({
+					request: {
+						method: 'fetchCurrencyPrice'
+					}
+				});
+
+				// Assert:
+				expect(stateManager.update).toHaveBeenCalledWith({
+					currencies: mockLatestCurrencies
+				});
 			});
 
-			// Assert:
-			expect(stateManager.update).toHaveBeenCalledWith({
-				currencies: mockLatestCurrencies
+			it('throws an error if the requested method does not exist', async () => {
+				// Act + Assert:
+				await expect(onCronjob({
+					request: {
+						method: 'unknownMethod'
+					}
+				})).rejects.toThrow('Method not found.');
 			});
 		});
 	});

--- a/snap/backend/test/services/cryptocompareClient_spec.js
+++ b/snap/backend/test/services/cryptocompareClient_spec.js
@@ -23,8 +23,12 @@ describe('cryptocompareClient', () => {
 			const result = await cryptoCompareClient.fetchPrice();
 
 			// Assert:
-			expect(result).toStrictEqual(prices);
-			expect(fetchUtils.fetchData).toHaveBeenCalledWith('https://min-api.cryptocompare.com/data/price?fsym=xym&tsyms=USD,JPY', 'GET');
+			expect(result).toStrictEqual({
+				usd: prices.USD,
+				jpy: prices.JPY
+
+			});
+			expect(fetchUtils.fetchData).toHaveBeenCalledWith('https://min-api.cryptocompare.com/data/price?fsym=xym&tsyms=usd,jpy', 'GET');
 		});
 
 		it('should throw an error when fetch fails', async () => {

--- a/snap/backend/test/services/cryptocompareClient_spec.js
+++ b/snap/backend/test/services/cryptocompareClient_spec.js
@@ -1,0 +1,39 @@
+import cryptoCompareClient from '../../src/services/cryptocompareClient.js';
+import fetchUtils from '../../src/utils/fetchUtils.js';
+import { describe, expect, jest } from '@jest/globals';
+
+jest.spyOn(fetchUtils, 'fetchData').mockImplementation();
+
+describe('cryptocompareClient', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('fetchPrice', () => {
+		it('can fetch price successfully', async () => {
+			// Arrange:
+			const prices = {
+				USD: 0.25,
+				JPY: 30
+			};
+
+			fetchUtils.fetchData.mockResolvedValue(prices);
+
+			// Act:
+			const result = await cryptoCompareClient.fetchPrice();
+
+			// Assert:
+			expect(result).toStrictEqual(prices);
+			expect(fetchUtils.fetchData).toHaveBeenCalledWith('https://min-api.cryptocompare.com/data/price?fsym=xym&tsyms=USD,JPY', 'GET');
+		});
+
+		it('should throw an error when fetch fails', async () => {
+			// Arrange:
+			fetchUtils.fetchData.mockRejectedValue(new Error('Failed to fetch'));
+
+			// Assert:
+			const errorMessage = 'Failed to fetch price from cryptoCompare service: Failed to fetch';
+			await expect(cryptoCompareClient.fetchPrice()).rejects.toThrow(errorMessage);
+		});
+	});
+});

--- a/snap/backend/test/utils/priceUtils_spec.js
+++ b/snap/backend/test/utils/priceUtils_spec.js
@@ -1,0 +1,68 @@
+import cryptoCompareClient from '../../src/services/cryptocompareClient.js';
+import stateManager from '../../src/stateManager.js';
+import priceUtils from '../../src/utils/priceUtils.js';
+import { describe, jest } from '@jest/globals';
+
+jest.spyOn(cryptoCompareClient, 'fetchPrice').mockResolvedValue();
+jest.spyOn(stateManager, 'update').mockResolvedValue();
+
+describe('priceUtils', () => {
+	describe('getPrice', () => {
+		it('should get price successfully', async () => {
+			// Arrange:
+			const state = {
+				currencies: {}
+			};
+
+			const prices = {
+				USD: 0.25,
+				JPY: 30
+			};
+
+			cryptoCompareClient.fetchPrice.mockResolvedValue(prices);
+
+			// Act:
+			await priceUtils.getPrice({ state });
+
+			// Assert:
+			expect(state.currencies).toStrictEqual(prices);
+			expect(stateManager.update).toHaveBeenCalledWith(state);
+		});
+	});
+
+	describe('getCurrencyPrice', () => {
+		// Arrange:
+		const state = {
+			currencies: {
+				USD: 0.25,
+				JPY: 30
+			}
+		};
+
+		it('should get currency price successfully', async () => {
+			// Arrange:
+			const requestParams = {
+				currency: 'USD'
+			};
+
+			// Act:
+			const result = await priceUtils.getCurrencyPrice({ state, requestParams });
+
+			// Assert:
+			expect(result).toStrictEqual({
+				symbol: requestParams.currency,
+				price: state.currencies[requestParams.currency]
+			});
+		});
+
+		it('should throw an error when currency is not supported', async () => {
+			// Arrange:
+			const requestParams = {
+				currency: 'EUR'
+			};
+
+			// Assert:
+			await expect(priceUtils.getCurrencyPrice({ state, requestParams })).rejects.toThrow('Currency not supported.');
+		});
+	});
+});

--- a/snap/backend/test/utils/priceUtils_spec.js
+++ b/snap/backend/test/utils/priceUtils_spec.js
@@ -39,10 +39,10 @@ describe('priceUtils', () => {
 			}
 		};
 
-		it('should get currency price successfully', async () => {
+		const assertGetCurrencyPriceSuccessfully = async symbol => {
 			// Arrange:
 			const requestParams = {
-				currency: 'USD'
+				currency: symbol
 			};
 
 			// Act:
@@ -53,6 +53,16 @@ describe('priceUtils', () => {
 				symbol: requestParams.currency,
 				price: state.currencies[requestParams.currency]
 			});
+		};
+
+		it('should get currency price successfully', async () => {
+			// upper case letters
+			await assertGetCurrencyPriceSuccessfully('USD');
+			await assertGetCurrencyPriceSuccessfully('JPY');
+
+			// lower case letters
+			await assertGetCurrencyPriceSuccessfully('usd');
+			await assertGetCurrencyPriceSuccessfully('jpy');
 		});
 
 		it('should throw an error when currency is not supported', async () => {

--- a/snap/frontend/app/page.spec.jsx
+++ b/snap/frontend/app/page.spec.jsx
@@ -25,6 +25,10 @@ describe('Main', () => {
 						addressIndex: 0,
 						type: 'metamask'
 					}
+				},
+				currency: {
+					symbol: 'usd',
+					price: 1.00
 				}
 			})
 		});

--- a/snap/frontend/components/AccountBalance/AccountBalance.spec.jsx
+++ b/snap/frontend/components/AccountBalance/AccountBalance.spec.jsx
@@ -7,7 +7,7 @@ const context = {
 	walletState: {
 		currency: {
 			symbol: 'usd',
-			currencyPerXYM: 0.25
+			price: 0.25
 		}
 	}
 };

--- a/snap/frontend/components/AccountBalance/index.jsx
+++ b/snap/frontend/components/AccountBalance/index.jsx
@@ -3,10 +3,10 @@ import { useWalletContext } from '../../context';
 const AccountBalance = () => {
 	const { walletState } = useWalletContext();
 	const { mosaics, currency } = walletState;
-	const { symbol, currencyPerXYM } = currency;
+	const { symbol, price } = currency;
 
 	const xymBalance = mosaics.find(m => 'symbol.xym' === m.name)?.amount || 0;
-	const convertToCurrency = (xymBalance * currencyPerXYM).toFixed(2);
+	const convertToCurrency = (xymBalance * price).toFixed(2);
 
 	return (
 		<div className='flex flex-col items-center'>

--- a/snap/frontend/components/Home/Home.spec.jsx
+++ b/snap/frontend/components/Home/Home.spec.jsx
@@ -75,11 +75,11 @@ describe('components/Home', () => {
 			network: mockNetwork,
 			accounts: {},
 			currencies: {
-				USD: 1,
-				JPY: 2
+				usd: 1,
+				jpy: 2
 			},
 			currency: {
-				symbol: 'USD',
+				symbol: 'usd',
 				price: 1
 			}
 		});
@@ -92,7 +92,7 @@ describe('components/Home', () => {
 		await act(() => testHelper.customRender(<Home />, context));
 
 		// Assert:
-		expect(helper.setupSnap).toHaveBeenCalledWith(context.dispatch, context.symbolSnap, 'mainnet', 'USD');
+		expect(helper.setupSnap).toHaveBeenCalledWith(context.dispatch, context.symbolSnap, 'mainnet', 'usd');
 	});
 
 	it('renders receive modal box when receive button is clicked', async () => {

--- a/snap/frontend/components/Home/Home.spec.jsx
+++ b/snap/frontend/components/Home/Home.spec.jsx
@@ -8,7 +8,8 @@ const context = {
 		setLoadingStatus: jest.fn(),
 		setNetwork: jest.fn(),
 		setSelectedAccount: jest.fn(),
-		setAccounts: jest.fn()
+		setAccounts: jest.fn(),
+		setCurrency: jest.fn()
 	},
 	walletState: {
 		loadingStatus: {
@@ -21,7 +22,7 @@ const context = {
 		transactions: [],
 		currency: {
 			symbol: 'usd',
-			currencyPerXYM: 0.25
+			price: 0.25
 		},
 		network: {
 			identifier: 104,
@@ -72,7 +73,15 @@ describe('components/Home', () => {
 
 		context.symbolSnap.initialSnap.mockResolvedValue({
 			network: mockNetwork,
-			accounts: {}
+			accounts: {},
+			currencies: {
+				USD: 1,
+				JPY: 2
+			},
+			currency: {
+				symbol: 'USD',
+				price: 1
+			}
 		});
 
 		context.symbolSnap.createAccount.mockResolvedValue({
@@ -83,7 +92,7 @@ describe('components/Home', () => {
 		await act(() => testHelper.customRender(<Home />, context));
 
 		// Assert:
-		expect(helper.setupSnap).toHaveBeenCalledWith(context.dispatch, context.symbolSnap, 'mainnet');
+		expect(helper.setupSnap).toHaveBeenCalledWith(context.dispatch, context.symbolSnap, 'mainnet', 'USD');
 	});
 
 	it('renders receive modal box when receive button is clicked', async () => {

--- a/snap/frontend/components/Home/index.jsx
+++ b/snap/frontend/components/Home/index.jsx
@@ -24,7 +24,7 @@ const Home = () => {
 	useEffect(() => {
 		const initializeSnap = async () => {
 			if (isSnapInstalled)
-				await helper.setupSnap(dispatch, symbolSnap, 'mainnet', 'USD');
+				await helper.setupSnap(dispatch, symbolSnap, 'mainnet', 'usd');
 		};
 
 		initializeSnap();

--- a/snap/frontend/components/Home/index.jsx
+++ b/snap/frontend/components/Home/index.jsx
@@ -24,7 +24,7 @@ const Home = () => {
 	useEffect(() => {
 		const initializeSnap = async () => {
 			if (isSnapInstalled)
-				await helper.setupSnap(dispatch, symbolSnap, 'mainnet');
+				await helper.setupSnap(dispatch, symbolSnap, 'mainnet', 'USD');
 		};
 
 		initializeSnap();

--- a/snap/frontend/components/Navbar/Navbar.spec.jsx
+++ b/snap/frontend/components/Navbar/Navbar.spec.jsx
@@ -166,7 +166,7 @@ describe('components/Navbar', () => {
 			]);
 		});
 
-		describe('currency', () => {
+		describe.only('currency', () => {
 			runBasicDropdownTest('Currency', ['USD', 'JPY'], 'getCurrency');
 
 			runBasicInitialDropdownNameTest('Currency', [

--- a/snap/frontend/components/Navbar/Navbar.spec.jsx
+++ b/snap/frontend/components/Navbar/Navbar.spec.jsx
@@ -166,7 +166,7 @@ describe('components/Navbar', () => {
 			]);
 		});
 
-		describe.only('currency', () => {
+		describe('currency', () => {
 			runBasicDropdownTest('Currency', ['USD', 'JPY'], 'getCurrency');
 
 			runBasicInitialDropdownNameTest('Currency', [

--- a/snap/frontend/components/Navbar/index.jsx
+++ b/snap/frontend/components/Navbar/index.jsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from 'react';
 
 const Navbar = () => {
 	const { walletState, dispatch, symbolSnap } = useWalletContext();
-	const { isSnapInstalled, network } = walletState;
+	const { isSnapInstalled, network, currency } = walletState;
 
 	const networks = [
 		{ label: 'Mainnet', value: 'mainnet' },
@@ -31,7 +31,13 @@ const Navbar = () => {
 		setSelectedNetwork(option.label);
 	};
 
-	const handleSelectCurrency = option => {
+	const handleSelectCurrency = async option => {
+		if (option.label === selectedCurrency)
+			return;
+
+		// switch currency
+		await helper.getCurrency(dispatch, symbolSnap, option.value);
+
 		setSelectedCurrency(option.label);
 	};
 
@@ -41,6 +47,13 @@ const Navbar = () => {
 			const selected = networks.find(n => n.value === network.networkName);
 			if (selected)
 				setSelectedNetwork(selected.label);
+		}
+
+		// set selected currency in dropdown label
+		if (currency) {
+			const selected = currencies.find(c => c.value === currency.symbol);
+			if (selected)
+				setSelectedCurrency(selected.label);
 		}
 	}, [network]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/snap/frontend/context/reducer.js
+++ b/snap/frontend/context/reducer.js
@@ -6,8 +6,8 @@ export const initialState = {
 	},
 	finalizedHeight: 0,
 	currency: {
-		symbol: 'usd',
-		currencyPerXYM: 0
+		symbol: 'USD',
+		price: 0
 	},
 	network: {},
 	selectedAccount: {},
@@ -21,7 +21,8 @@ export const actionTypes = {
 	SET_LOADING_STATUS: 'setLoadingStatus',
 	SET_NETWORK: 'setNetwork',
 	SET_SELECTED_ACCOUNT: 'setSelectedAccount',
-	SET_ACCOUNTS: 'setAccounts'
+	SET_ACCOUNTS: 'setAccounts',
+	SET_CURRENCY: 'setCurrency'
 };
 
 export const reducer = (state, action) => {
@@ -36,6 +37,8 @@ export const reducer = (state, action) => {
 		return { ...state, selectedAccount: action.payload };
 	case actionTypes.SET_ACCOUNTS:
 		return { ...state, accounts: action.payload };
+	case actionTypes.SET_CURRENCY:
+		return { ...state, currency: action.payload };
 	default:
 		return state;
 	}

--- a/snap/frontend/utils/dispatchUtils.js
+++ b/snap/frontend/utils/dispatchUtils.js
@@ -35,6 +35,13 @@ const dispatchUtils = dispatch => ({
 	 */
 	setAccounts: accounts => {
 		dispatch({ type: actionTypes.SET_ACCOUNTS, payload: accounts });
+	},
+	/**
+	 * Set currency
+	 * @param {{symbol: string, price: number}} currency - The currency object.
+	 */
+	setCurrency: currency => {
+		dispatch({ type: actionTypes.SET_CURRENCY, payload: currency });
 	}
 });
 

--- a/snap/frontend/utils/dispatchUtils.spec.js
+++ b/snap/frontend/utils/dispatchUtils.spec.js
@@ -104,4 +104,20 @@ describe('dispatchUtils', () => {
 			expect(dispatchState).toHaveBeenCalledWith({ type: 'setAccounts', payload: accounts });
 		});
 	});
+
+	describe('setCurrency', () => {
+		it('dispatches SET_CURRENCY action with currency', () => {
+			// Arrange:
+			const currency = {
+				symbol: 'USD',
+				price: 1
+			};
+
+			// Act:
+			dispatch.setCurrency(currency);
+
+			// Assert:
+			expect(dispatchState).toHaveBeenCalledWith({ type: 'setCurrency', payload: currency });
+		});
+	});
 });

--- a/snap/frontend/utils/helper.js
+++ b/snap/frontend/utils/helper.js
@@ -1,15 +1,16 @@
 import QRCode from 'qrcode';
 
 const helper = {
-	async setupSnap (dispatch, symbolSnap, networkName) {
+	async setupSnap (dispatch, symbolSnap, networkName, currency) {
 		dispatch.setLoadingStatus({
 			isLoading: true,
 			message: 'Initializing Snap...'
 		});
 
-		const snapState = await symbolSnap.initialSnap(networkName);
+		const snapState = await symbolSnap.initialSnap(networkName, currency);
 
 		dispatch.setNetwork(snapState.network);
+		dispatch.setCurrency(snapState.currency);
 
 		let account = {};
 
@@ -63,6 +64,11 @@ const helper = {
 				resolve(base64);
 			});
 		});
+	},
+	async getCurrency (dispatch, symbolSnap, symbol) {
+		const currency = await symbolSnap.getCurrency(symbol);
+
+		dispatch.setCurrency(currency);
 	}
 };
 

--- a/snap/frontend/utils/snap.js
+++ b/snap/frontend/utils/snap.js
@@ -88,9 +88,10 @@ const symbolSnapFactory = {
 			/**
 			 * Get the initial snap state.
 			 * @param {NetworkName} networkName - The name of the network to switch to.
+			 * @param {'usd' | 'jpy'} currency - The currency to get the price for.
 			 * @returns {object} The initial snap state.
 			 */
-			async initialSnap(networkName) {
+			async initialSnap(networkName, currency) {
 				const initialSnapState = await provider.request({
 					method: 'wallet_invokeSnap',
 					params: {
@@ -98,7 +99,8 @@ const symbolSnapFactory = {
 						request: {
 							method: 'initialSnap',
 							params: {
-								networkName
+								networkName,
+								currency
 							}
 						}
 					}
@@ -143,6 +145,27 @@ const symbolSnapFactory = {
 				});
 
 				return account;
+			},
+			/**
+			 * Get the currency price from snap MetaMask.
+			 * @param {string} currency - The currency to get the price for.
+			 * @returns {Promise<Currency>} The price of the currency.
+			 */
+			async getCurrency(currency) {
+				const price = await provider.request({
+					method: 'wallet_invokeSnap',
+					params: {
+						snapId: defaultSnapOrigin,
+						request: {
+							method: 'getCurrency',
+							params: {
+								currency
+							}
+						}
+					}
+				});
+
+				return price;
 			}
 		};
 	}
@@ -167,6 +190,13 @@ export default symbolSnapFactory;
  * @property {string} label - The account label.
  * @property {string} address - The account address.
  * @property {string} publicKey - The account public key.
+ */
+
+/**
+ * Currency price.
+ * @typedef {number} Currency
+ * @property {string} symbol - The currency symbol.
+ * @property {number} price - The currency price.
  */
 
 // endregion

--- a/snap/frontend/utils/snap.spec.js
+++ b/snap/frontend/utils/snap.spec.js
@@ -185,6 +185,7 @@ describe('symbolSnapFactory', () => {
 		it('returns initial snap state when provider request is successful', async () => {
 			// Arrange:
 			const networkName = 'mainnet';
+			const currency = 'usd';
 			const mockInitialSnapState = {
 				network: {
 					identifier: 104,
@@ -196,7 +197,7 @@ describe('symbolSnapFactory', () => {
 			mockProvider.request.mockResolvedValue(mockInitialSnapState);
 
 			// Act:
-			const result = await symbolSnap.initialSnap(networkName);
+			const result = await symbolSnap.initialSnap(networkName, currency);
 
 			// Assert:
 			expect(result).toEqual(mockInitialSnapState);
@@ -207,7 +208,8 @@ describe('symbolSnapFactory', () => {
 					request: {
 						method: 'initialSnap',
 						params: {
-							networkName
+							networkName,
+							currency
 						}
 					}
 				}
@@ -281,6 +283,37 @@ describe('symbolSnapFactory', () => {
 						params: {
 							accountLabel,
 							privateKey
+						}
+					}
+				}
+			});
+		});
+	});
+
+	describe('getCurrency', () => {
+		it('returns currency price when provider request is successful', async () => {
+			// Arrange:
+			const currency = 'usd';
+			const mockCurrencyPrice = {
+				symbol: currency,
+				price: 1.0
+			};
+
+			mockProvider.request.mockResolvedValue(mockCurrencyPrice);
+
+			// Act:
+			const result = await symbolSnap.getCurrency(currency);
+
+			// Assert:
+			expect(result).toEqual(mockCurrencyPrice);
+			expect(mockProvider.request).toHaveBeenCalledWith({
+				method: 'wallet_invokeSnap',
+				params: {
+					snapId: 'local:http://localhost:8080',
+					request: {
+						method: 'getCurrency',
+						params: {
+							currency
 						}
 					}
 				}


### PR DESCRIPTION
## What was the issue?
- Currency in the navbar has not been implemented.

## What's the fix?
- Added `cryptoCompareClient` to fetch XYM price in USD and JPY.
- Added `priceUtils`
    - `getPrice` fetch the price from `cryptoCompareClient`.
    - `getCurrencyPrice` return price by given symbol (usd/jpy).
- Added `currency` params in `setupSnap` method.
- Added cronjob every minute will fetch the price.
- Implement in frontend Navbar component, which the user can switch between USD / JPY

## Note
- In the backend, every minute (cronjob from snap) will request the latest price from `cryptoCompareClient` and store it as a cache.
- Frontend will access the currency price from the backend cache.
