### PR TITLE
[snap/backend]: Added transaction utils and rpc.

### DIFF
--- a/snap/backend/package-lock.json
+++ b/snap/backend/package-lock.json
@@ -14,6 +14,7 @@
 				"@metamask/snaps-sdk": "^3.1.0",
 				"crypto-js": "^4.2.0",
 				"empty-module": "^0.0.2",
+				"moment-timezone": "^0.5.45",
 				"process": "^0.11.10",
 				"symbol-sdk": "^3.2.2",
 				"uuid": "^9.0.1",
@@ -9667,6 +9668,25 @@
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"dependencies": {
 				"safe-buffer": "~5.1.0"
+			}
+		},
+		"node_modules/moment": {
+			"version": "2.30.1",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+			"integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/moment-timezone": {
+			"version": "0.5.45",
+			"resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.45.tgz",
+			"integrity": "sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==",
+			"dependencies": {
+				"moment": "^2.29.4"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/ms": {

--- a/snap/backend/package.json
+++ b/snap/backend/package.json
@@ -33,6 +33,7 @@
 		"@metamask/snaps-sdk": "^3.1.0",
 		"crypto-js": "^4.2.0",
 		"empty-module": "^0.0.2",
+		"moment-timezone": "^0.5.45",
 		"process": "^0.11.10",
 		"symbol-sdk": "^3.2.2",
 		"uuid": "^9.0.1",

--- a/snap/backend/snap.manifest.json
+++ b/snap/backend/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/symbol/product.git"
   },
   "source": {
-    "shasum": "YCrBAG6XY0xZB5WtNjrfpT16b8xXhxtv3qKfYYb6TRw=",
+    "shasum": "s/K0moPt0Whp88wJlDNNZWfKAt7JJQ+xRXUvpHm1ISc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/snap/backend/snap.manifest.json
+++ b/snap/backend/snap.manifest.json
@@ -27,6 +27,12 @@
           "request": {
             "method": "fetchCurrencyPrice"
           }
+        },
+        {
+          "expression": "* * * * *",
+          "request": {
+            "method": "fetchFeeMultiplier"
+          }
         }
       ]
     },

