### PR TITLE
[explorer/nodewatch] fix: update the catapult compatible matrix

### DIFF
--- a/explorer/nodewatch/nodewatch/RoutesFacade.py
+++ b/explorer/nodewatch/nodewatch/RoutesFacade.py
@@ -184,7 +184,7 @@ class NemRoutesFacade(BasicRoutesFacade):
 		tag = 'danger'
 		if not version:
 			tag = 'warning'
-		if version.startswith('0.6.10') and not '0.6.100' in version:
+		if version.startswith('0.6.10') and '0.6.100' not in version:
 			tag = 'success'
 
 		return tag

--- a/explorer/nodewatch/nodewatch/RoutesFacade.py
+++ b/explorer/nodewatch/nodewatch/RoutesFacade.py
@@ -156,8 +156,8 @@ class NemRoutesFacade(BasicRoutesFacade):
 		super().__init__(network, explorer_endpoint, 'nem', 'NEM', self._version_to_css_class, {
 			'0.6.102': (COMPATIBLE_VERSION_COLORS[0], 9),
 			'0.6.101': (COMPATIBLE_VERSION_COLORS[1], 8),
-			'delegating / updating': (AMBIGUOUS_COLORS[0], 6),
-			'0.6.100': (INCOMPATIBLE_VERSION_COLORS[0], 7),
+			'delegating / updating': (AMBIGUOUS_COLORS[0], 7),
+			'0.6.100': (INCOMPATIBLE_VERSION_COLORS[0], 6),
 			'0.6.99': (INCOMPATIBLE_VERSION_COLORS[-1], 5),
 			'0.6.98': (INCOMPATIBLE_VERSION_COLORS[-2], 4),
 			'0.6.97-BETA': (INCOMPATIBLE_VERSION_COLORS[-3], 3),

--- a/explorer/nodewatch/nodewatch/RoutesFacade.py
+++ b/explorer/nodewatch/nodewatch/RoutesFacade.py
@@ -154,9 +154,10 @@ class NemRoutesFacade(BasicRoutesFacade):
 		"""Creates a facade."""
 
 		super().__init__(network, explorer_endpoint, 'nem', 'NEM', self._version_to_css_class, {
-			'0.6.101': (COMPATIBLE_VERSION_COLORS[0], 8),
-			'0.6.100': (COMPATIBLE_VERSION_COLORS[1], 7),
+			'0.6.102': (COMPATIBLE_VERSION_COLORS[0], 9),
+			'0.6.101': (COMPATIBLE_VERSION_COLORS[1], 8),
 			'delegating / updating': (AMBIGUOUS_COLORS[0], 6),
+			'0.6.100': (INCOMPATIBLE_VERSION_COLORS[0], 7),
 			'0.6.99': (INCOMPATIBLE_VERSION_COLORS[-1], 5),
 			'0.6.98': (INCOMPATIBLE_VERSION_COLORS[-2], 4),
 			'0.6.97-BETA': (INCOMPATIBLE_VERSION_COLORS[-3], 3),
@@ -183,7 +184,7 @@ class NemRoutesFacade(BasicRoutesFacade):
 		tag = 'danger'
 		if not version:
 			tag = 'warning'
-		if '0.6.101' in version:
+		if version.startswith('0.6.10') and not '0.6.100' in version:
 			tag = 'success'
 
 		return tag
@@ -196,7 +197,8 @@ class SymbolRoutesFacade(BasicRoutesFacade):
 		"""Creates a facade."""
 
 		super().__init__(network, explorer_endpoint, 'symbol', 'Symbol', self._version_to_css_class, {
-			'1.0.3.7': (COMPATIBLE_VERSION_COLORS[0], 10),
+			'1.0.3.8': (COMPATIBLE_VERSION_COLORS[0], 11),
+			'1.0.3.7': (COMPATIBLE_VERSION_COLORS[1], 10),
 			'delegating / updating': (AMBIGUOUS_COLORS[0], 9),
 			'1.0.3.6': (INCOMPATIBLE_VERSION_COLORS[1], 8),
 			'1.0.3.5': (INCOMPATIBLE_VERSION_COLORS[1], 7),

--- a/explorer/nodewatch/tests/test_RoutesFacade.py
+++ b/explorer/nodewatch/tests/test_RoutesFacade.py
@@ -204,7 +204,7 @@ class NemRoutesFacadeTest(unittest.TestCase):
 	# region utils
 
 	def test_can_map_version_to_css_class(self):
-		self.assertEqual('success', _map_version_to_css_class(NemRoutesFacade, '0.6.101'))
+		self.assertEqual('success', _map_version_to_css_class(NemRoutesFacade, '0.6.102'))
 		self.assertEqual('warning', _map_version_to_css_class(NemRoutesFacade, ''))
 		for version in ['0.6.100', '0.6.99', '0.6.98', '0.6.97-BETA', '0.6.96-BETA', '0.6.95-BETA']:
 			self.assertEqual('danger', _map_version_to_css_class(NemRoutesFacade, version))
@@ -449,7 +449,7 @@ class SymbolRoutesFacadeTest(unittest.TestCase):
 	# region utils
 
 	def test_can_map_version_to_css_class(self):
-		for version in ['1.0.3.7']:
+		for version in ['1.0.3.7', '1.0.3.8']:
 			self.assertEqual('success', _map_version_to_css_class(SymbolRoutesFacade, version))
 
 		self.assertEqual('warning', _map_version_to_css_class(SymbolRoutesFacade, ''))


### PR DESCRIPTION
problem: NodeWatch does not show the latest versions of NIS and Catapult as green.
solution: Update NodeWatch to show the correct colors