### PR TITLE
[snap/backend]: Added fee multipler 

### DIFF
--- a/snap/backend/snap.manifest.json
+++ b/snap/backend/snap.manifest.json
@@ -27,6 +27,12 @@
           "request": {
             "method": "fetchCurrencyPrice"
           }
+        },
+        {
+          "expression": "* * * * *",
+          "request": {
+            "method": "fetchFeeMultiplier"
+          }
         }
       ]
     },

--- a/snap/backend/snap.manifest.json
+++ b/snap/backend/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/symbol/product.git"
   },
   "source": {
-    "shasum": "s/K0moPt0Whp88wJlDNNZWfKAt7JJQ+xRXUvpHm1ISc=",
+    "shasum": "BJNYqnWfv9688rGDvcSXAImB8d0Vi8if+wzMDZC55h8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/snap/backend/src/index.js
+++ b/snap/backend/src/index.js
@@ -70,6 +70,8 @@ export const onCronjob = async ({ request }) => {
 	switch (request.method) {
 	case 'fetchCurrencyPrice':
 		return priceUtils.getPrice({ state });
+	case 'fetchFeeMultiplier':
+		return transactionUtils.getFeeMultiplier({ state });
 	default:
 		throw new Error('Method not found.');
 	}

--- a/snap/backend/src/index.js
+++ b/snap/backend/src/index.js
@@ -16,7 +16,8 @@ export const onRpcRequest = async ({ request }) => {
 			currencies: {},
 			accounts: {},
 			network: {},
-			mosaicInfo: {}
+			mosaicInfo: {},
+			feeMultiplier: { slow: 0, average: 0, fast: 0 }
 		};
 	}
 
@@ -30,6 +31,7 @@ export const onRpcRequest = async ({ request }) => {
 	case 'initialSnap':
 		await networkUtils.switchNetwork(apiParams);
 		await priceUtils.getPrice(apiParams);
+		await transactionUtils.getFeeMultiplier(apiParams);
 
 		return {
 			...state,
@@ -55,6 +57,8 @@ export const onRpcRequest = async ({ request }) => {
 		return accountUtils.fetchAccountMosaics(apiParams);
 	case 'fetchAccountTransactions':
 		return transactionUtils.fetchAccountTransactions(apiParams);
+	case 'getFeeMultiplier':
+		return state.feeMultiplier;
 	default:
 		throw new Error('Method not found.');
 	}

--- a/snap/backend/src/services/symbolClient.js
+++ b/snap/backend/src/services/symbolClient.js
@@ -62,7 +62,7 @@ const symbolClient = {
 			/**
 			 * Fetch mosaics namespace from mosaic ids.
 			 * @param {Array<string>} mosaicIds - The mosaic ids to fetch namespace.
-			 * @returns {Promise<Record<string, Array<string>>} The mosaics namespace.
+			 * @returns {Promise<Record<string, Array<string>>>} The mosaics namespace.
 			 */
 			fetchMosaicNamespace: async mosaicIds => {
 				if (!mosaicIds.length)
@@ -124,6 +124,23 @@ const symbolClient = {
 					return innerTransactions;
 				} catch (error) {
 					throw new Error(`Failed to fetch inner transactions by aggregate ids: ${error.message}`);
+				}
+			},
+			/**
+			 * Fetch transaction fee multiplier.
+			 * @returns {Promise<FeeMultiplier>} The transaction fee multiplier.
+			 */
+			fetchTransactionFeeMultiplier: async () => {
+				try {
+					const fees = await fetchUtils.fetchData(`${nodeUrl}/network/fees/transaction`);
+
+					return {
+						slow: fees.minFeeMultiplier,
+						average: fees.averageFeeMultiplier,
+						fast: fees.highestFeeMultiplier
+					};
+				} catch (error) {
+					throw new Error(`Failed to fetch transaction fee multiplier: ${error.message}`);
 				}
 			}
 		};
@@ -187,6 +204,14 @@ export default symbolClient;
  * @property {Meta} meta - The metadata of the transaction.
  * @property {TransactionDetails} transaction - The details of the transaction.
  * @property {string} id - The transaction id.
+ */
+
+/**
+ * The transaction fee multiplier object.
+ * @typedef {object} FeeMultiplier
+ * @property {number} slow - The slow fee multiplier.
+ * @property {number} average - The average fee multiplier.
+ * @property {number} fast - The fast fee multiplier.
  */
 
 // endregion

--- a/snap/backend/src/utils/transactionUtils.js
+++ b/snap/backend/src/utils/transactionUtils.js
@@ -1,4 +1,5 @@
 import symbolClient from '../services/symbolClient.js';
+import stateManager from '../stateManager.js';
 import moment from 'moment'; // eslint-disable-line
 import { PublicKey } from 'symbol-sdk';
 import { SymbolFacade } from 'symbol-sdk/symbol';
@@ -134,6 +135,18 @@ const transactionUtils = {
 			message: isTransferTransaction ? (transaction.message || null) : null,
 			sender: senderAddress
 		};
+	},
+	getFeeMultiplier: async ({ state }) => {
+		const { network } = state;
+		const client = symbolClient.create(network.url);
+
+		const feeMultiplier = await client.fetchTransactionFeeMultiplier();
+
+		state.feeMultiplier = feeMultiplier;
+
+		await stateManager.update(state);
+
+		return feeMultiplier;
 	}
 };
 

--- a/snap/backend/test/index_spec.js
+++ b/snap/backend/test/index_spec.js
@@ -42,13 +42,20 @@ describe('index', () => {
 			EUR: 0.20
 		};
 
+		const mockFeeMultiplier = {
+			slow: 0,
+			average: 0,
+			fast: 0
+		}
+
 		beforeEach(() => {
 			jest.clearAllMocks();
 
 			stateManager.getState.mockResolvedValue({
 				accounts: {},
 				network: mockNodeInfo,
-				currencies: mockCurrencies
+				currencies: mockCurrencies,
+				feeMultiplier: mockFeeMultiplier
 			});
 		});
 
@@ -58,7 +65,12 @@ describe('index', () => {
 			const assertInitialSnap = async (state, expectedState) => {
 				// Arrange:
 				jest.spyOn(symbolClient, 'create').mockReturnValue({
-					fetchNetworkCurrencyMosaicId: jest.fn().mockResolvedValue('mosaicId')
+					fetchNetworkCurrencyMosaicId: jest.fn().mockResolvedValue('mosaicId'),
+					fetchTransactionFeeMultiplier: jest.fn().mockResolvedValue({
+						slow: 100,
+						average: 150,
+						fast: 200
+					})
 				});
 
 				stateManager.getState.mockResolvedValue(state);
@@ -92,7 +104,12 @@ describe('index', () => {
 						symbol: 'USD',
 						price: 0.25
 					},
-					mosaicInfo: {}
+					mosaicInfo: {},
+					feeMultiplier: {
+						slow: 100,
+						average: 150,
+						fast: 200
+					}
 				});
 			});
 
@@ -141,7 +158,12 @@ describe('index', () => {
 						symbol: 'USD',
 						price: 0.25
 					},
-					mosaicInfo: {}
+					mosaicInfo: {},
+					feeMultiplier: {
+						slow: 100,
+						average: 150,
+						fast: 200
+					}
 				});
 			});
 		});
