### PR TITLE
[Snap]: Apply live transaction fees calculator.

### DIFF
--- a/snap/backend/src/index.js
+++ b/snap/backend/src/index.js
@@ -32,6 +32,7 @@ export const onRpcRequest = async ({ request }) => {
 		await networkUtils.switchNetwork(apiParams);
 		await priceUtils.getPrice(apiParams);
 		await transactionUtils.getFeeMultiplier(apiParams);
+		await mosaicUtils.updateMosaicInfo(state, [state.network.currencyMosaicId]);
 
 		return {
 			...state,

--- a/snap/backend/src/utils/accountUtils.js
+++ b/snap/backend/src/utils/accountUtils.js
@@ -281,11 +281,11 @@ const accountUtils = {
 			recipient,
 			mosaics,
 			message,
-			feeMultiplierType
+			fees
 		} = requestParams;
 
 		const {
-			network, accounts, mosaicInfo, feeMultiplier
+			network, accounts, mosaicInfo
 		} = state;
 		const { currencyMosaicId, networkName } = network;
 
@@ -310,10 +310,9 @@ const accountUtils = {
 			deadline: facade.now().addHours(2).timestamp
 		});
 
-		const currencyMosaicDivisibility = mosaicInfo[currencyMosaicId].divisibility;
-		const fee = transferTransaction.size * feeMultiplier[feeMultiplierType];
+		transferTransaction.fee = new models.Amount(BigInt(fees));
 
-		transferTransaction.fee = new models.Amount(BigInt(fee));
+		const currencyMosaicDivisibility = mosaicInfo[currencyMosaicId].divisibility;
 
 		const buildContent = () => {
 			const content = [
@@ -324,7 +323,7 @@ const accountUtils = {
 				heading('Recipient Address:'),
 				copyable(`${recipient}`),
 				heading('Estimated Fee (XYM):'),
-				copyable(`${fee / (10 ** currencyMosaicDivisibility)}`)
+				copyable(`${fees / (10 ** currencyMosaicDivisibility)}`)
 			];
 
 			if ('' !== message) {

--- a/snap/backend/test/index_spec.js
+++ b/snap/backend/test/index_spec.js
@@ -65,11 +65,19 @@ describe('index', () => {
 			const assertInitialSnap = async (state, expectedState) => {
 				// Arrange:
 				jest.spyOn(symbolClient, 'create').mockReturnValue({
-					fetchNetworkCurrencyMosaicId: jest.fn().mockResolvedValue('mosaicId'),
+					fetchNetworkCurrencyMosaicId: jest.fn().mockResolvedValue('currencyMosaicId'),
 					fetchTransactionFeeMultiplier: jest.fn().mockResolvedValue({
 						slow: 100,
 						average: 150,
 						fast: 200
+					}),
+					fetchMosaicsInfo: jest.fn().mockResolvedValue({
+						currencyMosaicId: {
+							divisibility: 6
+						}
+					}),
+					fetchMosaicNamespace: jest.fn().mockResolvedValue({
+						currencyMosaicId: ['symbol.xym']
 					})
 				});
 
@@ -98,13 +106,19 @@ describe('index', () => {
 					currencies: mockCurrencies,
 					network: {
 						...mockNodeInfo,
-						currencyMosaicId: 'mosaicId'
+						currencyMosaicId: 'currencyMosaicId'
 					},
 					currency: {
 						symbol: 'USD',
 						price: 0.25
 					},
-					mosaicInfo: {},
+					mosaicInfo: {
+						currencyMosaicId: {
+							divisibility: 6,
+							networkName: 'mainnet',
+							name: ['symbol.xym']
+						}
+					},
 					feeMultiplier: {
 						slow: 100,
 						average: 150,
@@ -151,14 +165,20 @@ describe('index', () => {
 					},
 					network: {
 						...mockNodeInfo,
-						currencyMosaicId: 'mosaicId'
+						currencyMosaicId: 'currencyMosaicId'
 					},
 					currencies: mockCurrencies,
 					currency: {
 						symbol: 'USD',
 						price: 0.25
 					},
-					mosaicInfo: {},
+					mosaicInfo: {
+						currencyMosaicId: {
+							divisibility: 6,
+							networkName: 'mainnet',
+							name: ['symbol.xym']
+						}
+					},
 					feeMultiplier: {
 						slow: 100,
 						average: 150,

--- a/snap/backend/test/utils/accountUtils_spec.js
+++ b/snap/backend/test/utils/accountUtils_spec.js
@@ -794,7 +794,7 @@ describe('accountUtils', () => {
 					}
 				],
 				message: 'transfer message',
-				feeMultiplierType: 'slow'
+				fees: 10
 			};
 
 			const mockAnnounceTransaction = jest.fn();
@@ -822,7 +822,7 @@ describe('accountUtils', () => {
 				],
 				message: new TextEncoder('utf-8').encode(requestParams.message),
 				deadline: facade.now().addHours(2).timestamp,
-				fee: BigInt(192)
+				fee: BigInt(10)
 			});
 
 			expect(transactionObject.mosaics).toStrictEqual(expectedTransactionObject.mosaics);
@@ -845,7 +845,7 @@ describe('accountUtils', () => {
 					accountId: state.accounts[Object.keys(state.accounts)[0]].account.id,
 					recipient: 'TDCYZ45MX4IZ7SKEL5UL4ZA7O6KDDUAZZALCA6Y',
 					...moreParams,
-					feeMultiplierType: 'slow'
+					fees: 176
 				};
 
 				// Act:
@@ -884,7 +884,7 @@ describe('accountUtils', () => {
 					message: 'transfer message'
 				}, [
 					heading('Estimated Fee (XYM):'),
-					copyable('0.000208'),
+					copyable('0.000176'),
 					heading('Message:'),
 					copyable('transfer message'),
 					heading('Mosaics:'),
@@ -936,7 +936,7 @@ describe('accountUtils', () => {
 					}
 				],
 				message: 'transfer message',
-				feeMultiplierType: 'slow'
+				fees: 10
 			};
 
 			// Act:

--- a/snap/frontend/components/AssetList/AssetList.spec.jsx
+++ b/snap/frontend/components/AssetList/AssetList.spec.jsx
@@ -119,6 +119,50 @@ describe('components/AssetList', () => {
 		assertMosaicIcon(context, 'mosaic-icon');
 	});
 
+	const assertRenderCurrencyMosaic = (context, expectedAmount) => {
+		// Arrange:
+		testHelper.customRender(<AssetList />, context);
+
+		// Act:
+		const mosaicNameElement = screen.getByText('symbol');
+		const mosaicAmountElement = screen.getByText(expectedAmount);
+
+		// Assert:
+		expect(mosaicNameElement).toBeInTheDocument();
+		expect(mosaicAmountElement).toBeInTheDocument();
+	};
+
+	it('renders default currency mosaics when mosaics is empty', () => {
+		// Arrange:
+		context.walletState.selectedAccount.mosaics = [];
+
+		assertRenderCurrencyMosaic(context, '0 xym');
+	});
+
+	it('renders default currency mosaics when currency mosaic is not in mosaics', () => {
+		// Arrange:
+		context.walletState.selectedAccount.mosaics = [
+			{
+				id: '3C596F764B5A1160',
+				amount: 2
+			}
+		];
+
+		assertRenderCurrencyMosaic(context, '0 xym');
+	});
+
+	it('does not overwrite mosaic amount with existing currency mosaic is in mosaics', () => {
+		// Arrange:
+		context.walletState.selectedAccount.mosaics = [
+			{
+				id: 'E74B99BA41F4AFEE',
+				amount: 2000000
+			}
+		];
+
+		assertRenderCurrencyMosaic(context, '2 xym');
+	});
+
 	it('renders loading when mosaicInfo and selectedAccount is not loaded', () => {
 		// Arrange:
 		context.walletState.mosaicInfo = {};
@@ -132,15 +176,6 @@ describe('components/AssetList', () => {
 		context.walletState.selectedAccount = {};
 
 		assertLoading(context);
-	});
-
-	it('does not render when mosaics is empty', () => {
-		// Arrange + Act:
-		testHelper.customRender(<AssetList />, context);
-
-		// Assert:
-		const assetElement = screen.queryByRole('asset_0');
-		expect(assetElement).not.toBeInTheDocument();
 	});
 
 	it('throws error when mosaic information is not found', () => {

--- a/snap/frontend/components/AssetList/index.jsx
+++ b/snap/frontend/components/AssetList/index.jsx
@@ -50,10 +50,17 @@ const AssetList = () => {
 
 	useEffect(() => {
 		// Check if mosaicInfo and selectedAccount are loaded
-		if (mosaicInfo && selectedAccount && Array.isArray(selectedAccount.mosaics))
+		if (mosaicInfo && selectedAccount && Array.isArray(selectedAccount.mosaics)) {
+
+			// Check if currencyMosaicId is not in selectedAccount.mosaics
+			if (!selectedAccount.mosaics.find(mosaic => mosaic.id === network.currencyMosaicId))
+				selectedAccount.mosaics.push({ id: network.currencyMosaicId, amount: '0' });
+
 			setIsLoading(false);
-		else
+		}
+		else {
 			setIsLoading(true);
+		}
 
 	}, [mosaicInfo, selectedAccount]);
 

--- a/snap/frontend/components/FeeMultiplier/FeeMultiplier.spec.jsx
+++ b/snap/frontend/components/FeeMultiplier/FeeMultiplier.spec.jsx
@@ -9,42 +9,47 @@ const context = {
 };
 
 describe('components/FeeMultiplier', () => {
-	it('renders FeeMultiplier', async () => {
-		// Arrange:
+	let mockSetSelectedFeeMultiplier;
+	let mockSelectedFeeMultiplier;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
 		context.symbolSnap.getFeeMultiplier.mockResolvedValue({
 			slow: 10,
 			average: 100,
 			fast: 1000
 		});
 
+		mockSetSelectedFeeMultiplier = jest.fn();
+		mockSelectedFeeMultiplier = { key: 'slow', value: 10 };
+	});
+	it('renders FeeMultiplier', async () => {
 		// Act:
-		await act(async () => await testHelper.customRender(<FeeMultiplier />, context));
+		testHelper.customRender(<FeeMultiplier
+			selectedFeeMultiplier={mockSelectedFeeMultiplier}
+			setSelectedFeeMultiplier={mockSetSelectedFeeMultiplier} />, context);
 
 		// Assert:
 		await waitFor(() => {
 			expect(screen.getByText('SLOW')).toBeInTheDocument();
 			expect(screen.getByText('AVERAGE')).toBeInTheDocument();
 			expect(screen.getByText('FAST')).toBeInTheDocument();
+			expect(mockSetSelectedFeeMultiplier).toHaveBeenCalledWith(mockSelectedFeeMultiplier);
 		});
 	});
 
 	it('update selected fee multiplier (key)', async () => {
 		// Arrange:
-		context.symbolSnap.getFeeMultiplier.mockResolvedValue({
-			slow: 10,
-			average: 100,
-			fast: 1000
-		});
-
-		const mockSetSelectedFeeMultiplier = jest.fn();
-
-		await act(async () =>
-			await testHelper.customRender(<FeeMultiplier setSelectedFeeMultiplier={mockSetSelectedFeeMultiplier} />, context));
+		testHelper.customRender(<FeeMultiplier selectedFeeMultiplier={mockSelectedFeeMultiplier} setSelectedFeeMultiplier={mockSetSelectedFeeMultiplier} />, context);
 
 		// Act:
-		await waitFor(() => fireEvent.click(screen.getByText('SLOW')));
+		await waitFor(() => fireEvent.click(screen.getByText('FAST')));
 
 		// Assert:
-		expect(mockSetSelectedFeeMultiplier).toHaveBeenCalledWith('slow');
+		expect(mockSetSelectedFeeMultiplier).toHaveBeenCalledWith({
+			key: 'fast',
+			value: 1000
+		});
 	});
 });

--- a/snap/frontend/components/FeeMultiplier/FeeMultiplier.spec.jsx
+++ b/snap/frontend/components/FeeMultiplier/FeeMultiplier.spec.jsx
@@ -41,7 +41,9 @@ describe('components/FeeMultiplier', () => {
 
 	it('update selected fee multiplier (key)', async () => {
 		// Arrange:
-		testHelper.customRender(<FeeMultiplier selectedFeeMultiplier={mockSelectedFeeMultiplier} setSelectedFeeMultiplier={mockSetSelectedFeeMultiplier} />, context);
+		testHelper.customRender(<FeeMultiplier
+			selectedFeeMultiplier={mockSelectedFeeMultiplier}
+			setSelectedFeeMultiplier={mockSetSelectedFeeMultiplier} />, context);
 
 		// Act:
 		await waitFor(() => fireEvent.click(screen.getByText('FAST')));

--- a/snap/frontend/components/FeeMultiplier/index.jsx
+++ b/snap/frontend/components/FeeMultiplier/index.jsx
@@ -3,27 +3,33 @@ import React, { useEffect, useState } from 'react';
 
 const FeeMultiplier = ({selectedFeeMultiplier, setSelectedFeeMultiplier}) => {
 	const { symbolSnap } = useWalletContext();
-	const [feeMultiplier, setFeeMultiplier] = useState({});
+	const [feeMultiplierOption, setFeeMultiplierOption] = useState({});
 
 	useEffect(() => {
 		const getFeeMultiplier = async () => {
 			const result = await symbolSnap.getFeeMultiplier();
-			setFeeMultiplier(result);
+			setFeeMultiplierOption(result);
+
+			const [key, value] = Object.entries(result)[0];
+			setSelectedFeeMultiplier({ key, value });
 		};
 
 		getFeeMultiplier();
 	}, [symbolSnap]);
 
-	const renderFeeMultiplier = key => {
+	const renderFeeMultiplier = (key, value) => {
 		return (
 			<label key={key} className='flex items-center cursor-pointer highest'>
 				<input
 					type='radio'
 					name='feeMultiplier'
-					value={feeMultiplier[key]}
+					value={feeMultiplierOption[key]}
 					className='appearance-none'
-					onClick={() => setSelectedFeeMultiplier(key)} />
-				<div className={`rounded-xl text-center p-2 ${selectedFeeMultiplier === key ? 'border-2' : ''}`}>
+					onClick={() => setSelectedFeeMultiplier({
+						key,
+						value
+					}) } />
+				<div className={`rounded-xl text-center p-2 ${selectedFeeMultiplier.key === key ? 'border-2' : ''}`}>
 					{key.toUpperCase()}
 				</div>
 			</label>
@@ -33,9 +39,9 @@ const FeeMultiplier = ({selectedFeeMultiplier, setSelectedFeeMultiplier}) => {
 	return (
 		<div className='flex justify-evenly p-2'>
 			{
-				feeMultiplier && 0 < Object.keys(feeMultiplier).length && (
-					Object.keys(feeMultiplier).map(key => {
-						return renderFeeMultiplier(key);
+				feeMultiplierOption && 0 < Object.keys(feeMultiplierOption).length && (
+					Object.entries(feeMultiplierOption).map(([key, value]) => {
+						return renderFeeMultiplier(key, value);
 					})
 				)
 			}

--- a/snap/frontend/components/Home/Home.spec.jsx
+++ b/snap/frontend/components/Home/Home.spec.jsx
@@ -30,9 +30,14 @@ const context = {
 			identifier: 104,
 			networkName: 'mainnet',
 			url: 'http://localhost:3000',
-			networkGenerationHash: 'networkGenerationHash'
+			networkGenerationHash: 'networkGenerationHash',
+			currencyMosaicId: 'mosaicId'
 		},
-		mosaicInfo: {}
+		mosaicInfo: {
+			'mosaicId': {
+				divisibility: 6
+			}
+		}
 	},
 	symbolSnap: {
 		getSnap: jest.fn(),
@@ -51,6 +56,12 @@ describe('components/Home', () => {
 			return {
 				open: jest.fn()
 			};
+		});
+
+		context.symbolSnap.getFeeMultiplier.mockResolvedValue({
+			slow: 10,
+			average: 100,
+			fast: 1000
 		});
 	});
 	const assertModalScreen = async (walletState, expectedModal) => {

--- a/snap/frontend/components/TransferModalBox/TransferModalBox.spec.jsx
+++ b/snap/frontend/components/TransferModalBox/TransferModalBox.spec.jsx
@@ -344,7 +344,7 @@ describe('components/TransferModalBox', () => {
 		});
 	});
 
-	describe.skip('send transaction', () => {
+	describe('send transaction', () => {
 		beforeEach(() => {
 			context.symbolSnap.getFeeMultiplier.mockResolvedValue({
 				slow: 10,

--- a/snap/frontend/components/TransferModalBox/index.jsx
+++ b/snap/frontend/components/TransferModalBox/index.jsx
@@ -156,7 +156,7 @@ const TransferModalBox = ({ isOpen, onRequestClose }) => {
 			recipient: to,
 			mosaics: transferMosaics,
 			message,
-			feeMultiplierType: selectedFeeMultiplier.key
+			fees
 		});
 
 		if (result)

--- a/snap/frontend/utils/helper.spec.js
+++ b/snap/frontend/utils/helper.spec.js
@@ -2,6 +2,7 @@ import helper from './helper';
 import webSocketClient from './webSocketClient';
 import testHelper from '../components/testHelper';
 import QRCode from 'qrcode';
+import { SymbolFacade, models } from 'symbol-sdk/symbol';
 
 describe('helper', () => {
 	const dispatch = {
@@ -470,6 +471,45 @@ describe('helper', () => {
 			// Assert:
 			expect(symbolSnap.fetchAccountTransactions).toHaveBeenCalledWith(address, '', 'unconfirmed');
 			expect(dispatch.setTransactions).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('feeCalculator', () => {
+		// Arrange:
+		const facade = new SymbolFacade('testnet');
+
+		const mosaicInfo = {
+			'72C0212E67A08BCE': {
+				divisibility: 6,
+				networkName: 'testnet'
+			}
+		};
+		const params = {
+			signerPublicKey: 'FABAD1271A72816961B95CCCAAE1FD1E356F26A6AD3E0A91A25F703C1312F73D',
+			recipient: 'TDCYZ45MX4IZ7SKEL5UL4ZA7O6KDDUAZZALCA6Y',
+			mosaics: [
+				{
+					id: '72C0212E67A08BCE',
+					amount: 10
+				}
+			],
+			message: 'this is message',
+			feeMultiplier: 10
+		};
+
+		it('calculate transfer transaction fee', async () => {
+			// Act:
+			const fee = helper.feeCalculator(facade, models.TransactionType.TRANSFER.value, mosaicInfo, params);
+
+			// Assert:
+			expect(fee).toBe(1910);
+		});
+
+		it('throw error if transaction type is not found', async () => {
+			// Act + Assert:
+			expect(() => {
+				helper.feeCalculator(facade, 'unknown', mosaicInfo, params);
+			}).toThrow('Transaction type not support.');
 		});
 	});
 });

--- a/snap/frontend/utils/snap.js
+++ b/snap/frontend/utils/snap.js
@@ -262,7 +262,7 @@ const symbolSnapFactory = {
 			 * @param {TransferTransactionParams} params - The parameters to sign the transaction.
 			 * @returns {string | boolean} The transaction hash.
 			 */
-			async signTransferTransaction({ accountId, recipient, mosaics, message, feeMultiplierType }) {
+			async signTransferTransaction({ accountId, recipient, mosaics, message, fees }) {
 				const transactionHash = await provider.request({
 					method: 'wallet_invokeSnap',
 					params: {
@@ -274,7 +274,7 @@ const symbolSnapFactory = {
 								recipient,
 								mosaics,
 								message,
-								feeMultiplierType
+								fees
 							}
 						}
 					}

--- a/snap/frontend/utils/snap.spec.js
+++ b/snap/frontend/utils/snap.spec.js
@@ -516,13 +516,13 @@ describe('symbolSnapFactory', () => {
 				}
 			];
 			const message = 'message';
-			const feeMultiplierType = 'average';
+			const fees = 10;
 			const mockTransactionHash = 'transactionHash';
 
 			mockProvider.request.mockResolvedValue(mockTransactionHash);
 
 			// Act:
-			const result = await symbolSnap.signTransferTransaction({ accountId, recipient, mosaics, message, feeMultiplierType });
+			const result = await symbolSnap.signTransferTransaction({ accountId, recipient, mosaics, message, fees });
 
 			// Assert:
 			expect(result).toEqual(mockTransactionHash);
@@ -537,7 +537,7 @@ describe('symbolSnapFactory', () => {
 							recipient,
 							mosaics,
 							message,
-							feeMultiplierType
+							fees
 						}
 					}
 				}


### PR DESCRIPTION
## What was the issue?
- For better validation transaction fees, it should have fee calculation and keep updated when the user inputs some data such as a message.

## What's the fix?
- Added fee calculation, it displays fees in the transfer transaction form.
- Fees validation to ensure the account has enough balance to do transactions.
- Refactor `signTransferTransaction` method, and replace `feeMultiplierType` with `fees` because the calculation is done by frontend.

<img width="525" alt="image" src="https://github.com/user-attachments/assets/317ba804-2f69-4ebb-bb67-a07b7ed70686">
