### PR TITLE
[snap]: Implemented unconfirmed transactions

### DIFF
--- a/snap/backend/snap.manifest.json
+++ b/snap/backend/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/symbol/product.git"
   },
   "source": {
-    "shasum": "HUHXWUEaWtWX/gnI323yXvP676bmZT3oXjR76iZZ4v0=",
+    "shasum": "OxwaCYK3ZvaID9tryJGNLP+dleeUIKbV/F47aGHA6fo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/snap/backend/src/utils/transactionUtils.js
+++ b/snap/backend/src/utils/transactionUtils.js
@@ -18,11 +18,11 @@ const transactionUtils = {
      */
 	async fetchAccountTransactions({ state, requestParams }) {
 		const { network } = state;
-		const { address, offsetId } = requestParams;
+		const { address, offsetId, group } = requestParams;
 
 		const client = symbolClient.create(network.url);
 
-		const transactions = await client.fetchTransactionPageByAddress(address, offsetId);
+		const transactions = await client.fetchTransactionPageByAddress(address, offsetId, group);
 
 		const aggregateIds = [];
 
@@ -90,7 +90,10 @@ const transactionUtils = {
 	createTransaction(id, meta, transaction, network, transactionTypeOverride = null) {
 		const facade = new SymbolFacade(network.networkName);
 		const senderAddress = facade.network.publicKeyToAddress(new PublicKey(transaction.signerPublicKey)).toString();
-		const date = moment.utc(facade.network.toDatetime({ timestamp: BigInt(meta.timestamp) })).format('YYYY-MM-DD HH:mm:ss');
+
+		const date = meta && meta.timestamp
+			? moment.utc(facade.network.toDatetime({ timestamp: BigInt(meta.timestamp) })).format('YYYY-MM-DD HH:mm:ss')
+			: null;
 
 		const isTransferTransaction = transaction.type === models.TransactionType.TRANSFER.value;
 
@@ -132,7 +135,7 @@ export default transactionUtils;
  * state of create transaction object.
  * @typedef {object} TransactionInfo
  * @property {string} id - The transaction id.
- * @property {string} date - The transaction date time.
+ * @property {string | null} date - The transaction date time.
  * @property {number} height - The transaction block height.
  * @property {string} transactionHash - The transaction hash.
  * @property {string} transactionType - The transaction type.

--- a/snap/backend/src/utils/transactionUtils.js
+++ b/snap/backend/src/utils/transactionUtils.js
@@ -91,7 +91,7 @@ const transactionUtils = {
 		const facade = new SymbolFacade(network.networkName);
 		const senderAddress = facade.network.publicKeyToAddress(new PublicKey(transaction.signerPublicKey)).toString();
 
-		const date = meta && meta.timestamp
+		const date = meta.timestamp
 			? moment.utc(facade.network.toDatetime({ timestamp: BigInt(meta.timestamp) })).format('YYYY-MM-DD HH:mm:ss')
 			: null;
 

--- a/snap/frontend/app/page.spec.jsx
+++ b/snap/frontend/app/page.spec.jsx
@@ -14,6 +14,7 @@ describe('Main', () => {
 			return {
 				open: jest.fn(),
 				listenConfirmedTransaction: jest.fn(),
+				listenUnconfirmedTransaction: jest.fn(),
 				removeSubscriber: jest.fn()
 			};
 		});

--- a/snap/frontend/components/AccountListModalBox/AccountListModalBox.spec.jsx
+++ b/snap/frontend/components/AccountListModalBox/AccountListModalBox.spec.jsx
@@ -57,6 +57,8 @@ describe('components/AccountListModalBox', () => {
 		const numberOfAccounts = 2;
 		context.walletState.accounts = testHelper.generateAccountsState(numberOfAccounts);
 
+		jest.spyOn(helper, 'updateAccountMosaics').mockImplementation();
+
 		testHelper.customRender(<AccountListModalBox isOpen={true} onRequestClose={jest.fn()} />, context);
 
 		// Act:
@@ -64,7 +66,7 @@ describe('components/AccountListModalBox', () => {
 		fireEvent.click(accountAddress);
 
 		// Assert:
-		expect(context.dispatch.setSelectedAccount).toHaveBeenCalledWith(Object.values(context.walletState.accounts)[1]);
+		expect(helper.updateAccountMosaics).toHaveBeenCalledWith(context.dispatch, context.symbolSnap, 'accountId 1');
 	});
 
 	const assertErrorValidation = (buttonName, inputBox, inputValue, expectedErrorMessage) => {

--- a/snap/frontend/components/AccountListModalBox/index.jsx
+++ b/snap/frontend/components/AccountListModalBox/index.jsx
@@ -22,8 +22,8 @@ const AccountListModalBox = ({ isOpen, onRequestClose }) => {
 		onRequestClose(false);
 	};
 
-	const handleSelectAccount = account => {
-		dispatch.setSelectedAccount(account);
+	const handleSelectAccount = async account => {
+		await helper.updateAccountMosaics(dispatch, symbolSnap, account.id);
 		onRequestClose(false);
 	};
 

--- a/snap/frontend/components/TransactionTable/index.jsx
+++ b/snap/frontend/components/TransactionTable/index.jsx
@@ -40,8 +40,13 @@ const TransactionTable = () => {
 			helper.updateAccountMosaics(dispatch, symbolSnap, id);
 		}, address);
 
+		websocket.listenUnconfirmedTransaction(async () => {
+			helper.updateUnconfirmedTransactions(dispatch, symbolSnap, address, transactions);
+		}, address);
+
 		return () => {
 			websocket.removeSubscriber(`${Channels.confirmedAdded}/${address}`);
+			websocket.removeSubscriber(`${Channels.unconfirmedAdded}/${address}`);
 		};
 	}, [address]);
 
@@ -131,7 +136,7 @@ const TransactionTable = () => {
 									<td className='text-sub-title'>
 										<div className='flex items-center'>
 											{
-												transaction.height ?
+												'0' !== transaction.height ?
 													<a
 														target='_blank'
 														href={`${explorerUrl[network.networkName]}/blocks/${transaction.height}`}>
@@ -142,7 +147,7 @@ const TransactionTable = () => {
 											}
 
 											{
-												finalizedHeight >= transaction.height && transaction.height ?
+												finalizedHeight >= transaction.height && '0' !== transaction.height ?
 													<Image
 														className='pl-2'
 														src='/finalized-icon.svg'

--- a/snap/frontend/config/index.js
+++ b/snap/frontend/config/index.js
@@ -8,5 +8,11 @@ export const explorerUrl = {
 };
 
 export const Channels = {
-	confirmedAdded: 'confirmedAdded'
+	confirmedAdded: 'confirmedAdded',
+	unconfirmedAdded: 'unconfirmedAdded'
+};
+
+export const TransactionGroup = {
+	confirmed: 'confirmed',
+	unconfirmed: 'unconfirmed'
 };

--- a/snap/frontend/utils/snap.js
+++ b/snap/frontend/utils/snap.js
@@ -1,4 +1,4 @@
-import { defaultSnapOrigin } from '../config';
+import { TransactionGroup, defaultSnapOrigin } from '../config';
 
 const symbolSnapFactory = {
 	create(provider) {
@@ -222,7 +222,7 @@ const symbolSnapFactory = {
 
 				return mosaicInfo;
 			},
-			async fetchAccountTransactions(address, offsetId) {
+			async fetchAccountTransactions(address, offsetId, group = TransactionGroup.confirmed) {
 				const transactions = await provider.request({
 					method: 'wallet_invokeSnap',
 					params: {
@@ -231,7 +231,8 @@ const symbolSnapFactory = {
 							method: 'fetchAccountTransactions',
 							params: {
 								address,
-								offsetId
+								offsetId,
+								group
 							}
 						}
 					}

--- a/snap/frontend/utils/snap.spec.js
+++ b/snap/frontend/utils/snap.spec.js
@@ -467,7 +467,8 @@ describe('symbolSnapFactory', () => {
 						method: 'fetchAccountTransactions',
 						params: {
 							address,
-							offsetId
+							offsetId,
+							group: 'confirmed'
 						}
 					}
 				}

--- a/snap/frontend/utils/webSocketClient.js
+++ b/snap/frontend/utils/webSocketClient.js
@@ -62,6 +62,12 @@ const webSocketClient = {
 
 				this.subscribeTo(subscribe);
 				this.subscribers[subscribe] = callback;
+			},
+			listenUnconfirmedTransaction(callback, address) {
+				const subscribe = `${Channels.unconfirmedAdded}/${address}`;
+
+				this.subscribeTo(subscribe);
+				this.subscribers[subscribe] = callback;
 			}
 		};
 	}

--- a/snap/frontend/utils/webSocketClient.spec.js
+++ b/snap/frontend/utils/webSocketClient.spec.js
@@ -71,7 +71,7 @@ describe('webSocketClient', () => {
 		expect(wsInstance.subscribers['channel']).toBeUndefined();
 	});
 
-	it('can listen to confirmed transactions', async () => {
+	const assertListener = (listener, expectedData) => {
 		// Arrange:
 		wsInstance.webSocket = {
 			send: jest.fn()
@@ -79,9 +79,23 @@ describe('webSocketClient', () => {
 		wsInstance.uid = '1';
 
 		// Act:
-		wsInstance.listenConfirmedTransaction(jest.fn(), 'address');
+		wsInstance[listener](jest.fn(), 'address');
 
 		// Assert:
-		expect(wsInstance.webSocket.send).toHaveBeenCalledWith('{"uid":"1","subscribe":"confirmedAdded/address"}');
+		expect(wsInstance.webSocket.send).toHaveBeenCalledWith(expectedData);
+	};
+
+	it('can listen to confirmed transactions', async () => {
+		assertListener(
+			'listenConfirmedTransaction',
+			'{"uid":"1","subscribe":"confirmedAdded/address"}'
+		);
+	});
+
+	it('can listen to unconfirmed transactions', async () => {
+		assertListener(
+			'listenUnconfirmedTransaction',
+			'{"uid":"1","subscribe":"unconfirmedAdded/address"}'
+		);
 	});
 });


### PR DESCRIPTION
## What was the issue?
- Missing unconfirmed transaction display in table.

## What's the fix?
- Added unconfirmed transaction listener in WebSocket.
- Added transaction group into `fetchAccountTransactions` method param.
- Added `updateUnconfirmedTransactions` in helper, which updates unconfirmed transactions in the state.
- Implement unconfirmed transactions in transaction table component.