### PR TITLE
[Snap]: Rename account label

### DIFF
--- a/snap/backend/src/index.js
+++ b/snap/backend/src/index.js
@@ -62,6 +62,8 @@ export const onRpcRequest = async ({ request }) => {
 		return state.feeMultiplier;
 	case 'signTransferTransaction':
 		return accountUtils.signTransferTransaction(apiParams);
+	case 'renameAccountLabel':
+		return accountUtils.renameAccountLabel(apiParams);
 	default:
 		throw new Error('Method not found.');
 	}

--- a/snap/backend/src/utils/accountUtils.js
+++ b/snap/backend/src/utils/accountUtils.js
@@ -381,6 +381,26 @@ const accountUtils = {
 			transactionHash: facade.hashTransaction(transaction).toString(),
 			jsonPayload: JSON.parse(jsonPayload)
 		};
+	},
+	/**
+	 * Rename account label.
+	 * @param {object} state - The snap state object.
+	 * @param {{accountId: string, newLabel: string}} requestParams - The request parameters.
+	 * @returns {Promise<Account>} - The updated account object.
+	 */
+	async renameAccountLabel({ state, requestParams }) {
+		const { accountId, newLabel } = requestParams;
+		const { accounts } = state;
+		const account = accounts[accountId];
+
+		if (account) {
+			account.account.label = newLabel;
+			state.accounts[accountId] = account;
+			await stateManager.update(state);
+			return account.account;
+		}
+
+		throw new Error(`Account with id ${accountId} not found`);
 	}
 };
 

--- a/snap/backend/test/index_spec.js
+++ b/snap/backend/test/index_spec.js
@@ -420,6 +420,49 @@ describe('index', () => {
 				});
 			});
 		});
+
+		describe('renameAccountLabel', () => {
+			it('should invoke accountUtils.renameAccountLabel with the correct parameters', async () => {
+				// Arrange:
+				const mockParams = {
+					accountId: '123',
+					newLabel: 'New Account Label'
+				};
+
+				// Act & Assert:
+				await assertMethodCalled(accountUtils, 'renameAccountLabel', {
+					method: 'renameAccountLabel',
+					params: mockParams
+				}, {
+					state: {},
+					requestParams: mockParams
+				});
+			});
+
+			it('should return the result from accountUtils.renameAccountLabel', async () => {
+				// Arrange:
+				const mockParams = {
+					accountId: '123',
+					newLabel: 'New Account Label'
+				};
+				const mockResult = {
+					id: '123',
+					label: 'New Account Label'
+				};
+				accountUtils.renameAccountLabel.mockResolvedValue(mockResult);
+
+				// Act:
+				const response = await onRpcRequest({
+					request: {
+						method: 'renameAccountLabel',
+						params: mockParams
+					}
+				});
+
+				// Assert:
+				expect(response).toStrictEqual(mockResult);
+			});
+		});
 	});
 
 	describe('onCronjob', () => {

--- a/snap/backend/test/utils/accountUtils_spec.js
+++ b/snap/backend/test/utils/accountUtils_spec.js
@@ -1005,4 +1005,54 @@ describe('accountUtils', () => {
 			});
 		});
 	});
+
+	describe('renameAccountLabel', () => {
+		beforeEach(() => {
+			jest.clearAllMocks();
+		});
+
+		it('successfully renames an account label', async () => {
+			// Arrange
+			const state = {
+				accounts: {
+					123: {
+						account: {
+							id: '123',
+							label: 'Old Label'
+						}
+					}
+				}
+			};
+			const requestParams = {
+				accountId: '123',
+				newLabel: 'New Label'
+			};
+
+			// Act
+			const result = await accountUtils.renameAccountLabel({ state, requestParams });
+
+			// Assert
+			expect(result).toStrictEqual({
+				id: '123',
+				label: 'New Label'
+			});
+			expect(state.accounts['123'].account.label).toBe('New Label');
+			expect(stateManager.update).toHaveBeenCalledWith(state);
+		});
+
+		it('throws an error when account is not found', async () => {
+			// Arrange
+			const state = {
+				accounts: {}
+			};
+			const requestParams = {
+				accountId: 'nonexistent',
+				newLabel: 'New Label'
+			};
+
+			// Act & Assert
+			await expect(accountUtils.renameAccountLabel({ state, requestParams }))
+				.rejects.toThrow('Account with id nonexistent not found');
+		});
+	});
 });

