### PR TITLE
[tools/shoestring] fix: wizard upgrade does not get latest package file

### DIFF
--- a/tools/shoestring/shoestring/internal/ConfigurationManager.py
+++ b/tools/shoestring/shoestring/internal/ConfigurationManager.py
@@ -90,6 +90,21 @@ def load_patches_from_file(filename):
 	return patches
 
 
+def load_shoestring_patches_from_file(filename, only_sections=None):
+	"""Loads patch information from ini file."""
+
+	parser = configparser.ConfigParser()
+	parser.optionxform = str  # configure case-sensitive keys
+	parser.read(filename)
+
+	sections = parser.sections() if only_sections is None else only_sections
+	patches = []
+	for section in sections:
+		patches.extend([(section, key, parser[section][key]) for key in parser[section]])
+
+	return patches
+
+
 def parse_time_span(str_value):
 	"""Parses a time span configuration value."""
 

--- a/tools/shoestring/shoestring/wizard/setup_file_generator.py
+++ b/tools/shoestring/shoestring/wizard/setup_file_generator.py
@@ -122,8 +122,10 @@ async def prepare_shoestring_files(screens, directory):
 	ConfigurationManager(config_filepath.parent).patch(config_filepath.name, replacements)
 
 
-async def patch_shoestring_config(shoestring_filepath, new_config_filepath):
+def patch_shoestring_config(shoestring_filepath, package_config_filepath):
+	"""Patches shoestring configuration files."""
+
 	config_patches = load_shoestring_patches_from_file(shoestring_filepath, ['transaction', 'imports', 'node'])
-	new_config_manager = ConfigurationManager(new_config_filepath.parent)
-	new_config_manager.patch(new_config_filepath.name, config_patches)
-	shutil.copy(new_config_filepath, shoestring_filepath)
+	new_config_manager = ConfigurationManager(package_config_filepath.parent)
+	new_config_manager.patch(package_config_filepath.name, config_patches)
+	shutil.copy(package_config_filepath, shoestring_filepath)

--- a/tools/shoestring/shoestring/wizard/shoestring_dispatcher.py
+++ b/tools/shoestring/shoestring/wizard/shoestring_dispatcher.py
@@ -2,7 +2,13 @@ import shutil
 import tempfile
 from pathlib import Path
 
-from shoestring.wizard.setup_file_generator import prepare_overrides_file, prepare_shoestring_files, try_prepare_rest_overrides_file
+from shoestring.wizard.setup_file_generator import (
+	patch_shoestring_config,
+	prepare_overrides_file,
+	prepare_shoestring_config,
+	prepare_shoestring_files,
+	try_prepare_rest_overrides_file
+)
 from shoestring.wizard.ShoestringOperation import ShoestringOperation, build_shoestring_command
 
 
@@ -37,6 +43,12 @@ async def dispatch_shoestring_command(screens, executor):
 				if source_path.exists():
 					shutil.copy(source_path, shoestring_directory)
 	else:
+		if ShoestringOperation.UPGRADE == operation:
+			with tempfile.TemporaryDirectory() as temp_directory:
+				config_filepath = Path(temp_directory) / 'shoestring.ini'
+				await prepare_shoestring_config(screens.get('network-type').current_value, config_filepath)
+				await patch_shoestring_config(shoestring_directory / 'shoestring.ini', config_filepath)
+
 		shoestring_args = build_shoestring_command(
 			operation,
 			destination_directory,

--- a/tools/shoestring/shoestring/wizard/shoestring_dispatcher.py
+++ b/tools/shoestring/shoestring/wizard/shoestring_dispatcher.py
@@ -47,7 +47,7 @@ async def dispatch_shoestring_command(screens, executor):
 			with tempfile.TemporaryDirectory() as temp_directory:
 				config_filepath = Path(temp_directory) / 'shoestring.ini'
 				await prepare_shoestring_config(screens.get('network-type').current_value, config_filepath)
-				await patch_shoestring_config(shoestring_directory / 'shoestring.ini', config_filepath)
+				patch_shoestring_config(shoestring_directory / 'shoestring.ini', config_filepath)
 
 		shoestring_args = build_shoestring_command(
 			operation,

--- a/tools/shoestring/tests/wizard/test_setup_file_generator.py
+++ b/tools/shoestring/tests/wizard/test_setup_file_generator.py
@@ -279,7 +279,7 @@ async def _assert_can_patch_shoestring_file(new_content, expected_patches):
 			'fee = 20',
 			'',
 			'[imports]',
-			'node_key = 1233455222222222',
+			'nodeKey = 1233455222222222',
 			'',
 			'[node]',
 			'caCommonName = CA test',
@@ -289,10 +289,12 @@ async def _assert_can_patch_shoestring_file(new_content, expected_patches):
 		write_text_file(new_shoestring_filepath, new_content)
 
 		# Act:
-		await patch_shoestring_config(shoestring_filepath, new_shoestring_filepath)
+		patch_shoestring_config(shoestring_filepath, new_shoestring_filepath)
 
 		# Assert:
 		patches = load_shoestring_patches_from_file(shoestring_filepath)
+
+		# patches is a superset of expected_patches
 		for expected_patch in expected_patches:
 			assert expected_patch in patches
 
@@ -306,14 +308,14 @@ async def test_can_patch_shoestring_file():
 		'rest = symbolplatform/symbol-rest:2.4.0',
 		'',
 		'[imports]',
-		'node_key ='
+		'nodeKey ='
 		'',
 		'[node]',
 		'caCommonName =',
 		'nodeCommonName ='
 	]),
 		[
-			('imports', 'node_key', '1233455222222222'),
+			('imports', 'nodeKey', '1233455222222222'),
 			('node', 'caCommonName', 'CA test'),
 			('node', 'nodeCommonName', 'test 127.0.0.1')
 	])
