### PR TITLE
[explorer/nodewatch]: added api node status field

### DIFF
--- a/explorer/nodewatch/nodewatch/NetworkRepository.py
+++ b/explorer/nodewatch/nodewatch/NetworkRepository.py
@@ -23,6 +23,9 @@ class NodeDescriptor:
 		height=0,
 		finalized_height=0,
 		balance=0,
+		is_healthy=None,
+		is_ssl_enabled=None,
+		rest_version=None,
 		roles=0xFF):
 		"""Creates a descriptor."""
 
@@ -37,6 +40,9 @@ class NodeDescriptor:
 		self.height = height
 		self.finalized_height = finalized_height
 		self.balance = balance
+		self.is_healthy = is_healthy
+		self.is_ssl_enabled = is_ssl_enabled
+		self.rest_version = rest_version
 		self.roles = roles
 
 	@property
@@ -57,6 +63,9 @@ class NodeDescriptor:
 			'height': self.height,
 			'finalizedHeight': self.finalized_height,
 			'balance': self.balance,
+			'isHealthy': self.is_healthy,
+			'isSslEnabled': self.is_ssl_enabled,
+			'restVersion': self.rest_version,
 			'roles': self.roles
 		}
 
@@ -192,6 +201,14 @@ class NetworkRepository:
 		if self._network.generation_hash_seed != Hash256(json_node['networkGenerationHashSeed']):
 			return None
 
+		api_node_info_data = (None, None, None)
+		if 'apiNodeInfo' in json_node:
+			json_api_node_info_data = json_node['apiNodeInfo']
+			api_node_info_data = (
+				json_api_node_info_data.get('isHealth', None),
+				json_api_node_info_data.get('isSSL', None),
+				json_api_node_info_data.get('restVersion', None))
+
 		main_public_key = PublicKey(json_node['publicKey'])
 		node_public_key = PublicKey(json_node['nodePublicKey']) if 'nodePublicKey' in json_node else None
 		return NodeDescriptor(
@@ -202,6 +219,7 @@ class NetworkRepository:
 			json_node['friendlyName'],
 			self._format_symbol_version(json_node['version']),
 			*extra_data,
+			*api_node_info_data,
 			roles)
 
 	@staticmethod

--- a/explorer/nodewatch/nodewatch/NetworkRepository.py
+++ b/explorer/nodewatch/nodewatch/NetworkRepository.py
@@ -159,37 +159,31 @@ class NetworkRepository:
 		# sort by name
 		self.node_descriptors.sort(key=lambda descriptor: descriptor.name)
 
-	def _create_descriptor_from_json(self, json_node):
-		# network crawler extracts as much extra data as possible, but it might not always be available for all nodes
-		extra_data = (0, 0, 0)
-		if 'extraData' in json_node:
-			json_extra_data = json_node['extraData']
-			extra_data = (json_extra_data.get('height', 0), json_extra_data.get('finalizedHeight', 0), json_extra_data.get('balance', 0))
+	def _handle_nem_node(self, json_node, extra_data):
+		network_identifier = json_node['metaData']['networkId']
+		if network_identifier < 0:
+			network_identifier += 0x100
 
-		if self.is_nem:
-			network_identifier = json_node['metaData']['networkId']
-			if network_identifier < 0:
-				network_identifier += 0x100
+		if self._network.identifier != network_identifier:
+			return None
 
-			if self._network.identifier != network_identifier:
-				return None
+		node_protocol = json_node['endpoint']['protocol']
+		node_host = json_node['endpoint']['host']
+		node_port = json_node['endpoint']['port']
 
-			node_protocol = json_node['endpoint']['protocol']
-			node_host = json_node['endpoint']['host']
-			node_port = json_node['endpoint']['port']
+		json_identity = json_node['identity']
+		main_public_key = PublicKey(json_identity['public-key'])
+		node_public_key = PublicKey(json_identity['node-public-key']) if 'node-public-key' in json_identity else None
+		return NodeDescriptor(
+			self._network.public_key_to_address(main_public_key),
+			main_public_key,
+			node_public_key,
+			f'{node_protocol}://{node_host}:{node_port}',
+			json_identity['name'],
+			json_node['metaData']['version'],
+			*extra_data)
 
