### PR TITLE
[tools/shoestring]: add support for websockets 14

### DIFF
--- a/tools/shoestring/requirements.txt
+++ b/tools/shoestring/requirements.txt
@@ -5,5 +5,5 @@ PyYAML~=6.0.1
 requests~=2.32.2
 symbol-lightapi~=0.0.6
 symbol-sdk-python~=3.2.2
-websockets~=13.0
+websockets~=14.0
 zenlog~=1.1

--- a/tools/shoestring/tests/healthagents/test_websockets.py
+++ b/tools/shoestring/tests/healthagents/test_websockets.py
@@ -3,7 +3,7 @@ import tempfile
 from collections import namedtuple
 from pathlib import Path
 
-from websockets.server import serve
+from websockets.asyncio.server import serve
 
 from shoestring.healthagents.websockets import should_run, validate
 from shoestring.internal.ConfigurationManager import ConfigurationManager


### PR DESCRIPTION
problem: serve() moved to the asyncio.server
solution: update import to use new path