### PR TITLE
[Snap]: Add currecy mosaic in asset list as default.

### DIFF
--- a/snap/backend/src/index.js
+++ b/snap/backend/src/index.js
@@ -32,6 +32,7 @@ export const onRpcRequest = async ({ request }) => {
 		await networkUtils.switchNetwork(apiParams);
 		await priceUtils.getPrice(apiParams);
 		await transactionUtils.getFeeMultiplier(apiParams);
+		await mosaicUtils.updateMosaicInfo(state, [state.network.currencyMosaicId]);
 
 		return {
 			...state,

--- a/snap/backend/test/index_spec.js
+++ b/snap/backend/test/index_spec.js
@@ -65,11 +65,19 @@ describe('index', () => {
 			const assertInitialSnap = async (state, expectedState) => {
 				// Arrange:
 				jest.spyOn(symbolClient, 'create').mockReturnValue({
-					fetchNetworkCurrencyMosaicId: jest.fn().mockResolvedValue('mosaicId'),
+					fetchNetworkCurrencyMosaicId: jest.fn().mockResolvedValue('currencyMosaicId'),
 					fetchTransactionFeeMultiplier: jest.fn().mockResolvedValue({
 						slow: 100,
 						average: 150,
 						fast: 200
+					}),
+					fetchMosaicsInfo: jest.fn().mockResolvedValue({
+						currencyMosaicId: {
+							divisibility: 6
+						}
+					}),
+					fetchMosaicNamespace: jest.fn().mockResolvedValue({
+						currencyMosaicId: ['symbol.xym']
 					})
 				});
 
@@ -98,13 +106,19 @@ describe('index', () => {
 					currencies: mockCurrencies,
 					network: {
 						...mockNodeInfo,
-						currencyMosaicId: 'mosaicId'
+						currencyMosaicId: 'currencyMosaicId'
 					},
 					currency: {
 						symbol: 'USD',
 						price: 0.25
 					},
-					mosaicInfo: {},
+					mosaicInfo: {
+						currencyMosaicId: {
+							divisibility: 6,
+							networkName: 'mainnet',
+							name: ['symbol.xym']
+						}
+					},
 					feeMultiplier: {
 						slow: 100,
 						average: 150,
@@ -151,14 +165,20 @@ describe('index', () => {
 					},
 					network: {
 						...mockNodeInfo,
-						currencyMosaicId: 'mosaicId'
+						currencyMosaicId: 'currencyMosaicId'
 					},
 					currencies: mockCurrencies,
 					currency: {
 						symbol: 'USD',
 						price: 0.25
 					},
-					mosaicInfo: {},
+					mosaicInfo: {
+						currencyMosaicId: {
+							divisibility: 6,
+							networkName: 'mainnet',
+							name: ['symbol.xym']
+						}
+					},
 					feeMultiplier: {
 						slow: 100,
 						average: 150,

--- a/snap/frontend/components/AssetList/AssetList.spec.jsx
+++ b/snap/frontend/components/AssetList/AssetList.spec.jsx
@@ -25,6 +25,9 @@ const context = {
 				name: ['root'],
 				divisibility: 0
 			}
+		},
+		network: {
+			currencyMosaicId: 'E74B99BA41F4AFEE'
 		}
 	}
 };
@@ -103,6 +106,50 @@ describe('components/AssetList', () => {
 		assertMosaic(context, 'root', '10');
 	});
 
+	const assertRenderCurrencyMosaic = (context, expectedAmount) => {
+		// Arrange:
+		testHelper.customRender(<AssetList />, context);
+
+		// Act:
+		const mosaicNameElement = screen.getByText('symbol');
+		const mosaicAmountElement = screen.getByText(expectedAmount);
+
+		// Assert:
+		expect(mosaicNameElement).toBeInTheDocument();
+		expect(mosaicAmountElement).toBeInTheDocument();
+	};
+
+	it('renders default currency mosaics when mosaics is empty', () => {
+		// Arrange:
+		context.walletState.selectedAccount.mosaics = [];
+
+		assertRenderCurrencyMosaic(context, '0 xym');
+	});
+
+	it('renders default currency mosaics when currency mosaic is not in mosaics', () => {
+		// Arrange:
+		context.walletState.selectedAccount.mosaics = [
+			{
+				id: '3C596F764B5A1160',
+				amount: 2
+			}
+		];
+
+		assertRenderCurrencyMosaic(context, '0 xym');
+	});
+
+	it('does not overwrite mosaic amount with existing currency mosaic is in mosaics', () => {
+		// Arrange:
+		context.walletState.selectedAccount.mosaics = [
+			{
+				id: 'E74B99BA41F4AFEE',
+				amount: 2000000
+			}
+		];
+
+		assertRenderCurrencyMosaic(context, '2 xym');
+	});
+
 	it('renders loading when mosaicInfo and selectedAccount is not loaded', () => {
 		// Arrange:
 		context.walletState.mosaicInfo = {};
@@ -116,15 +163,6 @@ describe('components/AssetList', () => {
 		context.walletState.selectedAccount = {};
 
 		assertLoading(context);
-	});
-
-	it('does not render when mosaics is empty', () => {
-		// Arrange + Act:
-		testHelper.customRender(<AssetList />, context);
-
-		// Assert:
-		const assetElement = screen.queryByRole('asset_0');
-		expect(assetElement).not.toBeInTheDocument();
 	});
 
 	it('throws error when mosaic information is not found', () => {

--- a/snap/frontend/components/AssetList/index.jsx
+++ b/snap/frontend/components/AssetList/index.jsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 
 const AssetList = () => {
 	const { walletState } = useWalletContext();
-	const { selectedAccount, mosaicInfo } = walletState;
+	const { selectedAccount, mosaicInfo, network } = walletState;
 
 	const [isLoading, setIsLoading] = useState(true);
 
@@ -42,10 +42,17 @@ const AssetList = () => {
 
 	useEffect(() => {
 		// Check if mosaicInfo and selectedAccount are loaded
-		if (mosaicInfo && selectedAccount && Array.isArray(selectedAccount.mosaics))
+		if (mosaicInfo && selectedAccount && Array.isArray(selectedAccount.mosaics)) {
+
+			// Check if currencyMosaicId is not in selectedAccount.mosaics
+			if (!selectedAccount.mosaics.find(mosaic => mosaic.id === network.currencyMosaicId))
+				selectedAccount.mosaics.push({ id: network.currencyMosaicId, amount: '0' });
+
 			setIsLoading(false);
-		else
+		}
+		else {
 			setIsLoading(true);
+		}
 
 	}, [mosaicInfo, selectedAccount]);
 


### PR DESCRIPTION
## What was the issue?
- The asset list appears empty when the account doesn't have a mosaic.
- Added a currency mosaic to the asset list with an amount of 0 if the account lacks a currency mosaic.

## What's the fix?
- Query currency mosaic info when during the `initial setup`
- Added currency mosaic in asset list, if user account lacks of currency mosaic.

<img width="453" alt="Screenshot 2024-08-28 at 2 15 46 AM" src="https://github.com/user-attachments/assets/8ac6cc8b-48e7-487d-a450-8d1d99e81cfe">