@@ -328,14 +330,14 @@ async def test_can_patch_shoestring_file_overwrite():
 		'rest = symbolplatform/symbol-rest:2.4.0',
 		'',
 		'[imports]',
-		'node_key = 1111111111111'
+		'nodeKey = 1111111111111'
 		'',
 		'[node]',
 		'caCommonName = test',
 		'nodeCommonName = 127.0.0.1'
 	]),
 		[
-			('imports', 'node_key', '1233455222222222'),
+			('imports', 'nodeKey', '1233455222222222'),
 			('node', 'caCommonName', 'CA test'),
 			('node', 'nodeCommonName', 'test 127.0.0.1')
 	])
@@ -350,13 +352,13 @@ async def test_can_patch_shoestring_file_remove_old_property():
 		'rest = symbolplatform/symbol-rest:2.4.0',
 		'',
 		'[imports]',
-		'node_key = 1111111111111'
+		'nodeKey = 1111111111111'
 		'',
 		'[node]',
 		'caCommonName = test',
 	]),
 		[
-			('imports', 'node_key', '1233455222222222'),
+			('imports', 'nodeKey', '1233455222222222'),
 			('node', 'caCommonName', 'CA test')
 	])
 
@@ -370,18 +372,18 @@ async def test_can_patch_shoestring_file_new_property():
 		'rest = symbolplatform/symbol-rest:2.4.0',
 		'',
 		'[imports]',
-		'node_key = 1111111111111'
+		'nodeKey = 1111111111111'
 		'',
 		'[node]',
 		'caCommonName = test',
 		'nodeCommonName = 127.0.0.1',
-		'new_property = added'
+		'newProperty = added'
 	]),
 		[
-		('imports', 'node_key', '1233455222222222'),
+		('imports', 'nodeKey', '1233455222222222'),
 		('node', 'caCommonName', 'CA test'),
 		('node', 'nodeCommonName', 'test 127.0.0.1'),
-		('node', 'new_property', 'added'),
+		('node', 'newProperty', 'added'),
 	])
 
 # endregion

--- a/tools/shoestring/tests/wizard/test_setup_file_generator.py
+++ b/tools/shoestring/tests/wizard/test_setup_file_generator.py
@@ -2,10 +2,15 @@ import tempfile
 from collections import namedtuple
 from pathlib import Path
 
-from shoestring.internal.ConfigurationManager import ConfigurationManager
+from shoestring.internal.ConfigurationManager import ConfigurationManager, load_shoestring_patches_from_file
 from shoestring.internal.NodeFeatures import NodeFeatures
 from shoestring.internal.ShoestringConfiguration import parse_shoestring_configuration
-from shoestring.wizard.setup_file_generator import prepare_overrides_file, prepare_shoestring_files, try_prepare_rest_overrides_file
+from shoestring.wizard.setup_file_generator import (
+	patch_shoestring_config,
+	prepare_overrides_file,
+	prepare_shoestring_files,
+	try_prepare_rest_overrides_file
+)
 
 from ..test.TestPackager import prepare_testnet_package
 
@@ -247,5 +252,136 @@ async def test_can_prepare_shoestring_files_light():
 		'is_harvesting_active': True,
 		'is_voting_active': True
 	})
