### PR TITLE
[snap/frontend]: Added react-toastify (toast)

### DIFF
--- a/snap/frontend/app/page.jsx
+++ b/snap/frontend/app/page.jsx
@@ -7,6 +7,8 @@ import dispatchUtils from '../utils/dispatchUtils';
 import symbolSnapFactory from '../utils/snap';
 import detectEthereumProvider from '@metamask/detect-provider';
 import React, { useEffect, useMemo, useReducer, useState } from 'react';
+import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 
 /**
  * Renders the main page.
@@ -40,6 +42,7 @@ export default function Main() {
 
 	return (
 		<WalletContextProvider value={{ walletState, dispatch, symbolSnap }}>
+			<ToastContainer theme="dark" />
 			<HomeComponent />
 		</WalletContextProvider>
 	);

--- a/snap/frontend/app/page.spec.jsx
+++ b/snap/frontend/app/page.spec.jsx
@@ -75,7 +75,9 @@ describe('Main', () => {
 
 		// Assert:
 		const connectionStatus = component.queryByRole('connection-status');
+		const toastifyContainer = component.container.querySelector('.Toastify');
 		expect(connectionStatus).toBeInTheDocument();
+		expect(toastifyContainer).toBeInTheDocument();
 	});
 
 	it('renders the DetectMetamask component when provider is detected but symbolSnap is not created', async () => {

--- a/snap/frontend/components/TransactionTable/index.jsx
+++ b/snap/frontend/components/TransactionTable/index.jsx
@@ -4,6 +4,7 @@ import helper from '../../utils/helper';
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
+import { toast } from 'react-toastify';
 
 const TransactionTable = () => {
 
@@ -36,11 +37,13 @@ const TransactionTable = () => {
 		setIsLastPage(false);
 
 		websocket.listenConfirmedTransaction(async () => {
+			toast.success('New confirmed transaction');
 			helper.updateTransactions(dispatch, symbolSnap, address);
 			helper.updateAccountMosaics(dispatch, symbolSnap, id);
 		}, address);
 
 		websocket.listenUnconfirmedTransaction(async () => {
+			toast.success('New pending transaction');
 			helper.updateUnconfirmedTransactions(dispatch, symbolSnap, address, transactions);
 		}, address);
 

--- a/snap/frontend/components/TransferModalBox/TransferModalBox.spec.jsx
+++ b/snap/frontend/components/TransferModalBox/TransferModalBox.spec.jsx
@@ -1,7 +1,9 @@
 import TransferModalBox from '.';
 import helper from '../../utils/helper';
 import testHelper from '../testHelper';
+import { expect, jest } from '@jest/globals';
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import { toast } from 'react-toastify';
 
 const context = {
 	walletState: {
@@ -394,6 +396,7 @@ describe('components/TransferModalBox', () => {
 		const assertValidateForm = async (mockSignResult, expectedResult) => {
 			// Arrange:
 			const mockOnRequestClose = jest.fn();
+			jest.spyOn(toast, 'success');
 
 			testHelper.customRender(<TransferModalBox isOpen={true} onRequestClose={mockOnRequestClose} />, context);
 			const addressInput = screen.getByPlaceholderText('Recipient address');
@@ -428,10 +431,12 @@ describe('components/TransferModalBox', () => {
 				}
 			);
 
-			if (expectedResult)
+			if (expectedResult) {
 				expect(mockOnRequestClose).toHaveBeenCalled();
-			else
+				expect(toast.success).toHaveBeenCalledWith('Announcing transaction');
+			} else {
 				expect(mockOnRequestClose).not.toHaveBeenCalled();
+			}
 
 		};
 

--- a/snap/frontend/components/TransferModalBox/index.jsx
+++ b/snap/frontend/components/TransferModalBox/index.jsx
@@ -5,6 +5,7 @@ import FeeMultiplier from '../FeeMultiplier';
 import Input from '../Input';
 import ModalBox from '../ModalBox';
 import { useEffect, useState } from 'react';
+import { toast } from 'react-toastify';
 import { SymbolFacade, models } from 'symbol-sdk/symbol';
 
 const TransferModalBox = ({ isOpen, onRequestClose }) => {
@@ -159,8 +160,10 @@ const TransferModalBox = ({ isOpen, onRequestClose }) => {
 			fees
 		});
 
-		if (result)
+		if (result) {
 			onRequestClose();
+			toast.success('Announcing transaction');
+		}
 
 	};
 

--- a/snap/frontend/package-lock.json
+++ b/snap/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "react": "^18",
         "react-dom": "^18",
         "react-intersection-observer": "^9.13.0",
+        "react-toastify": "^10.0.5",
         "symbol-sdk": "^3.2.2"
       },
       "devDependencies": {
@@ -3262,6 +3263,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -8745,6 +8755,19 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-toastify": {
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-10.0.5.tgz",
+      "integrity": "sha512-mNKt2jBXJg4O7pSdbNUfDdTsK9FIdikfsIE/yUCxbAEXl4HMyJaivrVFcn3Elvt5xvCQYhUZm+hqTIu1UXM3Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",

--- a/snap/frontend/package.json
+++ b/snap/frontend/package.json
@@ -28,6 +28,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-intersection-observer": "^9.13.0",
+    "react-toastify": "^10.0.5",
     "symbol-sdk": "^3.2.2"
   },
   "devDependencies": {

--- a/snap/frontend/utils/snap.js
+++ b/snap/frontend/utils/snap.js
@@ -1,4 +1,5 @@
 import { TransactionGroup, defaultSnapOrigin } from '../config';
+import { toast } from 'react-toastify';
 
 const symbolSnapFactory = {
 	create(provider) {
@@ -11,16 +12,20 @@ const symbolSnapFactory = {
 			 * @returns {object} The response from the snap.
 			 */
 			async invokeSnapMethod(method, params = {}) {
-				return await this.provider.request({
-					method: 'wallet_invokeSnap',
-					params: {
-						snapId: defaultSnapOrigin,
-						request: {
-							method,
-							...(Object.keys(params).length && { params })
+				try {
+					return await this.provider.request({
+						method: 'wallet_invokeSnap',
+						params: {
+							snapId: defaultSnapOrigin,
+							request: {
+								method,
+								...(Object.keys(params).length && { params })
+							}
 						}
-					}
-				});
+					});
+				} catch (error) {
+					toast.error('Metamask RPC Error: ' + error.message);
+				}
 			},
 			/**
 			 * Get the installed snaps in MetaMask.

--- a/snap/frontend/utils/snap.spec.js
+++ b/snap/frontend/utils/snap.spec.js
@@ -1,5 +1,7 @@
 import symbolSnapFactory from './snap';
 import { defaultSnapOrigin } from '../config';
+import { jest } from '@jest/globals';
+import { toast } from 'react-toastify';
 
 describe('symbolSnapFactory', () => {
 	let mockProvider;
@@ -85,6 +87,19 @@ describe('symbolSnapFactory', () => {
 			const expectedParams = { method };
 
 			await assertInvokeSnapMethod(method, {}, expectedParams);
+		});
+
+		it('toasts error message when provider request fails', async () => {
+			// Arrange:
+			mockProvider.request.mockRejectedValue(new Error('Error message'));
+			jest.spyOn(toast, 'error');
+
+			// Act:
+			await symbolSnap.invokeSnapMethod('anyInvokeMethod');
+
+			// Assert:
+			expect(mockProvider.request).toHaveBeenCalled;
+			expect(toast.error).toHaveBeenCalledWith('Metamask RPC Error: Error message');
 		});
 	});
 


### PR DESCRIPTION
## What was the issue?
- All the errors will be thrown in console logs (browser), and adding a toast notification, will improve user experience.

## What's the fix?
- Added react-toastify library.
- Handle error messages from the snap factory.
- Handle successful messages: detect for announce/pending/confirmed transactions