--- a/snap/backend/snap.manifest.json
+++ b/snap/backend/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/symbol/product.git"
   },
   "source": {
-    "shasum": "s/K0moPt0Whp88wJlDNNZWfKAt7JJQ+xRXUvpHm1ISc=",
+    "shasum": "BJNYqnWfv9688rGDvcSXAImB8d0Vi8if+wzMDZC55h8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/snap/backend/src/index.js
+++ b/snap/backend/src/index.js
@@ -70,6 +70,8 @@ export const onCronjob = async ({ request }) => {
 	switch (request.method) {
 	case 'fetchCurrencyPrice':
 		return priceUtils.getPrice({ state });
+	case 'fetchFeeMultiplier':
+		return transactionUtils.getFeeMultiplier({ state });
 	default:
 		throw new Error('Method not found.');
 	}

--- a/snap/backend/src/index.js
+++ b/snap/backend/src/index.js
@@ -3,6 +3,7 @@ import accountUtils from './utils/accountUtils.js';
 import mosaicUtils from './utils/mosaicUtils.js';
 import networkUtils from './utils/networkUtils.js';
 import priceUtils from './utils/priceUtils.js';
+import transactionUtils from './utils/transactionUtils.js';
 
 // eslint-disable-next-line import/prefer-default-export
 export const onRpcRequest = async ({ request }) => {
@@ -52,6 +53,8 @@ export const onRpcRequest = async ({ request }) => {
 		return mosaicUtils.getMosaicInfo(apiParams);
 	case 'fetchAccountMosaics':
 		return accountUtils.fetchAccountMosaics(apiParams);
+	case 'fetchAccountTransactions':
+		return transactionUtils.fetchAccountTransactions(apiParams);
 	default:
 		throw new Error('Method not found.');
 	}

--- a/snap/backend/src/index.js
+++ b/snap/backend/src/index.js
@@ -16,7 +16,8 @@ export const onRpcRequest = async ({ request }) => {
 			currencies: {},
 			accounts: {},
 			network: {},
-			mosaicInfo: {}
+			mosaicInfo: {},
+			feeMultiplier: { slow: 0, average: 0, fast: 0 }
 		};
 	}
 
@@ -30,6 +31,7 @@ export const onRpcRequest = async ({ request }) => {
 	case 'initialSnap':
 		await networkUtils.switchNetwork(apiParams);
 		await priceUtils.getPrice(apiParams);
+		await transactionUtils.getFeeMultiplier(apiParams);
 
 		return {
 			...state,
@@ -55,6 +57,8 @@ export const onRpcRequest = async ({ request }) => {
 		return accountUtils.fetchAccountMosaics(apiParams);
 	case 'fetchAccountTransactions':
 		return transactionUtils.fetchAccountTransactions(apiParams);
+	case 'getFeeMultiplier':
+		return state.feeMultiplier;
 	default:
 		throw new Error('Method not found.');
 	}

--- a/snap/backend/src/services/symbolClient.js
+++ b/snap/backend/src/services/symbolClient.js
@@ -62,7 +62,7 @@ const symbolClient = {
 			/**
 			 * Fetch mosaics namespace from mosaic ids.
 			 * @param {Array<string>} mosaicIds - The mosaic ids to fetch namespace.
-			 * @returns {Promise<Record<string, Array<string>>} The mosaics namespace.
+			 * @returns {Promise<Record<string, Array<string>>>} The mosaics namespace.
 			 */
 			fetchMosaicNamespace: async mosaicIds => {
 				if (!mosaicIds.length)
@@ -124,6 +124,23 @@ const symbolClient = {
 					return innerTransactions;
 				} catch (error) {
 					throw new Error(`Failed to fetch inner transactions by aggregate ids: ${error.message}`);
+				}
+			},
+			/**
+			 * Fetch transaction fee multiplier.
+			 * @returns {Promise<FeeMultiplier>} The transaction fee multiplier.
+			 */
+			fetchTransactionFeeMultiplier: async () => {
+				try {
+					const fees = await fetchUtils.fetchData(`${nodeUrl}/network/fees/transaction`);
+
+					return {
+						slow: fees.minFeeMultiplier,
+						average: fees.averageFeeMultiplier,
+						fast: fees.highestFeeMultiplier
+					};
+				} catch (error) {
+					throw new Error(`Failed to fetch transaction fee multiplier: ${error.message}`);
 				}
 			}
 		};
@@ -187,6 +204,14 @@ export default symbolClient;
  * @property {Meta} meta - The metadata of the transaction.
  * @property {TransactionDetails} transaction - The details of the transaction.
  * @property {string} id - The transaction id.
+ */
+
+/**
+ * The transaction fee multiplier object.
+ * @typedef {object} FeeMultiplier
+ * @property {number} slow - The slow fee multiplier.
+ * @property {number} average - The average fee multiplier.
+ * @property {number} fast - The fast fee multiplier.
  */
 
 // endregion

--- a/snap/backend/src/utils/transactionUtils.js
+++ b/snap/backend/src/utils/transactionUtils.js
@@ -1,4 +1,5 @@
 import symbolClient from '../services/symbolClient.js';
+import stateManager from '../stateManager.js';
 import moment from 'moment'; // eslint-disable-line
 import { PublicKey } from 'symbol-sdk';
 import { SymbolFacade, models } from 'symbol-sdk/symbol';
@@ -108,6 +109,18 @@ const transactionUtils = {
 			message: isTransferTransaction ? (transaction.message || null) : null,
 			sender: senderAddress
 		};
+	},
+	getFeeMultiplier: async ({ state }) => {
+		const { network } = state;
+		const client = symbolClient.create(network.url);
+
+		const feeMultiplier = await client.fetchTransactionFeeMultiplier();
+
+		state.feeMultiplier = feeMultiplier;
+
+		await stateManager.update(state);
+
+		return feeMultiplier;
 	}
 };
 

--- a/snap/backend/src/utils/transactionUtils.js
+++ b/snap/backend/src/utils/transactionUtils.js
@@ -115,7 +115,7 @@ const transactionUtils = {
 	createTransaction(id, meta, transaction, network, transactionTypeOverride = null) {
 		const facade = new SymbolFacade(network.networkName);
 		const senderAddress = facade.network.publicKeyToAddress(new PublicKey(transaction.signerPublicKey)).toString();
-		const date = moment(facade.network.toDatetime({ timestamp: BigInt(meta.timestamp) })).format('YYYY-MM-DD HH:mm:ss');
+		const date = moment.utc(facade.network.toDatetime({ timestamp: BigInt(meta.timestamp) })).format('YYYY-MM-DD HH:mm:ss');
 
 		const isTransferTransaction = transaction.type === TRANSFER_TRANSACTION_TYPE;
 

--- a/snap/backend/src/utils/transactionUtils.js
+++ b/snap/backend/src/utils/transactionUtils.js
@@ -1,0 +1,149 @@
+import symbolClient from '../services/symbolClient.js';
+import { PublicKey } from 'symbol-sdk';
+import { SymbolFacade } from 'symbol-sdk/symbol';
+
+const AGGREGATE_COMPLETE_TRANSACTION_TYPE = 16705;
+const AGGREGATE_BONDED_TRANSACTION_TYPE = 16961;
+const TRANSFER_TRANSACTION_TYPE = 16724;
+
+const TRANSACTION_TYPE = {
+	16724: 'Transfer',
+	16718: 'Namespace Registration',
+	16974: 'Address Alias',
+	17230: 'Mosaic Alias',
+	16717: 'Mosaic Definition',
+	16973: 'Mosaic Supply Change',
+	17229: 'Mosaic Supply Revocation',
+	16725: 'Multisig Account Modification',
+	16705: 'Aggregate Complete',
+	16961: 'Aggregate Bonded',
+	16712: 'Hash Lock',
+	16722: 'Secret Lock',
+	16978: 'Secret Proof',
+	16720: 'Account Address Restriction',
+	16976: 'Account Mosaic Restriction',
+	17232: 'Account Operation Restriction',
+	16716: 'Account Key Link',
+	16977: 'Mosaic Address Restriction',
+	16721: 'Mosaic Global Restriction',
+	16708: 'Account Metadata',
+	16964: 'Mosaic Metadata',
+	17220: 'Namespace Metadata',
+	16963: 'VRF Key Link',
+	16707: 'Voting Key Link',
+	16972: 'Node Key Link'
+};
+
+const transactionUtils = {
+	/**
+     * Fetch account transactions and aggregate inner transactions.
+     * @param {{ state: object, requestParams: object }} params - The request params.
+     * @returns {Promise<Array<TransactionInfo>>} - The account transactions.
+     */
+	async fetchAccountTransactions({ state, requestParams }) {
+		const { network } = state;
+		const { address, offsetId } = requestParams;
+
+		const client = symbolClient.create(network.url);
+
+		const transactions = await client.fetchTransactionPageByAddress(address, offsetId);
+
+		const aggregateIds = [];
+
+		transactions.forEach(({ id, transaction }) => {
+			if (this.isAggregateTransaction(transaction))
+				aggregateIds.push(id);
+		});
+
+		if (aggregateIds.length) {
+			const innerTransactions = await client.fetchInnerTransactionByAggregateIds(aggregateIds);
+
+			transactions.forEach(({ id, transaction }) => {
+				if (innerTransactions[id])
+					transaction.innerTransactions = innerTransactions[id];
+			});
+		}
+
+		return this.formatTransactionToFlat(transactions, network);
+	},
+	/**
+     * Check if transaction is aggregate complete or aggregate bonded.
+     * @param {*} transaction
+     * @returns {boolean} returns true if transaction is aggregate.
+     */
+	isAggregateTransaction(transaction) {
+		return [AGGREGATE_COMPLETE_TRANSACTION_TYPE, AGGREGATE_BONDED_TRANSACTION_TYPE].includes(transaction.type);
+	},
+	/**
+     * Format transactions to flat object.
+     * @param {Array<object>} transactions - The transactions.
+     * @param {object} network - The network state.
+     * @returns {Array<TransactionInfo>} - The flat transactions.
+     */
+	formatTransactionToFlat(transactions, network) {
+		const flatTransactions = [];
+
+		transactions.forEach(({ id, meta, transaction }) => {
+			const pushTransaction = (tx, suffix = '') => {
+				const typeLabel = suffix ? `${suffix} | ${TRANSACTION_TYPE[tx.type]}` : '';
+				flatTransactions.push(this.createTransaction(id, meta, tx, network, typeLabel));
+			};
+
+			if (transaction.type === TRANSFER_TRANSACTION_TYPE) {
+				pushTransaction(transaction);
+			} else if (this.isAggregateTransaction(transaction)) {
+				transaction.innerTransactions.forEach(innerTransaction => {
+					pushTransaction(innerTransaction.transaction, `${TRANSACTION_TYPE[transaction.type]}`);
+				});
+			} else {
+				pushTransaction(transaction);
+			}
+		});
+
+		return flatTransactions;
+	},
+	/**
+     * Create custom transaction object.
+     * @param {string} id - The transaction id.
+     * @param {object} meta - The transaction meta.
+     * @param {object} transaction - The transaction object.
+     * @param {object} network - The network state.
+     * @param {string} transactionTypeOverride - The transaction type override.
+     * @returns {TransactionInfo} - The transaction object.
+     */
+	createTransaction(id, meta, transaction, network, transactionTypeOverride = null) {
+		const xymMosaic = transaction.mosaics?.find(mosaic => mosaic.id === network.currencyMosaicId) || null;
+		const facade = new SymbolFacade(network.networkName);
+		const senderAddress = facade.network.publicKeyToAddress(new PublicKey(transaction.signerPublicKey)).toString();
+
+		return {
+			id,
+			timestamp: meta.timestamp,
+			height: meta.height,
+			transactionHash: meta.hash,
+			transactionType: transactionTypeOverride || TRANSACTION_TYPE[transaction.type],
+			amount: xymMosaic ? xymMosaic.amount : null,
+			message: transaction.message || null,
+			sender: senderAddress
+		};
+	}
+};
+
+export default transactionUtils;
+
+// region type declarations
+
+/**
+ * state of create transaction object.
+ * @typedef {object} TransactionInfo
+ * @property {string} id - The transaction id.
+ * @property {string} timestamp - The transaction timestamp.
+ * @property {number} height - The transaction block height.
+ * @property {string} transactionHash - The transaction hash.
+ * @property {string} transactionType - The transaction type.
+ * @property {number | null} amount - The transaction XYM amount.
+ * @property {string | null} message - The transaction message.
+ * @property {string} sender - The sender address.
+ */
+
+// endregion

--- a/snap/backend/test/index_spec.js
+++ b/snap/backend/test/index_spec.js
@@ -42,13 +42,20 @@ describe('index', () => {
 			EUR: 0.20
 		};
 
+		const mockFeeMultiplier = {
+			slow: 0,
+			average: 0,
+			fast: 0
+		}
+
 		beforeEach(() => {
 			jest.clearAllMocks();
 
 			stateManager.getState.mockResolvedValue({
 				accounts: {},
 				network: mockNodeInfo,
-				currencies: mockCurrencies
+				currencies: mockCurrencies,
+				feeMultiplier: mockFeeMultiplier
 			});
 		});
 
@@ -58,7 +65,12 @@ describe('index', () => {
 			const assertInitialSnap = async (state, expectedState) => {
 				// Arrange:
 				jest.spyOn(symbolClient, 'create').mockReturnValue({
-					fetchNetworkCurrencyMosaicId: jest.fn().mockResolvedValue('mosaicId')
+					fetchNetworkCurrencyMosaicId: jest.fn().mockResolvedValue('mosaicId'),
+					fetchTransactionFeeMultiplier: jest.fn().mockResolvedValue({
+						slow: 100,
+						average: 150,
+						fast: 200
+					})
 				});
 
 				stateManager.getState.mockResolvedValue(state);
@@ -92,7 +104,12 @@ describe('index', () => {
 						symbol: 'USD',
 						price: 0.25
 					},
-					mosaicInfo: {}
+					mosaicInfo: {},
+					feeMultiplier: {
+						slow: 100,
+						average: 150,
+						fast: 200
+					}
 				});
 			});
 
@@ -141,7 +158,12 @@ describe('index', () => {
 						symbol: 'USD',
 						price: 0.25
 					},
-					mosaicInfo: {}
+					mosaicInfo: {},
+					feeMultiplier: {
+						slow: 100,
+						average: 150,
+						fast: 200
+					}
 				});
 			});
 		});
