### PR TITLE
[Snap]: fetch XYM mosaic balance and display in account balance components

### DIFF
--- a/snap/backend/snap.manifest.json
+++ b/snap/backend/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/symbol/product.git"
   },
   "source": {
-    "shasum": "RGSYTuioTQOf0MuhZPO3RRDOVHbVupuvF3Ibo932umw=",
+    "shasum": "pdtjzCw7rbM+sjFDo+rcrAfsLAkduFo8/koyyY4EvHg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/snap/backend/src/index.js
+++ b/snap/backend/src/index.js
@@ -1,5 +1,6 @@
 import stateManager from './stateManager.js';
 import accountUtils from './utils/accountUtils.js';
+import mosaicUtils from './utils/mosaicUtils.js';
 import networkUtils from './utils/networkUtils.js';
 import priceUtils from './utils/priceUtils.js';
 
@@ -13,7 +14,8 @@ export const onRpcRequest = async ({ request }) => {
 		state = {
 			currencies: {},
 			accounts: {},
-			network: {}
+			network: {},
+			mosaicInfo: {}
 		};
 	}
 
@@ -31,7 +33,8 @@ export const onRpcRequest = async ({ request }) => {
 		return {
 			...state,
 			accounts: accountUtils.getAccounts(apiParams),
-			currency: await priceUtils.getCurrencyPrice(apiParams)
+			currency: await priceUtils.getCurrencyPrice(apiParams),
+			mosaicInfo: mosaicUtils.getMosaicInfo(apiParams)
 		};
 	case 'createAccount':
 		return accountUtils.createAccount(apiParams);
@@ -39,10 +42,16 @@ export const onRpcRequest = async ({ request }) => {
 		return accountUtils.importAccount(apiParams);
 	case 'getNetwork':
 		return state.network;
+	case 'getAccounts':
+		return accountUtils.getAccounts(apiParams);
 	case 'switchNetwork':
 		return networkUtils.switchNetwork(apiParams);
 	case 'getCurrency':
 		return priceUtils.getCurrencyPrice(apiParams);
+	case 'getMosaicInfo':
+		return mosaicUtils.getMosaicInfo(apiParams);
+	case 'fetchAccountMosaics':
+		return accountUtils.fetchAccountMosaics(apiParams);
 	default:
 		throw new Error('Method not found.');
 	}

--- a/snap/backend/src/services/symbolClient.js
+++ b/snap/backend/src/services/symbolClient.js
@@ -1,0 +1,18 @@
+import fetchUtils from '../utils/fetchUtils.js';
+
+const symbolClient = nodeUrl => ({
+	/**
+	 * Fetch native mosaic from network properties.
+	 * @returns {Promise<string>} the network currency mosaic id
+	 */
+	fetchNetworkCurrencyMosaicId: async () => {
+		try {
+			const { chain } = await fetchUtils.fetchData(`${nodeUrl}/network/properties`);
+			return chain.currencyMosaicId.slice(2).replace(/'/g, '');
+		} catch (error) {
+			throw new Error(`Failed to fetch network properties info: ${error.message}`);
+		}
+	}
+});
+
+export default symbolClient;

--- a/snap/backend/src/services/symbolClient.js
+++ b/snap/backend/src/services/symbolClient.js
@@ -1,18 +1,22 @@
 import fetchUtils from '../utils/fetchUtils.js';
 
-const symbolClient = nodeUrl => ({
-	/**
-	 * Fetch native mosaic from network properties.
-	 * @returns {Promise<string>} the network currency mosaic id
-	 */
-	fetchNetworkCurrencyMosaicId: async () => {
-		try {
-			const { chain } = await fetchUtils.fetchData(`${nodeUrl}/network/properties`);
-			return chain.currencyMosaicId.slice(2).replace(/'/g, '');
-		} catch (error) {
-			throw new Error(`Failed to fetch network properties info: ${error.message}`);
-		}
+const symbolClient = {
+	create(nodeUrl) {
+		return {
+			/**
+			 * Fetch native mosaic from network properties.
+			 * @returns {Promise<string>} the network currency mosaic id
+			 */
+			fetchNetworkCurrencyMosaicId: async () => {
+				try {
+					const { chain } = await fetchUtils.fetchData(`${nodeUrl}/network/properties`);
+					return chain.currencyMosaicId.slice(2).replace(/'/g, '');
+				} catch (error) {
+					throw new Error(`Failed to fetch network properties info: ${error.message}`);
+				}
+			}
+		};
 	}
-});
+};
 
 export default symbolClient;

--- a/snap/backend/src/utils/accountUtils.js
+++ b/snap/backend/src/utils/accountUtils.js
@@ -14,6 +14,18 @@ const AccountType = {
 	IMPORTED: 'import'
 };
 
+/**
+ * Sort mosaics array, XYM will always at top.
+ * @param {Array<AccountMosaics>} mosaics - The mosaics array.
+ * @param {string} mosaicId - The mosaic id.
+ * @returns {Array<AccountMosaics>} - The sorted mosaics array.
+ */
+const sortXYMMosaics = (mosaics, mosaicId) => {
+	const xymMosaics = mosaics.filter(mosaic => mosaic.id === mosaicId);
+	const otherMosaics = mosaics.filter(mosaic => mosaic.id !== mosaicId);
+	return [...xymMosaics, ...otherMosaics];
+};
+
 const accountUtils = {
 	/**
 	 * * Derives a key pair from a mnemonic and an address index.
@@ -82,15 +94,19 @@ const accountUtils = {
 		const { network } = state;
 		const accountId = uuidv4();
 
+		const address = symbolAccount.address.toString();
+		const accountsMosaics = await this.fetchAndUpdateAccountMosaics(state, [address]);
+
 		const newAccount = {
 			account: {
 				id: accountId,
 				addressIndex,
 				type,
 				label: accountLabel,
-				address: symbolAccount.address.toString(),
+				address,
 				publicKey: symbolAccount.publicKey.toString(),
-				networkName: network.networkName
+				networkName: network.networkName,
+				mosaics: sortXYMMosaics(accountsMosaics[address] || [], network.currencyMosaicId)
 			},
 			privateKey: symbolAccount.keyPair.privateKey.toString()
 		};
@@ -218,6 +234,7 @@ export default accountUtils;
  * @property {string} label - The account label.
  * @property {string} address - The account address.
  * @property {string} publicKey - The account public key.
+ * @property {Array<AccountMosaics>} mosaics - The account mosaics.
  */
 
 /**

--- a/snap/backend/src/utils/mosaicUtils.js
+++ b/snap/backend/src/utils/mosaicUtils.js
@@ -1,0 +1,65 @@
+import symbolClient from '../services/symbolClient.js';
+import stateManager from '../stateManager.js';
+
+const mosaicUtils = {
+	/**
+     * Update mosaic info in state if given mosaic ids not exist in mosaicInfo.
+     * @param {object} state - The state object.
+     * @param {Array<string>} mosaicIds - The mosaic ids.
+     * @returns {Promise<void>} - A promise that resolves when mosaic info is updated.
+     */
+	updateMosaicInfo: async (state, mosaicIds) => {
+		try {
+			const { network, mosaicInfo } = state;
+
+			// filter out mosaic id didn't exist in mosaicInfo
+			const missingMosaicIds = mosaicIds.filter(mosaicId => !mosaicInfo[mosaicId]);
+
+			if (0 === missingMosaicIds.length)
+				return;
+
+			const client = symbolClient.create(network.url);
+
+			const mosaics = await client.fetchMosaicsInfo(missingMosaicIds);
+
+			// update networkName in mosaic info
+			Object.keys(mosaics).forEach(mosaicId => {
+				mosaics[mosaicId].networkName = network.networkName;
+			});
+
+			state.mosaicInfo = { ...mosaicInfo, ...mosaics };
+
+			await stateManager.update(state);
+		} catch (error) {
+			throw new Error(`Failed to update mosaic info: ${error.message}`);
+		}
+	},
+	/**
+     * Get mosaic info from state filter by network name.
+     * @param {object} state - The state object.
+     * @returns {object<string, MosaicInfo>} - The mosaic info.
+     */
+	getMosaicInfo: ({ state }) => {
+		const { network, mosaicInfo } = state;
+
+		return Object.keys(mosaicInfo).reduce((info, key) => {
+			if (mosaicInfo[key].networkName === network.networkName)
+				info[key] = mosaicInfo[key];
+
+			return info;
+		}, {});
+	}
+};
+
+export default mosaicUtils;
+
+// region type declarations
+
+/**
+ * state of the mosaic.
+ * @typedef {object} MosaicInfo
+ * @property {number} divisibility - The divisibility.
+ * @property {string} networkName - The network name.
+ */
+
+// endregion

--- a/snap/backend/src/utils/networkUtils.js
+++ b/snap/backend/src/utils/networkUtils.js
@@ -1,4 +1,5 @@
 import statisticsClient from '../services/statisticsClient.js';
+import symbolClient from '../services/symbolClient.js';
 import stateManager from '../stateManager.js';
 
 const networkUtils = {
@@ -6,8 +7,12 @@ const networkUtils = {
 		const { networkName } = requestParams;
 		const nodeInfo = await statisticsClient.getNodeInfo(networkName);
 
+		const client = symbolClient.create(nodeInfo.url);
+		const currencyMosaicId = await client.fetchNetworkCurrencyMosaicId();
+
 		state.network = {
-			...nodeInfo
+			...nodeInfo,
+			currencyMosaicId
 		};
 
 		await stateManager.update(state);

--- a/snap/backend/test/.eslintrc
+++ b/snap/backend/test/.eslintrc
@@ -1,0 +1,3 @@
+---
+rules:
+    jest/expect-expect: 'off'

--- a/snap/backend/test/services/symbolClient_spec.js
+++ b/snap/backend/test/services/symbolClient_spec.js
@@ -4,15 +4,17 @@ import { describe, expect, jest } from '@jest/globals';
 
 describe('symbolClient', () => {
 	jest.spyOn(fetchUtils, 'fetchData').mockImplementation();
+	const nodeUrl = 'http://localhost:3000';
+	let client;
 
 	beforeEach(() => {
 		jest.clearAllMocks();
+		client = symbolClient(nodeUrl);
 	});
 
 	describe('fetchNetworkCurrencyMosaicId', () => {
 		it('can fetch network currency mosaic id successfully', async () => {
 			// Arrange:
-			const nodeUrl = 'http://localhost:3000';
 			const chain = {
 				currencyMosaicId: '0x72C0\'212E\'67A0\'8BCE'
 			};
@@ -20,7 +22,7 @@ describe('symbolClient', () => {
 			fetchUtils.fetchData.mockResolvedValue({ chain });
 
 			// Act:
-			const result = await symbolClient(nodeUrl).fetchNetworkCurrencyMosaicId();
+			const result = await client.fetchNetworkCurrencyMosaicId();
 
 			// Assert:
 			expect(result).toBe('72C0212E67A08BCE');
@@ -29,12 +31,11 @@ describe('symbolClient', () => {
 
 		it('should throw an error when fetch fails', async () => {
 			// Arrange:
-			const nodeUrl = 'http://localhost:3000';
 			fetchUtils.fetchData.mockRejectedValue(new Error('Failed to fetch'));
 
 			// Assert:
 			const errorMessage = 'Failed to fetch network properties info: Failed to fetch';
-			await expect(symbolClient(nodeUrl).fetchNetworkCurrencyMosaicId()).rejects.toThrow(errorMessage);
+			await expect(client.fetchNetworkCurrencyMosaicId()).rejects.toThrow(errorMessage);
 		});
 	});
 });

--- a/snap/backend/test/services/symbolClient_spec.js
+++ b/snap/backend/test/services/symbolClient_spec.js
@@ -1,0 +1,40 @@
+import symbolClient from '../../src/services/symbolClient.js';
+import fetchUtils from '../../src/utils/fetchUtils.js';
+import { describe, expect, jest } from '@jest/globals';
+
+describe('symbolClient', () => {
+	jest.spyOn(fetchUtils, 'fetchData').mockImplementation();
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('fetchNetworkCurrencyMosaicId', () => {
+		it('can fetch network currency mosaic id successfully', async () => {
+			// Arrange:
+			const nodeUrl = 'http://localhost:3000';
+			const chain = {
+				currencyMosaicId: '0x72C0\'212E\'67A0\'8BCE'
+			};
+
+			fetchUtils.fetchData.mockResolvedValue({ chain });
+
+			// Act:
+			const result = await symbolClient(nodeUrl).fetchNetworkCurrencyMosaicId();
+
+			// Assert:
+			expect(result).toBe('72C0212E67A08BCE');
+			expect(fetchUtils.fetchData).toHaveBeenCalledWith(`${nodeUrl}/network/properties`);
+		});
+
+		it('should throw an error when fetch fails', async () => {
+			// Arrange:
+			const nodeUrl = 'http://localhost:3000';
+			fetchUtils.fetchData.mockRejectedValue(new Error('Failed to fetch'));
+
+			// Assert:
+			const errorMessage = 'Failed to fetch network properties info: Failed to fetch';
+			await expect(symbolClient(nodeUrl).fetchNetworkCurrencyMosaicId()).rejects.toThrow(errorMessage);
+		});
+	});
+});

--- a/snap/backend/test/services/symbolClient_spec.js
+++ b/snap/backend/test/services/symbolClient_spec.js
@@ -9,7 +9,7 @@ describe('symbolClient', () => {
 
 	beforeEach(() => {
 		jest.clearAllMocks();
-		client = symbolClient(nodeUrl);
+		client = symbolClient.create(nodeUrl);
 	});
 
 	describe('fetchNetworkCurrencyMosaicId', () => {

--- a/snap/backend/test/services/symbolClient_spec.js
+++ b/snap/backend/test/services/symbolClient_spec.js
@@ -1,6 +1,8 @@
 import symbolClient from '../../src/services/symbolClient.js';
 import fetchUtils from '../../src/utils/fetchUtils.js';
-import { describe, expect, jest } from '@jest/globals';
+import {
+	describe, expect, it, jest
+} from '@jest/globals';
 
 describe('symbolClient', () => {
 	jest.spyOn(fetchUtils, 'fetchData').mockImplementation();
@@ -36,6 +38,146 @@ describe('symbolClient', () => {
 			// Assert:
 			const errorMessage = 'Failed to fetch network properties info: Failed to fetch';
 			await expect(client.fetchNetworkCurrencyMosaicId()).rejects.toThrow(errorMessage);
+		});
+	});
+
+	describe('fetchMosaicsInfo', () => {
+		it('can fetch mosaics info successfully', async () => {
+			// Arrange:
+			const mosaicIds = ['393AFB0B19902759', '0005EC25E3F9072D'];
+
+			const mockResponse = [
+				{
+					mosaic: {
+						id: '393AFB0B19902759',
+						divisibility: 6
+					}
+				},
+				{
+					mosaic: {
+						id: '0005EC25E3F9072D',
+						divisibility: 2
+					}
+				}
+			];
+
+			fetchUtils.fetchData.mockResolvedValue(mockResponse);
+
+			// Act:
+			const result = await client.fetchMosaicsInfo(mosaicIds);
+
+			// Assert:
+			expect(result).toStrictEqual({
+				'0005EC25E3F9072D': {
+					divisibility: 2
+				},
+				'393AFB0B19902759': {
+					divisibility: 6
+				}
+			});
+			expect(fetchUtils.fetchData).toHaveBeenCalledWith(`${nodeUrl}/mosaics`, 'POST', { mosaicIds });
+		});
+
+		it('should return empty object when mosaicIds is empty', async () => {
+			// Act:
+			const result = await client.fetchMosaicsInfo([]);
+
+			// Assert:
+			expect(result).toStrictEqual({});
+			expect(fetchUtils.fetchData).not.toHaveBeenCalled();
+		});
+
+		it('should throw an error when fetch fails', async () => {
+			// Arrange:
+			const mosaicIds = ['393AFB0B19902759', '0005EC25E3F9072D'];
+
+			fetchUtils.fetchData.mockRejectedValue(new Error('Failed to fetch'));
+
+			// Assert:
+			const errorMessage = 'Failed to fetch mosaics info: Failed to fetch';
+			await expect(client.fetchMosaicsInfo(mosaicIds)).rejects.toThrow(errorMessage);
+		});
+	});
+
+	describe('fetchAccountsMosaics', () => {
+		it('can fetch accounts mosaics successfully', async () => {
+			// Arrange:
+			const addresses = ['TARDV42KTAIZEF64EQT4NXT7K55DHWBEFIXVJQY', 'TAUYVCHWXD7KPNLJIPRLKBBFKCNIHLJMQCE6BFQ'];
+
+			const mockResponse = [
+				{
+					account: {
+						address: '98223AF34A98119217DC2427C6DE7F577A33D8242A2F54C3',
+						mosaics: [
+							{
+								id: '72C0212E67A08BCE',
+								amount: '100'
+							},
+							{
+								id: '62AAA97AD859F66A',
+								amount: '20'
+							}
+						]
+					}
+				},
+				{
+					account: {
+						address: '98298A88F6B8FEA7B56943E2B50425509A83AD2C8089E096',
+						mosaics: [
+							{
+								id: '72C0212E67A08BCE',
+								amount: '30'
+							}
+						]
+					}
+				}
+			];
+
+			fetchUtils.fetchData.mockResolvedValue(mockResponse);
+
+			// Act:
+			const result = await client.fetchAccountsMosaics(addresses);
+
+			// Assert:
+			expect(result).toStrictEqual({
+				TARDV42KTAIZEF64EQT4NXT7K55DHWBEFIXVJQY: [
+					{
+						id: '72C0212E67A08BCE',
+						amount: '100'
+					},
+					{
+						id: '62AAA97AD859F66A',
+						amount: '20'
+					}
+				],
+				TAUYVCHWXD7KPNLJIPRLKBBFKCNIHLJMQCE6BFQ: [
+					{
+						id: '72C0212E67A08BCE',
+						amount: '30'
+					}
+				]
+			});
+			expect(fetchUtils.fetchData).toHaveBeenCalledWith(`${nodeUrl}/accounts`, 'POST', { addresses });
+		});
+
+		it('should return empty object when addresses is empty', async () => {
+			// Act:
+			const result = await client.fetchAccountsMosaics([]);
+
+			// Assert:
+			expect(result).toStrictEqual({});
+			expect(fetchUtils.fetchData).not.toHaveBeenCalled();
+		});
+
+		it('should throw an error when fetch fails', async () => {
+			// Arrange:
+			const addresses = ['TARDV42KTAIZEF64EQT4NXT7K55DHWBEFIXVJQY'];
+
+			fetchUtils.fetchData.mockRejectedValue(new Error('Failed to fetch'));
+
+			// Assert:
+			const errorMessage = 'Failed to fetch account mosaics: Failed to fetch';
+			await expect(client.fetchAccountsMosaics(addresses)).rejects.toThrow(errorMessage);
 		});
 	});
 });

--- a/snap/backend/test/utils/mosaicUtils_spec.js
+++ b/snap/backend/test/utils/mosaicUtils_spec.js
@@ -1,0 +1,139 @@
+import symbolClient from '../../src/services/symbolClient.js';
+import stateManager from '../../src/stateManager.js';
+import mosaicUtils from '../../src/utils/mosaicUtils.js';
+import { beforeEach, describe, jest } from '@jest/globals';
+
+global.snap = {
+	request: jest.fn()
+};
+
+jest.spyOn(stateManager, 'update').mockResolvedValue();
+
+describe('mosaicUtils', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('updateMosaicInfo', () => {
+		it('should update mosaic info in state if given mosaic ids not exist in mosaicInfo', async () => {
+			// Arrange:
+			const state = {
+				network: {
+					url: 'http://localhost:3000',
+					networkName: 'testnet'
+				},
+				mosaicInfo: {}
+			};
+
+			const mosaicIds = ['mosaicId1', 'mosaicId2'];
+
+			const mockFetchMosaicsInfo = jest.fn().mockResolvedValue({
+				mosaicId1: { divisibility: 6 }
+			});
+
+			jest.spyOn(symbolClient, 'create').mockImplementation(() => ({
+				fetchMosaicsInfo: mockFetchMosaicsInfo
+			}));
+
+			// Act:
+			await mosaicUtils.updateMosaicInfo(state, mosaicIds);
+
+			// Assert:
+			expect(mockFetchMosaicsInfo).toHaveBeenCalledWith(mosaicIds);
+			expect(stateManager.update).toHaveBeenCalledWith({
+				network: state.network,
+				mosaicInfo: {
+					mosaicId1: {
+						divisibility: 6,
+						networkName: 'testnet'
+					}
+				}
+			});
+		});
+
+		it('skip updating mosaic info in state if all given mosaic ids exist in mosaicInfo', async () => {
+			// Arrange:
+			const state = {
+				network: {
+					url: 'http://localhost:3000',
+					networkName: 'testnet'
+				},
+				mosaicInfo: {
+					mosaicId1: {
+						divisibility: 6,
+						networkName: 'testnet'
+					}
+				}
+			};
+
+			const mosaicIds = ['mosaicId1'];
+
+			// Act:
+			await mosaicUtils.updateMosaicInfo(state, mosaicIds);
+
+			// Assert:
+			expect(stateManager.update).not.toHaveBeenCalled();
+		});
+
+		it('throw error if failed to update mosaic info', async () => {
+			// Arrange:
+			const state = {
+				network: {
+					url: 'http://localhost:3000',
+					networkName: 'testnet'
+				},
+				mosaicInfo: {
+					mosaicId1: { networkName: 'testnet' }
+				}
+			};
+
+			const mosaicIds = ['mosaicId2'];
+
+			const client = {
+				fetchMosaicsInfo: jest.fn().mockRejectedValue(new Error('error'))
+			};
+
+			jest.spyOn(symbolClient, 'create').mockReturnValue(client);
+
+			// Act + Assert:
+			await expect(mosaicUtils.updateMosaicInfo(state, mosaicIds)).rejects.toThrow('Failed to update mosaic info: error');
+		});
+	});
+
+	describe('getMosaicInfo', () => {
+		const assertMosaicInfoFilterByNetworkName = (networkName, expectedResult) => {
+			// Arrange:
+			const state = {
+				network: {
+					networkName
+				},
+				mosaicInfo: {
+					mosaicId1: {
+						networkName: 'testnet'
+					},
+					mosaicId2: {
+						networkName: 'mainnet'
+					}
+				}
+			};
+
+			// Act:
+			const mosaicInfo = mosaicUtils.getMosaicInfo({ state });
+
+			// Assert:
+			expect(mosaicInfo).toStrictEqual(expectedResult);
+		};
+
+		it('returns mosaic info from state filter by testnet', () => {
+			assertMosaicInfoFilterByNetworkName('testnet', {
+				mosaicId1: { networkName: 'testnet' }
+			});
+		});
+
+		it('returns mosaic info from state filter by mainnet', () => {
+			assertMosaicInfoFilterByNetworkName('mainnet', {
+				mosaicId2: { networkName: 'mainnet' }
+			});
+		});
+	});
+});

--- a/snap/backend/test/utils/networkUtils_spec.js
+++ b/snap/backend/test/utils/networkUtils_spec.js
@@ -1,4 +1,5 @@
 import statisticsClient from '../../src/services/statisticsClient.js';
+import symbolClient from '../../src/services/symbolClient.js';
 import stateManager from '../../src/stateManager.js';
 import networkUtils from '../../src/utils/networkUtils.js';
 import { describe, jest } from '@jest/globals';
@@ -12,7 +13,7 @@ describe('networkUtils', () => {
 	});
 
 	describe('switchNetwork', () => {
-		it('should switch network when giving network name', async () => {
+		it('should switch network and fetch mosaic id when giving network name', async () => {
 			// Arrange:
 			const state = {
 				network: {}
@@ -27,16 +28,27 @@ describe('networkUtils', () => {
 				networkName: requestParams.networkName,
 				url: 'http://localhost:3000'
 			};
+			const mockCurrencyMosaicId = 'mosaicId';
 
 			statisticsClient.getNodeInfo.mockResolvedValue(mockNodeInfo);
+			jest.spyOn(symbolClient, 'create').mockReturnValue({
+				fetchNetworkCurrencyMosaicId: jest.fn().mockResolvedValue(mockCurrencyMosaicId)
+			});
 
 			// Act:
 			const result = await networkUtils.switchNetwork({ state, requestParams });
 
 			// Assert:
+			const expectedResult = {
+				...mockNodeInfo,
+				currencyMosaicId: mockCurrencyMosaicId
+			};
+
 			expect(statisticsClient.getNodeInfo).toHaveBeenCalledWith(requestParams.networkName);
-			expect(stateManager.update).toHaveBeenCalledWith({ network: mockNodeInfo });
-			expect(result).toStrictEqual(mockNodeInfo);
+			expect(stateManager.update).toHaveBeenCalledWith({
+				network: expectedResult
+			});
+			expect(result).toStrictEqual(expectedResult);
 		});
 	});
 });

--- a/snap/frontend/app/page.spec.jsx
+++ b/snap/frontend/app/page.spec.jsx
@@ -1,4 +1,5 @@
 import Main from './page';
+import testHelper from '../components/testHelper';
 import symbolSnapFactory from '../utils/snap';
 import detectEthereumProvider from '@metamask/detect-provider';
 import { act, render } from '@testing-library/react';
@@ -30,7 +31,25 @@ describe('Main', () => {
 					symbol: 'usd',
 					price: 1.00
 				}
-			})
+			}),
+			fetchAccountMosaics: () => ({
+				'account1': {
+					id: 'account1',
+					addressIndex: 1,
+					type: 'metamask',
+					networkName: 'network',
+					label: 'label',
+					address: 'address',
+					publicKey: 'publicKey'
+				}
+			}),
+			getMosaicInfo: () => ({
+				'mosaicId1': {
+					divisibility: 6,
+					networkName: 'testnet'
+				}
+			}),
+			getAccounts: () => testHelper.generateAccountsState(1)
 		});
 
 		// Act:

--- a/snap/frontend/components/AccountBalance/AccountBalance.spec.jsx
+++ b/snap/frontend/components/AccountBalance/AccountBalance.spec.jsx
@@ -5,9 +5,23 @@ import { screen } from '@testing-library/react';
 const context = {
 	dispatch: jest.fn(),
 	walletState: {
+		selectedAccount: {
+			...testHelper.generateAccountsState(1)
+		},
 		currency: {
 			symbol: 'usd',
 			price: 0.25
+		},
+		network: {
+			currencyMosaicId: 'E74B99BA41F4AFEE'
+		},
+		mosaicInfo: {
+			'E74B99BA41F4AFEE': {
+				divisibility: 6
+			},
+			'3C596F764B5A1160': {
+				divisibility: 2
+			}
 		}
 	}
 };
@@ -28,37 +42,49 @@ describe('components/AccountBalance', () => {
 
 	it('renders xym balance and converted currency when found symbol.xym mosaic', () => {
 		// Arrange:
-		context.walletState.mosaics = [
+		context.walletState.selectedAccount.mosaics = [
 			{
 				id: 'E74B99BA41F4AFEE',
-				name: 'symbol.xym',
-				amount: 100
+				amount: 100000000
 			},
 			{
 				id: '3C596F764B5A1160',
-				name: null,
-				amount: 2
+				amount: 200
 			}
 		];
 
-		assertAccountBalance(context, '100 XYM', '25.00 usd');
+		assertAccountBalance(context, '100 XYM', '25.00 USD');
+	});
+
+	it('renders xym balance with decimal and converted currency when found symbol.xym mosaic', () => {
+		// Arrange:
+		context.walletState.selectedAccount.mosaics = [
+			{
+				id: 'E74B99BA41F4AFEE',
+				amount: 100100000
+			},
+			{
+				id: '3C596F764B5A1160',
+				amount: 200
+			}
+		];
+
+		assertAccountBalance(context, '100.1 XYM', '25.02 USD');
 	});
 
 	it('renders xym balance and converted currency with 0 balance when symbol.xym mosaic does not found', () => {
 		// Arrange:
-		context.walletState.mosaics = [
+		context.walletState.selectedAccount.mosaics = [
 			{
 				id: '3C596F764B5A1160',
-				name: null,
-				amount: 2
+				amount: 200
 			}
 		];
 
-		assertAccountBalance(context, '0 XYM', '0.00 usd');
+		assertAccountBalance(context, '0 XYM', '0.00 USD');
 	});
 
 	it('renders xym balance and converted currency with 0 balance when mosaics is empty', () => {
-		assertAccountBalance(context, '0 XYM', '0.00 usd');
+		assertAccountBalance(context, '0 XYM', '0.00 USD');
 	});
-
 });

--- a/snap/frontend/components/AccountBalance/index.jsx
+++ b/snap/frontend/components/AccountBalance/index.jsx
@@ -2,16 +2,24 @@ import { useWalletContext } from '../../context';
 
 const AccountBalance = () => {
 	const { walletState } = useWalletContext();
-	const { mosaics, currency } = walletState;
+	const { selectedAccount, currency, network, mosaicInfo } = walletState;
 	const { symbol, price } = currency;
 
-	const xymBalance = mosaics.find(m => 'symbol.xym' === m.name)?.amount || 0;
-	const convertToCurrency = (xymBalance * price).toFixed(2);
+	const getXYMMosaic = () => {
+		const balance = selectedAccount?.mosaics?.find(m => network.currencyMosaicId === m.id)?.amount || 0;
+
+		if (mosaicInfo[network.currencyMosaicId])
+			return balance / (10 ** mosaicInfo[network.currencyMosaicId].divisibility);
+
+		return balance;
+	};
+
+	const convertToCurrency = (getXYMMosaic() * price).toFixed(2);
 
 	return (
 		<div className='flex flex-col items-center'>
-			<div className='text-2xl font-bold'> {xymBalance} XYM</div>
-			<div className='text-2xl text-sub-title'>{convertToCurrency} {symbol}</div>
+			<div className='text-2xl font-bold'> {getXYMMosaic()} XYM</div>
+			<div className='text-2xl text-sub-title'>{convertToCurrency} {symbol.toUpperCase()}</div>
 		</div>
 	);
 

--- a/snap/frontend/components/Home/Home.spec.jsx
+++ b/snap/frontend/components/Home/Home.spec.jsx
@@ -9,7 +9,8 @@ const context = {
 		setNetwork: jest.fn(),
 		setSelectedAccount: jest.fn(),
 		setAccounts: jest.fn(),
-		setCurrency: jest.fn()
+		setCurrency: jest.fn(),
+		setMosaicInfo: jest.fn()
 	},
 	walletState: {
 		loadingStatus: {
@@ -29,12 +30,16 @@ const context = {
 			networkName: 'mainnet',
 			url: 'http://localhost:3000',
 			networkGenerationHash: 'networkGenerationHash'
-		}
+		},
+		mosaicInfo: {}
 	},
 	symbolSnap: {
 		getSnap: jest.fn(),
 		initialSnap: jest.fn(),
-		createAccount: jest.fn()
+		createAccount: jest.fn(),
+		getMosaicInfo: jest.fn(),
+		getAccounts: jest.fn(),
+		fetchAccountMosaics: jest.fn()
 	}
 };
 
@@ -70,6 +75,7 @@ describe('components/Home', () => {
 		context.walletState.isSnapInstalled = true;
 
 		jest.spyOn(helper, 'setupSnap');
+		jest.spyOn(helper, 'updateAccountAndMosaicInfoState');
 
 		context.symbolSnap.initialSnap.mockResolvedValue({
 			network: mockNetwork,
@@ -88,11 +94,14 @@ describe('components/Home', () => {
 			...Object.values(testHelper.generateAccountsState(1))[0]
 		});
 
+		context.symbolSnap.getAccounts.mockResolvedValue(testHelper.generateAccountsState(1));
+
 		// Act:
 		await act(() => testHelper.customRender(<Home />, context));
 
 		// Assert:
 		expect(helper.setupSnap).toHaveBeenCalledWith(context.dispatch, context.symbolSnap, 'mainnet', 'usd');
+		expect(helper.updateAccountAndMosaicInfoState).toHaveBeenCalledWith(context.dispatch, context.symbolSnap);
 	});
 
 	it('renders receive modal box when receive button is clicked', async () => {

--- a/snap/frontend/components/Home/index.jsx
+++ b/snap/frontend/components/Home/index.jsx
@@ -23,8 +23,11 @@ const Home = () => {
 
 	useEffect(() => {
 		const initializeSnap = async () => {
-			if (isSnapInstalled)
+			if (isSnapInstalled) {
 				await helper.setupSnap(dispatch, symbolSnap, 'mainnet', 'usd');
+				// update account and mosaic info state in background
+				helper.updateAccountAndMosaicInfoState(dispatch, symbolSnap);
+			}
 		};
 
 		initializeSnap();

--- a/snap/frontend/components/Navbar/index.jsx
+++ b/snap/frontend/components/Navbar/index.jsx
@@ -26,7 +26,9 @@ const Navbar = () => {
 			return;
 
 		// switch network
-		await helper.setupSnap(dispatch, symbolSnap, option.value);
+		await helper.setupSnap(dispatch, symbolSnap, option.value, currency.symbol);
+		// update account and mosaic info state in background
+		helper.updateAccountAndMosaicInfoState(dispatch, symbolSnap);
 
 		setSelectedNetwork(option.label);
 	};

--- a/snap/frontend/components/testHelper.js
+++ b/snap/frontend/components/testHelper.js
@@ -19,7 +19,8 @@ const testHelper = {
 				networkName: 'network',
 				label: `Account ${index}`,
 				address: `Address ${index}`,
-				publicKey: `publicKey ${index}`
+				publicKey: `publicKey ${index}`,
+				mosaics: []
 			};
 		}
 		return accounts;

--- a/snap/frontend/context/reducer.js
+++ b/snap/frontend/context/reducer.js
@@ -13,7 +13,8 @@ export const initialState = {
 	selectedAccount: {},
 	accounts: {},
 	mosaics: [],
-	transactions: []
+	transactions: [],
+	mosaicInfo: {}
 };
 
 export const actionTypes = {
@@ -22,7 +23,8 @@ export const actionTypes = {
 	SET_NETWORK: 'setNetwork',
 	SET_SELECTED_ACCOUNT: 'setSelectedAccount',
 	SET_ACCOUNTS: 'setAccounts',
-	SET_CURRENCY: 'setCurrency'
+	SET_CURRENCY: 'setCurrency',
+	SET_MOSAIC_INFO: 'setMosaicInfo'
 };
 
 export const reducer = (state, action) => {
@@ -39,6 +41,8 @@ export const reducer = (state, action) => {
 		return { ...state, accounts: action.payload };
 	case actionTypes.SET_CURRENCY:
 		return { ...state, currency: action.payload };
+	case actionTypes.SET_MOSAIC_INFO:
+		return { ...state, mosaicInfo: action.payload };
 	default:
 		return state;
 	}

--- a/snap/frontend/utils/dispatchUtils.js
+++ b/snap/frontend/utils/dispatchUtils.js
@@ -42,6 +42,13 @@ const dispatchUtils = dispatch => ({
 	 */
 	setCurrency: currency => {
 		dispatch({ type: actionTypes.SET_CURRENCY, payload: currency });
+	},
+	/**
+	 * Set mosaic info
+	 * @param {Record<string, MosaicInfo>} mosaicInfo - The mosaic info object.
+	 */
+	setMosaicInfo: mosaicInfo => {
+		dispatch({ type: actionTypes.SET_MOSAIC_INFO, payload: mosaicInfo });
 	}
 });
 
@@ -75,5 +82,11 @@ export default dispatchUtils;
  * @typedef {Record<string, { account: Account, privateKey: string }>} Accounts
  */
 
+/**
+ * mosaic info object.
+ * @typedef {object} MosaicInfo
+ * @property {number} divisibility - The mosaic divisibility.
+ * @property {string} networkName - The network name.
+ */
 
 // endregion

--- a/snap/frontend/utils/dispatchUtils.js
+++ b/snap/frontend/utils/dispatchUtils.js
@@ -55,6 +55,7 @@ export default dispatchUtils;
  * @property {number} identifier - The network identifier.
  * @property {string} networkName - The network name.
  * @property {string} url - The node URL.
+ * @property {string} currencyMosaicId - The native currency mosaic id.
  */
 
 /**

--- a/snap/frontend/utils/dispatchUtils.spec.js
+++ b/snap/frontend/utils/dispatchUtils.spec.js
@@ -50,7 +50,8 @@ describe('dispatchUtils', () => {
 			const network = {
 				identifier: 1,
 				networkName: 'network',
-				url: 'url'
+				url: 'url',
+				currencyMosaicId: 'mosaicId'
 			};
 
 			// Act:

--- a/snap/frontend/utils/dispatchUtils.spec.js
+++ b/snap/frontend/utils/dispatchUtils.spec.js
@@ -121,4 +121,26 @@ describe('dispatchUtils', () => {
 			expect(dispatchState).toHaveBeenCalledWith({ type: 'setCurrency', payload: currency });
 		});
 	});
+
+	describe('setMosaicInfo', () => {
+		it('dispatches SET_MOSAIC_INFO action with mosaicInfo', () => {
+			// Arrange:
+			const mosaicInfo = {
+				'mosaicId1': {
+					divisibility: 6,
+					networkName: 'testnet'
+				},
+				'mosaicId2': {
+					divisibility: 2,
+					networkName: 'testnet'
+				}
+			};
+
+			// Act:
+			dispatch.setMosaicInfo(mosaicInfo);
+
+			// Assert:
+			expect(dispatchState).toHaveBeenCalledWith({ type: 'setMosaicInfo', payload: mosaicInfo });
+		});
+	});
 });

--- a/snap/frontend/utils/helper.js
+++ b/snap/frontend/utils/helper.js
@@ -77,6 +77,21 @@ const helper = {
 		const currency = await symbolSnap.getCurrency(symbol);
 
 		dispatch.setCurrency(currency);
+	},
+	async updateAccountAndMosaicInfoState (dispatch, symbolSnap) {
+		const accounts = await symbolSnap.getAccounts();
+		const accountIds = Object.values(accounts).map(account => account.id);
+
+		await symbolSnap.fetchAccountMosaics(accountIds);
+
+		// fetch mosaic info and accounts
+		const [mosaicInfo, updateAccounts] = await Promise.all([
+			symbolSnap.getMosaicInfo(),
+			symbolSnap.getAccounts()
+		]);
+
+		dispatch.setMosaicInfo(mosaicInfo);
+		dispatch.setAccounts(updateAccounts);
 	}
 };
 

--- a/snap/frontend/utils/helper.js
+++ b/snap/frontend/utils/helper.js
@@ -16,17 +16,25 @@ const helper = {
 
 		if (0 < Object.keys(snapState.accounts).length) {
 			// set first account as selected account
-			account = Object.values(snapState.accounts)[0];
-			dispatch.setAccounts(snapState.accounts);
+			const accountId = Object.values(snapState.accounts)[0].id;
+			const accountMosaics = await symbolSnap.fetchAccountMosaics([accountId]);
+
+			account = Object.values(accountMosaics)[0];
 		} else {
 			// create account from snap
 			account = await symbolSnap.createAccount('Wallet 1');
-			dispatch.setAccounts({
-				[account.id]: account
-			});
 		}
 
 		dispatch.setSelectedAccount(account);
+
+		// fetch mosaic info and accounts
+		const [mosaicInfo, updateAccounts] = await Promise.all([
+			symbolSnap.getMosaicInfo(),
+			symbolSnap.getAccounts()
+		]);
+
+		dispatch.setMosaicInfo(mosaicInfo);
+		dispatch.setAccounts(updateAccounts);
 
 		dispatch.setLoadingStatus({
 			isLoading: false,

--- a/snap/frontend/utils/helper.spec.js
+++ b/snap/frontend/utils/helper.spec.js
@@ -239,4 +239,31 @@ describe('helper', () => {
 			expect(dispatch.setCurrency).toHaveBeenCalledWith(mockCurrency);
 		});
 	});
+
+	describe('updateAccountAndMosaicInfoState', () => {
+		it('fetch accounts and mosaic info and updates state', async () => {
+			// Arrange:
+			const mockAccounts = testHelper.generateAccountsState(2);
+			const mockMosaicInfo = {
+				'mosaicId 0': {
+					divisibility: 6,
+					networkName: 'testnet'
+				}
+			};
+
+			symbolSnap.getAccounts.mockResolvedValue(mockAccounts);
+			symbolSnap.getMosaicInfo.mockResolvedValue(mockMosaicInfo);
+
+			// Act:
+			await helper.updateAccountAndMosaicInfoState(dispatch, symbolSnap);
+
+			// Assert:
+			expect(symbolSnap.getAccounts).toHaveBeenCalled();
+			expect(symbolSnap.fetchAccountMosaics).toHaveBeenCalledWith(['accountId 0', 'accountId 1']);
+			expect(symbolSnap.getMosaicInfo).toHaveBeenCalled();
+			expect(symbolSnap.getAccounts).toHaveBeenNthCalledWith(2);
+			expect(dispatch.setMosaicInfo).toHaveBeenCalledWith(mockMosaicInfo);
+			expect(dispatch.setAccounts).toHaveBeenCalledWith(mockAccounts);
+		});
+	});
 });

--- a/snap/frontend/utils/helper.spec.js
+++ b/snap/frontend/utils/helper.spec.js
@@ -8,14 +8,18 @@ describe('helper', () => {
 		setNetwork: jest.fn(),
 		setSelectedAccount: jest.fn(),
 		setAccounts: jest.fn(),
-		setCurrency: jest.fn()
+		setCurrency: jest.fn(),
+		setMosaicInfo: jest.fn()
 	};
 
 	const symbolSnap = {
 		initialSnap: jest.fn(),
 		createAccount: jest.fn(),
 		importAccount: jest.fn(),
-		getCurrency: jest.fn()
+		getCurrency: jest.fn(),
+		fetchAccountMosaics: jest.fn(),
+		getMosaicInfo: jest.fn(),
+		getAccounts: jest.fn()
 	};
 
 	describe('setupSnap', () => {
@@ -29,7 +33,8 @@ describe('helper', () => {
 				networkName: 'testnet',
 				url: 'http://localhost:3000'
 			},
-			accounts: {}
+			accounts: {},
+			mosaicInfo: {}
 		};
 
 		const assertSetupSnap = (mockSnapState, networkName, symbol) => {
@@ -45,9 +50,10 @@ describe('helper', () => {
 			expect(symbolSnap.initialSnap).toHaveBeenCalledWith(networkName, symbol);
 			expect(dispatch.setNetwork).toHaveBeenCalledWith(mockSnapState.network);
 			expect(dispatch.setCurrency).toHaveBeenCalledWith(mockSnapState.currency);
+			expect(dispatch.setMosaicInfo).toHaveBeenCalledWith({});
 		};
 
-		it('initializes snap and sets network and selected account if accounts exist', async () => {
+		it('initializes snap and sets network and selected account and fetch first account mosaic if accounts exist', async () => {
 			// Arrange:
 			const networkName = 'testnet';
 			const symbol = 'usd';
@@ -68,6 +74,11 @@ describe('helper', () => {
 			};
 
 			symbolSnap.initialSnap.mockResolvedValue(mockSnapState);
+			symbolSnap.fetchAccountMosaics.mockResolvedValue({
+				[mockSnapState.accounts['0x1'].id]: mockSnapState.accounts['0x1']
+			});
+			symbolSnap.getMosaicInfo.mockResolvedValue({});
+			symbolSnap.getAccounts.mockResolvedValue(mockSnapState.accounts);
 
 			// Act:
 			await helper.setupSnap(dispatch, symbolSnap, networkName, symbol);
@@ -92,6 +103,10 @@ describe('helper', () => {
 
 			symbolSnap.initialSnap.mockResolvedValue(mockSnapState);
 			symbolSnap.createAccount.mockResolvedValue(mockAccount);
+			symbolSnap.getAccounts.mockResolvedValue({
+				[mockAccount.id]: mockAccount
+			});
+			symbolSnap.getMosaicInfo.mockResolvedValue({});
 
 			// Act:
 			await helper.setupSnap(dispatch, symbolSnap, networkName, symbol);

--- a/snap/frontend/utils/snap.js
+++ b/snap/frontend/utils/snap.js
@@ -166,6 +166,61 @@ const symbolSnapFactory = {
 				});
 
 				return price;
+			},
+			/**
+			 * Fetch account mosaics from snap MetaMask.
+			 * @param {Array<string>} accountIds - The ID of the account.
+			 * @returns {Promise<Record<string, Account>>} The mosaics object returned by the snap.
+			 */
+			async fetchAccountMosaics(accountIds) {
+				const accounts = await provider.request({
+					method: 'wallet_invokeSnap',
+					params: {
+						snapId: defaultSnapOrigin,
+						request: {
+							method: 'fetchAccountMosaics',
+							params: {
+								accountIds
+							}
+						}
+					}
+				});
+
+				return accounts;
+			},
+			/**
+			 * Get accounts from snap MetaMask.
+			 * @returns {Promise<Record<string, Account>>} The accounts object returned by the snap.
+			 */
+			async getAccounts() {
+				const accounts = await provider.request({
+					method: 'wallet_invokeSnap',
+					params: {
+						snapId: defaultSnapOrigin,
+						request: {
+							method: 'getAccounts'
+						}
+					}
+				});
+
+				return accounts;
+			},
+			/**
+			 * Get mosaic info from snap MetaMask.
+			 * @returns {object} The mosaic info object returned by the snap.
+			 */
+			async getMosaicInfo() {
+				const mosaicInfo = await provider.request({
+					method: 'wallet_invokeSnap',
+					params: {
+						snapId: defaultSnapOrigin,
+						request: {
+							method: 'getMosaicInfo'
+						}
+					}
+				});
+
+				return mosaicInfo;
 			}
 		};
 	}

--- a/snap/frontend/utils/snap.spec.js
+++ b/snap/frontend/utils/snap.spec.js
@@ -320,4 +320,107 @@ describe('symbolSnapFactory', () => {
 			});
 		});
 	});
+
+	describe('fetchAccountMosaics', () => {
+		it('returns account mosaics when provider request is successful', async () => {
+			// Arrange:
+			const mockAccountMosaics = {
+				'account1': {
+					id: 'account1',
+					addressIndex: 1,
+					type: 'metamask',
+					networkName: 'network',
+					label: 'label',
+					address: 'address',
+					publicKey: 'publicKey'
+				}
+			};
+
+			const accountIds = ['account1'];
+
+			mockProvider.request.mockResolvedValue(mockAccountMosaics);
+
+			// Act:
+			const result = await symbolSnap.fetchAccountMosaics(accountIds);
+
+			// Assert:
+			expect(result).toEqual(mockAccountMosaics);
+			expect(mockProvider.request).toHaveBeenCalledWith({
+				method: 'wallet_invokeSnap',
+				params: {
+					snapId: 'local:http://localhost:8080',
+					request: {
+						method: 'fetchAccountMosaics',
+						params: {
+							accountIds
+						}
+					}
+				}
+			});
+		});
+	});
+
+	describe('getAccounts', () => {
+		it('returns accounts when provider request is successful', async () => {
+			// Arrange:
+			const mockAccounts = {
+				'account1': {
+					id: 'account1',
+					addressIndex: 1,
+					type: 'metamask',
+					networkName: 'network',
+					label: 'label',
+					address: 'address',
+					publicKey: 'publicKey'
+				}
+			};
+
+			mockProvider.request.mockResolvedValue(mockAccounts);
+
+			// Act:
+			const result = await symbolSnap.getAccounts();
+
+			// Assert:
+			expect(result).toEqual(mockAccounts);
+			expect(mockProvider.request).toHaveBeenCalledWith({
+				method: 'wallet_invokeSnap',
+				params: {
+					snapId: 'local:http://localhost:8080',
+					request: {
+						method: 'getAccounts'
+					}
+				}
+			});
+		});
+	});
+
+	describe('getMosaicInfo', () => {
+		it('returns mosaic info when provider request is successful', async () => {
+			// Arrange:
+			const mosaicInfo = {
+				'mosaicId': {
+					id: 'mosaicId',
+					divisibility: 6,
+					networkName: 'network'
+				}
+			};
+
+			mockProvider.request.mockResolvedValue(mosaicInfo);
+
+			// Act:
+			const result = await symbolSnap.getMosaicInfo();
+
+			// Assert:
+			expect(result).toEqual(mosaicInfo);
+			expect(mockProvider.request).toHaveBeenCalledWith({
+				method: 'wallet_invokeSnap',
+				params: {
+					snapId: 'local:http://localhost:8080',
+					request: {
+						method: 'getMosaicInfo'
+					}
+				}
+			});
+		});
+	});
 });


### PR DESCRIPTION
## What was the issue?
- The XYM balance was not being fetched from the network.

## What's the fix?
- Added a SymbolClient service to query the REST API.
- Added `currencyMoasicId` properties in the snap network state.
- Added `mosaicInfo` state to store all mosaic information as a cache, reducing the number of queries and making it easier to format the mosaic balance.
- Implemented querying of the account balance when create / import actions are triggered.
- Implemented querying of the first account balance when visiting the wallet. Subsequent updates of all accounts will happen in the background for a better user experience.
- Implemented these changes in the frontend account balance components.