### PR TITLE
[tools/shoestring] fix: upgrade command fails with harvesting node

### DIFF
--- a/tools/shoestring/shoestring/commands/upgrade.py
+++ b/tools/shoestring/shoestring/commands/upgrade.py
@@ -58,7 +58,7 @@ async def run_main(args):
 	if NodeFeatures.HARVESTER in config.node.features:
 		harvesting_properties_filepath = directories.resources / 'config-harvesting.properties'
 		harvesting_properties_filepath.chmod(0o600)
-		config_manager.patch(harvesting_properties_filepath, harvester_config_patches)
+		config_manager.patch(harvesting_properties_filepath.name, harvester_config_patches)
 		harvesting_properties_filepath.chmod(0o400)
 
 


### PR DESCRIPTION
problem: the config patch operation fails due to an invalid path in the config-harvesting.properties file.
                 the patch() method only requires the filename.
solution: pass only the filename to the configuration manager patch method


```
  File "/lib/python3.12/site-packages/shoestring/internal/ConfigurationManager.py", line 48, in patch
    with open(config_filepath, 'rt', encoding='utf8') as infile:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'userconfig/resources/userconfig/resources/config-harvesting.properties'
```

The reason why tests are passing is that the [absolute path](https://docs.python.org/3/library/pathlib.html#operators) is used.