@@ -166,7 +188,8 @@ describe('index', () => {
 					state: {
 						accounts: {},
 						network: mockNodeInfo,
-						currencies: mockCurrencies
+						currencies: mockCurrencies,
+						feeMultiplier: mockFeeMultiplier
 					},
 					requestParams: {
 						accountLabel: 'my wallet'
@@ -196,7 +219,8 @@ describe('index', () => {
 					state: {
 						accounts: {},
 						currencies: mockCurrencies,
-						network: mockNodeInfo
+						network: mockNodeInfo,
+						feeMultiplier: mockFeeMultiplier
 					},
 					requestParams: {
 						accountLabel: 'my wallet',
@@ -339,6 +363,20 @@ describe('index', () => {
 						offsetId: ''
 					}
 				});
+			});
+		});
+
+		describe('getFeeMultiplier', () => {
+			it('returns state fee multiplier', async () => {
+				// Act:
+				const response = await onRpcRequest({
+					request: {
+						method: 'getFeeMultiplier'
+					}
+				});
+
+				// Assert:
+				expect(response).toStrictEqual(mockFeeMultiplier);
 			});
 		});
 	});

--- a/snap/backend/test/index_spec.js
+++ b/snap/backend/test/index_spec.js
@@ -415,5 +415,38 @@ describe('index', () => {
 				});
 			});
 		});
