### PR TITLE
[Snap]: Process mosaic's namespace name in asset list

### DIFF
--- a/snap/backend/snap.manifest.json
+++ b/snap/backend/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/symbol/product.git"
   },
   "source": {
-    "shasum": "pdtjzCw7rbM+sjFDo+rcrAfsLAkduFo8/koyyY4EvHg=",
+    "shasum": "YCrBAG6XY0xZB5WtNjrfpT16b8xXhxtv3qKfYYb6TRw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/snap/backend/src/services/symbolClient.js
+++ b/snap/backend/src/services/symbolClient.js
@@ -58,6 +58,29 @@ const symbolClient = {
 				} catch (error) {
 					throw new Error(`Failed to fetch account mosaics: ${error.message}`);
 				}
+			},
+			/**
+			 * Fetch mosaics namespace from mosaic ids.
+			 * @param {Array<string>} mosaicIds - The mosaic ids to fetch namespace.
+			 * @returns {Promise<Record<string, Array<string>>} The mosaics namespace.
+			 */
+			fetchMosaicNamespace: async mosaicIds => {
+				if (!mosaicIds.length)
+					return {};
+
+				try {
+					const mosaicNamespace = {};
+
+					const { mosaicNames } = await fetchUtils.fetchData(`${nodeUrl}/namespaces/mosaic/names`, 'POST', { mosaicIds });
+
+					mosaicNames.forEach(({ mosaicId, names }) => {
+						mosaicNamespace[mosaicId] = names;
+					});
+
+					return mosaicNamespace;
+				} catch (error) {
+					throw new Error(`Failed to fetch mosaics namespace: ${error.message}`);
+				}
 			}
 		};
 	}

--- a/snap/backend/src/utils/mosaicUtils.js
+++ b/snap/backend/src/utils/mosaicUtils.js
@@ -20,11 +20,15 @@ const mosaicUtils = {
 
 			const client = symbolClient.create(network.url);
 
-			const mosaics = await client.fetchMosaicsInfo(missingMosaicIds);
+			const [mosaics, namespaceNames] = await Promise.all([
+				client.fetchMosaicsInfo(missingMosaicIds),
+				client.fetchMosaicNamespace(missingMosaicIds)
+			]);
 
 			// update networkName in mosaic info
 			Object.keys(mosaics).forEach(mosaicId => {
 				mosaics[mosaicId].networkName = network.networkName;
+				mosaics[mosaicId].name = namespaceNames[mosaicId];
 			});
 
 			state.mosaicInfo = { ...mosaicInfo, ...mosaics };
@@ -60,6 +64,7 @@ export default mosaicUtils;
  * @typedef {object} MosaicInfo
  * @property {number} divisibility - The divisibility.
  * @property {string} networkName - The network name.
+ * @property {Array<string>} name - The mosaic namespace.
  */
 
 // endregion

--- a/snap/backend/test/services/symbolClient_spec.js
+++ b/snap/backend/test/services/symbolClient_spec.js
@@ -180,4 +180,63 @@ describe('symbolClient', () => {
 			await expect(client.fetchAccountsMosaics(addresses)).rejects.toThrow(errorMessage);
 		});
 	});
+
+	describe('fetchMosaicNamespace', () => {
+		it('can fetch mosaics namespace successfully', async () => {
+			// Arrange:
+			const mosaicIds = ['393AFB0B19902759', '0005EC25E3F9072D', '12CE9F2D2BCEE57D'];
+
+			const mockResponse = {
+				mosaicNames: [
+					{
+						mosaicId: '393AFB0B19902759',
+						names: []
+					},
+					{
+						mosaicId: '0005EC25E3F9072D',
+						names: [
+							'root.subnamespace'
+						]
+					},
+					{
+						mosaicId: '12CE9F2D2BCEE57D',
+						names: ['root.subNamespace_1', 'root.subnamespace_2']
+					}
+				]
+			};
+
+			fetchUtils.fetchData.mockResolvedValue(mockResponse);
+
+			// Act:
+			const result = await client.fetchMosaicNamespace(mosaicIds);
+
+			// Assert:
+			expect(result).toStrictEqual({
+				'393AFB0B19902759': [],
+				'0005EC25E3F9072D': ['root.subnamespace'],
+				'12CE9F2D2BCEE57D': ['root.subNamespace_1', 'root.subnamespace_2']
+			});
+			expect(fetchUtils.fetchData).toHaveBeenCalledWith(`${nodeUrl}/namespaces/mosaic/names`, 'POST', { mosaicIds });
+		});
+
+		it('returns empty object when mosaicIds is empty', async () => {
+			// Act:
+			const result = await client.fetchMosaicNamespace([]);
+
+			// Assert:
+			expect(result).toStrictEqual({});
+			expect(fetchUtils.fetchData).not.toHaveBeenCalled();
+		});
+
+		it('throws an error when fetch fails', async () => {
+			// Arrange:
+			const mosaicIds = ['393AFB0B19902759', '0005EC25E3F9072D'];
+
+			fetchUtils.fetchData.mockRejectedValue(new Error('Failed to fetch'));
+
+			// Assert:
+			const errorMessage = 'Failed to fetch mosaics namespace: Failed to fetch';
+			await expect(client.fetchMosaicNamespace(mosaicIds)).rejects.toThrow(errorMessage);
+		});
+	});
 });

