### PR TITLE
[explorer/nodewatch]: Added query params for get node list endpoint

### DIFF
--- a/explorer/nodewatch/nodewatch/RoutesFacade.py
+++ b/explorer/nodewatch/nodewatch/RoutesFacade.py
@@ -73,19 +73,16 @@ class BasicRoutesFacade:
 		"""Returns all nodes with condition."""
 
 		role = kwargs.get('role')
-		exact_match = kwargs.get('exact_match')
+		exact_match = kwargs.get('exact_match', False)
 
 		limit = kwargs.get('limit')
 		only_ssl = kwargs.get('only_ssl')
 		order = kwargs.get('order')
 
 		def custom_filter(descriptor):
-			if role is not None:
-				role_condition = role == descriptor.roles if exact_match else role == (role & descriptor.roles)
-				if not role_condition:
-					return False
+			role_condition = role == descriptor.roles if exact_match else role == (role & descriptor.roles)
 
-			return descriptor.is_ssl_enabled if only_ssl else True
+			return role_condition and (descriptor.is_ssl_enabled if only_ssl else True)
 
 		nodes = list(map(
 			lambda descriptor: descriptor.to_json(),

--- a/explorer/nodewatch/nodewatch/RoutesFacade.py
+++ b/explorer/nodewatch/nodewatch/RoutesFacade.py
@@ -69,10 +69,9 @@ class BasicRoutesFacade:
 			'explorer_endpoint': self.explorer_endpoint
 		})
 
-	def json_nodes(self, **kwargs):
+	def json_nodes(self, role, **kwargs):
 		"""Returns all nodes with condition."""
 
-		role = kwargs.get('role')
 		exact_match = kwargs.get('exact_match', False)
 
 		limit = kwargs.get('limit')

--- a/explorer/nodewatch/nodewatch/RoutesFacade.py
+++ b/explorer/nodewatch/nodewatch/RoutesFacade.py
@@ -80,15 +80,12 @@ class BasicRoutesFacade:
 		order = kwargs.get('order')
 
 		def custom_filter(descriptor):
-			role_condition = True
-
 			if role is not None:
 				role_condition = role == descriptor.roles if exact_match else role == (role & descriptor.roles)
+				if not role_condition:
+					return False
 
