### PR TITLE
[tools/shoestring] fix: fail to delete docker compose recover on upgrade

### DIFF
--- a/tools/shoestring/shoestring/commands/upgrade.py
+++ b/tools/shoestring/shoestring/commands/upgrade.py
@@ -40,7 +40,7 @@ async def run_main(args):
 		harvester_config_patches = _load_harvester_configuration_patches(config_manager)
 
 	(directories.output_directory / 'docker-compose.yaml').unlink()
-	(directories.output_directory / 'docker-compose-recovery.yaml').unlink()
+	(directories.output_directory / 'docker-compose-recovery.yaml').unlink(missing_ok=True)
 
 	_purge_directory(directories.userconfig)
 	_recreate_directory(directories.userconfig)


### PR DESCRIPTION
problem: shoestring upgrade fails to delete the recovery docker compose due to it not present
solution: ignore unlink failure for the docker compose recovery file since it does not exist