-			json_identity = json_node['identity']
-			main_public_key = PublicKey(json_identity['public-key'])
-			node_public_key = PublicKey(json_identity['node-public-key']) if 'node-public-key' in json_identity else None
-			return NodeDescriptor(
-				self._network.public_key_to_address(main_public_key),
-				main_public_key,
-				node_public_key,
-				f'{node_protocol}://{node_host}:{node_port}',
-				json_identity['name'],
-				json_node['metaData']['version'],
-				*extra_data)
-
+	def _handle_symbol_node(self, json_node, extra_data):
 		symbol_endpoint = ''
 		roles = json_node['roles']
 		has_api = bool(roles & 2)
@@ -221,6 +215,18 @@ class NetworkRepository:
 			*extra_data,
 			*api_node_info_data,
 			roles)
+
+	def _create_descriptor_from_json(self, json_node):
+		# network crawler extracts as much extra data as possible, but it might not always be available for all nodes
+		extra_data = (0, 0, 0)
+		if 'extraData' in json_node:
+			json_extra_data = json_node['extraData']
+			extra_data = (json_extra_data.get('height', 0), json_extra_data.get('finalizedHeight', 0), json_extra_data.get('balance', 0))
+
+		if self.is_nem:
+			return self._handle_nem_node(json_node, extra_data)
+
+		return self._handle_symbol_node(json_node, extra_data)
 
 	@staticmethod
 	def _format_symbol_version(version):

--- a/explorer/nodewatch/tests/resources/symbol_nodes.json
+++ b/explorer/nodewatch/tests/resources/symbol_nodes.json
@@ -5,6 +5,11 @@
       "finalizedHeight": 1486740,
       "height": 1486760
     },
+    "apiNodeInfo": {
+      "isHealth": true,
+      "isSSL": true,
+      "restVersion": "2.4.4"
+    },
     "friendlyName": "ibone74",
     "host": "symbol.shizuilab.com",
     "networkGenerationHashSeed": "57F7DA205008026C776CB6AED843393F04CD458E0AA2D9F1D5F31A402072B2D6",
@@ -32,6 +37,7 @@
       "finalizedHeight": 1486742,
       "height": 1486761
     },
+    "apiNodeInfo": {},
     "friendlyName": "jaguar",
     "host": "jaguar.catapult.ninja",
     "networkGenerationHashSeed": "57F7DA205008026C776CB6AED843393F04CD458E0AA2D9F1D5F31A402072B2D6",
@@ -59,6 +65,11 @@
       "balance": 3155632.471994,
       "finalizedHeight": 1486740,
       "height": 1486762
+    },
+    "apiNodeInfo": {
+      "isHealth": true,
+      "isSSL": true,
+      "restVersion": "2.4.4"
     },
     "friendlyName": "Allnodes250",
     "host": "",

--- a/explorer/nodewatch/tests/test_NetworkRepository.py
+++ b/explorer/nodewatch/tests/test_NetworkRepository.py
@@ -214,6 +214,9 @@ class NetworkRepositoryTest(unittest.TestCase):
 			'finalizedHeight': 1486742,
 			'version': '1.0.3.5',
 			'balance': 28083310.571743,
+			'isHealthy': None,
+			'isSslEnabled': None,
+			'restVersion': None,
 			'roles': 5,
 		}, json_object)
 
@@ -236,6 +239,9 @@ class NetworkRepositoryTest(unittest.TestCase):
 			'version': '1.0.3.5',
 			'balance': 82375.554976,
 			'roles': 3,
+			'isHealthy': True,
+			'isSslEnabled': True,
+			'restVersion': '2.4.4',
 		}, json_object)
 
 	# endregion

--- a/explorer/nodewatch/tests/test_RoutesFacade.py
+++ b/explorer/nodewatch/tests/test_RoutesFacade.py
@@ -425,6 +425,9 @@ class SymbolRoutesFacadeTest(unittest.TestCase):
 			'height': 1486762,
 			'finalizedHeight': 1486740,
 			'balance': 3155632.471994,
+			'isHealthy': True,
+			'isSslEnabled': True,
+			'restVersion': '2.4.4',
 			'roles': 2
 		}
 


### PR DESCRIPTION
Problem: The API node status field is missing.
Solution: Added API node status properties in **NodeDescriptor**.