### PR TITLE
[lightapi/python] fix: publish fails due to older twine version

### DIFF
--- a/lightapi/python/scripts/ci/publish.sh
+++ b/lightapi/python/scripts/ci/publish.sh
@@ -2,9 +2,11 @@
 
 set -ex
 
-
-export TWINE_USERNAME='__token__'
 export TWINE_PASSWORD="${PYPI_TOKEN}"
-export TWINE_REPOSITORY="${PYPI_URL}"
-
-python3 -m twine upload dist/*
+if [ -z "${USERNAME}" ]; then
+  export TWINE_USERNAME='__token__'
+  python3 -m twine upload dist/*
+else
+  export TWINE_USERNAME="${USERNAME}"
+  python3 -m twine upload --repository-url="${PYPI_URL}" dist/*
+fi

--- a/lightapi/python/scripts/ci/publish.sh
+++ b/lightapi/python/scripts/ci/publish.sh
@@ -2,11 +2,9 @@
 
 set -ex
 
+
 export TWINE_USERNAME='__token__'
 export TWINE_PASSWORD="${PYPI_TOKEN}"
+export TWINE_REPOSITORY="${PYPI_URL}"
 
-if [ "$(git rev-parse --abbrev-ref HEAD)" == "main" ]; then
-	twine upload dist/*
-else
-	twine upload --repository testpypi dist/*
-fi
+python3 -m twine upload dist/*


### PR DESCRIPTION
problem: twine shipped with Ubuntu is outdated and fails with newer metadata versions
solution: use twine from the local Python environment
                for the test package, publish to our internal repository