### PR TITLE
[lightapi/python]: ignore deprecation warnings raised by zenlog library

### DIFF
--- a/lightapi/python/pyproject.toml
+++ b/lightapi/python/pyproject.toml
@@ -5,3 +5,8 @@ requires = [
 	"cffi>=1.15.0",
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+filterwarnings = [
+	"ignore:The 'warn' method is deprecated:DeprecationWarning"
+]


### PR DESCRIPTION
 problem: zenlog is calling deprecated warn function on Logger object from logger library
solution: configure pytest to ignore these warnings