### PR TITLE
[tools/shoestring]: add support for advanced customization of rest.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ _data/
 .next/
 
 # python
+.python-version
 __pycache__/
 *.egg-info/
 build/

--- a/tools/shoestring/README.md
+++ b/tools/shoestring/README.md
@@ -134,17 +134,17 @@ setup \
     [--package PACKAGE] \
     [--directory DIRECTORY] \
     [--overrides OVERRIDES] \
-    [--metadata METADATA] \
+    [--rest-overrides REST_OVERRIDES] \
     [--security {default,paranoid,insecure}] \
     --ca-key-path CA_KEY_PATH
 
-  --config CONFIG           path to shoestring configuration file
-  --package PACKAGE         Network configuration package. Possible values: (name | file:///filename | http(s)://uri) (default: mainnet)
-  --directory DIRECTORY     installation directory (default: $HOME)
-  --overrides OVERRIDES     path to custom user settings
-  --metadata METADATA       custom node metadata (this is only valid for API roles)
-  --security                security mode (default: default)
-  --ca-key-path CA_KEY_PATH path to main private key PEM file
+  --config CONFIG                       path to shoestring configuration file
+  --package PACKAGE                     Network configuration package. Possible values: (name | file:///filename | http(s)://uri) (default: mainnet)
+  --directory DIRECTORY                 installation directory (default: $HOME)
+  --overrides OVERRIDES                 path to custom user settings
+  --rest-overrides REST_OVERRIDES       path to custom user REST settings (this is only valid for API roles)
+  --security                            security mode (default: default)
+  --ca-key-path CA_KEY_PATH             path to main private key PEM file
 ```
 
 Please note that only security mode "default" is supported at this time.
@@ -201,13 +201,13 @@ upgrade \
     [--package PACKAGE] \
     [--directory DIRECTORY] \
     [--overrides OVERRIDES] \
-    [--metadata METADATA]
+    [--rest-overrides REST_OVERRIDES]
 
-  --config CONFIG           path to shoestring configuration file
-  --package PACKAGE         Network configuration package. Possible values: (name | file:///filename | http(s)://uri) (default: mainnet)
-  --directory DIRECTORY     installation directory (default: $HOME)
-  --overrides OVERRIDES     path to custom user settings
-  --metadata METADATA       custom node metadata (this is only valid for API roles)
+  --config CONFIG                       path to shoestring configuration file
+  --package PACKAGE                     Network configuration package. Possible values: (name | file:///filename | http(s)://uri) (default: mainnet)
+  --directory DIRECTORY                 installation directory (default: $HOME)
+  --overrides OVERRIDES                 path to custom user settings
+  --rest-overrides REST_OVERRIDES       path to custom user REST settings (this is only valid for API roles)
 ```
 
 ### renew-certificates
@@ -371,10 +371,9 @@ maxUnlockedAccounts = 2
 Notice that these custom settings are applied *BEFORE* shoestring updates the Symbol configuration files.
 In cases of conflicts, the shoestring changes will take precedence.
 
-### Node Metadata
+### REST Overrides
 
-JSON file that is ingested and used to replace the contents of `nodeMetadata` in rest.json.
-This data is then accessible via the `node/metadata` REST endpoint.
+JSON file that is ingested and used to update the contents of rest.json.
 This file is optional and only used for deployments including API role.
 
 # Running

--- a/tools/shoestring/shoestring/commands/setup.py
+++ b/tools/shoestring/shoestring/commands/setup.py
@@ -112,7 +112,7 @@ async def run_main(args):
 			user_patches = load_patches_from_file(args.overrides)
 
 		preparer.configure_resources(user_patches)
-		preparer.configure_rest(args.metadata)
+		preparer.configure_rest(args.rest_overrides)
 
 		hostname = _resolve_hostname_and_configure_https(config, preparer)
 
@@ -137,7 +137,7 @@ def add_arguments(parser, is_initial_setup=True):
 	parser.add_argument('--package', help=_('argument-help-setup-package'), default='mainnet')
 	parser.add_argument('--directory', help=_('argument-help-directory').format(default_path=Path.home()), default=str(Path.home()))
 	parser.add_argument('--overrides', help=_('argument-help-setup-overrides'))
-	parser.add_argument('--metadata', help=_('argument-help-setup-metadata'))
+	parser.add_argument('--rest-overrides', help=_('argument-help-setup-rest-overrides'))
 
 	if is_initial_setup:
 		parser.add_argument('--security', help=_('argument-help-setup-security'), choices=SECURITY_MODES, default='default')

--- a/tools/shoestring/shoestring/internal/ConfigurationManager.py
+++ b/tools/shoestring/shoestring/internal/ConfigurationManager.py
@@ -111,3 +111,13 @@ def parse_time_span(str_value):
 		raise ValueError(f'time span specified in unknown units \'{unit_indicator}\'')
 
 	return value.timestamp
+
+
+def merge_json_configuration(lhs, rhs):
+	"""Merges two json configuration objects."""
+
+	for key in rhs.keys():
+		if isinstance(rhs[key], dict) and key in lhs and isinstance(lhs[key], dict):
+			merge_json_configuration(lhs[key], rhs[key])
+		else:
+			lhs[key] = rhs[key]

--- a/tools/shoestring/shoestring/internal/Preparer.py
+++ b/tools/shoestring/shoestring/internal/Preparer.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from symbolchain.symbol.Network import NetworkTimestamp
 
 from .CertificateFactory import CertificateFactory
-from .ConfigurationManager import ConfigurationManager
+from .ConfigurationManager import ConfigurationManager, merge_json_configuration
 from .FileTemplater import apply_template
 from .HarvesterConfigurator import HarvesterConfigurator
 from .LinkTransactionBuilder import LinkTransactionBuilder
@@ -266,7 +266,7 @@ class Preparer:
 		# make all resources read only
 		self._make_files_readonly(self.directories.resources)
 
-	def configure_rest(self, node_metadata_filename=None):
+	def configure_rest(self, rest_overrides_filename=None):
 		"""Copies mongo and rest files."""
 
 		if NodeFeatures.API not in self.config.node.features:
@@ -277,16 +277,16 @@ class Preparer:
 
 		self._copy_file(self.directories.temp / 'rest' / 'rest.json', self.directories.userconfig)
 
-		if node_metadata_filename:
+		if rest_overrides_filename:
 			rest_json_filepath = self.directories.userconfig / 'rest.json'
 
 			# load the rest config
 			with open(rest_json_filepath, 'rt', encoding='utf8') as rest_config_infile:
 				rest_config = json.load(rest_config_infile)
 
-			# replace user metadata
-			with open(node_metadata_filename, 'rt', encoding='utf8') as node_metadata_infile:
-				rest_config['nodeMetadata'] = json.load(node_metadata_infile)
+			# customize user rest config
+			with open(rest_overrides_filename, 'rt', encoding='utf8') as rest_overrides_infile:
+				merge_json_configuration(rest_config, json.load(rest_overrides_infile))
 
 			# rewrite the rest config
 			with open(rest_json_filepath, 'wt', encoding='utf8') as rest_config_outfile:

--- a/tools/shoestring/shoestring/lang/en/LC_MESSAGES/messages.po
+++ b/tools/shoestring/shoestring/lang/en/LC_MESSAGES/messages.po
@@ -27,7 +27,7 @@ msgstr "path to main private key PEM file"
 
 #: shoestring/commands/announce_transaction.py:35
 #: shoestring/commands/health.py:74 shoestring/commands/import_bootstrap.py:33
-#: shoestring/commands/import_harvesters.py:94 shoestring/commands/init.py:29
+#: shoestring/commands/import_harvesters.py:97 shoestring/commands/init.py:29
 #: shoestring/commands/min_cosignatures_count.py:34
 #: shoestring/commands/renew_certificates.py:29
 #: shoestring/commands/renew_voting_keys.py:112
@@ -47,19 +47,19 @@ msgstr "installation directory (default: {default_path})"
 msgid "argument-help-import-bootstrap-bootstrap"
 msgstr "path to bootstrap target directory"
 
-#: shoestring/commands/import_harvesters.py:95
+#: shoestring/commands/import_harvesters.py:98
 msgid "argument-help-import-harvesters-in-harvesters"
 msgstr "input harvesters.dat file that is encrypted with in-pem"
 
-#: shoestring/commands/import_harvesters.py:96
+#: shoestring/commands/import_harvesters.py:99
 msgid "argument-help-import-harvesters-in-pem"
 msgstr "PEM file that can be used to decrypt in-harvesters"
 
-#: shoestring/commands/import_harvesters.py:98
+#: shoestring/commands/import_harvesters.py:101
 msgid "argument-help-import-harvesters-out-harvesters"
 msgstr "output harvesters.dat file that will be encrypted with out-pem"
 
-#: shoestring/commands/import_harvesters.py:99
+#: shoestring/commands/import_harvesters.py:102
 msgid "argument-help-import-harvesters-out-pem"
 msgstr "PEM file that can be used to encrypt out-harvesters"
 
@@ -91,10 +91,6 @@ msgstr "renews CA certificate too"
 msgid "argument-help-reset-data-purge-harvesters"
 msgstr "purge harvesters.dat file"
 
-#: shoestring/commands/setup.py:140
-msgid "argument-help-setup-metadata"
-msgstr "Custom node metadata (this is only valid for API roles)"
-
 #: shoestring/commands/setup.py:139
 msgid "argument-help-setup-overrides"
 msgstr "path to custom user settings"
@@ -104,6 +100,10 @@ msgid "argument-help-setup-package"
 msgstr ""
 "Network configuration package. Possible values: (name | file:///filename "
 "| http(s)://uri) (default: mainnet)"
+
+#: shoestring/commands/setup.py:140
+msgid "argument-help-setup-rest-overrides"
+msgstr "path to custom user REST settings (this is only valid for API roles)"
 
 #: shoestring/commands/setup.py:143
 msgid "argument-help-setup-security"
@@ -260,11 +260,11 @@ msgstr ""
 "bootstrap directory provided ({directory}) does not look like bootstrap's"
 " target directory, nothing to import"
 
-#: shoestring/commands/import_harvesters.py:74
+#: shoestring/commands/import_harvesters.py:75
 msgid "import-harvesters-error-in-harvesters-is-equal-to-out-harvesters"
 msgstr "in-harvesters and out-harvesters must be different"
 
-#: shoestring/commands/import_harvesters.py:51
+#: shoestring/commands/import_harvesters.py:52
 msgid "import-harvesters-list-header"
 msgstr "listing harvesters in {filepath} using public key {public_key}"
 
@@ -826,4 +826,3 @@ msgstr "Welcome"
 #: shoestring/wizard/screens/welcome.py:36
 msgid "wizard-welcome-upgrade"
 msgstr "upgrade"
-

--- a/tools/shoestring/shoestring/lang/ja/LC_MESSAGES/messages.po
+++ b/tools/shoestring/shoestring/lang/ja/LC_MESSAGES/messages.po
@@ -25,7 +25,7 @@ msgstr ""
 
 #: shoestring/commands/announce_transaction.py:35
 #: shoestring/commands/health.py:74 shoestring/commands/import_bootstrap.py:33
-#: shoestring/commands/import_harvesters.py:94 shoestring/commands/init.py:29
+#: shoestring/commands/import_harvesters.py:97 shoestring/commands/init.py:29
 #: shoestring/commands/min_cosignatures_count.py:34
 #: shoestring/commands/renew_certificates.py:29
 #: shoestring/commands/renew_voting_keys.py:112
@@ -45,19 +45,19 @@ msgstr ""
 msgid "argument-help-import-bootstrap-bootstrap"
 msgstr ""
 
-#: shoestring/commands/import_harvesters.py:95
+#: shoestring/commands/import_harvesters.py:98
 msgid "argument-help-import-harvesters-in-harvesters"
 msgstr ""
 
-#: shoestring/commands/import_harvesters.py:96
+#: shoestring/commands/import_harvesters.py:99
 msgid "argument-help-import-harvesters-in-pem"
 msgstr ""
 
-#: shoestring/commands/import_harvesters.py:98
+#: shoestring/commands/import_harvesters.py:101
 msgid "argument-help-import-harvesters-out-harvesters"
 msgstr ""
 
-#: shoestring/commands/import_harvesters.py:99
+#: shoestring/commands/import_harvesters.py:102
 msgid "argument-help-import-harvesters-out-pem"
 msgstr ""
 
@@ -89,16 +89,16 @@ msgstr ""
 msgid "argument-help-reset-data-purge-harvesters"
 msgstr ""
 
-#: shoestring/commands/setup.py:140
-msgid "argument-help-setup-metadata"
-msgstr ""
-
 #: shoestring/commands/setup.py:139
 msgid "argument-help-setup-overrides"
 msgstr ""
 
 #: shoestring/commands/init.py:28 shoestring/commands/setup.py:137
 msgid "argument-help-setup-package"
+msgstr ""
+
+#: shoestring/commands/setup.py:140
+msgid "argument-help-setup-rest-overrides"
 msgstr ""
 
 #: shoestring/commands/setup.py:143
@@ -250,11 +250,11 @@ msgstr ""
 msgid "import-bootstrap-invalid-directory"
 msgstr ""
 
-#: shoestring/commands/import_harvesters.py:74
+#: shoestring/commands/import_harvesters.py:75
 msgid "import-harvesters-error-in-harvesters-is-equal-to-out-harvesters"
 msgstr ""
 
-#: shoestring/commands/import_harvesters.py:51
+#: shoestring/commands/import_harvesters.py:52
 msgid "import-harvesters-list-header"
 msgstr ""
 
@@ -803,4 +803,3 @@ msgstr ""
 #: shoestring/wizard/screens/welcome.py:36
 msgid "wizard-welcome-upgrade"
 msgstr ""
-

--- a/tools/shoestring/shoestring/lang/messages.pot
+++ b/tools/shoestring/shoestring/lang/messages.pot
@@ -18,7 +18,7 @@ msgstr ""
 
 #: shoestring/commands/announce_transaction.py:35
 #: shoestring/commands/health.py:74 shoestring/commands/import_bootstrap.py:33
-#: shoestring/commands/import_harvesters.py:94 shoestring/commands/init.py:29
+#: shoestring/commands/import_harvesters.py:97 shoestring/commands/init.py:29
 #: shoestring/commands/min_cosignatures_count.py:34
 #: shoestring/commands/renew_certificates.py:29
 #: shoestring/commands/renew_voting_keys.py:112
@@ -38,19 +38,19 @@ msgstr ""
 msgid "argument-help-import-bootstrap-bootstrap"
 msgstr ""
 
-#: shoestring/commands/import_harvesters.py:95
+#: shoestring/commands/import_harvesters.py:98
 msgid "argument-help-import-harvesters-in-harvesters"
 msgstr ""
 
-#: shoestring/commands/import_harvesters.py:96
+#: shoestring/commands/import_harvesters.py:99
 msgid "argument-help-import-harvesters-in-pem"
 msgstr ""
 
-#: shoestring/commands/import_harvesters.py:98
+#: shoestring/commands/import_harvesters.py:101
 msgid "argument-help-import-harvesters-out-harvesters"
 msgstr ""
 
-#: shoestring/commands/import_harvesters.py:99
+#: shoestring/commands/import_harvesters.py:102
 msgid "argument-help-import-harvesters-out-pem"
 msgstr ""
 
@@ -82,16 +82,16 @@ msgstr ""
 msgid "argument-help-reset-data-purge-harvesters"
 msgstr ""
 
-#: shoestring/commands/setup.py:140
-msgid "argument-help-setup-metadata"
-msgstr ""
-
 #: shoestring/commands/setup.py:139
 msgid "argument-help-setup-overrides"
 msgstr ""
 
 #: shoestring/commands/init.py:28 shoestring/commands/setup.py:137
 msgid "argument-help-setup-package"
+msgstr ""
+
+#: shoestring/commands/setup.py:140
+msgid "argument-help-setup-rest-overrides"
 msgstr ""
 
 #: shoestring/commands/setup.py:143
@@ -243,11 +243,11 @@ msgstr ""
 msgid "import-bootstrap-invalid-directory"
 msgstr ""
 
-#: shoestring/commands/import_harvesters.py:74
+#: shoestring/commands/import_harvesters.py:75
 msgid "import-harvesters-error-in-harvesters-is-equal-to-out-harvesters"
 msgstr ""
 
-#: shoestring/commands/import_harvesters.py:51
+#: shoestring/commands/import_harvesters.py:52
 msgid "import-harvesters-list-header"
 msgstr ""
 

--- a/tools/shoestring/shoestring/wizard/ShoestringOperation.py
+++ b/tools/shoestring/shoestring/wizard/ShoestringOperation.py
@@ -24,7 +24,7 @@ def build_shoestring_command(
 	shoestring_directory,
 	ca_pem_path,
 	package,
-	has_custom_node_metadata=False
+	has_custom_rest_overrides=False
 ):  # pylint: disable=too-many-arguments
 	"""Builds shoestring command arguments."""
 
@@ -58,7 +58,7 @@ def build_shoestring_command(
 	if ShoestringOperation.SETUP == operation:
 		shoestring_args.extend(['--security', 'insecure'])
 
-		if has_custom_node_metadata:
-			shoestring_args.extend(['--metadata', str(Path(shoestring_directory) / 'node_metadata.json')])
+		if has_custom_rest_overrides:
+			shoestring_args.extend(['--rest-overrides', str(Path(shoestring_directory) / 'rest_overrides.json')])
 
 	return shoestring_args

--- a/tools/shoestring/shoestring/wizard/setup_file_generator.py
+++ b/tools/shoestring/shoestring/wizard/setup_file_generator.py
@@ -20,8 +20,8 @@ def _to_bool_string(flag):
 	return 'true' if flag else 'false'
 
 
-def try_prepare_node_metadata_file(screens, output_filename):
-	"""Prepares a node metadata file based on screens, if specified."""
+def try_prepare_rest_overrides_file(screens, output_filename):
+	"""Prepares a REST overrides file based on screens, if specified."""
 
 	node_type = screens.get('node-type').current_value
 	node_settings = screens.get('node-settings')
@@ -30,7 +30,7 @@ def try_prepare_node_metadata_file(screens, output_filename):
 		return False
 
 	with open(output_filename, 'wt', encoding='utf8') as outfile:
-		outfile.write(node_settings.metadata_info)
+		outfile.write(f'{{"nodeMetadata":{node_settings.metadata_info}}}')
 
 	return True
 

--- a/tools/shoestring/shoestring/wizard/shoestring_dispatcher.py
+++ b/tools/shoestring/shoestring/wizard/shoestring_dispatcher.py
@@ -2,7 +2,7 @@ import shutil
 import tempfile
 from pathlib import Path
 
-from shoestring.wizard.setup_file_generator import prepare_overrides_file, prepare_shoestring_files, try_prepare_node_metadata_file
+from shoestring.wizard.setup_file_generator import prepare_overrides_file, prepare_shoestring_files, try_prepare_rest_overrides_file
 from shoestring.wizard.ShoestringOperation import ShoestringOperation, build_shoestring_command
 
 
@@ -18,7 +18,7 @@ async def dispatch_shoestring_command(screens, executor):
 
 	if ShoestringOperation.SETUP == operation:
 		with tempfile.TemporaryDirectory() as temp_directory:
-			has_custom_node_metadata = try_prepare_node_metadata_file(screens, Path(temp_directory) / 'node_metadata.json')
+			has_custom_rest_overrides = try_prepare_rest_overrides_file(screens, Path(temp_directory) / 'rest_overrides.json')
 			prepare_overrides_file(screens, Path(temp_directory) / 'overrides.ini')
 			await prepare_shoestring_files(screens, Path(temp_directory))
 
@@ -28,11 +28,11 @@ async def dispatch_shoestring_command(screens, executor):
 				temp_directory,
 				obligatory_settings.ca_pem_path,
 				package,
-				has_custom_node_metadata)
+				has_custom_rest_overrides)
 			await executor(shoestring_args)
 
 			shoestring_directory.mkdir()
-			for filename in ('shoestring.ini', 'overrides.ini', 'node_metadata.json'):
+			for filename in ('shoestring.ini', 'overrides.ini', 'rest_overrides.json'):
 				source_path = Path(temp_directory) / filename
 				if source_path.exists():
 					shutil.copy(source_path, shoestring_directory)

--- a/tools/shoestring/tests/commands/test_setup.py
+++ b/tools/shoestring/tests/commands/test_setup.py
@@ -332,7 +332,7 @@ async def test_can_apply_user_overrides(server):  # pylint: disable=redefined-ou
 	await _assert_can_prepare_with_hostname(server, 'symbol.fyi', NodeFeatures.PEER, False)
 
 
-async def test_can_apply_custom_node_metadata(server):  # pylint: disable=redefined-outer-name
+async def test_can_apply_custom_rest_overrides(server):  # pylint: disable=redefined-outer-name
 	# Arrange:
 	with tempfile.TemporaryDirectory() as output_directory:
 		with tempfile.TemporaryDirectory() as package_directory:
@@ -340,13 +340,16 @@ async def test_can_apply_custom_node_metadata(server):  # pylint: disable=redefi
 			prepare_shoestring_configuration(package_directory, NodeFeatures.API, server.make_url(''))
 			prepare_testnet_package(package_directory, 'resources.zip')
 
-			node_metadata_filepath = Path(package_directory) / 'metadata.json'
-			with open(node_metadata_filepath, 'wt', encoding='utf8') as outfile:
+			rest_overrides_filepath = Path(package_directory) / 'metadata.json'
+			with open(rest_overrides_filepath, 'wt', encoding='utf8') as outfile:
 				outfile.write('\n'.join([
 					'{',
-					'  "animal": "wolf",',
-					'  "weight": "43kg",',
-					'  "height": "72cm"',
+					'  "nodeMetadata": {',
+					'    "_info": "",',
+					'    "animal": "wolf",',
+					'    "weight": "43kg",',
+					'    "height": "72cm"',
+					'  }'
 					'}'
 				]))
 
@@ -360,7 +363,7 @@ async def test_can_apply_custom_node_metadata(server):  # pylint: disable=redefi
 					'--directory', output_directory,
 					'--ca-key-path', str(Path(ca_directory) / 'xyz.key.pem'),
 					'--overrides', str(Path(package_directory) / 'user_overrides.ini'),
-					'--metadata', str(node_metadata_filepath)
+					'--rest-overrides', str(rest_overrides_filepath)
 				])
 
 				# Assert: check custom node metadata was applied