+
+		describe('fetchFeeMultiplier', () => {
+			it('fetches latest fee multiplier and update state', async () => {
+				// Arrange:
+				const state = {
+					feeMultiplier: {
+						slow: 0,
+						average: 0,
+						fast: 0
+					}
+				};
+
+				stateManager.getState.mockResolvedValue(state);
+
+				jest.spyOn(transactionUtils, 'getFeeMultiplier').mockResolvedValue({
+					slow: 100,
+					average: 150,
+					fast: 200
+				});
+
+				// Act:
+				await onCronjob({
+					request: {
+						method: 'fetchFeeMultiplier'
+					}
+				});
+
+				// Assert:
+				expect(transactionUtils.getFeeMultiplier).toHaveBeenCalledWith({
+					state
+				});
+			});
+		});
 	});
 });

--- a/snap/backend/test/index_spec.js
+++ b/snap/backend/test/index_spec.js
@@ -46,7 +46,7 @@ describe('index', () => {
 			slow: 0,
 			average: 0,
 			fast: 0
-		}
+		};
 
 		beforeEach(() => {
 			jest.clearAllMocks();
@@ -413,15 +413,6 @@ describe('index', () => {
 				expect(stateManager.update).toHaveBeenCalledWith({
 					currencies: mockLatestCurrencies
 				});
-			});
-
-			it('throws an error if the requested method does not exist', async () => {
-				// Act + Assert:
-				await expect(onCronjob({
-					request: {
-						method: 'unknownMethod'
-					}
-				})).rejects.toThrow('Method not found.');
 			});
 		});
 	});

--- a/snap/backend/test/services/symbolClient_spec.js
+++ b/snap/backend/test/services/symbolClient_spec.js
@@ -375,4 +375,39 @@ describe('symbolClient', () => {
 			await expect(client.fetchInnerTransactionByAggregateIds(mockTransactionIds)).rejects.toThrow(errorMessage);
 		});
 	});
+
+	describe('fetchTransactionFeeMultiplier', () => {
+		it('can fetch transaction fee multiplier successfully', async () => {
+			// Arrange:
+			const mockResponse = {
+				averageFeeMultiplier: 118,
+				medianFeeMultiplier: 100,
+				highestFeeMultiplier: 5681,
+				lowestFeeMultiplier: 0,
+				minFeeMultiplier: 100
+			};
+
+			fetchUtils.fetchData.mockResolvedValue(mockResponse);
+
+			// Act:
+			const result = await client.fetchTransactionFeeMultiplier();
+
+			// Assert:
+			expect(result).toStrictEqual({
+				slow: 100,
+				average: 118,
+				fast: 5681
+			});
+			expect(fetchUtils.fetchData).toHaveBeenCalledWith(`${nodeUrl}/network/fees/transaction`);
+		});
+
+		it('throws an error when fetch fails', async () => {
+			// Arrange:
+			fetchUtils.fetchData.mockRejectedValue(new Error('Failed to fetch'));
+
+			// Assert:
+			const errorMessage = 'Failed to fetch transaction fee multiplier: Failed to fetch';
+			await expect(client.fetchTransactionFeeMultiplier()).rejects.toThrow(errorMessage);
+		});
+	});
 });


### PR DESCRIPTION
## What was the issue?
- The fee multiplier is missing; we will use it to calculate the transaction fee.

## What's the fix?
- Added fee multiplier endpoint
- Extract slow, average, and fast multiplier
- Added fetch multiplier in onCronjob