@@ -166,7 +188,8 @@ describe('index', () => {
 					state: {
 						accounts: {},
 						network: mockNodeInfo,
-						currencies: mockCurrencies
+						currencies: mockCurrencies,
+						feeMultiplier: mockFeeMultiplier
 					},
 					requestParams: {
 						accountLabel: 'my wallet'
@@ -196,7 +219,8 @@ describe('index', () => {
 					state: {
 						accounts: {},
 						currencies: mockCurrencies,
-						network: mockNodeInfo
+						network: mockNodeInfo,
+						feeMultiplier: mockFeeMultiplier
 					},
 					requestParams: {
 						accountLabel: 'my wallet',
@@ -339,6 +363,20 @@ describe('index', () => {
 						offsetId: ''
 					}
 				});
+			});
+		});
+
+		describe('getFeeMultiplier', () => {
+			it('returns state fee multiplier', async () => {
+				// Act:
+				const response = await onRpcRequest({
+					request: {
+						method: 'getFeeMultiplier'
+					}
+				});
+
+				// Assert:
+				expect(response).toStrictEqual(mockFeeMultiplier);
 			});
 		});
 	});

--- a/snap/backend/test/index_spec.js
+++ b/snap/backend/test/index_spec.js
@@ -415,5 +415,38 @@ describe('index', () => {
 				});
 			});
 		});
+
+		describe('fetchFeeMultiplier', () => {
+			it('fetches latest fee multiplier and update state', async () => {
+				// Arrange:
+				const state = {
+					feeMultiplier: {
+						slow: 0,
+						average: 0,
+						fast: 0
+					}
+				};
+
+				stateManager.getState.mockResolvedValue(state);
+
+				jest.spyOn(transactionUtils, 'getFeeMultiplier').mockResolvedValue({
+					slow: 100,
+					average: 150,
+					fast: 200
+				});
+
+				// Act:
+				await onCronjob({
+					request: {
+						method: 'fetchFeeMultiplier'
+					}
+				});
+
+				// Assert:
+				expect(transactionUtils.getFeeMultiplier).toHaveBeenCalledWith({
+					state
+				});
+			});
+		});
 	});
 });

--- a/snap/backend/test/index_spec.js
+++ b/snap/backend/test/index_spec.js
@@ -5,6 +5,7 @@ import symbolClient from '../src/services/symbolClient.js';
 import stateManager from '../src/stateManager.js';
 import accountUtils from '../src/utils/accountUtils.js';
 import mosaicUtils from '../src/utils/mosaicUtils.js';
