### PR TITLE
[snap/frontend]: fix mosaic info is not load correctly.

### DIFF
--- a/snap/frontend/components/AssetList/index.jsx
+++ b/snap/frontend/components/AssetList/index.jsx
@@ -16,21 +16,8 @@ const AssetList = () => {
 		return split.slice(1).join('.');
 	};
 
-	const renderMosaicNameOrId = mosaic => {
+	const renderMosaicDetailsWithName = mosaic => {
 		// Check if mosaic information exists and render based on condition
-		const mosaicDetail = mosaicInfo[mosaic.id];
-
-		if (!mosaicDetail)
-			throw new Error('Mosaic information not found');
-
-		return 0 === mosaicDetail.name.length ? (
-			<div>{mosaic.id}</div>
-		) : (
-			<div>{mosaicDetail.name[0].split('.')[0]}</div>
-		);
-	};
-
-	const renderMosaicDetails = mosaic => {
 		const mosaicDetail = mosaicInfo[mosaic.id];
 
 		if (!mosaicDetail)
@@ -40,8 +27,15 @@ const AssetList = () => {
 		const subNamespace = 0 === mosaicDetail.name.length ? null : renderSubNamespace(mosaicDetail.name[0]);
 
 		return (
-			<div className='text-xs text-gray-400'>
-				{amount} {subNamespace}
+			<div>
+				{0 === mosaicDetail.name.length ? (
+					<div>{mosaic.id}</div>
+				) : (
+					<div>{mosaicDetail.name[0].split('.')[0]}</div>
+				)}
+				<div className='text-xs text-gray-400'>
+					{amount} {subNamespace}
+				</div>
 			</div>
 		);
 	};
@@ -66,8 +60,7 @@ const AssetList = () => {
 					<div key={`asset_${index}`} className='flex items-center justify-start p-2'>
 						<div role={`mosaic-image_${index}`} className="rounded-full w-5 h-5 bg-gray-300 mr-2" />
 						<div className='text-xs'>
-							{ renderMosaicNameOrId(mosaic) }
-							{ renderMosaicDetails(mosaic) }
+							{ renderMosaicDetailsWithName(mosaic) }
 						</div>
 					</div>
 				))

--- a/snap/frontend/utils/helper.js
+++ b/snap/frontend/utils/helper.js
@@ -49,8 +49,10 @@ const helper = {
 	},
 	async createNewAccount (dispatch, symbolSnap, accounts, walletName) {
 		const newAccount = await symbolSnap.createAccount(walletName);
+		const mosaicInfo = await symbolSnap.getMosaicInfo();
 
-		// update account state
+		// update mosaic info and account state
+		dispatch.setMosaicInfo(mosaicInfo);
 		dispatch.setAccounts({ ...accounts, [newAccount.id]: newAccount });
 		dispatch.setSelectedAccount(newAccount);
 	},
@@ -61,7 +63,10 @@ const helper = {
 		if(!newAccount)
 			return;
 
-		// update account state
+		const mosaicInfo = await symbolSnap.getMosaicInfo();
+
+		// update mosaic info and account state
+		dispatch.setMosaicInfo(mosaicInfo);
 		dispatch.setAccounts({ ...accounts, [newAccount.id]: newAccount });
 		dispatch.setSelectedAccount(newAccount);
 	},

--- a/snap/frontend/utils/helper.spec.js
+++ b/snap/frontend/utils/helper.spec.js
@@ -148,15 +148,25 @@ describe('helper', () => {
 			const walletName = 'new Wallet';
 			const newAccount = Object.values(testHelper.generateAccountsState(1))[0];
 
+			const mosaicInfo = {
+				'mosaicId 0': {
+					divisibility: 6,
+					networkName: 'testnet'
+				}
+			};
+
 			symbolSnap.createAccount.mockResolvedValue(newAccount);
+			symbolSnap.getMosaicInfo.mockResolvedValue(mosaicInfo);
 
 			// Act:
 			await helper.createNewAccount(dispatch, symbolSnap, accounts, walletName);
 
 			// Assert:
 			expect(symbolSnap.createAccount).toHaveBeenCalledWith(walletName);
+			expect(symbolSnap.getMosaicInfo).toHaveBeenCalled();
 			expect(dispatch.setAccounts).toHaveBeenCalledWith({ ...accounts, [newAccount.id]: newAccount });
 			expect(dispatch.setSelectedAccount).toHaveBeenCalledWith(newAccount);
+			expect(dispatch.setMosaicInfo).toHaveBeenCalledWith(mosaicInfo);
 		});
 	});
 
@@ -172,7 +182,15 @@ describe('helper', () => {
 			const accountName = 'import wallet';
 			const privateKey = '1F53BA3DA42800D092A0C331A20A41ACCE81D2DD6F710106953ADA277C502010';
 
+			const mosaicInfo = {
+				'mosaicId 0': {
+					divisibility: 6,
+					networkName: 'testnet'
+				}
+			};
+
 			symbolSnap.importAccount.mockResolvedValue(mockImportAccount);
+			symbolSnap.getMosaicInfo.mockResolvedValue(mosaicInfo);
 
 			// Act:
 			await helper.importAccount(dispatch, symbolSnap, accounts, accountName, privateKey);
@@ -181,11 +199,14 @@ describe('helper', () => {
 			expect(symbolSnap.importAccount).toHaveBeenCalledWith(accountName, privateKey);
 
 			if (expectedResult) {
+				expect(symbolSnap.getMosaicInfo).toHaveBeenCalled();
 				expect(dispatch.setAccounts).toHaveBeenCalledWith({ ...accounts, [mockImportAccount.id]: mockImportAccount });
 				expect(dispatch.setSelectedAccount).toHaveBeenCalledWith(mockImportAccount);
+				expect(dispatch.setMosaicInfo).toHaveBeenCalledWith(mosaicInfo);
 			} else {
 				expect(dispatch.setAccounts).not.toHaveBeenCalled();
 				expect(dispatch.setSelectedAccount).not.toHaveBeenCalled();
+				expect(dispatch.setMosaicInfo).not.toHaveBeenCalled();
 			}
 		};
 


### PR DESCRIPTION
## What was the issue?
- An error occurs when the user creates or imports an account with an existing mosaic, and the mosaic info in the snap state is not current.

## What's the fix?
- Refactor AssetList component, join `renderMosaicNameOrId` and `renderMosaicDetails` method in `renderMosaicDetailsWithName` method
- Query the latest mosaic Info after creating / import the account