### PR TITLE
[explorer/nodewatch]: added new endpoint to query node by main public key

### DIFF
--- a/explorer/nodewatch/nodewatch/RoutesFacade.py
+++ b/explorer/nodewatch/nodewatch/RoutesFacade.py
@@ -78,6 +78,13 @@ class BasicRoutesFacade:
 			lambda descriptor: descriptor.to_json(),
 			filter(role_filter, self.repository.node_descriptors)))
 
+	def json_node(self, filter_field, public_key):
+		"""Returns a node with matching public key."""
+
+		matching_items = [item for item in self.repository.node_descriptors if str(getattr(item, filter_field)) == public_key]
+
+		return next((item.to_json() for item in matching_items), None)
+
 	def json_height_chart(self):
 		"""Builds a JSON height chart."""
 

--- a/explorer/nodewatch/nodewatch/RoutesFacade.py
+++ b/explorer/nodewatch/nodewatch/RoutesFacade.py
@@ -81,9 +81,11 @@ class BasicRoutesFacade:
 	def json_node(self, filter_field, public_key):
 		"""Returns a node with matching public key."""
 
-		matching_items = [item for item in self.repository.node_descriptors if str(getattr(item, filter_field)) == public_key]
-
-		return next((item.to_json() for item in matching_items), None)
+		try:
+			matching_items = [item for item in self.repository.node_descriptors if str(getattr(item, filter_field)) == public_key]
+			return next((item.to_json() for item in matching_items), None)
+		except AttributeError:
+			return None
 
 	def json_height_chart(self):
 		"""Builds a JSON height chart."""

--- a/explorer/nodewatch/nodewatch/RoutesFacade.py
+++ b/explorer/nodewatch/nodewatch/RoutesFacade.py
@@ -79,7 +79,7 @@ class BasicRoutesFacade:
 			filter(role_filter, self.repository.node_descriptors)))
 
 	def json_node(self, filter_field, public_key):
-		"""Returns a node with matching public key."""
+		"""Returns a node with matching main or node public key."""
 
 		try:
 			matching_items = [item for item in self.repository.node_descriptors if str(getattr(item, filter_field)) == public_key]

--- a/explorer/nodewatch/tests/test_RoutesFacade.py
+++ b/explorer/nodewatch/tests/test_RoutesFacade.py
@@ -442,6 +442,17 @@ class SymbolRoutesFacadeTest(unittest.TestCase):
 		# Assert:
 		self.assertIsNone(node_descriptors)
 
+	def test_json_node_with_invalid_field(self):  # pylint: disable=invalid-name
+		# Arrange:
+		facade = SymbolRoutesFacade(SymbolNetwork.MAINNET, '<symbol_explorer>')
+		facade.reload_all(Path('tests/resources'), True)
+
+		# Act:
+		node_descriptors = facade.json_node(filter_field='invalid_field', public_key='invalidKey')
+
+		# Assert:
+		self.assertIsNone(node_descriptors)
+
 	def test_can_generate_height_chart_json(self):
 		# Arrange:
 		facade = SymbolRoutesFacade(SymbolNetwork.MAINNET, '<symbol_explorer>', 1)

--- a/explorer/nodewatch/tests/test_RoutesFacade.py
+++ b/explorer/nodewatch/tests/test_RoutesFacade.py
@@ -406,6 +406,42 @@ class SymbolRoutesFacadeTest(unittest.TestCase):
 			[2],
 			list(map(lambda descriptor: descriptor['roles'], node_descriptors)))
 
+	def test_can_find_known_node_by_main_public_key(self):  # pylint: disable=invalid-name
+		# Arrange:
+		facade = SymbolRoutesFacade(SymbolNetwork.MAINNET, '<symbol_explorer>')
+		facade.reload_all(Path('tests/resources'), True)
+
+		# Act: select a node match with main public key
+		node_descriptors = facade.json_node(
+			filter_field='main_public_key',
+			public_key='A0AA48B6417BDB1845EB55FB0B1E13255EA8BD0D8FA29AD2D8A906E220571F21'
+		)
+		expected_node = {
+			'mainPublicKey': 'A0AA48B6417BDB1845EB55FB0B1E13255EA8BD0D8FA29AD2D8A906E220571F21',
+			'nodePublicKey': '403D890915B68E290B3F519A602A13B17C58499A077D77DB7CCC6327761C84DC',
+			'endpoint': '',
+			'name': 'Allnodes250',
+			'version': '1.0.3.4',
+			'height': 1486762,
+			'finalizedHeight': 1486740,
+			'balance': 3155632.471994,
+			'roles': 2
+		}
+
+		# Assert:
+		self.assertEqual(node_descriptors, expected_node)
+
+	def test_cannot_find_unknown_node_by_main_public_key(self):  # pylint: disable=invalid-name
+		# Arrange:
+		facade = SymbolRoutesFacade(SymbolNetwork.MAINNET, '<symbol_explorer>')
+		facade.reload_all(Path('tests/resources'), True)
+
+		# Act:
+		node_descriptors = facade.json_node(filter_field='main_public_key', public_key='invalidKey')
+
+		# Assert:
+		self.assertIsNone(node_descriptors)
+
 	def test_can_generate_height_chart_json(self):
 		# Arrange:
 		facade = SymbolRoutesFacade(SymbolNetwork.MAINNET, '<symbol_explorer>', 1)

--- a/explorer/nodewatch/tests/test_app.py
+++ b/explorer/nodewatch/tests/test_app.py
@@ -214,4 +214,37 @@ def test_get_api_symbol_network_height_chart(client):  # pylint: disable=redefin
 	assert 4 == len(chart_json['data'])
 	assert re.match(r'\d\d:\d\d', response_json['lastRefreshTime'])
 
+
+def test_get_api_symbol_node_with_invalid_main_public_key(client):  # pylint: disable=redefined-outer-name
+	# Act:
+	response = client.get('/api/symbol/nodes/mainPublicKey/invalid')
+	response_json = json.loads(response.data)
+
+	# Assert:
+	assert 400 == response.status_code
+	assert 'application/json' == response.headers['Content-Type']
+	assert response_json == {'message': 'Bad request', 'status': 400}
+
+
+def test_get_api_symbol_node_with_main_public_key_not_found(client):  # pylint: disable=redefined-outer-name
+	# Act:
+	response = client.get('/api/symbol/nodes/mainPublicKey/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+	response_json = json.loads(response.data)
+
+	# Assert:
+	assert 404 == response.status_code
+	assert 'application/json' == response.headers['Content-Type']
+	assert response_json == {'message': 'Resource not found', 'status': 404}
+
+
+def test_get_api_symbol_node_with_main_public_key(client):  # pylint: disable=redefined-outer-name
+	# Act:
+	response = client.get('/api/symbol/nodes/mainPublicKey/A0AA48B6417BDB1845EB55FB0B1E13255EA8BD0D8FA29AD2D8A906E220571F21')
+	response_json = json.loads(response.data)
+
+	# Assert: spot check names
+	assert 200 == response.status_code
+	assert 'application/json' == response.headers['Content-Type']
+	assert 'Allnodes250' == response_json['name']
+
 # endregion


### PR DESCRIPTION
Problem: The endpoint is missing when using the main public key to query node info.
Solution: 
- Added a new endpoint to query node info by the main public key.
- Added error handler for 400 and 404