### PR TITLE
[snap/frontend]: WS implementation

### DIFF
--- a/snap/frontend/app/page.spec.jsx
+++ b/snap/frontend/app/page.spec.jsx
@@ -1,11 +1,24 @@
 import Main from './page';
 import testHelper from '../components/testHelper';
 import symbolSnapFactory from '../utils/snap';
+import webSocketClient from '../utils/webSocketClient';
 import detectEthereumProvider from '@metamask/detect-provider';
 import { act, render } from '@testing-library/react';
 import React from 'react';
 
 describe('Main', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		jest.spyOn(webSocketClient, 'create').mockImplementation(() => {
+			return {
+				open: jest.fn(),
+				listenConfirmedTransaction: jest.fn(),
+				removeSubscriber: jest.fn()
+			};
+		});
+	});
+
 	it('renders the HomeComponent when a provider is detected and symbolSnapFactory is created', async () => {
 		// Arrange:
 		const mockProvider = { isMetaMask: true };

--- a/snap/frontend/components/FeeMultiplier/index.jsx
+++ b/snap/frontend/components/FeeMultiplier/index.jsx
@@ -33,7 +33,7 @@ const FeeMultiplier = ({selectedFeeMultiplier, setSelectedFeeMultiplier}) => {
 	return (
 		<div className='flex justify-evenly p-2'>
 			{
-				0 < Object.keys(feeMultiplier).length && (
+				feeMultiplier && 0 < Object.keys(feeMultiplier).length && (
 					Object.keys(feeMultiplier).map(key => {
 						return renderFeeMultiplier(key);
 					})

--- a/snap/frontend/components/Home/Home.spec.jsx
+++ b/snap/frontend/components/Home/Home.spec.jsx
@@ -1,7 +1,8 @@
 import Home from '.';
 import helper from '../../utils/helper';
+import webSocketClient from '../../utils/webSocketClient';
 import testHelper from '../testHelper';
-import { act, fireEvent, screen } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 
 const context = {
 	dispatch: {
@@ -10,7 +11,8 @@ const context = {
 		setSelectedAccount: jest.fn(),
 		setAccounts: jest.fn(),
 		setCurrency: jest.fn(),
-		setMosaicInfo: jest.fn()
+		setMosaicInfo: jest.fn(),
+		setWebsocket: jest.fn()
 	},
 	walletState: {
 		loadingStatus: {
@@ -44,6 +46,13 @@ const context = {
 };
 
 describe('components/Home', () => {
+	beforeEach(() => {
+		jest.spyOn(webSocketClient, 'create').mockImplementation(() => {
+			return {
+				open: jest.fn()
+			};
+		});
+	});
 	const assertModalScreen = async (walletState, expectedModal) => {
 		// Arrange:
 		context.walletState = {
@@ -128,7 +137,9 @@ describe('components/Home', () => {
 		fireEvent.click(sendButton);
 
 		// Assert:
-		const modalBox = screen.getByRole('transfer-form');
-		expect(modalBox).toBeInTheDocument();
+		await waitFor(() => {
+			const modalBox = screen.getByRole('transfer-form');
+			expect(modalBox).toBeInTheDocument();
+		});
 	});
 });

--- a/snap/frontend/components/TransactionTable/index.jsx
+++ b/snap/frontend/components/TransactionTable/index.jsx
@@ -1,4 +1,4 @@
-import { explorerUrl } from '../../config';
+import { Channels, explorerUrl } from '../../config';
 import { useWalletContext } from '../../context';
 import helper from '../../utils/helper';
 import Image from 'next/image';
@@ -8,8 +8,8 @@ import { useInView } from 'react-intersection-observer';
 const TransactionTable = () => {
 
 	const { walletState, symbolSnap, dispatch } = useWalletContext();
-	const { selectedAccount, finalizedHeight, mosaicInfo, network, currency, transactions } = walletState;
-	const { address } = selectedAccount;
+	const { selectedAccount, finalizedHeight, mosaicInfo, network, currency, transactions, websocket } = walletState;
+	const { address, id } = selectedAccount;
 	const { symbol, price } = currency;
 	const [isLoading, setIsLoading] = useState(false);
 	const [isLastPage, setIsLastPage] = useState(false);
@@ -34,6 +34,15 @@ const TransactionTable = () => {
 		setIsLoading(false);
 
 		setIsLastPage(false);
+
+		websocket.listenConfirmedTransaction(async () => {
+			helper.updateTransactions(dispatch, symbolSnap, address);
+			helper.updateAccountMosaics(dispatch, symbolSnap, id);
+		}, address);
+
+		return () => {
+			websocket.removeSubscriber(`${Channels.confirmedAdded}/${address}`);
+		};
 	}, [address]);
 
 	useEffect(() => {

--- a/snap/frontend/config/index.js
+++ b/snap/frontend/config/index.js
@@ -6,3 +6,7 @@ export const explorerUrl = {
 	mainnet: 'https://symbol.fyi',
 	testnet: 'https://testnet.symbol.fyi'
 };
+
+export const Channels = {
+	confirmedAdded: 'confirmedAdded'
+};

--- a/snap/frontend/context/reducer.js
+++ b/snap/frontend/context/reducer.js
@@ -14,7 +14,8 @@ export const initialState = {
 	accounts: {},
 	mosaics: [],
 	transactions: [],
-	mosaicInfo: {}
+	mosaicInfo: {},
+	websocket: null
 };
 
 export const actionTypes = {
@@ -25,7 +26,8 @@ export const actionTypes = {
 	SET_ACCOUNTS: 'setAccounts',
 	SET_CURRENCY: 'setCurrency',
 	SET_MOSAIC_INFO: 'setMosaicInfo',
-	SET_TRANSACTIONS: 'setTransactions'
+	SET_TRANSACTIONS: 'setTransactions',
+	SET_WEBSOCKET: 'setWebsocket'
 };
 
 export const reducer = (state, action) => {
@@ -46,6 +48,8 @@ export const reducer = (state, action) => {
 		return { ...state, mosaicInfo: action.payload };
 	case actionTypes.SET_TRANSACTIONS:
 		return { ...state, transactions: action.payload };
+	case actionTypes.SET_WEBSOCKET:
+		return { ...state, websocket: action.payload };
 	default:
 		return state;
 	}

--- a/snap/frontend/utils/dispatchUtils.js
+++ b/snap/frontend/utils/dispatchUtils.js
@@ -56,6 +56,13 @@ const dispatchUtils = dispatch => ({
 	 */
 	setTransactions: transactions => {
 		dispatch({ type: actionTypes.SET_TRANSACTIONS, payload: transactions });
+	},
+	/**
+	 * Set websocket
+	 * @param {WebSocket} websocket - The websocket object.
+	 */
+	setWebsocket: websocket => {
+		dispatch({ type: actionTypes.SET_WEBSOCKET, payload: websocket });
 	}
 });
 

--- a/snap/frontend/utils/dispatchUtils.spec.js
+++ b/snap/frontend/utils/dispatchUtils.spec.js
@@ -165,4 +165,21 @@ describe('dispatchUtils', () => {
 			expect(dispatchState).toHaveBeenCalledWith({ type: 'setTransactions', payload: transactions });
 		});
 	});
+
+	describe('setWebsocket', () => {
+		it('dispatches SET_WEBSOCKET action with websocket', () => {
+			// Arrange:
+			const websocket = {
+				url: 'url',
+				listenConfirmedTransaction: jest.fn(),
+				removeSubscriber: jest.fn()
+			};
+
+			// Act:
+			dispatch.setWebsocket(websocket);
+
+			// Assert:
+			expect(dispatchState).toHaveBeenCalledWith({ type: 'setWebsocket', payload: websocket });
+		});
+	});
 });

--- a/snap/frontend/utils/helper.js
+++ b/snap/frontend/utils/helper.js
@@ -116,6 +116,13 @@ const helper = {
 			isLoading: false,
 			message: ''
 		});
+	},
+	async updateAccountMosaics (dispatch, symbolSnap, accountId) {
+		const accountMosaics = await symbolSnap.fetchAccountMosaics([accountId]);
+		const mosaicInfo = await symbolSnap.getMosaicInfo();
+
+		dispatch.setMosaicInfo(mosaicInfo);
+		dispatch.setSelectedAccount(Object.values(accountMosaics)[0]);
 	}
 };
 

--- a/snap/frontend/utils/helper.js
+++ b/snap/frontend/utils/helper.js
@@ -1,3 +1,4 @@
+import webSocketClient from './webSocketClient';
 import QRCode from 'qrcode';
 
 const helper = {
@@ -11,6 +12,10 @@ const helper = {
 
 		dispatch.setNetwork(snapState.network);
 		dispatch.setCurrency(snapState.currency);
+
+		const webSocket = webSocketClient.create(snapState.network.url);
+		await webSocket.open();
+		dispatch.setWebsocket(webSocket);
 
 		let account = {};
 

--- a/snap/frontend/utils/helper.spec.js
+++ b/snap/frontend/utils/helper.spec.js
@@ -1,4 +1,5 @@
 import helper from './helper';
+import webSocketClient from './webSocketClient';
 import testHelper from '../components/testHelper';
 import QRCode from 'qrcode';
 
@@ -10,7 +11,8 @@ describe('helper', () => {
 		setAccounts: jest.fn(),
 		setCurrency: jest.fn(),
 		setMosaicInfo: jest.fn(),
-		setTransactions: jest.fn()
+		setTransactions: jest.fn(),
+		setWebsocket: jest.fn()
 	};
 
 	const symbolSnap = {
@@ -26,8 +28,19 @@ describe('helper', () => {
 	};
 
 	describe('setupSnap', () => {
+		let mockWebSocketOpen;
+
 		beforeEach(() => {
 			jest.clearAllMocks();
+
+			mockWebSocketOpen = jest.fn();
+
+			jest.spyOn(webSocketClient, 'create').mockImplementation(() => {
+				return {
+					open: mockWebSocketOpen
+				};
+			});
+
 		});
 
 		const mockSnapState = {
@@ -54,6 +67,9 @@ describe('helper', () => {
 			expect(dispatch.setNetwork).toHaveBeenCalledWith(mockSnapState.network);
 			expect(dispatch.setCurrency).toHaveBeenCalledWith(mockSnapState.currency);
 			expect(dispatch.setMosaicInfo).toHaveBeenCalledWith({});
+			expect(dispatch.setWebsocket).toHaveBeenCalled();
+			expect(webSocketClient.create).toHaveBeenCalledWith('http://localhost:3000');
+			expect(mockWebSocketOpen).toHaveBeenCalled();
 		};
 
 		it('initializes snap and sets network and selected account and fetch first account mosaic if accounts exist', async () => {

--- a/snap/frontend/utils/helper.spec.js
+++ b/snap/frontend/utils/helper.spec.js
@@ -342,4 +342,41 @@ describe('helper', () => {
 			});
 		});
 	});
+
+	describe('updateAccountMosaics', () => {
+		it('fetch account mosaics and mosaic info and updates state', async () => {
+			// Arrange:
+			const accountId = 'account1';
+			const mockAccountMosaics = {
+				'account1': {
+					id: 'account1',
+					addressIndex: 1,
+					type: 'metamask',
+					networkName: 'network',
+					label: 'label',
+					address: 'address',
+					publicKey: 'publicKey'
+				}
+			};
+
+			const mockMosaicInfo = {
+				'mosaicId': {
+					divisibility: 6,
+					networkName: 'testnet'
+				}
+			};
+
+			symbolSnap.fetchAccountMosaics.mockResolvedValue(mockAccountMosaics);
+			symbolSnap.getMosaicInfo.mockResolvedValue(mockMosaicInfo);
+
+			// Act:
+			await helper.updateAccountMosaics(dispatch, symbolSnap, accountId);
+
+			// Assert:
+			expect(symbolSnap.fetchAccountMosaics).toHaveBeenCalledWith([accountId]);
+			expect(symbolSnap.getMosaicInfo).toHaveBeenCalled();
+			expect(dispatch.setMosaicInfo).toHaveBeenCalledWith(mockMosaicInfo);
+			expect(dispatch.setSelectedAccount).toHaveBeenCalledWith(mockAccountMosaics[accountId]);
+		});
+	});
 });

--- a/snap/frontend/utils/webSocketClient.js
+++ b/snap/frontend/utils/webSocketClient.js
@@ -1,3 +1,5 @@
+import { Channels } from '../config';
+
 const webSocketClient = {
 	create(url) {
 		return {
@@ -51,6 +53,15 @@ const webSocketClient = {
 					subscribe: channel
 				};
 				this.webSocket.send(JSON.stringify(subscriptionMessage));
+			},
+			removeSubscriber(channel) {
+				delete this.subscribers[channel];
+			},
+			listenConfirmedTransaction(callback, address) {
+				const subscribe = `${Channels.confirmedAdded}/${address}`;
+
+				this.subscribeTo(subscribe);
+				this.subscribers[subscribe] = callback;
 			}
 		};
 	}

--- a/snap/frontend/utils/webSocketClient.js
+++ b/snap/frontend/utils/webSocketClient.js
@@ -1,0 +1,59 @@
+const webSocketClient = {
+	create(url) {
+		return {
+			url: url.replace('http', 'ws') + '/ws',
+			webSocket: null,
+			subscribers: {},
+			uid: '',
+			open() {
+				return new Promise((resolve, reject) => {
+					if (null === this.webSocket || this.webSocket.readyState === WebSocket.CLOSED) {
+						this.webSocket = new WebSocket(this.url);
+
+						this.webSocket.onopen = () => {};
+
+						this.webSocket.onerror = err => {
+							reject(err);
+						};
+
+						this.webSocket.onclose = event => {
+							this.webSocket = null;
+						};
+
+						this.webSocket.onmessage = event => {
+							const parsedMessage = JSON.parse(event.data);
+							if ('uid' in parsedMessage) {
+								this.uid = parsedMessage.uid;
+								resolve();
+							}
+
+							// Handle websocket message
+							const { topic, data } = parsedMessage;
+
+							if (this.subscribers[topic])
+								this.subscribers[topic](data);
+
+						};
+					} else {
+						resolve();
+					}
+				});
+			},
+			close() {
+				if (this.webSocket &&
+					(this.webSocket.readyState === WebSocket.OPEN || this.webSocket.readyState === WebSocket.CONNECTING))
+					this.webSocket.close();
+
+			},
+			subscribeTo(channel) {
+				const subscriptionMessage = {
+					uid: this.uid,
+					subscribe: channel
+				};
+				this.webSocket.send(JSON.stringify(subscriptionMessage));
+			}
+		};
+	}
+};
+
+export default webSocketClient;

--- a/snap/frontend/utils/webSocketClient.spec.js
+++ b/snap/frontend/utils/webSocketClient.spec.js
@@ -1,0 +1,62 @@
+import webSocketClient from './webSocketClient';
+
+class MockWebSocket {
+    static OPEN = 1;
+    static CONNECTING = 0;
+}
+
+global.WebSocket = MockWebSocket;
+
+describe('webSocketClient', () => {
+	let wsInstance;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		wsInstance = webSocketClient.create('http://example.com');
+	});
+
+	it('create with the correct websocket URL', () => {
+		// assert:
+		expect(wsInstance.url).toBe('ws://example.com/ws');
+	});
+
+	it('open the websocket connection and set uid', async () => {
+		// Arrange + Act:
+		wsInstance.open();
+
+		const mockMessage = { data: JSON.stringify({ uid: '12345' }) };
+		wsInstance.webSocket.onmessage(mockMessage);
+
+		// Assert:
+		expect(wsInstance.uid).toBe('12345');
+	});
+
+	it('close the websocket connection', () => {
+		// Arrange:
+		wsInstance.webSocket = {
+			...wsInstance.webSocket,
+			readyState: 1,
+			close: jest.fn()
+		};
+
+		// Act:
+		wsInstance.close();
+
+		// Assert:
+		expect(wsInstance.webSocket.close).toHaveBeenCalled();
+	});
+
+	it('can subscribe to a channel', async () => {
+		// Arrange:
+		wsInstance.webSocket = {
+			send: jest.fn()
+		};
+		wsInstance.uid = '1';
+
+		// Act:
+		wsInstance.subscribeTo('channel');
+
+		// Assert:
+		expect(wsInstance.webSocket.send).toHaveBeenCalledWith('{"uid":"1","subscribe":"channel"}');
+	});
+});

--- a/snap/frontend/utils/webSocketClient.spec.js
+++ b/snap/frontend/utils/webSocketClient.spec.js
@@ -59,4 +59,29 @@ describe('webSocketClient', () => {
 		// Assert:
 		expect(wsInstance.webSocket.send).toHaveBeenCalledWith('{"uid":"1","subscribe":"channel"}');
 	});
+
+	it('can remove a subscriber', () => {
+		// Arrange:
+		wsInstance.subscribers['channel'] = jest.fn();
+
+		// Act:
+		wsInstance.removeSubscriber('channel');
+
+		// Assert:
+		expect(wsInstance.subscribers['channel']).toBeUndefined();
+	});
+
+	it('can listen to confirmed transactions', async () => {
+		// Arrange:
+		wsInstance.webSocket = {
+			send: jest.fn()
+		};
+		wsInstance.uid = '1';
+
+		// Act:
+		wsInstance.listenConfirmedTransaction(jest.fn(), 'address');
+
+		// Assert:
+		expect(wsInstance.webSocket.send).toHaveBeenCalledWith('{"uid":"1","subscribe":"confirmedAdded/address"}');
+	});
 });


### PR DESCRIPTION
## What was the issue?
- We need a WebSocket implementation to improve the wallet's user experience.

## What's the fix?
- Added WebSocket client.
- Added listenConfrimTransaction method listener.
- Implement web socket in the `helper.setupSnap` and `open()` socket when the network changes.
- Store socket in context state,
- Implementation of listenConfrimTransaction in the transaction table component. 