-			if only_ssl:
-				return role_condition and descriptor.is_ssl_enabled
-
-			return role_condition
+			return descriptor.is_ssl_enabled if only_ssl else True
 
 		nodes = list(map(
 			lambda descriptor: descriptor.to_json(),

--- a/explorer/nodewatch/nodewatch/__init__.py
+++ b/explorer/nodewatch/nodewatch/__init__.py
@@ -92,10 +92,7 @@ def create_app():
 		return render_template(template_name, **context)
 
 	def _get_json_nodes(role, exact_match, request_args):
-		only_ssl = request_args.get('only_ssl')
-
-		if only_ssl is not None:
-			only_ssl = only_ssl == '' or only_ssl.lower() == 'true'
+		only_ssl = request_args.get('only_ssl', 'false').lower() in ('', 'true')
 
 		order = request_args.get('order', None)
 

--- a/explorer/nodewatch/nodewatch/__init__.py
+++ b/explorer/nodewatch/nodewatch/__init__.py
@@ -92,9 +92,7 @@ def create_app():
 		return render_template(template_name, **context)
 
 	def _get_json_nodes(role, exact_match, request_args):
-		only_ssl = None
-		if 'only_ssl' in request_args:
-			only_ssl = True
+		only_ssl = True if 'only_ssl' in request_args else None
 
 		order = request_args.get('order', None)
 

--- a/explorer/nodewatch/nodewatch/__init__.py
+++ b/explorer/nodewatch/nodewatch/__init__.py
@@ -61,7 +61,7 @@ def create_app():
 
 	@app.route('/api/nem/nodes')
 	def api_nem_nodes():  # pylint: disable=unused-variable
-		return jsonify(nem_routes_facade.json_nodes(1))
+		return jsonify(nem_routes_facade.json_nodes(role=1))
 
 	@app.route('/api/nem/chart/height')
 	def api_nem_chart_height():  # pylint: disable=unused-variable
@@ -91,6 +91,17 @@ def create_app():
 		template_name, context = symbol_routes_facade.html_summary()
 		return render_template(template_name, **context)
 
+	def _get_json_nodes(role, exact_match, request_args):
+		only_ssl = None
+		if 'only_ssl' in request_args:
+			only_ssl = True
+
+		order = request_args.get('order', None)
+
+		limit = int(request_args.get('limit', 0))
+
+		return jsonify(symbol_routes_facade.json_nodes(role=role, exact_match=exact_match, only_ssl=only_ssl, limit=limit, order=order))
+
 	def _get_json_node(result):
 		if not result:
 			abort(404)
@@ -105,11 +116,11 @@ def create_app():
 
 	@app.route('/api/symbol/nodes/api')
 	def api_symbol_nodes_api():  # pylint: disable=unused-variable
-		return jsonify(symbol_routes_facade.json_nodes(2, exact_match=True))
+		return _get_json_nodes(2, True, request.args)
 
 	@app.route('/api/symbol/nodes/peer')
 	def api_symbol_nodes_peer():  # pylint: disable=unused-variable
-		return jsonify(symbol_routes_facade.json_nodes(1))
+		return _get_json_nodes(1, False, request.args)
 
 	@app.route('/api/symbol/nodes/mainPublicKey/<main_public_key>')
 	def api_symbol_nodes_get_main_public_key(main_public_key):  # pylint: disable=unused-variable

--- a/explorer/nodewatch/nodewatch/__init__.py
+++ b/explorer/nodewatch/nodewatch/__init__.py
@@ -61,7 +61,7 @@ def create_app():
 
 	@app.route('/api/nem/nodes')
 	def api_nem_nodes():  # pylint: disable=unused-variable
-		return jsonify(nem_routes_facade.json_nodes(role=1))
+		return jsonify(nem_routes_facade.json_nodes(1))
 
 	@app.route('/api/nem/chart/height')
 	def api_nem_chart_height():  # pylint: disable=unused-variable
@@ -98,7 +98,7 @@ def create_app():
 
 		limit = int(request_args.get('limit', 0))
 
-		return jsonify(symbol_routes_facade.json_nodes(role=role, exact_match=exact_match, only_ssl=only_ssl, limit=limit, order=order))
+		return jsonify(symbol_routes_facade.json_nodes(role, exact_match=exact_match, only_ssl=only_ssl, limit=limit, order=order))
 
 	def _get_json_node(result):
 		if not result:

--- a/explorer/nodewatch/nodewatch/__init__.py
+++ b/explorer/nodewatch/nodewatch/__init__.py
@@ -92,7 +92,10 @@ def create_app():
 		return render_template(template_name, **context)
 
 	def _get_json_nodes(role, exact_match, request_args):
-		only_ssl = True if 'only_ssl' in request_args else None
+		only_ssl = request_args.get('only_ssl')
+
+		if only_ssl is not None:
+			only_ssl = only_ssl == '' or only_ssl.lower() == 'true'
 
 		order = request_args.get('order', None)
 

--- a/explorer/nodewatch/tests/test_RoutesFacade.py
+++ b/explorer/nodewatch/tests/test_RoutesFacade.py
@@ -150,7 +150,7 @@ class NemRoutesFacadeTest(unittest.TestCase):
 		facade.reload_all(Path('tests/resources'), True)
 
 		# Act:
-		node_descriptors = facade.json_nodes(1)
+		node_descriptors = facade.json_nodes(role=1)
 
 		# Assert: spot check names and roles
 		self.assertEqual(4, len(node_descriptors))
@@ -361,7 +361,7 @@ class SymbolRoutesFacadeTest(unittest.TestCase):
 		facade.reload_all(Path('tests/resources'), True)
 
 		# Act:
-		node_descriptors = facade.json_nodes(1)
+		node_descriptors = facade.json_nodes(role=1)
 
 		# Assert: spot check names and roles
 		self.assertEqual(5, len(node_descriptors))
@@ -378,7 +378,7 @@ class SymbolRoutesFacadeTest(unittest.TestCase):
 		facade.reload_all(Path('tests/resources'), True)
 
 		# Act: select nodes with api role (role 2)
-		node_descriptors = facade.json_nodes(2)
+		node_descriptors = facade.json_nodes(role=2)
 
 		# Assert: spot check names and roles
 		self.assertEqual(5, len(node_descriptors))
@@ -395,7 +395,7 @@ class SymbolRoutesFacadeTest(unittest.TestCase):
 		facade.reload_all(Path('tests/resources'), True)
 
 		# Act: select nodes with only api role (role 2)
-		node_descriptors = facade.json_nodes(2, True)
+		node_descriptors = facade.json_nodes(role=2, exact_match=True)
 
 		# Assert: spot check names and roles
 		self.assertEqual(1, len(node_descriptors))
@@ -404,6 +404,56 @@ class SymbolRoutesFacadeTest(unittest.TestCase):
 			list(map(lambda descriptor: descriptor['name'], node_descriptors)))
 		self.assertEqual(
 			[2],
+			list(map(lambda descriptor: descriptor['roles'], node_descriptors)))
+
+	def test_can_generate_nodes_json_filtered_only_ssl(self):
+		# Arrange:
+		facade = SymbolRoutesFacade(SymbolNetwork.MAINNET, '<symbol_explorer>')
+		facade.reload_all(Path('tests/resources'), True)
+
+		# Act: select nodes with only ssl enabled
+		node_descriptors = facade.json_nodes(only_ssl=True)
+
+		# Assert: spot check names and roles
+		self.assertEqual(2, len(node_descriptors))
+		self.assertEqual(
+			['Allnodes250', 'ibone74'],
+			list(map(lambda descriptor: descriptor['name'], node_descriptors)))
+
+	def test_can_generate_nodes_json_filtered_order_random_subset(self):
+		# Arrange:
+		facade = SymbolRoutesFacade(SymbolNetwork.MAINNET, '<symbol_explorer>')
+		facade.reload_all(Path('tests/resources'), True)
+
+		# Act: select 2 nodes with order random
+		node_descriptors = facade.json_nodes(limit=2, order='random')
+
+		# Assert:
+		all_node_descriptors = facade.json_nodes()
+
+		full_node_names = list(map(lambda descriptor: descriptor['name'], all_node_descriptors))
+		random_node_names = list(map(lambda descriptor: descriptor['name'], node_descriptors))
+
+		self.assertEqual(2, len(node_descriptors))
+		self.assertEqual(2, len(set(random_node_names)))
+		for name in random_node_names:
+			self.assertIn(name, full_node_names)
+
+	def test_can_generate_nodes_json_filtered_limit_5(self):
+		# Arrange:
+		facade = SymbolRoutesFacade(SymbolNetwork.MAINNET, '<symbol_explorer>')
+		facade.reload_all(Path('tests/resources'), True)
+
+		# Act:
+		node_descriptors = facade.json_nodes(limit=5)
+
+		# Assert: spot check names
+		self.assertEqual(5, len(node_descriptors))
+		self.assertEqual(
+			['Allnodes250', 'Apple', 'Shin-Kuma-Node', 'ibone74', 'jaguar'],
+			list(map(lambda descriptor: descriptor['name'], node_descriptors)))
+		self.assertEqual(
+			[2, 7, 3, 3, 5],
 			list(map(lambda descriptor: descriptor['roles'], node_descriptors)))
 
 	def test_can_find_known_node_by_main_public_key(self):  # pylint: disable=invalid-name

--- a/explorer/nodewatch/tests/test_RoutesFacade.py
+++ b/explorer/nodewatch/tests/test_RoutesFacade.py
@@ -212,7 +212,7 @@ class NemRoutesFacadeTest(unittest.TestCase):
 	# endregion
 
 
-class SymbolRoutesFacadeTest(unittest.TestCase):
+class SymbolRoutesFacadeTest(unittest.TestCase):  # pylint: disable=too-many-public-methods
 	# region reload / refresh
 
 	def test_can_reload_all(self):

--- a/explorer/nodewatch/tests/test_RoutesFacade.py
+++ b/explorer/nodewatch/tests/test_RoutesFacade.py
@@ -412,7 +412,7 @@ class SymbolRoutesFacadeTest(unittest.TestCase):  # pylint: disable=too-many-pub
 		facade.reload_all(Path('tests/resources'), True)
 
 		# Act: select nodes with only ssl enabled
-		node_descriptors = facade.json_nodes(only_ssl=True)
+		node_descriptors = facade.json_nodes(role=2, only_ssl=True)
 
 		# Assert: spot check names and roles
 		self.assertEqual(2, len(node_descriptors))
@@ -426,10 +426,10 @@ class SymbolRoutesFacadeTest(unittest.TestCase):  # pylint: disable=too-many-pub
 		facade.reload_all(Path('tests/resources'), True)
 
 		# Act: select 2 nodes with order random
-		node_descriptors = facade.json_nodes(limit=2, order='random')
+		node_descriptors = facade.json_nodes(role=2, limit=2)
 
 		# Assert:
-		all_node_descriptors = facade.json_nodes()
+		all_node_descriptors = facade.json_nodes(role=2)
 
 		full_node_names = list(map(lambda descriptor: descriptor['name'], all_node_descriptors))
 		random_node_names = list(map(lambda descriptor: descriptor['name'], node_descriptors))
@@ -445,15 +445,15 @@ class SymbolRoutesFacadeTest(unittest.TestCase):  # pylint: disable=too-many-pub
 		facade.reload_all(Path('tests/resources'), True)
 
 		# Act:
-		node_descriptors = facade.json_nodes(limit=5)
+		node_descriptors = facade.json_nodes(role=2, limit=5)
 
 		# Assert: spot check names
 		self.assertEqual(5, len(node_descriptors))
 		self.assertEqual(
-			['Allnodes250', 'Apple', 'Shin-Kuma-Node', 'ibone74', 'jaguar'],
+			['Allnodes250', 'Apple', 'Shin-Kuma-Node', 'ibone74', 'symbol.ooo maxUnlockedAccounts:100'],
 			list(map(lambda descriptor: descriptor['name'], node_descriptors)))
 		self.assertEqual(
-			[2, 7, 3, 3, 5],
+			[2, 7, 3, 3, 3],
 			list(map(lambda descriptor: descriptor['roles'], node_descriptors)))
 
 	def test_can_find_known_node_by_main_public_key(self):  # pylint: disable=invalid-name

--- a/explorer/nodewatch/tests/test_RoutesFacade.py
+++ b/explorer/nodewatch/tests/test_RoutesFacade.py
@@ -150,7 +150,7 @@ class NemRoutesFacadeTest(unittest.TestCase):
 		facade.reload_all(Path('tests/resources'), True)
 
 		# Act:
-		node_descriptors = facade.json_nodes(role=1)
+		node_descriptors = facade.json_nodes(1)
 
 		# Assert: spot check names and roles
 		self.assertEqual(4, len(node_descriptors))
@@ -361,7 +361,7 @@ class SymbolRoutesFacadeTest(unittest.TestCase):  # pylint: disable=too-many-pub
 		facade.reload_all(Path('tests/resources'), True)
 
 		# Act:
-		node_descriptors = facade.json_nodes(role=1)
+		node_descriptors = facade.json_nodes(1)
 
 		# Assert: spot check names and roles
 		self.assertEqual(5, len(node_descriptors))
@@ -378,7 +378,7 @@ class SymbolRoutesFacadeTest(unittest.TestCase):  # pylint: disable=too-many-pub
 		facade.reload_all(Path('tests/resources'), True)
 
 		# Act: select nodes with api role (role 2)
-		node_descriptors = facade.json_nodes(role=2)
+		node_descriptors = facade.json_nodes(2)
 
 		# Assert: spot check names and roles
 		self.assertEqual(5, len(node_descriptors))
@@ -395,7 +395,7 @@ class SymbolRoutesFacadeTest(unittest.TestCase):  # pylint: disable=too-many-pub
 		facade.reload_all(Path('tests/resources'), True)
 
 		# Act: select nodes with only api role (role 2)
-		node_descriptors = facade.json_nodes(role=2, exact_match=True)
+		node_descriptors = facade.json_nodes(2, exact_match=True)
 
 		# Assert: spot check names and roles
 		self.assertEqual(1, len(node_descriptors))
@@ -412,7 +412,7 @@ class SymbolRoutesFacadeTest(unittest.TestCase):  # pylint: disable=too-many-pub
 		facade.reload_all(Path('tests/resources'), True)
 
 		# Act: select nodes with only ssl enabled
-		node_descriptors = facade.json_nodes(role=2, only_ssl=True)
+		node_descriptors = facade.json_nodes(2, only_ssl=True)
 
 		# Assert: spot check names and roles
 		self.assertEqual(2, len(node_descriptors))
@@ -426,10 +426,10 @@ class SymbolRoutesFacadeTest(unittest.TestCase):  # pylint: disable=too-many-pub
 		facade.reload_all(Path('tests/resources'), True)
 
 		# Act: select 2 nodes with order random
-		node_descriptors = facade.json_nodes(role=2, limit=2)
+		node_descriptors = facade.json_nodes(2, limit=2)
 
 		# Assert:
-		all_node_descriptors = facade.json_nodes(role=2)
+		all_node_descriptors = facade.json_nodes(2)
 
 		full_node_names = list(map(lambda descriptor: descriptor['name'], all_node_descriptors))
 		random_node_names = list(map(lambda descriptor: descriptor['name'], node_descriptors))
@@ -445,7 +445,7 @@ class SymbolRoutesFacadeTest(unittest.TestCase):  # pylint: disable=too-many-pub
 		facade.reload_all(Path('tests/resources'), True)
 
 		# Act:
-		node_descriptors = facade.json_nodes(role=2, limit=5)
+		node_descriptors = facade.json_nodes(2, limit=5)
 
 		# Assert: spot check names
 		self.assertEqual(5, len(node_descriptors))

--- a/explorer/nodewatch/tests/test_app.py
+++ b/explorer/nodewatch/tests/test_app.py
@@ -162,32 +162,41 @@ def test_get_api_nem_network_height_chart(client):  # pylint: disable=redefined-
 	assert re.match(r'\d\d:\d\d', response_json['lastRefreshTime'])
 
 
-def test_get_api_symbol_nodes_api(client):  # pylint: disable=redefined-outer-name
+def _assert_get_api_nodes(response, expected_node_names):
 	# Act:
-	response = client.get('/api/symbol/nodes/api')
 	response_json = json.loads(response.data)
 
 	# Assert: spot check names
 	assert 200 == response.status_code
 	assert 'application/json' == response.headers['Content-Type']
-	assert 1 == len(response_json)
-	assert [
-		'Allnodes250'
-	] == list(map(lambda descriptor: descriptor['name'], response_json))
+	assert len(expected_node_names) == len(response_json)
+	assert expected_node_names == list(map(lambda descriptor: descriptor['name'], response_json))
+
+
+def test_get_api_symbol_nodes_api(client):  # pylint: disable=redefined-outer-name
+	_assert_get_api_nodes(client.get('/api/symbol/nodes/api'), ['Allnodes250'])
 
 
 def test_get_api_symbol_nodes_peer(client):  # pylint: disable=redefined-outer-name
-	# Act:
-	response = client.get('/api/symbol/nodes/peer')
-	response_json = json.loads(response.data)
+	_assert_get_api_nodes(
+		client.get('/api/symbol/nodes/peer'),
+		['Apple', 'Shin-Kuma-Node', 'ibone74', 'jaguar', 'symbol.ooo maxUnlockedAccounts:100']
+	)
 
-	# Assert: spot check names
-	assert 200 == response.status_code
-	assert 'application/json' == response.headers['Content-Type']
-	assert 5 == len(response_json)
-	assert [
-		'Apple', 'Shin-Kuma-Node', 'ibone74', 'jaguar', 'symbol.ooo maxUnlockedAccounts:100'
-	] == list(map(lambda descriptor: descriptor['name'], response_json))
+
+def test_get_api_symbol_nodes_peer_with_only_ssl(client):  # pylint: disable=redefined-outer-name
+	_assert_get_api_nodes(client.get('/api/symbol/nodes/peer?only_ssl'), ['ibone74'])
+
+
+def test_get_api_symbol_nodes_peer_with_only_ssl_true(client):  # pylint: disable=redefined-outer-name
+	_assert_get_api_nodes(client.get('/api/symbol/nodes/peer?only_ssl=true'), ['ibone74'])
+
+
+def test_get_api_symbol_nodes_peer_with_only_ssl_false(client):  # pylint: disable=redefined-outer-name
+	_assert_get_api_nodes(
+		client.get('/api/symbol/nodes/peer?only_ssl=false'),
+		['Apple', 'Shin-Kuma-Node', 'ibone74', 'jaguar', 'symbol.ooo maxUnlockedAccounts:100']
+	)
 
 
 def test_get_api_symbol_network_height(client):  # pylint: disable=redefined-outer-name


### PR DESCRIPTION
Problem: The filter node is missing on the API node list endpoint.
Solution: Added query params `only_ssl`, `limit`, and `order`.

`only_ssl`: to filter out SSL enable node, it needs explorer and wallet.
`limit`: the number of numbers returned from the endpoint.
`order`: shuffle node list when required