### PR TITLE
[tools/shoestring] fix: pytest asyncio removed event loop

### DIFF
--- a/tools/shoestring/tests/commands/test_announce_transaction.py
+++ b/tools/shoestring/tests/commands/test_announce_transaction.py
@@ -17,8 +17,8 @@ from ..test.MockNodewatchServer import setup_mock_nodewatch_server
 
 
 @pytest.fixture
-def server(event_loop, aiohttp_client):
-	return setup_mock_nodewatch_server(event_loop, aiohttp_client, True)
+async def server(aiohttp_client):
+	return await setup_mock_nodewatch_server(aiohttp_client, True)
 
 # endregion
 

--- a/tools/shoestring/tests/commands/test_min_cosignatures_count.py
+++ b/tools/shoestring/tests/commands/test_min_cosignatures_count.py
@@ -20,8 +20,8 @@ from ..test.MockNodewatchServer import setup_mock_nodewatch_server
 
 
 @pytest.fixture
-def server(event_loop, aiohttp_client):
-	return setup_mock_nodewatch_server(event_loop, aiohttp_client, True)
+async def server(aiohttp_client):
+	return await setup_mock_nodewatch_server(aiohttp_client, True)
 
 # endregion
 

--- a/tools/shoestring/tests/commands/test_renew_voting_keys.py
+++ b/tools/shoestring/tests/commands/test_renew_voting_keys.py
@@ -28,8 +28,8 @@ from ..test.TransactionTestUtils import AggregateDescriptor, LinkDescriptor, ass
 
 
 @pytest.fixture
-def server(event_loop, aiohttp_client):
-	return setup_mock_nodewatch_server(event_loop, aiohttp_client, True)
+async def server(aiohttp_client):
+	return await setup_mock_nodewatch_server(aiohttp_client, True)
 
 
 # mock server is configured to return last finalized height as 2033136,

--- a/tools/shoestring/tests/commands/test_setup.py
+++ b/tools/shoestring/tests/commands/test_setup.py
@@ -22,8 +22,8 @@ from ..test.TestPackager import prepare_testnet_package
 
 
 @pytest.fixture
-def server(event_loop, aiohttp_client):
-	return setup_mock_nodewatch_server(event_loop, aiohttp_client, True)
+async def server(aiohttp_client):
+	return await setup_mock_nodewatch_server(aiohttp_client, True)
 
 # endregion
 