+import transactionUtils from '../src/utils/transactionUtils.js';
 import {
 	describe, expect, it, jest
 } from '@jest/globals';
@@ -318,6 +319,24 @@ describe('index', () => {
 					state: {},
 					requestParams: {
 						accountIds: ['0x1']
+					}
+				});
+			});
+		});
+
+		describe('fetchAccountTransactions', () => {
+			it('should invoke transactionUtils.fetchAccountTransactions with the correct parameters', async () => {
+				await assertMethodCalled(transactionUtils, 'fetchAccountTransactions', {
+					method: 'fetchAccountTransactions',
+					params: {
+						address: 'address',
+						offsetId: ''
+					}
+				}, {
+					state: {},
+					requestParams: {
+						address: 'address',
+						offsetId: ''
 					}
 				});
 			});

--- a/snap/backend/test/index_spec.js
+++ b/snap/backend/test/index_spec.js
@@ -46,7 +46,7 @@ describe('index', () => {
 			slow: 0,
 			average: 0,
 			fast: 0
-		}
+		};
 
 		beforeEach(() => {
 			jest.clearAllMocks();
@@ -413,15 +413,6 @@ describe('index', () => {
 				expect(stateManager.update).toHaveBeenCalledWith({
 					currencies: mockLatestCurrencies
 				});
-			});
-
-			it('throws an error if the requested method does not exist', async () => {
-				// Act + Assert:
-				await expect(onCronjob({
-					request: {
-						method: 'unknownMethod'
-					}
-				})).rejects.toThrow('Method not found.');
 			});
 		});
 	});

--- a/snap/backend/test/services/symbolClient_spec.js
+++ b/snap/backend/test/services/symbolClient_spec.js
@@ -375,4 +375,39 @@ describe('symbolClient', () => {
 			await expect(client.fetchInnerTransactionByAggregateIds(mockTransactionIds)).rejects.toThrow(errorMessage);
 		});
 	});
+
+	describe('fetchTransactionFeeMultiplier', () => {
+		it('can fetch transaction fee multiplier successfully', async () => {
+			// Arrange:
+			const mockResponse = {
+				averageFeeMultiplier: 118,
+				medianFeeMultiplier: 100,
+				highestFeeMultiplier: 5681,
+				lowestFeeMultiplier: 0,
+				minFeeMultiplier: 100
+			};
+
+			fetchUtils.fetchData.mockResolvedValue(mockResponse);
+
+			// Act:
+			const result = await client.fetchTransactionFeeMultiplier();
+
+			// Assert:
+			expect(result).toStrictEqual({
+				slow: 100,
+				average: 118,
+				fast: 5681
+			});
+			expect(fetchUtils.fetchData).toHaveBeenCalledWith(`${nodeUrl}/network/fees/transaction`);
+		});
+
+		it('throws an error when fetch fails', async () => {
+			// Arrange:
+			fetchUtils.fetchData.mockRejectedValue(new Error('Failed to fetch'));
+
+			// Assert:
+			const errorMessage = 'Failed to fetch transaction fee multiplier: Failed to fetch';
+			await expect(client.fetchTransactionFeeMultiplier()).rejects.toThrow(errorMessage);
+		});
+	});
 });

