### PR TITLE
[tools/shoestring] fix: exception handling during hostname validation in the wizard

### DIFF
--- a/tools/shoestring/shoestring/wizard/ValidatingTextBox.py
+++ b/tools/shoestring/shoestring/wizard/ValidatingTextBox.py
@@ -72,6 +72,8 @@ def is_hostname(value):
 		return True
 	except socket.gaierror:
 		return False
+	except ValueError:
+		return False
 
 
 def is_json(value):

--- a/tools/shoestring/shoestring/wizard/ValidatingTextBox.py
+++ b/tools/shoestring/shoestring/wizard/ValidatingTextBox.py
@@ -70,9 +70,7 @@ def is_hostname(value):
 	try:
 		socket.getaddrinfo(value, 7890)
 		return True
-	except socket.gaierror:
-		return False
-	except ValueError:
+	except (socket.gaierror, ValueError):
 		return False
 
 

--- a/tools/shoestring/tests/wizard/test_ValidatingTextBox.py
+++ b/tools/shoestring/tests/wizard/test_ValidatingTextBox.py
@@ -77,6 +77,7 @@ def test_is_hostname_returns_true_only_for_valid_hostname():
 	assert is_hostname('localhost')
 	assert not is_hostname('foo')
 	assert not is_hostname('')
+	assert not is_hostname('.')
 
 
 def test_is_json_returns_true_only_for_valid_json():


### PR DESCRIPTION
## Problem

- When entering a hostname that starts with a dot (e.g. `.example.com`) in the wizard, an exception occurs and a stack trace is displayed.

## Solution

- Although a `UnicodeError` is being raised, it can also be caught as a `ValueError`, so the exception handling is adjusted to catch `ValueError` to match the surrounding code.
