### PR TITLE
[lightapi/python] fix: pytest asyncio removed event loop

### DIFF
--- a/lightapi/python/tests/connector/test_BasicConnector.py
+++ b/lightapi/python/tests/connector/test_BasicConnector.py
@@ -10,7 +10,7 @@ from symbollightapi.connector.BasicConnector import BasicConnector, NodeExceptio
 
 
 @pytest.fixture
-def server(event_loop, aiohttp_client):
+async def server(aiohttp_client):
 	class MockHttpServer:
 		def __init__(self):
 			self.urls = []
@@ -64,7 +64,7 @@ def server(event_loop, aiohttp_client):
 	app.router.add_get('/node/info', mock_server.node_info)
 	app.router.add_put('/echo/put', mock_server.echo_put)
 	app.router.add_get(r'/status/{status_code}', mock_server.status_code)
-	server = event_loop.run_until_complete(aiohttp_client(app))  # pylint: disable=redefined-outer-name
+	server = await aiohttp_client(app)  # pylint: disable=redefined-outer-name
 
 	server.mock = mock_server
 	return server

--- a/lightapi/python/tests/connector/test_NemConnector.py
+++ b/lightapi/python/tests/connector/test_NemConnector.py
@@ -172,7 +172,7 @@ ACCOUNT_INFO_4 = {
 # region server fixture
 
 @pytest.fixture
-def server(event_loop, aiohttp_client):
+async def server(aiohttp_client):
 	class MockNemServer:
 		def __init__(self):
 			self.urls = []
@@ -215,7 +215,7 @@ def server(event_loop, aiohttp_client):
 	app.router.add_get('/node/peer-list/reachable', mock_server.node_peers_reachable)
 	app.router.add_get('/account/get', mock_server.account_info)
 	app.router.add_get('/account/get/forwarded', mock_server.account_info_forwarded)
-	server = event_loop.run_until_complete(aiohttp_client(app))  # pylint: disable=redefined-outer-name
+	server = await aiohttp_client(app)  # pylint: disable=redefined-outer-name
 
 	server.mock = mock_server
 	return server

--- a/lightapi/python/tests/connector/test_SymbolConnector.py
+++ b/lightapi/python/tests/connector/test_SymbolConnector.py
@@ -73,7 +73,7 @@ MULTISIG_INFO_1 = {
 # region server fixture
 
 @pytest.fixture
-def server(event_loop, aiohttp_client):
+async def server(aiohttp_client):
 	class MockSymbolServer:
 		def __init__(self):
 			self.urls = []
@@ -180,7 +180,7 @@ def server(event_loop, aiohttp_client):
 	app.router.add_get(r'/account/{address}/multisig', mock_server.account_multisig)
 	app.router.add_put('/transactions', mock_server.announce_transaction)
 	app.router.add_put('/transactions/partial', mock_server.announce_transaction)
-	server = event_loop.run_until_complete(aiohttp_client(app))  # pylint: disable=redefined-outer-name
+	server = await aiohttp_client(app)  # pylint: disable=redefined-outer-name
 
 	server.mock = mock_server
 	return server


### PR DESCRIPTION
problem: in pytest asyncio v1 the event loop was removed
solution: remove the dependency on event loop and convert fixures and tests to async where needed