--- a/snap/backend/test/utils/transactionUtils_spec.js
+++ b/snap/backend/test/utils/transactionUtils_spec.js
@@ -95,7 +95,7 @@ describe('transactionUtils', () => {
 			expect(result).toStrictEqual([
 				{
 					id: '1',
-					timestamp: '12345',
+					date: '2022-11-01 05:07:59',
 					height: '1552748',
 					transactionHash: 'hash',
 					transactionType: 'Transfer',
@@ -105,7 +105,7 @@ describe('transactionUtils', () => {
 				},
 				{
 					id: '2',
-					timestamp: '12345',
+					date: '2022-11-01 05:07:59',
 					height: '1552750',
 					transactionHash: 'hash',
 					transactionType: 'Node Key Link',
@@ -219,7 +219,7 @@ describe('transactionUtils', () => {
 			expect(result).toStrictEqual([
 				{
 					id: '3',
-					timestamp: '53513952699',
+					date: '2024-07-12 14:06:59',
 					height: '1571464',
 					transactionHash: 'hash',
 					transactionType: 'Aggregate Complete | Transfer',
@@ -229,11 +229,11 @@ describe('transactionUtils', () => {
 				},
 				{
 					id: '3',
-					timestamp: '53513952699',
+					date: '2024-07-12 14:06:59',
 					height: '1571464',
 					transactionHash: 'hash',
 					transactionType: 'Aggregate Complete | Transfer',
-					amount: null,
+					amount: 0,
 					message: 'message',
 					sender: 'TDJRSQNOOIZLAB4OQEETH2UNBQ4HC2MNQZY4P6A'
 				}

--- a/snap/backend/test/utils/transactionUtils_spec.js
+++ b/snap/backend/test/utils/transactionUtils_spec.js
@@ -95,7 +95,7 @@ describe('transactionUtils', () => {
 			expect(result).toStrictEqual([
 				{
 					id: '1',
-					date: '2022-11-01 05:07:59',
+					date: '2022-10-31 21:07:59',
 					height: '1552748',
 					transactionHash: 'hash',
 					transactionType: 'Transfer',
@@ -105,7 +105,7 @@ describe('transactionUtils', () => {
 				},
 				{
 					id: '2',
-					date: '2022-11-01 05:07:59',
+					date: '2022-10-31 21:07:59',
 					height: '1552750',
 					transactionHash: 'hash',
 					transactionType: 'Node Key Link',
@@ -219,7 +219,7 @@ describe('transactionUtils', () => {
 			expect(result).toStrictEqual([
 				{
 					id: '3',
-					date: '2024-07-12 14:06:59',
+					date: '2024-07-12 06:06:59',
 					height: '1571464',
 					transactionHash: 'hash',
 					transactionType: 'Aggregate Complete | Transfer',
@@ -229,7 +229,7 @@ describe('transactionUtils', () => {
 				},
 				{
 					id: '3',
-					date: '2024-07-12 14:06:59',
+					date: '2024-07-12 06:06:59',
 					height: '1571464',
 					transactionHash: 'hash',
 					transactionType: 'Aggregate Complete | Transfer',

--- a/snap/backend/test/utils/transactionUtils_spec.js
+++ b/snap/backend/test/utils/transactionUtils_spec.js
@@ -1,0 +1,245 @@
+import symbolClient from '../../src/services/symbolClient.js';
+import transactionUtils from '../../src/utils/transactionUtils.js';
+import { describe, jest } from '@jest/globals';
+
+describe('transactionUtils', () => {
+	// Arrange:
+	const mockState = {
+		network: {
+			networkName: 'testnet',
+			url: 'http://localhost:3000',
+			currencyMosaicId: 'mosaicId'
+		}
+	};
+
+	const createMockTransaction = (meta, transaction, id) => ({ meta, transaction, id });
+
+	const createMockMeta = height => ({
+		height,
+		hash: 'hash',
+		merkleComponentHash: 'merkleComponentHash',
+		index: 0,
+		timestamp: '12345',
+		feeMultiplier: 100
+	});
+
+	const createMockTransferTransaction = (id, height) => createMockTransaction(
+		createMockMeta(height),
+		{
+			size: 176,
+			signature: 'signature',
+			signerPublicKey: 'AC2B4FD9F3D5C3565B5BBB1D723F24EFEA5DBD63FAD91863D5B338EC8A530E42',
+			version: 1,
+			network: 152,
+			type: 16724,
+			maxFee: '17600',
+			deadline: '52880817608',
+			recipientAddress: '981A4E4073D7DC9DC874B66A09D0AFF51EDFFC1AC5A27FBA',
+			mosaics: [
+				{
+					id: 'mosaicId',
+					amount: '1000000'
+				},
+				{
+					id: 'mosaicId2',
+					amount: '1'
+				}
+			]
+		},
+		id
+	);
+
+	const createMockVRFTransaction = (id, height) =>
+		createMockTransaction(
+			createMockMeta(height),
+			{
+				size: 161,
+				signature: 'signature',
+				signerPublicKey: 'D10B705D5D997B551211A666A0FB5B8CB1A1471B07C184F7448937D710B340DB',
+				version: 1,
+				network: 152,
+				type: 16972,
+				maxFee: '16100',
+				deadline: '53762151416',
+				linkedPublicKey: 'D10B705D5D997B551211A666A0FB5B8CB1A1471B07C184F7448937D700000000',
+				linkAction: 0
+			},
+			id
+		);
+
+	describe('fetchAccountTransactions', () => {
+		it('return account transactions without aggregate transaction', async () => {
+			// Arrange:
+			const mockRequestParams = {
+				address: 'address',
+				offsetId: ''
+			};
+
+			const mockTransactionResponse = [
+				createMockTransferTransaction('1', '1552748'),
+				createMockVRFTransaction('2', '1552750')
+			];
+
+			const mockFetchTransactionPageByAddress = jest.fn().mockResolvedValue(mockTransactionResponse);
+			const mockFetchInnerTransactionByAggregateIds = jest.fn().mockResolvedValue();
+
+			jest.spyOn(symbolClient, 'create').mockImplementation(() => ({
+				fetchTransactionPageByAddress: mockFetchTransactionPageByAddress,
+				fetchInnerTransactionByAggregateIds: mockFetchInnerTransactionByAggregateIds
+			}));
+
+			// Act:
+			const result = await transactionUtils.fetchAccountTransactions({ state: mockState, requestParams: mockRequestParams });
+
+			// Assert:
+			expect(result).toStrictEqual([
+				{
+					id: '1',
+					timestamp: '12345',
+					height: '1552748',
+					transactionHash: 'hash',
+					transactionType: 'Transfer',
+					amount: '1000000',
+					message: null,
+					sender: 'TCZTBI7HCCFPREBWJPZIPJA3FVKC2S2NSSPJ6YQ'
+				},
+				{
+					id: '2',
+					timestamp: '12345',
+					height: '1552750',
+					transactionHash: 'hash',
+					transactionType: 'Node Key Link',
+					amount: null,
+					message: null,
+					sender: 'TCMDJ7EW5YMATRDH2D4ZQZEAXXAZE4YEHS3JSCA'
+				}
+			]);
+			expect(mockFetchTransactionPageByAddress).toHaveBeenCalledWith('address', '');
+			expect(mockFetchInnerTransactionByAggregateIds).not.toHaveBeenCalled();
+		});
+
+		it('return account transactions with aggregate transaction', async () => {
+			// Arrange:
+			const mockRequestParams = {
+				address: 'address',
+				offsetId: ''
+			};
+
+			const mockTransactionResponse = [
+				{
+					meta: {
+						height: '1571464',
+						hash: 'hash',
+						merkleComponentHash: 'merkleComponentHash',
+						index: 1,
+						timestamp: '53513952699',
+						feeMultiplier: 100
+					},
+					transaction: {
+						size: 264,
+						signature: 'signature',
+						signerPublicKey: '07BDA13095105886A9A8A623E630C90DB7B02260F835420E95B1FBEE7686E4C2',
+						version: 2,
+						network: 152,
+						type: 16705,
+						maxFee: '26400',
+						deadline: '53517549052',
+						transactionsHash: 'F70063AEBEA12E4CF4D7E5CB5747E060FAFC94F586FA8EBD07B12E1496EA6400',
+						cosignatures: []
+					},
+					id: '3'
+				}
+			];
+
+			const mockTransactionDetailResponse = {
+				3: [
+					{
+						meta: {
+							height: '1571464',
+							aggregateHash: 'aggregateHash',
+							aggregateId: '3',
+							index: 0,
+							timestamp: '53513952699',
+							feeMultiplier: 100
+						},
+						transaction: {
+							signerPublicKey: '07BDA13095105886A9A8A623E630C90DB7B02260F835420E95B1FBEE7686E4C2',
+							version: 1,
+							network: 152,
+							type: 16724,
+							recipientAddress: '98DA51AD51C065A958FAC4D62B9B3F58B58B6503BF53C3D5',
+							mosaics: [
+								{
+									id: 'mosaicId',
+									amount: '9213486'
+								},
+								{
+									id: 'mosaicId2',
+									amount: '1'
+								}
+							]
+						},
+						id: '3'
+					},
+					{
+						meta: {
+							height: '1571464',
+							aggregateHash: 'aggregateHash',
+							aggregateId: '4',
+							index: 1,
+							timestamp: '53513952699',
+							feeMultiplier: 100
+						},
+						transaction: {
+							signerPublicKey: '07BDA13095105886A9A8A623E630C90DB7B02260F835420E95B1FBEE7686E4C2',
+							version: 1,
+							network: 152,
+							type: 16724,
+							recipientAddress: '98DA51AD51C065A958FAC4D62B9B3F58B58B6503BF53C3D5',
+							mosaics: [],
+							message: 'message'
+						},
+						id: '4'
+					}
+				]
+			};
+
+			const mockFetchTransactionPageByAddress = jest.fn().mockResolvedValue(mockTransactionResponse);
+			const mockFetchInnerTransactionByAggregateIds = jest.fn().mockResolvedValue(mockTransactionDetailResponse);
+
+			jest.spyOn(symbolClient, 'create').mockImplementation(() => ({
+				fetchTransactionPageByAddress: mockFetchTransactionPageByAddress,
+				fetchInnerTransactionByAggregateIds: mockFetchInnerTransactionByAggregateIds
+			}));
+
+			// Act:
+			const result = await transactionUtils.fetchAccountTransactions({ state: mockState, requestParams: mockRequestParams });
+
+			// Assert:
+			expect(result).toStrictEqual([
+				{
+					id: '3',
+					timestamp: '53513952699',
+					height: '1571464',
+					transactionHash: 'hash',
+					transactionType: 'Aggregate Complete | Transfer',
+					amount: '9213486',
+					message: null,
+					sender: 'TDJRSQNOOIZLAB4OQEETH2UNBQ4HC2MNQZY4P6A'
+				},
+				{
+					id: '3',
+					timestamp: '53513952699',
+					height: '1571464',
+					transactionHash: 'hash',
+					transactionType: 'Aggregate Complete | Transfer',
+					amount: null,
+					message: 'message',
+					sender: 'TDJRSQNOOIZLAB4OQEETH2UNBQ4HC2MNQZY4P6A'
+				}
+			]);
+			expect(mockFetchTransactionPageByAddress).toHaveBeenCalledWith('address', '');
+			expect(mockFetchInnerTransactionByAggregateIds).toHaveBeenCalledWith(['3']);
+		});
+	});
+});

--- a/snap/frontend/app/page.spec.jsx
+++ b/snap/frontend/app/page.spec.jsx
@@ -49,7 +49,8 @@ describe('Main', () => {
 					networkName: 'testnet'
 				}
 			}),
-			getAccounts: () => testHelper.generateAccountsState(1)
+			getAccounts: () => testHelper.generateAccountsState(1),
+			fetchAccountTransactions: () => []
 		});
 
 		// Act:

--- a/snap/frontend/components/Home/index.jsx
+++ b/snap/frontend/components/Home/index.jsx
@@ -62,7 +62,7 @@ const Home = () => {
 				{/* Right Panel */}
 				<div className='flex flex-col h-[500px] min-w-[670px] w-3/4 rounded-md  bg-primary'>
 					{/* Account Balance container */}
-					<div className='flex flex-col h-48 justify-center items-center w-full'>
+					<div className='flex flex-col h-[180px] justify-center items-center w-full'>
 						<AccountBalance />
 
 						{/* Show Button Receive and Send */}
@@ -75,7 +75,9 @@ const Home = () => {
 						<ReceiveModalBox isOpen={receiveModalBoxVisible} onRequestClose={setReceiveModalBoxVisible} />
 					</div>
 
-					<TransactionTable />
+					<div className='flex flex-col h-[320px] border-t-2'>
+						<TransactionTable />
+					</div>
 				</div>
 			</div>
 		</div>

--- a/snap/frontend/config/index.js
+++ b/snap/frontend/config/index.js
@@ -1,3 +1,8 @@
 export const defaultSnapOrigin =
 // eslint-disable-next-line no-restricted-globals
     process.env.SNAP_ORIGIN ?? 'local:http://localhost:8080';
+
+export const explorerUrl = {
+	mainnet: 'https://symbol.fyi',
+	testnet: 'https://testnet.symbol.fyi'
+};

--- a/snap/frontend/context/reducer.js
+++ b/snap/frontend/context/reducer.js
@@ -24,7 +24,8 @@ export const actionTypes = {
 	SET_SELECTED_ACCOUNT: 'setSelectedAccount',
 	SET_ACCOUNTS: 'setAccounts',
 	SET_CURRENCY: 'setCurrency',
-	SET_MOSAIC_INFO: 'setMosaicInfo'
+	SET_MOSAIC_INFO: 'setMosaicInfo',
+	SET_TRANSACTIONS: 'setTransactions'
 };
 
 export const reducer = (state, action) => {
@@ -43,6 +44,8 @@ export const reducer = (state, action) => {
 		return { ...state, currency: action.payload };
 	case actionTypes.SET_MOSAIC_INFO:
 		return { ...state, mosaicInfo: action.payload };
+	case actionTypes.SET_TRANSACTIONS:
+		return { ...state, transactions: action.payload };
 	default:
 		return state;
 	}

--- a/snap/frontend/package-lock.json
+++ b/snap/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "qrcode": "^1.5.3",
         "react": "^18",
         "react-dom": "^18",
+        "react-intersection-observer": "^9.13.0",
         "symbol-sdk": "^3.2.2"
       },
       "devDependencies": {
@@ -1377,6 +1378,126 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.1.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.1.3.tgz",
+      "integrity": "sha512-E/9WQeXxkqw2dfcn5UcjApFgUq73jqNKaE5bysDm58hEUdUGedVrnRhblhJM7HbCZNhtVl0j+6TXsK0PuzXTCg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.1.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.1.3.tgz",
+      "integrity": "sha512-USArX9B+3rZSXYLFvgy0NVWQgqh6LHWDmMt38O4lmiJNQcwazeI6xRvSsliDLKt+78KChVacNiwvOMbl6g6BBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.1.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.1.3.tgz",
+      "integrity": "sha512-esk1RkRBLSIEp1qaQXv1+s6ZdYzuVCnDAZySpa62iFTMGTisCyNQmqyCTL9P+cLJ4N9FKCI3ojtSfsyPHJDQNw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.1.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.1.3.tgz",
+      "integrity": "sha512-8uOgRlYEYiKo0L8YGeS+3TudHVDWDjPVDUcST+z+dUzgBbTEwSSIaSgF/vkcC1T/iwl4QX9iuUyUdQEl0Kxalg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.1.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.1.3.tgz",
+      "integrity": "sha512-DX2zqz05ziElLoxskgHasaJBREC5Y9TJcbR2LYqu4r7naff25B4iXkfXWfcp69uD75/0URmmoSgT8JclJtrBoQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.1.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.1.3.tgz",
+      "integrity": "sha512-HjssFsCdsD4GHstXSQxsi2l70F/5FsRTRQp8xNgmQs15SxUfUJRvSI9qKny/jLkY3gLgiCR3+6A7wzzK0DBlfA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.1.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.1.3.tgz",
+      "integrity": "sha512-DRuxD5axfDM1/Ue4VahwSxl1O5rn61hX8/sF0HY8y0iCbpqdxw3rB3QasdHn/LJ6Wb2y5DoWzXcz3L1Cr+Thrw==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.1.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.1.3.tgz",
+      "integrity": "sha512-uC2DaDoWH7h1P/aJ4Fok3Xiw6P0Lo4ez7NbowW2VGNXw/Xv6tOuLUcxhBYZxsSUJtpeknCi8/fvnSpyCFp4Rcg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 10"
@@ -8017,6 +8138,20 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-intersection-observer": {
+      "version": "9.13.0",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.13.0.tgz",
+      "integrity": "sha512-y0UvBfjDiXqC8h0EWccyaj4dVBWMxgEx0t5RGNzQsvkfvZwugnKwxpu70StY4ivzYuMajavwUDjH4LJyIki9Lw==",
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -9919,126 +10054,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "14.1.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.1.3.tgz",
-      "integrity": "sha512-E/9WQeXxkqw2dfcn5UcjApFgUq73jqNKaE5bysDm58hEUdUGedVrnRhblhJM7HbCZNhtVl0j+6TXsK0PuzXTCg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.1.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.1.3.tgz",
-      "integrity": "sha512-USArX9B+3rZSXYLFvgy0NVWQgqh6LHWDmMt38O4lmiJNQcwazeI6xRvSsliDLKt+78KChVacNiwvOMbl6g6BBw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.1.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.1.3.tgz",
-      "integrity": "sha512-esk1RkRBLSIEp1qaQXv1+s6ZdYzuVCnDAZySpa62iFTMGTisCyNQmqyCTL9P+cLJ4N9FKCI3ojtSfsyPHJDQNw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.1.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.1.3.tgz",
-      "integrity": "sha512-8uOgRlYEYiKo0L8YGeS+3TudHVDWDjPVDUcST+z+dUzgBbTEwSSIaSgF/vkcC1T/iwl4QX9iuUyUdQEl0Kxalg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.1.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.1.3.tgz",
-      "integrity": "sha512-DX2zqz05ziElLoxskgHasaJBREC5Y9TJcbR2LYqu4r7naff25B4iXkfXWfcp69uD75/0URmmoSgT8JclJtrBoQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.1.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.1.3.tgz",
-      "integrity": "sha512-HjssFsCdsD4GHstXSQxsi2l70F/5FsRTRQp8xNgmQs15SxUfUJRvSI9qKny/jLkY3gLgiCR3+6A7wzzK0DBlfA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.1.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.1.3.tgz",
-      "integrity": "sha512-DRuxD5axfDM1/Ue4VahwSxl1O5rn61hX8/sF0HY8y0iCbpqdxw3rB3QasdHn/LJ6Wb2y5DoWzXcz3L1Cr+Thrw==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.1.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.1.3.tgz",
-      "integrity": "sha512-uC2DaDoWH7h1P/aJ4Fok3Xiw6P0Lo4ez7NbowW2VGNXw/Xv6tOuLUcxhBYZxsSUJtpeknCi8/fvnSpyCFp4Rcg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     }
   }

--- a/snap/frontend/package.json
+++ b/snap/frontend/package.json
@@ -26,6 +26,7 @@
     "qrcode": "^1.5.3",
     "react": "^18",
     "react-dom": "^18",
+    "react-intersection-observer": "^9.13.0",
     "symbol-sdk": "^3.2.2"
   },
   "devDependencies": {

--- a/snap/frontend/setupTests.js
+++ b/snap/frontend/setupTests.js
@@ -3,6 +3,24 @@ import '@testing-library/jest-dom';
 import { jest } from '@jest/globals';
 
 global.jest = jest;
+global.IntersectionObserver = jest.fn().mockImplementation(() => ({
+	observe: () => null,
+	unobserve: () => null,
+	disconnect: () => null
+}));
+
+
+class IntersectionObserver {
+	constructor(callback) {
+		this.callback = callback;
+	}
+
+	observe() {}
+
+	disconnect() {}
+
+	unobserve() {}
+};
 
 /* eslint-disable jsx-a11y/alt-text, @next/next/no-img-element */
 jest.mock('next/image', () => {
@@ -13,4 +31,12 @@ jest.mock('next/image', () => {
 jest.mock('@metamask/detect-provider', () => {
 	const detectEthereumProvider = jest.fn();
 	return detectEthereumProvider;
+});
+
+jest.mock('react-intersection-observer', () => {
+	const useInView = {
+		ref: jest.fn(),
+		inView: jest.fn()
+	};
+	return useInView;
 });

--- a/snap/frontend/utils/dispatchUtils.js
+++ b/snap/frontend/utils/dispatchUtils.js
@@ -49,6 +49,13 @@ const dispatchUtils = dispatch => ({
 	 */
 	setMosaicInfo: mosaicInfo => {
 		dispatch({ type: actionTypes.SET_MOSAIC_INFO, payload: mosaicInfo });
+	},
+	/**
+	 * Set transactions
+	 * @param {Array<TransactionInfo>} transactions - The transactions array.
+	 */
+	setTransactions: transactions => {
+		dispatch({ type: actionTypes.SET_TRANSACTIONS, payload: transactions });
 	}
 });
 
@@ -87,6 +94,19 @@ export default dispatchUtils;
  * @typedef {object} MosaicInfo
  * @property {number} divisibility - The mosaic divisibility.
  * @property {string} networkName - The network name.
+ */
+
+/**
+ * state of create transaction object.
+ * @typedef {object} TransactionInfo
+ * @property {string} id - The transaction id.
+ * @property {string} date - The transaction date time.
+ * @property {number} height - The transaction block height.
+ * @property {string} transactionHash - The transaction hash.
+ * @property {string} transactionType - The transaction type.
+ * @property {number | null} amount - The transaction XYM amount.
+ * @property {string | null} message - The transaction message.
+ * @property {string} sender - The sender address.
  */
 
 // endregion

--- a/snap/frontend/utils/dispatchUtils.spec.js
+++ b/snap/frontend/utils/dispatchUtils.spec.js
@@ -143,4 +143,26 @@ describe('dispatchUtils', () => {
 			expect(dispatchState).toHaveBeenCalledWith({ type: 'setMosaicInfo', payload: mosaicInfo });
 		});
 	});
+
+	describe('setTransactions', () => {
+		it('dispatches SET_TRANSACTIONS action with transactions', () => {
+			// Arrange:
+			const transactions = [
+				{
+					id: 'transaction1',
+					transactionInfo: 'info1'
+				},
+				{
+					id: 'transaction2',
+					transactionInfo: 'info2'
+				}
+			];
+
+			// Act:
+			dispatch.setTransactions(transactions);
+
+			// Assert:
+			expect(dispatchState).toHaveBeenCalledWith({ type: 'setTransactions', payload: transactions });
+		});
+	});
 });

--- a/snap/frontend/utils/helper.js
+++ b/snap/frontend/utils/helper.js
@@ -92,6 +92,12 @@ const helper = {
 
 		dispatch.setMosaicInfo(mosaicInfo);
 		dispatch.setAccounts(updateAccounts);
+	},
+	async updateTransactions (dispatch, symbolSnap, address) {
+		dispatch.setTransactions([]);
+		const transactions = await symbolSnap.fetchAccountTransactions(address, '');
+
+		dispatch.setTransactions(transactions);
 	}
 };
 

--- a/snap/frontend/utils/helper.spec.js
+++ b/snap/frontend/utils/helper.spec.js
@@ -9,7 +9,8 @@ describe('helper', () => {
 		setSelectedAccount: jest.fn(),
 		setAccounts: jest.fn(),
 		setCurrency: jest.fn(),
-		setMosaicInfo: jest.fn()
+		setMosaicInfo: jest.fn(),
+		setTransactions: jest.fn()
 	};
 
 	const symbolSnap = {
@@ -19,7 +20,8 @@ describe('helper', () => {
 		getCurrency: jest.fn(),
 		fetchAccountMosaics: jest.fn(),
 		getMosaicInfo: jest.fn(),
-		getAccounts: jest.fn()
+		getAccounts: jest.fn(),
+		fetchAccountTransactions: jest.fn()
 	};
 
 	describe('setupSnap', () => {
@@ -264,6 +266,36 @@ describe('helper', () => {
 			expect(symbolSnap.getAccounts).toHaveBeenNthCalledWith(2);
 			expect(dispatch.setMosaicInfo).toHaveBeenCalledWith(mockMosaicInfo);
 			expect(dispatch.setAccounts).toHaveBeenCalledWith(mockAccounts);
+		});
+	});
+
+	describe('updateTransactions', () => {
+		it('reset transaction state and fetch transactions and updates state', async () => {
+			// Arrange:
+			const mockTransactions = [
+				{
+					id: '1',
+					amount: 10,
+					sender: 'address'
+				},
+				{
+					id: '2',
+					amount: 10,
+					sender: 'address'
+				}
+			];
+
+			const address = 'address';
+
+			symbolSnap.fetchAccountTransactions.mockResolvedValue(mockTransactions);
+
+			// Act:
+			await helper.updateTransactions(dispatch, symbolSnap, address);
+
+			// Assert:
+			expect(dispatch.setTransactions).toHaveBeenNthCalledWith(1, []);
+			expect(symbolSnap.fetchAccountTransactions).toHaveBeenCalledWith(address, '');
+			expect(dispatch.setTransactions).toHaveBeenNthCalledWith(2, mockTransactions);
 		});
 	});
 });

--- a/snap/frontend/utils/snap.js
+++ b/snap/frontend/utils/snap.js
@@ -221,6 +221,23 @@ const symbolSnapFactory = {
 				});
 
 				return mosaicInfo;
+			},
+			async fetchAccountTransactions(address, offsetId) {
+				const transactions = await provider.request({
+					method: 'wallet_invokeSnap',
+					params: {
+						snapId: defaultSnapOrigin,
+						request: {
+							method: 'fetchAccountTransactions',
+							params: {
+								address,
+								offsetId
+							}
+						}
+					}
+				});
+
+				return transactions;
 			}
 		};
 	}

--- a/snap/frontend/utils/snap.spec.js
+++ b/snap/frontend/utils/snap.spec.js
@@ -423,4 +423,55 @@ describe('symbolSnapFactory', () => {
 			});
 		});
 	});
+
+	describe('fetchAccountTransactions', () => {
+		it('returns account transactions when provider request is successful', async () => {
+			// Arrange:
+			const address = 'address';
+			const offsetId = 'offsetId';
+			const mockTransactions = [
+				{
+					id: '2',
+					date: '2024-05-22 01:44:56',
+					height: 12,
+					transactionHash: 'hash',
+					transactionType: 'Transfer',
+					amount: 0,
+					message: null,
+					sender: 'sender address'
+				},
+				{
+					id: '1',
+					date: '2024-07-16 14:13:54',
+					height: 10,
+					transactionHash: 'hash',
+					transactionType: 'Transfer',
+					amount: 100,
+					message: 'message',
+					sender: 'sender address'
+				}
+			];
+
+			mockProvider.request.mockResolvedValue(mockTransactions);
+
+			// Act:
+			const result = await symbolSnap.fetchAccountTransactions(address, offsetId);
+
+			// Assert:
+			expect(result).toEqual(mockTransactions);
+			expect(mockProvider.request).toHaveBeenCalledWith({
+				method: 'wallet_invokeSnap',
+				params: {
+					snapId: 'local:http://localhost:8080',
+					request: {
+						method: 'fetchAccountTransactions',
+						params: {
+							address,
+							offsetId
+						}
+					}
+				}
+			});
+		});
+	});
 });


### PR DESCRIPTION
## What was the issue?
- Missing implementation transaction utils and RPC.

## What's the fix?
- Added `fetchAccountTransactions` to the RPC request.
- Added `fetchAccountTransactions` in `transactionUtils` to query account transactions, and request inner transactions if there is an aggregate transaction.
- Added transaction formatting and converted all inner transactions to a flat structure.