### PR TITLE
[faucet/frontend] fix: linting error on import/extensions for the SDK

### DIFF
--- a/faucet/frontend/.eslintrc
+++ b/faucet/frontend/.eslintrc
@@ -10,5 +10,6 @@ rules:
     - json: always
       js: never
       jsx: never
+      ts: never
 globals:
   $t: false


### PR DESCRIPTION
problem: missing file extension "ts" for "symbol-sdk/symbol"  import/extensions
solution: disable the import extension for TS