--- a/tools/shoestring/tests/commands/test_upgrade.py
+++ b/tools/shoestring/tests/commands/test_upgrade.py
@@ -25,8 +25,8 @@ from .test_setup import (
 
 
 @pytest.fixture
-def server(event_loop, aiohttp_client):
-	return setup_mock_nodewatch_server(event_loop, aiohttp_client, True)
+async def server(aiohttp_client):
+	return await setup_mock_nodewatch_server(aiohttp_client, True)
 
 # endregion
 

--- a/tools/shoestring/tests/healthagents/test_rest_api.py
+++ b/tools/shoestring/tests/healthagents/test_rest_api.py
@@ -13,8 +13,7 @@ from ..test.LogTestUtils import LogLevel, assert_max_log_level, assert_message_i
 # region (REST) server fixture
 
 
-@pytest.fixture
-def server(event_loop, aiohttp_client):
+async def server_impl(aiohttp_client):
 	class MockSymbolServer:
 		async def chain_info(self, request):
 			return await self._process(request, {
@@ -40,10 +39,15 @@ def server(event_loop, aiohttp_client):
 	app = web.Application()
 	app.router.add_get('/chain/info', mock_server.chain_info)
 	server_kwargs = {}
-	server = event_loop.run_until_complete(aiohttp_client(app, server_kwargs=server_kwargs))  # pylint: disable=redefined-outer-name
+	server = await aiohttp_client(app, server_kwargs=server_kwargs)  # pylint: disable=redefined-outer-name
 
 	server.mock = mock_server
 	return server
+
+
+@pytest.fixture
+async def server(aiohttp_client):
+	return await server_impl(aiohttp_client)
 
 # endregion
 

--- a/tools/shoestring/tests/healthagents/test_voting_keys.py
+++ b/tools/shoestring/tests/healthagents/test_voting_keys.py
@@ -20,8 +20,8 @@ from ..test.MockNodewatchServer import setup_mock_nodewatch_server
 
 
 @pytest.fixture
-def server(event_loop, aiohttp_client):
-	return setup_mock_nodewatch_server(event_loop, aiohttp_client, True)
+async def server(aiohttp_client):
+	return await setup_mock_nodewatch_server(aiohttp_client, True)
 
 # endregion
 

--- a/tools/shoestring/tests/internal/test_FileDownloader.py
+++ b/tools/shoestring/tests/internal/test_FileDownloader.py
@@ -14,8 +14,7 @@ SHA3_HASH_ABC = (
 # region server fixture
 
 
-@pytest.fixture
-def server(event_loop, aiohttp_client):
+async def server_impl(aiohttp_client):
 	class MockFileServer:
 		def __init__(self):
 			self.urls = []
@@ -33,10 +32,15 @@ def server(event_loop, aiohttp_client):
 	# create an app using the server
 	app = web.Application()
 	app.router.add_get('/known/file', mock_server.known_file)
-	server = event_loop.run_until_complete(aiohttp_client(app))  # pylint: disable=redefined-outer-name
+	server = await aiohttp_client(app)  # pylint: disable=redefined-outer-name
 
 	server.mock = mock_server
 	return server
+
+
+@pytest.fixture
+async def server(aiohttp_client):
+	return await server_impl(aiohttp_client)
 
 # endregion
 

--- a/tools/shoestring/tests/internal/test_NodeDownloader.py
+++ b/tools/shoestring/tests/internal/test_NodeDownloader.py
@@ -10,8 +10,8 @@ from ..test.MockNodewatchServer import setup_mock_nodewatch_server
 
 
 @pytest.fixture
-def server(event_loop, aiohttp_client):
-	return setup_mock_nodewatch_server(event_loop, aiohttp_client)
+async def server(aiohttp_client):
+	return await setup_mock_nodewatch_server(aiohttp_client)
 
 # endregion
 

--- a/tools/shoestring/tests/internal/test_NodewatchClient.py
+++ b/tools/shoestring/tests/internal/test_NodewatchClient.py
@@ -12,8 +12,8 @@ from ..test.MockNodewatchServer import setup_mock_nodewatch_server
 
 
 @pytest.fixture
-def server(event_loop, aiohttp_client):
-	return setup_mock_nodewatch_server(event_loop, aiohttp_client)
+async def server(aiohttp_client):
+	return await setup_mock_nodewatch_server(aiohttp_client)
 
 # endregion
 

--- a/tools/shoestring/tests/internal/test_OpensslExecutor.py
+++ b/tools/shoestring/tests/internal/test_OpensslExecutor.py
@@ -59,13 +59,13 @@ def test_can_dispatch_openssl_command_with_additional_command_input(capfd):
 	executor = _create_executor()
 
 	# Act:
-	output_lines = executor.dispatch(['s_client', '-connect', 'jenkins.symboldev.com:443'], command_input='Q')
+	output_lines = executor.dispatch(['s_client', '-connect', 'jenkins.symbolsyndicate.us:443'], command_input='Q')
 	standard_output, standard_error = capfd.readouterr()
 	subject_line = next(line for line in output_lines if line.startswith('subject='))
 
 	# Assert:
 	assert 0 != len(output_lines)
-	assert re.fullmatch(r'subject=CN ?= ?jenkins\.symboldev\.com\n', subject_line)
+	assert re.fullmatch(r'subject=CN ?= ?jenkins\.symbolsyndicate\.us\n', subject_line)
 	assert standard_output
 	assert not standard_error
 

--- a/tools/shoestring/tests/internal/test_PackageResolver.py
+++ b/tools/shoestring/tests/internal/test_PackageResolver.py
@@ -14,7 +14,7 @@ from ..test.TestPackager import prepare_testnet_package
 
 
 @pytest.fixture
-def server(event_loop, aiohttp_client):
+async def server(aiohttp_client):
 	class MockReleasesServer:
 		def __init__(self):
 			self.urls = []
@@ -59,7 +59,7 @@ def server(event_loop, aiohttp_client):
 	# create an app using the server
 	app = web.Application()
 	app.router.add_get('/releases', mock_server.api_symbol_height)
-	server = event_loop.run_until_complete(aiohttp_client(app))  # pylint: disable=redefined-outer-name
+	server = await aiohttp_client(app)  # pylint: disable=redefined-outer-name
 
 	server.mock = mock_server
 	return server
@@ -162,7 +162,7 @@ async def test_testnet_resolution_can_resolve_custom_testnet(server):  # pylint:
 # region download_and_extract_package
 
 @pytest.fixture
-def package_server(event_loop, aiohttp_client):
+async def package_server(aiohttp_client):
 	class MockPackageServer:
 		def __init__(self):
 			self.urls = []
@@ -181,7 +181,7 @@ def package_server(event_loop, aiohttp_client):
 	# create an app using the server
 	app = web.Application()
 	app.router.add_get('/package.zip', mock_server.package)
-	server = event_loop.run_until_complete(aiohttp_client(app))  # pylint: disable=redefined-outer-name
+	server = await aiohttp_client(app)  # pylint: disable=redefined-outer-name
 
 	server.mock = mock_server
 	return server

--- a/tools/shoestring/tests/internal/test_PeerDownloader.py
+++ b/tools/shoestring/tests/internal/test_PeerDownloader.py
@@ -12,8 +12,8 @@ from ..test.MockNodewatchServer import setup_mock_nodewatch_server
 
 
 @pytest.fixture
-def nodewatch_server(event_loop, aiohttp_client):
-	return setup_mock_nodewatch_server(event_loop, aiohttp_client)
+async def nodewatch_server(aiohttp_client):
+	return await setup_mock_nodewatch_server(aiohttp_client)
 
 # endregion
 

--- a/tools/shoestring/tests/test/MockNodewatchServer.py
+++ b/tools/shoestring/tests/test/MockNodewatchServer.py
@@ -80,7 +80,7 @@ NODEWATCH_API_NODES = [
 ]
 
 
-def setup_mock_nodewatch_server(event_loop, aiohttp_client, redirect_network_requests=False):
+async def setup_mock_nodewatch_server(aiohttp_client, redirect_network_requests=False):
 	class MockNodewatchServer:
 		def __init__(self):
 			self.urls = []
@@ -172,7 +172,7 @@ def setup_mock_nodewatch_server(event_loop, aiohttp_client, redirect_network_req
 		app.router.add_put('/transactions', mock_server.announce_transaction)
 		app.router.add_put('/transactions/partial', mock_server.announce_transaction)
 
-	server = event_loop.run_until_complete(aiohttp_client(app))  # pylint: disable=redefined-outer-name
+	server = await aiohttp_client(app)  # pylint: disable=redefined-outer-name
 
 	mock_server.endpoint = server.make_url('')
 	server.mock = mock_server


### PR DESCRIPTION
problem: in pytest asyncio v1 the event loop was removed
solution: remove the dependency on event loop and convert fixures and tests to async where needed