### PR TITLE
[snap/backend]: bug fix filter account private key and network

### DIFF
--- a/snap/backend/src/utils/accountUtils.js
+++ b/snap/backend/src/utils/accountUtils.js
@@ -124,12 +124,16 @@ const accountUtils = {
 	},
 	/**
 	 * Find account by private key.
-	 * @param {Accounts} accounts - The accounts object.
+	 * @param {{ accounts: Accounts, network: object }} state - The snap state object.
 	 * @param {string} privateKey - The private key.
 	 * @returns {Account | undefined} - The account object.
 	 */
-	findAccountByPrivateKey(accounts, privateKey) {
-		return Object.values(accounts).find(account => account.privateKey === privateKey);
+	findAccountByPrivateKey(state, privateKey) {
+		const { accounts, network } = state;
+
+		return Object.values(accounts)
+			.find(({ account, privateKey: storedPrivateKey }) => storedPrivateKey === privateKey
+				&& account.networkName === network.networkName);
 	},
 	async createAccount({ state, requestParams }) {
 		try {
@@ -153,12 +157,12 @@ const accountUtils = {
 	async importAccount({ state, requestParams }) {
 		try {
 			const { privateKey, accountLabel } = requestParams;
-			const { accounts, network } = state;
+			const { network } = state;
 
 			const facade = new SymbolFacade(network.networkName);
 
 			const symbolAccount = facade.createAccount(new PrivateKey(privateKey));
-			const existingAccount = this.findAccountByPrivateKey(accounts, symbolAccount.keyPair.privateKey.toString());
+			const existingAccount = this.findAccountByPrivateKey(state, symbolAccount.keyPair.privateKey.toString());
 
 			if (existingAccount) {
 				await snap.request({

--- a/snap/backend/test/utils/accountUtils_spec.js
+++ b/snap/backend/test/utils/accountUtils_spec.js
@@ -186,6 +186,20 @@ describe('accountUtils', () => {
 
 	describe('findAccountByPrivateKey', () => {
 		const privateKey = '1F53BA3DA42800D092A0C331A20A41ACCE81D2DD6F710106953ADA277C502010';
+		const accountsState = {
+			'0x1234': {
+				account: {
+					id: '0x1234',
+					addressIndex: 0,
+					type: 'metamask',
+					networkName: 'testnet',
+					label: 'Wallet 0',
+					address: 'address 0',
+					publicKey: 'public key 0'
+				},
+				privateKey
+			}
+		};
 
 		const assertFindAccountByPrivateKey = (accounts, expectedResult) => {
 			// Act:
@@ -195,31 +209,40 @@ describe('accountUtils', () => {
 			expect(account).toStrictEqual(expectedResult);
 		};
 
-		it('returns account given private key', () => {
+		it('returns account given private key with same network', () => {
 			// Arrange:
-			const accounts = {
-				'0x1234': {
-					account: {
-						id: '0x1234',
-						addressIndex: 0,
-						type: 'metamask',
-						networkName: 'testnet',
-						label: 'Wallet 0',
-						address: 'address 0',
-						publicKey: 'public key 0'
-					},
-					privateKey
-				}
+			const state = {
+				network: {
+					networkName: 'testnet'
+				},
+				accounts: accountsState
 			};
 
-			assertFindAccountByPrivateKey(accounts, accounts['0x1234']);
+			assertFindAccountByPrivateKey(state, state.accounts['0x1234']);
+		});
+
+		it('returns undefined when account exist in different network', () => {
+			// Arrange:
+			const state = {
+				network: {
+					networkName: 'mainnet'
+				},
+				accounts: accountsState
+			};
+
+			assertFindAccountByPrivateKey(state, undefined);
 		});
 
 		it('returns undefined when account not found', () => {
 			// Arrange:
-			const accounts = {};
+			const state = {
+				accounts: {},
+				network: {
+					networkName: 'testnet'
+				}
+			};
 
-			assertFindAccountByPrivateKey(accounts, undefined);
+			assertFindAccountByPrivateKey(state, undefined);
 		});
 	});
 


### PR DESCRIPTION
## What was the issue?
- Users cannot import the same private key in different networks.

## What's the fix?
- Validate filter private key and network.