### PR TITLE
[snap/backend]: Fix config naming in env

### DIFF
--- a/snap/frontend/config/index.js
+++ b/snap/frontend/config/index.js
@@ -1,6 +1,6 @@
 export const defaultSnapOrigin =
 // eslint-disable-next-line no-restricted-globals
-    process.env.SNAP_ORIGIN ?? 'local:http://localhost:8080';
+    process.env.NEXT_PUBLIC_SNAP_ORIGIN ?? 'local:http://localhost:8080';
 
 export const explorerUrl = {
 	mainnet: 'https://symbol.fyi',


### PR DESCRIPTION
## What was the issue?
- Missing `NEXT_PUBLIC_` naming in env config

## What's the fix?
- Added `NEXT_PUBLIC_` naming.