@@ -368,6 +371,7 @@ async def test_can_apply_custom_node_metadata(server):  # pylint: disable=redefi
 					rest_config = json.load(rest_config_infile)
 
 				assert {
+					'_info': '',
 					'animal': 'wolf',
 					'weight': '43kg',
 					'height': '72cm'

--- a/tools/shoestring/tests/internal/test_ConfigurationManager.py
+++ b/tools/shoestring/tests/internal/test_ConfigurationManager.py
@@ -2,7 +2,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from shoestring.internal.ConfigurationManager import ConfigurationManager, load_patches_from_file, parse_time_span
+from shoestring.internal.ConfigurationManager import ConfigurationManager, load_patches_from_file, merge_json_configuration, parse_time_span
 
 
 class ConfigurationManagerTest(unittest.TestCase):
@@ -258,5 +258,70 @@ class ConfigurationManagerTest(unittest.TestCase):
 		for invalid_str in ('12H4s', '', 's', '1234g'):
 			with self.assertRaises(ValueError):
 				parse_time_span(invalid_str)
+
+	# endregion
+
+	# region merge_json_configuration
+
+	def _run_merge_json_configuration_test(self, config2, expected_result_config):
+		# Arrange:
+		config1 = {
+			'foo': 123,
+			'car': {
+				'color': 'blue',
+				'brand': 'toyota'
+			}
+		}
+
+		# Act:
+		merge_json_configuration(config1, config2)
+
+		# Assert:
+		self.assertEqual(expected_result_config, config1)
+
+	def test_merge_json_configuration_can_merge_empty_object(self):
+		self._run_merge_json_configuration_test({}, {
+			'foo': 123,
+			'car': {
+				'color': 'blue',
+				'brand': 'toyota'
+			}
+		})
+
+	def test_merge_json_configuration_can_merge_outer_property_change(self):
+		self._run_merge_json_configuration_test({'foo': 'alpha'}, {
+			'foo': 'alpha',
+			'car': {
+				'color': 'blue',
+				'brand': 'toyota'
+			}
+		})
+
+	def test_merge_json_configuration_can_merge_inner_property_change(self):
+		self._run_merge_json_configuration_test({'car': {'brand': 'honda'}}, {
+			'foo': 123,
+			'car': {
+				'color': 'blue',
+				'brand': 'honda'
+			}
+		})
+
+	def test_merge_json_configuration_can_flatten_object(self):
+		self._run_merge_json_configuration_test({'car': 'alpha'}, {
+			'foo': 123,
+			'car': 'alpha'
+		})
+
+	def test_merge_json_configuration_can_add_object(self):
+		self._run_merge_json_configuration_test({'metal': {'type': 'bar'}}, {
+			'foo': 123,
+			'car': {
+				'color': 'blue',
+				'brand': 'toyota'
+			},
+			'metal': {
+				'type': 'bar'
+			}
+		})
 
 	# endregion

--- a/tools/shoestring/tests/internal/test_Preparer.py
+++ b/tools/shoestring/tests/internal/test_Preparer.py
@@ -417,29 +417,33 @@ class PreparerTest(unittest.TestCase):
 			'mongoRestrictionMosaicDbPrepare.js',
 		])
 
