### PR TITLE
[lightapi/python] fix: disable RFC5280 validation

### DIFF
--- a/lightapi/python/symbollightapi/connector/SymbolPeerConnector.py
+++ b/lightapi/python/symbollightapi/connector/SymbolPeerConnector.py
@@ -27,6 +27,7 @@ class SymbolPeerConnector:
 		self.node_public_key = None
 
 		self.ssl_context = ssl.create_default_context()
+		self.ssl_context.verify_flags &= ~ssl.VERIFY_X509_STRICT
 		self.ssl_context.check_hostname = False
 		self.ssl_context.load_cert_chain(
 			certificate_directory / 'node.full.crt.pem',


### PR DESCRIPTION
problem: RFC5280 validation is enabled by default in Python 3.13 which causes cert validation failure.
solution: disable RFC5280 validation since our certs are X509 compliant and RFC5280 is not needed.