### PR TITLE
[tools/shoestring] fix: move the bootstrap import files under Shoestrng folder

### DIFF
--- a/tools/shoestring/shoestring/commands/import_bootstrap.py
+++ b/tools/shoestring/shoestring/commands/import_bootstrap.py
@@ -1,3 +1,4 @@
+import shutil
 import sys
 from pathlib import Path
 
@@ -8,6 +9,9 @@ from shoestring.internal.ConfigurationManager import ConfigurationManager
 
 async def run_main(args):
 	replacements = []
+	config_filepath = Path(args.config).absolute()
+	bootstrap_import_path = config_filepath.parent / 'bootstrap-import'
+	bootstrap_import_path.mkdir(parents=True, exist_ok=True)
 
 	bootstrap_node_path = Path(args.bootstrap) / 'nodes/node'
 	if not bootstrap_node_path.exists():
@@ -17,24 +21,27 @@ async def run_main(args):
 	bootstrap_harvesting_properties = bootstrap_node_path / 'server-config/resources/config-harvesting.properties'
 	if bootstrap_harvesting_properties.exists():
 		log.info(_('import-bootstrap-importing-harvester').format(path=bootstrap_harvesting_properties))
-		replacements.append(('imports', 'harvester', str(bootstrap_harvesting_properties)))
+		shutil.copy(bootstrap_harvesting_properties, bootstrap_import_path)
+		replacements.append(('imports', 'harvester', str(bootstrap_import_path / bootstrap_harvesting_properties.name)))
 
 	bootstrap_voting_keys_directory = bootstrap_node_path / 'votingkeys'
 	if bootstrap_voting_keys_directory.exists():
 		log.info(_('import-bootstrap-importing-voter').format(path=bootstrap_voting_keys_directory))
-		replacements.append(('imports', 'voter', str(bootstrap_voting_keys_directory)))
+		config_votingkeys_path = bootstrap_import_path / 'votingkeys'
+		shutil.copytree(bootstrap_voting_keys_directory, config_votingkeys_path)
+		replacements.append(('imports', 'voter', str(config_votingkeys_path)))
 
 	if args.include_node_key:
 		bootstrap_node_key = bootstrap_node_path / 'cert/node.key.pem'
 		if bootstrap_node_key.exists():
 			log.info(_('import-bootstrap-importing-node-key').format(path=bootstrap_node_key))
-			replacements.append(('imports', 'nodeKey', str(bootstrap_node_key.absolute())))
+			shutil.copy(bootstrap_node_key, bootstrap_import_path)
+			replacements.append(('imports', 'nodeKey', str(bootstrap_import_path / bootstrap_node_key.name)))
 		else:
 			log.error(_('import-bootstrap-importing-node-key-not-found').format(path=bootstrap_node_key))
 			sys.exit(1)
 
 	if replacements:
-		config_filepath = Path(args.config)
 		ConfigurationManager(config_filepath.parent).patch(config_filepath.name, replacements)
 
 

--- a/tools/shoestring/tests/commands/test_import_bootstrap.py
+++ b/tools/shoestring/tests/commands/test_import_bootstrap.py
@@ -16,9 +16,9 @@ EnabledImports = namedtuple('ImportsExpected', ['has_harvester', 'has_voter', 'h
 
 def build_expected_imports(enabled_imports):
 	return ImportsConfiguration(
-		'{bootstrap_root}/nodes/node/server-config/resources/config-harvesting.properties' if enabled_imports.has_harvester else '',
-		'{bootstrap_root}/nodes/node/votingkeys' if enabled_imports.has_voter else '',
-		'{bootstrap_root}/nodes/node/cert/node.key.pem' if enabled_imports.has_node_key else ''
+		'{config_path}/bootstrap-import/config-harvesting.properties' if enabled_imports.has_harvester else '',
+		'{config_path}/bootstrap-import/votingkeys' if enabled_imports.has_voter else '',
+		'{config_path}/bootstrap-import/node.key.pem' if enabled_imports.has_node_key else ''
 	)
 
 
@@ -42,8 +42,11 @@ async def _run_test(enabled_imports, expected_imports):
 				bootstrap_voting_keys_path.mkdir(parents=True)
 
 			if enabled_imports.has_node_key:
-				bootstrap_node_key_path = bootstrap_node_path / 'cert/node.key.pem'
+				bootstrap_node_key_path = bootstrap_node_path / 'cert'
 				bootstrap_node_key_path.mkdir(parents=True)
+				with open(bootstrap_node_key_path / 'node.key.pem', 'wt', encoding='utf8') as outfile:
+					outfile.write('node key')
+
 
 			# Act:
 			await main([
@@ -61,10 +64,13 @@ async def _run_test(enabled_imports, expected_imports):
 			])
 
 			assert [
-				expected_imports.harvester.format(bootstrap_root=bootstrap_directory),
-				expected_imports.voter.format(bootstrap_root=bootstrap_directory),
-				expected_imports.node_key.format(bootstrap_root=bootstrap_directory)
+				expected_imports.harvester.format(config_path=config_filepath.parent),
+				expected_imports.voter.format(config_path=config_filepath.parent),
+				expected_imports.node_key.format(config_path=config_filepath.parent),
 			] == imports
+
+			for file_path in imports:
+				assert Path(file_path).exists()
 
 
 # pylint: disable=invalid-name

--- a/tools/shoestring/tests/commands/test_import_bootstrap.py
+++ b/tools/shoestring/tests/commands/test_import_bootstrap.py
@@ -47,7 +47,6 @@ async def _run_test(enabled_imports, expected_imports):
 				with open(bootstrap_node_key_path / 'node.key.pem', 'wt', encoding='utf8') as outfile:
 					outfile.write('node key')
 
-
 			# Act:
 			await main([
 				'import-bootstrap',


### PR DESCRIPTION
problem: user delete their bootstrap folder after executing the import-bootstrap command 
solution: move the required Bootstrap import files under the shoestring configuration folder