### PR TITLE
[snap/frontend]: bug fix return transaction hash

### DIFF
--- a/snap/frontend/utils/helper.js
+++ b/snap/frontend/utils/helper.js
@@ -118,12 +118,14 @@ const helper = {
 			message: 'Sending...'
 		});
 
-		await symbolSnap.signTransferTransaction(transferTransactionParams);
+		const transactionHash = await symbolSnap.signTransferTransaction(transferTransactionParams);
 
 		dispatch.setLoadingStatus({
 			isLoading: false,
 			message: ''
 		});
+
+		return transactionHash;
 	},
 	async updateAccountMosaics (dispatch, symbolSnap, accountId) {
 		const accountMosaics = await symbolSnap.fetchAccountMosaics([accountId]);

--- a/snap/frontend/utils/helper.spec.js
+++ b/snap/frontend/utils/helper.spec.js
@@ -340,8 +340,10 @@ describe('helper', () => {
 				feeMultiplierType: 'slow'
 			};
 
+			symbolSnap.signTransferTransaction.mockResolvedValue('transactionHash');
+
 			// Act:
-			await helper.signTransferTransaction(dispatch, symbolSnap, mockTransferTransactionParams);
+			const transactionHash = await helper.signTransferTransaction(dispatch, symbolSnap, mockTransferTransactionParams);
 
 			// Assert:
 			expect(symbolSnap.signTransferTransaction).toHaveBeenCalledWith(mockTransferTransactionParams);
@@ -353,6 +355,7 @@ describe('helper', () => {
 				isLoading: false,
 				message: ''
 			});
+			expect(transactionHash).toBe('transactionHash');
 		});
 	});
 


### PR DESCRIPTION
## What was the issue?
- After approving the transactions, the transfer transaction modal box didn't close, the reason is that after signing the transaction, it didn't return the transaction hash.

## What's the fix?
- Return transaction hash after signing the transaction in helper.