--- a/snap/frontend/components/AccountListModalBox/index.jsx
+++ b/snap/frontend/components/AccountListModalBox/index.jsx
@@ -1,6 +1,7 @@
 import { useWalletContext } from '../../context';
 import helper from '../../utils/helper';
 import AccountCreationFormModalBox from '../AccountCreationFormModalBox';
+import AccountRenameModalBox from '../AccountRenameModalBox';
 import Button from '../Button';
 import ModalBox from '../ModalBox';
 import makeBlockie from 'ethereum-blockies-base64';
@@ -13,6 +14,7 @@ const AccountListModalBox = ({ isOpen, onRequestClose }) => {
 	const { accounts } = walletState;
 	const [ accountCreateFormVisible, setAccountCreateFormVisible ] = useState(false);
 	const [ accountImportFormVisible, setAccountImportFormVisible ] = useState(false);
+	const [ renameAccountId, setRenameAccountId ] = useState(null);
 
 	const handleOpenAccountCreateForm = () => {
 		setAccountCreateFormVisible(!accountCreateFormVisible);
@@ -21,6 +23,11 @@ const AccountListModalBox = ({ isOpen, onRequestClose }) => {
 
 	const handleOpenAccountImportForm = () => {
 		setAccountImportFormVisible(!accountImportFormVisible);
+		onRequestClose(false);
+	};
+
+	const handleOpenRenameForm = accountId => {
+		setRenameAccountId(accountId);
 		onRequestClose(false);
 	};
 
@@ -66,20 +73,35 @@ const AccountListModalBox = ({ isOpen, onRequestClose }) => {
 
 	const renderAccount = account => {
 		return (
-			<div key={`wallet_${account.id}`} className='flex items-center cursor-pointer'
-				onClick={() => handleSelectAccount(account)}>
-				<Image
-					src={makeBlockie(account.address)}
-					alt='account-profile'
-					width={24}
-					height={24}
-					className='rounded-full w-10 h-10' />
-				<div className='flex flex-col items-start justify-center p-2'>
-					<div className='font-bold'>{account.label} {renderImportType(account.type)}</div>
-					<div className='truncate w-[180px]'>{account.address}</div>
+			<div key={`wallet_${account.id}`} className='flex items-center justify-between'>
+				<div className='flex items-center cursor-pointer'
+					onClick={() => handleSelectAccount(account)}>
+					<Image
+						src={makeBlockie(account.address)}
+						alt='account-profile'
+						width={24}
+						height={24}
+						className='rounded-full w-10 h-10' />
+					<div className='flex flex-col items-start justify-center p-2'>
+						<div className='font-bold'>{account.label} {renderImportType(account.type)}</div>
+						<div className='truncate w-[180px]'>{account.address}</div>
+					</div>
 				</div>
+				<Button
+					className='uppercase w-20 h-8 bg-secondary text-xs'
+					onClick={() => handleOpenRenameForm(account.id)}
+				>
+					Rename
+				</Button>
 			</div>
 		);
+	};
+
+	const handleRenameAccount = newLabel => {
+		if (renameAccountId) {
+			helper.renameAccountLabel(dispatch, symbolSnap, renameAccountId, newLabel);
+			setRenameAccountId(null);
+		}
 	};
 
 	return (
@@ -87,7 +109,7 @@ const AccountListModalBox = ({ isOpen, onRequestClose }) => {
 			<ModalBox isOpen={isOpen} onRequestClose={onRequestClose}>
 				<div className='flex flex-col px-5 text-center'>
 					<div className='text-2xl font-bold mb-6'>
-                    Wallet
+							Wallet
 					</div>
 
 					<div className='flex flex-col overflow-y-auto h-72 items-center justify-start mb-6 text-xs'>
@@ -98,10 +120,10 @@ const AccountListModalBox = ({ isOpen, onRequestClose }) => {
 
 					<div className='flex justify-center font-bold pt-2'>
 						<Button className='uppercase w-40 h-10 bg-secondary m-2' onClick={handleOpenAccountCreateForm}>
-                        Create
+								Create
 						</Button>
 						<Button className='uppercase w-40 h-10 bg-secondary m-2' onClick={handleOpenAccountImportForm}>
-                        Import
+								Import
 						</Button>
 					</div>
 				</div>
@@ -144,6 +166,14 @@ const AccountListModalBox = ({ isOpen, onRequestClose }) => {
 						validate: value => validatePrivateKey(value)
 					}
 				]}
+			/>
+
+			<AccountRenameModalBox
+				isOpen={!!renameAccountId}
+				onRequestClose={() => setRenameAccountId(null)}
+				onRename={handleRenameAccount}
+				currentName={renameAccountId ? accounts[renameAccountId].label : ''}
+				validateAccountName={validateAccountName}
 			/>
 		</>
 	);

--- a/snap/frontend/components/AccountRenameModalBox/AccountRenameModalBox.spec.jsx
+++ b/snap/frontend/components/AccountRenameModalBox/AccountRenameModalBox.spec.jsx
@@ -1,0 +1,107 @@
+import AccountRenameModalBox from '.';
+import testHelper from '../testHelper';
+import { fireEvent, screen } from '@testing-library/react';
+
+const context = {};
+
+describe('components/AccountRenameModalBox', () => {
+	it('renders the modal with current account name', () => {
+		// Arrange
+		testHelper.customRender(
+			<AccountRenameModalBox
+				isOpen={true}
+				onRequestClose={jest.fn()}
+				onRename={jest.fn()}
+				currentName="Original Name"
+				validateAccountName={jest.fn()}
+			/>,
+			context
+		);
+
+		// Act
+		const input = screen.getByPlaceholderText('New Account Name');
+
+		// Assert
+		expect(input).toHaveValue('Original Name');
+	});
+
+	it('calls onRename when submitting a valid name', async () => {
+		// Arrange
+		const onRenameMock = jest.fn();
+		const mockValidateAccountName = jest.fn().mockReturnValue('');
+		const mockOnRequestClose = jest.fn();
+
+		testHelper.customRender(
+			<AccountRenameModalBox
+				isOpen={true}
+				onRequestClose={mockOnRequestClose}
+				onRename={onRenameMock}
+				currentName="Original Name"
+				validateAccountName={mockValidateAccountName}
+			/>,
+			context
+		);
+
+		// Act
+		const input = screen.getByPlaceholderText('New Account Name');
+		fireEvent.change(input, { target: { value: 'New Name' } });
+
+		const renameButton = screen.getByText('Rename');
+		fireEvent.click(renameButton);
+
+		// Assert
+		expect(mockValidateAccountName).toHaveBeenCalledWith('New Name');
+		expect(onRenameMock).toHaveBeenCalledWith('New Name');
+		expect(mockOnRequestClose).toHaveBeenCalled();
+	});
+
+	it('displays error message for invalid name', () => {
+		// Arrange
+		const mockValidateAccountName = jest.fn().mockReturnValue('Invalid name');
+
+		testHelper.customRender(
+			<AccountRenameModalBox
+				isOpen={true}
+				onRequestClose={jest.fn()}
+				onRename={jest.fn()}
+				currentName="Original Name"
+				validateAccountName={mockValidateAccountName}
+			/>,
+			context
+		);
+
+		// Act
+		const input = screen.getByPlaceholderText('New Account Name');
+		fireEvent.change(input, { target: { value: 'Invalid Name' } });
+
+		const renameButton = screen.getByText('Rename');
+		fireEvent.click(renameButton);
+
+		// Assert
+		const errorMessage = screen.getByText('Invalid name');
+		expect(errorMessage).toBeInTheDocument();
+	});
+
+	it('closes modal when cancel button is clicked', () => {
+		// Arrange
+		const mockOnRequestClose = jest.fn();
+
+		testHelper.customRender(
+			<AccountRenameModalBox
+				isOpen={true}
+				onRequestClose={mockOnRequestClose}
+				onRename={jest.fn()}
+				currentName="Original Name"
+				validateAccountName={jest.fn()}
+			/>,
+			context
+		);
+
+		// Act
+		const cancelButton = screen.getByText('Cancel');
+		fireEvent.click(cancelButton);
+
+		// Assert
+		expect(mockOnRequestClose).toHaveBeenCalled();
+	});
+});

--- a/snap/frontend/components/AccountRenameModalBox/AccountRenameModalBox.spec.jsx
+++ b/snap/frontend/components/AccountRenameModalBox/AccountRenameModalBox.spec.jsx
@@ -46,8 +46,8 @@ describe('components/AccountRenameModalBox', () => {
 		const input = screen.getByPlaceholderText('New Account Name');
 		fireEvent.change(input, { target: { value: 'New Name' } });
 
-		const renameButton = screen.getByText('Rename');
-		fireEvent.click(renameButton);
+		const submitButton = screen.getByText('Submit');
+		fireEvent.click(submitButton);
 
 		// Assert
 		expect(mockValidateAccountName).toHaveBeenCalledWith('New Name');
@@ -74,8 +74,8 @@ describe('components/AccountRenameModalBox', () => {
 		const input = screen.getByPlaceholderText('New Account Name');
 		fireEvent.change(input, { target: { value: 'Invalid Name' } });
 
-		const renameButton = screen.getByText('Rename');
-		fireEvent.click(renameButton);
+		const submitButton = screen.getByText('Submit');
+		fireEvent.click(submitButton);
 
 		// Assert
 		const errorMessage = screen.getByText('Invalid name');

--- a/snap/frontend/components/AccountRenameModalBox/index.jsx
+++ b/snap/frontend/components/AccountRenameModalBox/index.jsx
@@ -43,10 +43,10 @@ const AccountRenameModalBox = ({ isOpen, onRequestClose, onRename, currentName, 
 				/>
 				<div className='flex justify-center'>
 					<Button className='uppercase w-40 h-10 bg-secondary m-2' onClick={handleSubmit}>
-            Rename
+						Submit
 					</Button>
 					<Button className='uppercase w-40 h-10 bg-secondary m-2' onClick={onRequestClose}>
-            Cancel
+						Cancel
 					</Button>
 				</div>
 			</div>

--- a/snap/frontend/components/AccountRenameModalBox/index.jsx
+++ b/snap/frontend/components/AccountRenameModalBox/index.jsx
@@ -1,0 +1,57 @@
+import Button from '../Button';
+import Input from '../Input';
+import ModalBox from '../ModalBox';
+import { useEffect, useState } from 'react';
+
+const AccountRenameModalBox = ({ isOpen, onRequestClose, onRename, currentName, validateAccountName }) => {
+	const [newName, setNewName] = useState(currentName);
+	const [error, setError] = useState('');
+
+	// Reset newName and error when the modal opens
+	useEffect(() => {
+		if (isOpen) {
+			setNewName(currentName);
+			setError('');
+		}
+	}, [isOpen, currentName]);
+
+	const handleSubmit = () => {
+		const validationError = validateAccountName(newName);
+		if (validationError) {
+			setError(validationError);
+		} else {
+			onRename(newName);
+			onRequestClose();
+		}
+	};
+
+	const handleInputChange = e => {
+		setNewName(e.target.value);
+		setError('');
+	};
+
+	return (
+		<ModalBox isOpen={isOpen} onRequestClose={onRequestClose}>
+			<div className='flex flex-col px-5 text-center'>
+				<div className='text-2xl font-bold mb-6'>Rename Account</div>
+				<Input
+					value={newName}
+					onChange={handleInputChange}
+					placeholder='New Account Name'
+					errorMessage={error}
+					className='mb-4'
+				/>
+				<div className='flex justify-center'>
+					<Button className='uppercase w-40 h-10 bg-secondary m-2' onClick={handleSubmit}>
+            Rename
+					</Button>
+					<Button className='uppercase w-40 h-10 bg-secondary m-2' onClick={onRequestClose}>
+            Cancel
+					</Button>
+				</div>
+			</div>
+		</ModalBox>
+	);
+};
+
+export default AccountRenameModalBox;

--- a/snap/frontend/components/AssetList/AssetList.spec.jsx
+++ b/snap/frontend/components/AssetList/AssetList.spec.jsx
@@ -163,19 +163,6 @@ describe('components/AssetList', () => {
 		assertRenderCurrencyMosaic(context, '2 xym');
 	});
 
-	const assertRenderCurrencyMosaic = (context, expectedAmount) => {
-		// Arrange:
-		testHelper.customRender(<AssetList />, context);
-
-		// Act:
-		const mosaicNameElement = screen.getByText('symbol');
-		const mosaicAmountElement = screen.getByText(expectedAmount);
-
-		// Assert:
-		expect(mosaicNameElement).toBeInTheDocument();
-		expect(mosaicAmountElement).toBeInTheDocument();
-	};
-
 	it('renders default currency mosaics when mosaics is empty', () => {
 		// Arrange:
 		context.walletState.selectedAccount.mosaics = [];

--- a/snap/frontend/context/reducer.js
+++ b/snap/frontend/context/reducer.js
@@ -27,7 +27,8 @@ export const actionTypes = {
 	SET_CURRENCY: 'setCurrency',
 	SET_MOSAIC_INFO: 'setMosaicInfo',
 	SET_TRANSACTIONS: 'setTransactions',
-	SET_WEBSOCKET: 'setWebsocket'
+	SET_WEBSOCKET: 'setWebsocket',
+	UPDATE_ACCOUNT: 'updateAccount'
 };
 
 export const reducer = (state, action) => {
@@ -50,6 +51,21 @@ export const reducer = (state, action) => {
 		return { ...state, transactions: action.payload };
 	case actionTypes.SET_WEBSOCKET:
 		return { ...state, websocket: action.payload };
+	case actionTypes.UPDATE_ACCOUNT:
+		const updatedAccount = action.payload;
+		const updatedState = {
+			...state,
+			accounts: {
+				...state.accounts,
+				[updatedAccount.id]: updatedAccount
+			}
+		};
+		
+		// If the updated account is the currently selected account, update selectedAccount as well
+		if (state.selectedAccount && state.selectedAccount.id === updatedAccount.id) 
+			updatedState.selectedAccount = updatedAccount;
+		
+		return updatedState;
 	default:
 		return state;
 	}

--- a/snap/frontend/context/reducer.spec.js
+++ b/snap/frontend/context/reducer.spec.js
@@ -1,0 +1,59 @@
+import { actionTypes, initialState, reducer } from './reducer';
+
+describe('reducer', () => {
+	describe('UPDATE_ACCOUNT', () => {
+		// Arrange:
+		const initialStateWithAccounts = {
+			...initialState,
+			accounts: {
+				'1': { id: '1', label: 'Account 1' },
+				'2': { id: '2', label: 'Account 2' }
+			},
+			selectedAccount: { id: '1', label: 'Account 1' }
+		};
+
+		it('should update the account and selectedAccount if the updated account is the currently selected account', () => {
+			// Act:
+			const action = {
+				type: actionTypes.UPDATE_ACCOUNT,
+				payload: { id: '1', label: 'Updated Account 1' }
+			};
+
+			const newState = reducer(initialStateWithAccounts, action);
+
+			// Assert:
+			expect(newState.accounts['1']).toBe(action.payload);
+			expect(newState.selectedAccount).toBe(action.payload);
+		});
+
+		it('should update the account but not selectedAccount if the updated account is not the currently selected account', () => {
+			// Act:
+			const action = {
+				type: actionTypes.UPDATE_ACCOUNT,
+				payload: { id: '2', label: 'Updated Account 2' }
+			};
+
+			const newState = reducer(initialStateWithAccounts, action);
+
+			// Assert:
+			expect(newState.accounts['2']).toBe(action.payload);
+			expect(newState.selectedAccount).toBe(initialStateWithAccounts.selectedAccount);
+		});
+	});
+
+	describe('Default', () => {
+		it('should return the initial state if the action is not recognized', () => {
+			// Arrange:
+			const action = {
+				type: 'UNKNOWN_ACTION',
+				payload: {}
+			};
+
+			// Act:
+			const newState = reducer(initialState, action);
+
+			// Assert:
+			expect(newState).toBe(initialState);
+		});
+	});
+});

--- a/snap/frontend/utils/dispatchUtils.js
+++ b/snap/frontend/utils/dispatchUtils.js
@@ -63,6 +63,13 @@ const dispatchUtils = dispatch => ({
 	 */
 	setWebsocket: websocket => {
 		dispatch({ type: actionTypes.SET_WEBSOCKET, payload: websocket });
+	},
+	/**
+	 * Update account after renaming
+	 * @param {Account} updatedAccount - The updated account object.
+	 */
+	updateAccount: updatedAccount => {
+		dispatch({ type: actionTypes.UPDATE_ACCOUNT, payload: updatedAccount });
 	}
 });
 

--- a/snap/frontend/utils/dispatchUtils.spec.js
+++ b/snap/frontend/utils/dispatchUtils.spec.js
@@ -182,4 +182,25 @@ describe('dispatchUtils', () => {
 			expect(dispatchState).toHaveBeenCalledWith({ type: 'setWebsocket', payload: websocket });
 		});
 	});
+
+	describe('updateAccount', () => {
+		it('dispatches UPDATE_ACCOUNT action with updated account', () => {
+			// Arrange:
+			const updatedAccount = {
+				id: 'accountId',
+				addressIndex: 1,
+				type: 'metamask',
+				networkName: 'network',
+				label: 'newLabel',
+				address: 'address',
+				publicKey: 'publicKey'
+			};
+
+			// Act:
+			dispatch.updateAccount(updatedAccount);
+
+			// Assert:
+			expect(dispatchState).toHaveBeenCalledWith({ type: 'updateAccount', payload: updatedAccount });
+		});
+	});
 });

--- a/snap/frontend/utils/helper.js
+++ b/snap/frontend/utils/helper.js
@@ -176,6 +176,11 @@ const helper = {
 		default:
 			throw new Error('Transaction type not support.');
 		}
+	},
+	async renameAccountLabel (dispatch, symbolSnap, accountId, newLabel) {
+		const updatedAccount = await symbolSnap.renameAccountLabel(accountId, newLabel);
+
+		dispatch.updateAccount(updatedAccount);
 	}
 };
 

--- a/snap/frontend/utils/helper.spec.js
+++ b/snap/frontend/utils/helper.spec.js
@@ -13,7 +13,8 @@ describe('helper', () => {
 		setCurrency: jest.fn(),
 		setMosaicInfo: jest.fn(),
 		setTransactions: jest.fn(),
-		setWebsocket: jest.fn()
+		setWebsocket: jest.fn(),
+		updateAccount: jest.fn()
 	};
 
 	const symbolSnap = {
@@ -25,7 +26,8 @@ describe('helper', () => {
 		getMosaicInfo: jest.fn(),
 		getAccounts: jest.fn(),
 		fetchAccountTransactions: jest.fn(),
-		signTransferTransaction: jest.fn()
+		signTransferTransaction: jest.fn(),
+		renameAccountLabel: jest.fn()
 	};
 
 	describe('setupSnap', () => {
@@ -510,6 +512,32 @@ describe('helper', () => {
 			expect(() => {
 				helper.feeCalculator(facade, 'unknown', mosaicInfo, params);
 			}).toThrow('Transaction type not support.');
+		});
+	});
+
+	describe('renameAccountLabel', () => {
+		it('updates account label and dispatches updateAccount action', async () => {
+			// Arrange:
+			const accountId = 'accountId';
+			const newLabel = 'newLabel';
+			const mockUpdatedAccount = {
+				id: 'accountId',
+				addressIndex: 1,
+				type: 'metamask',
+				networkName: 'network',
+				label: newLabel,
+				address: 'address',
+				publicKey: 'publicKey'
+			};
+
+			symbolSnap.renameAccountLabel.mockResolvedValue(mockUpdatedAccount);
+
+			// Act:
+			await helper.renameAccountLabel(dispatch, symbolSnap, accountId, newLabel);
+
+			// Assert:
+			expect(symbolSnap.renameAccountLabel).toHaveBeenCalledWith(accountId, newLabel);
+			expect(dispatch.updateAccount).toHaveBeenCalledWith(mockUpdatedAccount);
 		});
 	});
 });

--- a/snap/frontend/utils/snap.js
+++ b/snap/frontend/utils/snap.js
@@ -281,6 +281,29 @@ const symbolSnapFactory = {
 				});
 
 				return transactionHash;
+			},
+			/**
+			 * Rename account label in snap MetaMask.
+			 * @param {string} accountId - The account id.
+			 * @param {string} newLabel - The new label for the account.
+			 * @returns {Promise<Account>} The updated account object.
+			 */
+			async renameAccountLabel(accountId, newLabel) {
+				const updatedAccount = await provider.request({
+					method: 'wallet_invokeSnap',
+					params: {
+						snapId: defaultSnapOrigin,
+						request: {
+							method: 'renameAccountLabel',
+							params: {
+								accountId,
+								newLabel
+							}
+						}
+					}
+				});
+
+				return updatedAccount;
 			}
 		};
 	}

--- a/snap/frontend/utils/snap.spec.js
+++ b/snap/frontend/utils/snap.spec.js
@@ -544,4 +544,41 @@ describe('symbolSnapFactory', () => {
 			});
 		});
 	});
