### PR TITLE
[explorer/frontend] fix: next.js config for docker support

### DIFF
--- a/explorer/frontend/README.md
+++ b/explorer/frontend/README.md
@@ -168,7 +168,7 @@ docker build -t symbolplatform/explorer-frontend .
 
 Run the Docker container:
 ```bash
-docker run -p 3000:3000 -v $(pwd)/accounts:/app/public/accounts symbolplatform/explorer-frontend
+docker run -p 3000:3000 -v $(pwd)/public/accounts:/app/public/accounts symbolplatform/explorer-frontend
 ```
 
 This command will start the container and expose the application on port 3000.

--- a/explorer/frontend/docker-compose.yaml
+++ b/explorer/frontend/docker-compose.yaml
@@ -5,4 +5,4 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - ./accounts:/app/public/accounts
+      - ./public/accounts:/app/public/accounts

--- a/explorer/frontend/next.config.js
+++ b/explorer/frontend/next.config.js
@@ -1,8 +1,7 @@
 const i18nConfig = require('./next-i18next.config.js'); // eslint-disable-line import/extensions
-const webpack = require('webpack');
 
 module.exports = {
-	distDir: 'build',
+	output: 'standalone',
 	reactStrictMode: true,
 	experimental: {
 		scrollRestoration: true


### PR DESCRIPTION
## Problem
The Next.js build was not runnable inside a Docker container outside the Vercel environment due to the missing `output: 'standalone'` configuration. 

The Docker Compose volume mapping for the accounts directory was incorrect.

## Solution
- Added `output: 'standalone'` to `next.config.js`.
- Updated the Docker Compose volume mapping from `./accounts:/app/public/accounts` to `./public/accounts:/app/public/accounts`.
- Updated the README.
```