--- a/snap/frontend/components/AssetList/AssetList.spec.jsx
+++ b/snap/frontend/components/AssetList/AssetList.spec.jsx
@@ -5,7 +5,27 @@ import { screen } from '@testing-library/react';
 const context = {
 	dispatch: jest.fn(),
 	walletState: {
-		mosaics: []
+		selectedAccount: {
+			...testHelper.generateAccountsState(1)['accountId 0']
+		},
+		mosaicInfo: {
+			'3C596F764B5A1160': {
+				name: [],
+				divisibility: 0
+			},
+			'E74B99BA41F4AFEE': {
+				name: ['symbol.xym'],
+				divisibility: 6
+			},
+			'393AFB0B19902759': {
+				name: ['a.b.c'],
+				divisibility: 6
+			},
+			'0005EC25E3F9072D': {
+				name: ['root'],
+				divisibility: 0
+			}
+		}
 	}
 };
 
@@ -25,12 +45,20 @@ describe('components/AssetList', () => {
 		expect(mosaicAmountElement).toBeInTheDocument();
 	};
 
+	const assertLoading = context => {
+		// Act:
+		testHelper.customRender(<AssetList />, context);
+
+		// Assert:
+		const loadingElement = screen.getByText('Loading...');
+		expect(loadingElement).toBeInTheDocument();
+	};
+
 	it('renders mosaic id when name is undefined', () => {
 		// Arrange:
-		context.walletState.mosaics = [
+		context.walletState.selectedAccount.mosaics = [
 			{
 				id: '3C596F764B5A1160',
-				name: null,
 				amount: 2
 			}
 		];
@@ -40,11 +68,10 @@ describe('components/AssetList', () => {
 
 	it('renders mosaic name when name is defined', () => {
 		// Arrange:
-		context.walletState.mosaics = [
+		context.walletState.selectedAccount.mosaics = [
 			{
 				id: 'E74B99BA41F4AFEE',
-				name: 'symbol.xym',
-				amount: 10.023123
+				amount: 10023123
 			}
 		];
 
@@ -53,11 +80,10 @@ describe('components/AssetList', () => {
 
 	it('renders multilevel mosaic name', () => {
 		// Arrange:
-		context.walletState.mosaics = [
+		context.walletState.selectedAccount.mosaics = [
 			{
 				id: '393AFB0B19902759',
-				name: 'a.b.c',
-				amount: 0.000001
+				amount: 1
 			}
 		];
 
@@ -66,9 +92,9 @@ describe('components/AssetList', () => {
 
 	it('renders mosaic name without sub namespace', () => {
 		// Arrange:
-		context.walletState.mosaics = [
+		context.walletState.selectedAccount.mosaics = [
 			{
-				id: 'E74B99BA41F4AFEE',
+				id: '0005EC25E3F9072D',
 				name: 'root',
 				amount: 10
 			}
@@ -76,6 +102,22 @@ describe('components/AssetList', () => {
 
 		assertMosaic(context, 'root', '10');
 	});
+
+	it('renders loading when mosaicInfo and selectedAccount is not loaded', () => {
+		// Arrange:
+		context.walletState.mosaicInfo = {};
+		context.walletState.selectedAccount = {};
+
+		assertLoading(context);
+	});
+
+	it('renders loading when selected account mosaics is not loaded', () => {
+		// Arrange:
+		context.walletState.selectedAccount = {};
+
+		assertLoading(context);
+	});
+
 
 	it('does not render when mosaics is empty', () => {
 		// Arrange + Act:

--- a/snap/frontend/components/AssetList/AssetList.spec.jsx
+++ b/snap/frontend/components/AssetList/AssetList.spec.jsx
@@ -118,7 +118,6 @@ describe('components/AssetList', () => {
 		assertLoading(context);
 	});
 
-
 	it('does not render when mosaics is empty', () => {
 		// Arrange + Act:
 		testHelper.customRender(<AssetList />, context);
@@ -126,5 +125,21 @@ describe('components/AssetList', () => {
 		// Assert:
 		const assetElement = screen.queryByRole('asset_0');
 		expect(assetElement).not.toBeInTheDocument();
+	});
+
+	it('throws error when mosaic information is not found', () => {
+		// Arrange:
+		context.walletState.selectedAccount.mosaics = [
+			{
+				id: '3C596F764B5A1160',
+				amount: 2
+			}
+		];
+		context.walletState.mosaicInfo = {};
+
+		// Act + Assert:
+		expect(() => {
+			testHelper.customRender(<AssetList />, context);
+		}).toThrowError('Mosaic information not found');
 	});
 });

--- a/snap/frontend/components/AssetList/index.jsx
+++ b/snap/frontend/components/AssetList/index.jsx
@@ -20,21 +20,21 @@ const AssetList = () => {
 		// Check if mosaic information exists and render based on condition
 		const mosaicDetail = mosaicInfo[mosaic.id];
 
-		if (mosaicDetail) {
-			return 0 === mosaicDetail.name.length ? (
-				<div>{mosaic.id}</div>
-			) : (
-				<div>{mosaicDetail.name[0].split('.')[0]}</div>
-			);
-		}
-		return null;
+		if (!mosaicDetail)
+			throw new Error('Mosaic information not found');
+
+		return 0 === mosaicDetail.name.length ? (
+			<div>{mosaic.id}</div>
+		) : (
+			<div>{mosaicDetail.name[0].split('.')[0]}</div>
+		);
 	};
 
 	const renderMosaicDetails = mosaic => {
 		const mosaicDetail = mosaicInfo[mosaic.id];
 
 		if (!mosaicDetail)
-			return null;
+			throw new Error('Mosaic information not found');
 
 		const amount = mosaic.amount / (10 ** mosaicDetail.divisibility);
 		const subNamespace = 0 === mosaicDetail.name.length ? null : renderSubNamespace(mosaicDetail.name[0]);

--- a/snap/frontend/components/AssetList/index.jsx
+++ b/snap/frontend/components/AssetList/index.jsx
@@ -1,8 +1,11 @@
 import { useWalletContext } from '../../context';
+import { useEffect, useState } from 'react';
 
 const AssetList = () => {
 	const { walletState } = useWalletContext();
-	const { mosaics } = walletState;
+	const { selectedAccount, mosaicInfo } = walletState;
+
+	const [isLoading, setIsLoading] = useState(true);
 
 	const renderSubNamespace = name => {
 		const split = name.split('.');
@@ -13,20 +16,58 @@ const AssetList = () => {
 		return split.slice(1).join('.');
 	};
 
+	const renderMosaicNameOrId = mosaic => {
+		// Check if mosaic information exists and render based on condition
+		const mosaicDetail = mosaicInfo[mosaic.id];
+
+		if (mosaicDetail) {
+			return 0 === mosaicDetail.name.length ? (
+				<div>{mosaic.id}</div>
+			) : (
+				<div>{mosaicDetail.name[0].split('.')[0]}</div>
+			);
+		}
+		return null;
+	};
+
+	const renderMosaicDetails = mosaic => {
+		const mosaicDetail = mosaicInfo[mosaic.id];
+
+		if (!mosaicDetail)
+			return null;
+
+		const amount = mosaic.amount / (10 ** mosaicDetail.divisibility);
+		const subNamespace = 0 === mosaicDetail.name.length ? null : renderSubNamespace(mosaicDetail.name[0]);
+
+		return (
+			<div className='text-xs text-gray-400'>
+				{amount} {subNamespace}
+			</div>
+		);
+	};
+
+	useEffect(() => {
+		// Check if mosaicInfo and selectedAccount are loaded
+		if (mosaicInfo && selectedAccount && Array.isArray(selectedAccount.mosaics))
+			setIsLoading(false);
+		else
+			setIsLoading(true);
+
+	}, [mosaicInfo, selectedAccount]);
+
+	if (isLoading)
+		return <div>Loading...</div>;
+
+
 	return (
 		<div className='flex flex-col overflow-y-auto'>
 			{
-				mosaics.map((mosaic, index) => (
+				selectedAccount.mosaics.map((mosaic, index) => (
 					<div key={`asset_${index}`} className='flex items-center justify-start p-2'>
 						<div role={`mosaic-image_${index}`} className="rounded-full w-5 h-5 bg-gray-300 mr-2" />
 						<div className='text-xs'>
-							{
-								null === mosaic.name ?
-									<div>{mosaic.id}</div> :
-									<div>{mosaic.name.split('.')[0]}</div>
-							}
-
-							<div>{mosaic.amount} {null !== mosaic.name ? renderSubNamespace(mosaic.name) : null}</div>
+							{ renderMosaicNameOrId(mosaic) }
+							{ renderMosaicDetails(mosaic) }
 						</div>
 					</div>
 				))

--- a/snap/frontend/utils/helper.js
+++ b/snap/frontend/utils/helper.js
@@ -25,8 +25,6 @@ const helper = {
 			account = await symbolSnap.createAccount('Wallet 1');
 		}
 
-		dispatch.setSelectedAccount(account);
-
 		// fetch mosaic info and accounts
 		const [mosaicInfo, updateAccounts] = await Promise.all([
 			symbolSnap.getMosaicInfo(),
@@ -35,6 +33,8 @@ const helper = {
 
 		dispatch.setMosaicInfo(mosaicInfo);
 		dispatch.setAccounts(updateAccounts);
+
+		dispatch.setSelectedAccount(account);
 
 		dispatch.setLoadingStatus({
 			isLoading: false,


### PR DESCRIPTION
## What was the issue?
- Mosaic didn't have a namespace name.

## What's the fix?
- Added mosaic namespace name query by mosaic id.
- Implement fetch mosaic namespace while fetching mosaic info.
- Implement selected account mosaic in the asset list components.

## Note: 
asset list

<img width="433" alt="image" src="https://github.com/symbol/product/assets/5649156/e787c6d2-94e0-4a1a-a74d-d08d847f468c">