+
+	describe('renameAccountLabel', () => {
+		it('returns updated account when provider request is successful', async () => {
+			// Arrange:
+			const accountId = 'accountId';
+			const newLabel = 'newLabel';
+			const mockUpdatedAccount = {
+				id: 'accountId',
+				addressIndex: 1,
+				type: 'metamask',
+				networkName: 'network',
+				label: newLabel,
+				address: 'address',
+				publicKey: 'publicKey'
+			};
+
+			mockProvider.request.mockResolvedValue(mockUpdatedAccount);
+
+			// Act:
+			const result = await symbolSnap.renameAccountLabel(accountId, newLabel);
+			// Assert:
+			expect(result).toEqual(mockUpdatedAccount);
+			expect(mockProvider.request).toHaveBeenCalledWith({
+				method: 'wallet_invokeSnap',
+				params: {
+					snapId: 'local:http://localhost:8080',
+					request: {
+						method: 'renameAccountLabel',
+						params: {
+							accountId,
+							newLabel
+						}
+					}
+				}
+			});
+		});
+	});
 });


### PR DESCRIPTION
## What was the issue?
- Account label unable to update.

## What's the fix?
- Implemented an updated account label in the Snap backend.
- Added rename account modal box component.
- Implemented renaming the modal box in the account list components.

## Screenshot:
<img width="625" alt="Screenshot 2024-09-04 at 3 35 13 PM" src="https://github.com/user-attachments/assets/2a7d7e30-f62c-4ce6-bf33-89e3a8c04c9c">

<img width="576" alt="Screenshot 2024-09-04 at 3 35 18 PM" src="https://github.com/user-attachments/assets/c70d8748-0063-45da-a736-6cb7783e63ec">