+
+# endregion
+
+
+# region patch_shoestring_config
+
+def write_text_file(filepath, text):
+	with open(filepath, 'wt', encoding='utf8') as outfile:
+		outfile.write(text)
+
+
+async def _assert_can_patch_shoestring_file(new_content, expected_patches):
+	# Arrange:
+	with tempfile.TemporaryDirectory() as temp_directory:
+		shoestring_path = Path(temp_directory)
+		shoestring_filepath = shoestring_path / 'shoe.ini'
+		write_text_file(shoestring_filepath, '\n'.join([
+			'[network]',
+			'ubuntuCore = 22.04',
+			'',
+			'[images]',
+			'rest = symbolplatform/symbol-rest:2.4.0',
+			'',
+			'[transaction]',
+			'fee = 20',
+			'',
+			'[imports]',
+			'node_key = 1233455222222222',
+			'',
+			'[node]',
+			'caCommonName = CA test',
+			'nodeCommonName = test 127.0.0.1'
+		]))
+		new_shoestring_filepath = shoestring_path / 'shoe_new.ini'
+		write_text_file(new_shoestring_filepath, new_content)
+
+		# Act:
+		await patch_shoestring_config(shoestring_filepath, new_shoestring_filepath)
+
+		# Assert:
+		patches = load_shoestring_patches_from_file(shoestring_filepath)
+		for expected_patch in expected_patches:
+			assert expected_patch in patches
+
+
+async def test_can_patch_shoestring_file():
+	await _assert_can_patch_shoestring_file('\n'.join([
+		'[network]',
+		'ubuntuCore = 22.04',
+		'',
+		'[images]',
+		'rest = symbolplatform/symbol-rest:2.4.0',
+		'',
+		'[imports]',
+		'node_key ='
+		'',
+		'[node]',
+		'caCommonName =',
+		'nodeCommonName ='
+	]),
+		[
+			('imports', 'node_key', '1233455222222222'),
+			('node', 'caCommonName', 'CA test'),
+			('node', 'nodeCommonName', 'test 127.0.0.1')
+	])
+
+
+async def test_can_patch_shoestring_file_overwrite():
+	await _assert_can_patch_shoestring_file('\n'.join([
+		'[network]',
+		'ubuntuCore = 22.04',
+		'',
+		'[images]',
+		'rest = symbolplatform/symbol-rest:2.4.0',
+		'',
+		'[imports]',
+		'node_key = 1111111111111'
+		'',
+		'[node]',
+		'caCommonName = test',
+		'nodeCommonName = 127.0.0.1'
+	]),
+		[
+			('imports', 'node_key', '1233455222222222'),
+			('node', 'caCommonName', 'CA test'),
+			('node', 'nodeCommonName', 'test 127.0.0.1')
+	])
+
+
+async def test_can_patch_shoestring_file_remove_old_property():
+	await _assert_can_patch_shoestring_file('\n'.join([
+		'[network]',
+		'ubuntuCore = 22.04',
+		'',
+		'[images]',
+		'rest = symbolplatform/symbol-rest:2.4.0',
+		'',
+		'[imports]',
+		'node_key = 1111111111111'
+		'',
+		'[node]',
+		'caCommonName = test',
+	]),
+		[
+			('imports', 'node_key', '1233455222222222'),
+			('node', 'caCommonName', 'CA test')
+	])
+
+
+async def test_can_patch_shoestring_file_new_property():
+	await _assert_can_patch_shoestring_file('\n'.join([
+		'[network]',
+		'ubuntuCore = 22.04',
+		'',
+		'[images]',
+		'rest = symbolplatform/symbol-rest:2.4.0',
+		'',
+		'[imports]',
+		'node_key = 1111111111111'
+		'',
+		'[node]',
+		'caCommonName = test',
+		'nodeCommonName = 127.0.0.1',
+		'new_property = added'
+	]),
+		[
+		('imports', 'node_key', '1233455222222222'),
+		('node', 'caCommonName', 'CA test'),
+		('node', 'nodeCommonName', 'test 127.0.0.1'),
+		('node', 'new_property', 'added'),
+	])
 
 # endregion

--- a/tools/shoestring/tests/wizard/test_shoestring_dispatcher.py
+++ b/tools/shoestring/tests/wizard/test_shoestring_dispatcher.py
@@ -133,7 +133,7 @@ def _prepare_shoestring_file(output_filename):
 
 
 async def test_can_dispatch_upgrade_command():