-	def test_can_configure_rest_api_node_with_custom_metadata(self):
+	def test_can_configure_rest_api_node_with_custom_rest_overrides(self):
 		# Arrange:
 		with tempfile.TemporaryDirectory() as output_directory:
 			with Preparer(output_directory, self._create_configuration(NodeFeatures.API)) as preparer:
 				self._initialize_temp_directory_with_package_files(preparer)
 
-				with open(preparer.directories.temp / 'metadata.json', 'wt', encoding='utf8') as outfile:
+				with open(preparer.directories.temp / 'rest_overrides.json', 'wt', encoding='utf8') as outfile:
 					outfile.write('\n'.join([
 						'{',
-						'  "animal": "wolf",',
-						'  "weight": "43kg",',
-						'  "height": "72cm"',
+						'  "nodeMetadata": {',  # pylint: disable=duplicate-code
+						'    "_info": "",',
+						'    "animal": "wolf",',
+						'    "weight": "43kg",',
+						'    "height": "72cm"',
+						'  }',
 						'}'
 					]))
 
 				# Act:
-				preparer.configure_rest(preparer.directories.temp / 'metadata.json')
+				preparer.configure_rest(preparer.directories.temp / 'rest_overrides.json')
 
 				# Assert: check rest config
 				with open(preparer.directories.userconfig / 'rest.json', 'rt', encoding='utf8') as rest_config_infile:
 					rest_config = json.load(rest_config_infile)
 
 				self.assertEqual({
+					'_info': '',
 					'animal': 'wolf',
 					'weight': '43kg',
 					'height': '72cm'

--- a/tools/shoestring/tests/wizard/test_ShoestringOperation.py
+++ b/tools/shoestring/tests/wizard/test_ShoestringOperation.py
@@ -17,9 +17,9 @@ def test_requires_ca_key_path_returns_true_for_operations_requiring_ca_key_path(
 
 # region build_shoestring_command
 
-def _assert_can_build_shoestring_command_setup(has_custom_node_metadata, expected_additional_args):
+def _assert_can_build_shoestring_command_setup(has_custom_rest_overrides, expected_additional_args):
 	# Act:
-	args = build_shoestring_command(ShoestringOperation.SETUP, 'symbol', 'shoestring', 'cert/ca.key.pem', 'sai', has_custom_node_metadata)
+	args = build_shoestring_command(ShoestringOperation.SETUP, 'symbol', 'shoestring', 'cert/ca.key.pem', 'sai', has_custom_rest_overrides)
 
 	# Assert:
 	assert [
@@ -37,8 +37,8 @@ def test_can_build_shoestring_command_setup():
 	_assert_can_build_shoestring_command_setup(False, [])
 
 
-def test_can_build_shoestring_command_setup_with_custom_node_metadata():
-	_assert_can_build_shoestring_command_setup(True, ['--metadata', 'shoestring/node_metadata.json'])
+def test_can_build_shoestring_command_setup_with_custom_rest_overrides():
+	_assert_can_build_shoestring_command_setup(True, ['--rest-overrides', 'shoestring/rest_overrides.json'])
 
 
 def test_can_build_shoestring_command_upgrade():

--- a/tools/shoestring/tests/wizard/test_setup_file_generator.py
+++ b/tools/shoestring/tests/wizard/test_setup_file_generator.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from shoestring.internal.ConfigurationManager import ConfigurationManager
 from shoestring.internal.NodeFeatures import NodeFeatures
 from shoestring.internal.ShoestringConfiguration import parse_shoestring_configuration
-from shoestring.wizard.setup_file_generator import prepare_overrides_file, prepare_shoestring_files, try_prepare_node_metadata_file
+from shoestring.wizard.setup_file_generator import prepare_overrides_file, prepare_shoestring_files, try_prepare_rest_overrides_file
 
 from ..test.TestPackager import prepare_testnet_package
 
@@ -29,38 +29,38 @@ VotingScreen = namedtuple('VotingScreen', ['active'])
 # pylint: disable=invalid-name
 
 
-# region try_prepare_node_metadata_file
+# region try_prepare_rest_overrides_file
 
-def _assert_can_prepare_node_metadata_file(node_type, node_metadata, should_create):
+def _assert_can_prepare_rest_overrides_file(node_type, node_metadata, should_create):
 	# Arrange:
 	with tempfile.TemporaryDirectory() as output_directory:
-		metadata_filepath = Path(output_directory) / 'metadata.json'
+		rest_overrides_filepath = Path(output_directory) / 'metadata.json'
 
 		# Act:
-		try_prepare_node_metadata_file({
+		try_prepare_rest_overrides_file({
 			'node-type': SingleValueScreen(node_type),
 			'node-settings': NodeSettingsScreen(None, None, None, node_metadata)
-		}, metadata_filepath)
+		}, rest_overrides_filepath)
 
 		# Assert:
-		assert should_create == metadata_filepath.exists()
+		assert should_create == rest_overrides_filepath.exists()
 
 		if should_create:
-			with open(metadata_filepath, 'rt', encoding='utf8') as infile:
+			with open(rest_overrides_filepath, 'rt', encoding='utf8') as infile:
 				metadata_contents = infile.read()
-				assert '{"animal": "wolf"}' == metadata_contents
+				assert '{"nodeMetadata":{"animal": "wolf"}}' == metadata_contents
 
 
-def test_can_prepare_node_metadata_file_when_dual_mode_and_metadata_specified():
-	_assert_can_prepare_node_metadata_file('dual', '{"animal": "wolf"}', True)
+def test_can_prepare_rest_overrides_file_when_dual_mode_and_metadata_specified():
+	_assert_can_prepare_rest_overrides_file('dual', '{"animal": "wolf"}', True)
 
 
-def test_cannot_prepare_node_metadata_file_when_peer_mode_and_metadata_specified():
-	_assert_can_prepare_node_metadata_file('peer', '{"animal": "wolf"}', False)
+def test_cannot_prepare_rest_overrides_file_when_peer_mode_and_metadata_specified():
+	_assert_can_prepare_rest_overrides_file('peer', '{"animal": "wolf"}', False)
 
 
-def test_cannot_prepare_node_metadata_file_when_dual_mode_and_no_metadata_specified():
-	_assert_can_prepare_node_metadata_file('dual', '', False)
+def test_cannot_prepare_rest_overrides_file_when_dual_mode_and_no_metadata_specified():
+	_assert_can_prepare_rest_overrides_file('dual', '', False)
 
 # endregion
 

--- a/tools/shoestring/tests/wizard/test_shoestring_dispatcher.py
+++ b/tools/shoestring/tests/wizard/test_shoestring_dispatcher.py
@@ -73,10 +73,10 @@ async def test_can_dispatch_setup_command():
 			assert shoestring_directory.exists()
 			assert (shoestring_directory / 'shoestring.ini').exists()
 			assert (shoestring_directory / 'overrides.ini').exists()
-			assert not (shoestring_directory / 'node_metadata.json').exists()
+			assert not (shoestring_directory / 'rest_overrides.json').exists()
 
 
-async def test_can_dispatch_setup_command_with_custom_metadata():
+async def test_can_dispatch_setup_command_with_custom_rest_overrides():
 	# Arrange:
 	dispatched_args = []
 	with tempfile.TemporaryDirectory() as package_directory:
@@ -100,7 +100,7 @@ async def test_can_dispatch_setup_command_with_custom_metadata():
 				'--overrides', 'overrides.ini',
 				'--package', f'file://{Path(package_directory) / "resources.zip"}',
 				'--security', 'insecure',
-				'--metadata', 'node_metadata.json'
+				'--rest-overrides', 'rest_overrides.json'
 			] == dispatched_args
 
 			# - shoestring configuration files were created
@@ -108,7 +108,7 @@ async def test_can_dispatch_setup_command_with_custom_metadata():
 			assert shoestring_directory.exists()
 			assert (shoestring_directory / 'shoestring.ini').exists()
 			assert (shoestring_directory / 'overrides.ini').exists()
-			assert (shoestring_directory / 'node_metadata.json').exists()
+			assert (shoestring_directory / 'rest_overrides.json').exists()
 
 
 async def test_can_dispatch_upgrade_command():


### PR DESCRIPTION
     problem: shoestring only allows user to specify nodeMetadata property of rest.config
    solution: allow user to provide differential config file that overrides defaults (similar to REST native support)
    
       issue: #1090