-	# Act:
+	# Arrange:
 	expected_keys = [
 		('node', 'apiHttps', 'false'),
 		('node', 'caCommonName', 'upgrade'),
@@ -146,6 +146,8 @@ async def test_can_dispatch_upgrade_command():
 		shoestring_directory.mkdir()
 		shoestring_filepath = shoestring_directory / 'shoestring.ini'
 		_prepare_shoestring_file(shoestring_filepath)
+
+		# Act:
 		await dispatch_shoestring_command({
 			'obligatory': ObligatoryScreen(package_directory, str(Path(package_directory) / 'ca.pem')),
 			'network-type': SingleValueScreen('sai'),
@@ -161,6 +163,7 @@ async def test_can_dispatch_upgrade_command():
 			'--package', 'sai'
 		] == dispatched_args
 
+		# node_patches is a superset of expected_keys
 		node_patches = load_shoestring_patches_from_file(shoestring_filepath, ['node'])
 		for key in expected_keys:
 			assert key in node_patches

--- a/tools/shoestring/tests/wizard/test_shoestring_dispatcher.py
+++ b/tools/shoestring/tests/wizard/test_shoestring_dispatcher.py
@@ -2,6 +2,7 @@ import tempfile
 from collections import namedtuple
 from pathlib import Path
 
+from shoestring.internal.ConfigurationManager import load_shoestring_patches_from_file
 from shoestring.wizard.shoestring_dispatcher import dispatch_shoestring_command
 from shoestring.wizard.ShoestringOperation import ShoestringOperation
 
@@ -111,20 +112,55 @@ async def test_can_dispatch_setup_command_with_custom_rest_overrides():
 			assert (shoestring_directory / 'rest_overrides.json').exists()
 
 
+def _prepare_shoestring_file(output_filename):
+	with open(output_filename, 'wt', encoding='utf8') as outfile:
+		outfile.write('\n'.join([
+			'[network]',
+			'ubuntuCore = 24.04',
+			'',
+			'[imports]',
+			'rest = symbol-rest:2.4.0',
+			'',
+			'[transaction]',
+			'fee = 20',
+			'',
+			'[node]',
+			'apiHttps = false',
+			'caCommonName = upgrade',
+			'nodeCommonName = node.upgrade',
+			'features = API'
+		]))
+
+
 async def test_can_dispatch_upgrade_command():
 	# Act:
+	expected_keys = [
+		('node', 'apiHttps', 'false'),
+		('node', 'caCommonName', 'upgrade'),
+		('node', 'nodeCommonName', 'node.upgrade'),
+		('node', 'features', 'API')
+	]
 	dispatched_args = []
-	await dispatch_shoestring_command({
-		'obligatory': ObligatoryScreen('/path/to/symbol', '/path/to/ca.pem'),
-		'network-type': SingleValueScreen('sai'),
-		'welcome': WelcomeScreen(ShoestringOperation.UPGRADE)
-	}, _create_executor(dispatched_args))
+	with tempfile.TemporaryDirectory() as package_directory:
+		shoestring_directory = Path(package_directory) / 'shoestring'
+		shoestring_directory.mkdir()
+		shoestring_filepath = shoestring_directory / 'shoestring.ini'
+		_prepare_shoestring_file(shoestring_filepath)
+		await dispatch_shoestring_command({
+			'obligatory': ObligatoryScreen(package_directory, str(Path(package_directory) / 'ca.pem')),
+			'network-type': SingleValueScreen('sai'),
+			'welcome': WelcomeScreen(ShoestringOperation.UPGRADE)
+		}, _create_executor(dispatched_args))
 
-	# Assert:
-	assert [
-		'upgrade',
-		'--config', '/path/to/symbol/shoestring/shoestring.ini',
-		'--directory', '/path/to/symbol',
-		'--overrides', '/path/to/symbol/shoestring/overrides.ini',
-		'--package', 'sai'
-	] == dispatched_args
+		# Assert:
+		assert [
+			'upgrade',
+			'--config', f'{shoestring_directory}/shoestring.ini',
+			'--directory', package_directory,
+			'--overrides', f'{shoestring_directory}/overrides.ini',
+			'--package', 'sai'
+		] == dispatched_args
+
+		node_patches = load_shoestring_patches_from_file(shoestring_filepath, ['node'])
+		for key in expected_keys:
+			assert key in node_patches


### PR DESCRIPTION
problem: shoestring wizard upgrade does not upgrade to the latest release
         this is because latest package config is not downloaded
solution: download the latest package config while keeping user config