### PR TITLE
[lightapi/python]: explicitly order Symbol transactions in desc order

### DIFF
--- a/lightapi/python/symbollightapi/connector/ConnectorExtensions.py
+++ b/lightapi/python/symbollightapi/connector/ConnectorExtensions.py
@@ -1,16 +1,20 @@
-async def get_incoming_transactions_from(connector, address, start_height):
-	"""Uses the specified connector to retrieve all transactions sent an account at or after a specified block height."""
+async def get_incoming_transactions_from(connector, address, start_height=None, end_height=None):
+	"""Uses the specified connector to retrieve all transactions sent to an account in the range [start_height, end_height)."""
 
 	start_id = None
 	while True:
-		transactions = await connector.incoming_transactions(address, start_id)
-		if not transactions:
+		transactions_json = await connector.incoming_transactions(address, start_id)
+		if not transactions_json:
 			return
 
-		for transaction in transactions:
-			if int(transaction['meta']['height']) < start_height:
+		for transaction_json in transactions_json:
+			transaction_height = int(transaction_json['meta']['height'])
+			if start_height and transaction_height < start_height:
 				return
 
-			yield transaction
+			if end_height and transaction_height >= end_height:
+				continue
 
-		start_id = connector.extract_transaction_id(transactions[-1])
+			yield transaction_json
+
+		start_id = connector.extract_transaction_id(transactions_json[-1])

--- a/lightapi/python/symbollightapi/connector/SymbolConnector.py
+++ b/lightapi/python/symbollightapi/connector/SymbolConnector.py
@@ -212,7 +212,7 @@ class SymbolConnector(BasicConnector):
 		return await self._transactions(f'recipientAddress={address}', start_id)
 
 	async def _transactions(self, query_filter, start_id=None):
-		url_path = f'transactions/confirmed?{query_filter}&embedded=true&fromHeight=2&pageSize=100'
+		url_path = f'transactions/confirmed?{query_filter}&embedded=true&pageSize=100&order=desc'
 		if start_id:
 			url_path += f'&offset={start_id}'
 

--- a/lightapi/python/tests/connector/test_ConnectorExtensions.py
+++ b/lightapi/python/tests/connector/test_ConnectorExtensions.py
@@ -21,6 +21,14 @@ class MockConnector:
 
 # region get_incoming_transactions_from
 
+def _make_transaction_template_from_height(height):
+	transaction_json = {'meta': {'height': height}}
+	if 0 == height % 25:
+		transaction_json['meta']['id'] = (height // 25) * (height // 25)
+
+	return transaction_json
+
+
 async def test_get_incoming_transactions_from_can_return_none():
 	# Arrange:
 	connector = MockConnector({
@@ -28,52 +36,93 @@ async def test_get_incoming_transactions_from_can_return_none():
 	})
 
 	# Act:
-	transactions = [transaction async for transaction in get_incoming_transactions_from(connector, 'foo_address', 100)]
+	transactions = [transaction async for transaction in get_incoming_transactions_from(connector, 'foo_address')]
 
 	# Assert:
 	assert [] == transactions
 
 
-async def test_get_incoming_transactions_from_can_complete_in_single_remote_call():
+async def _assert_get_incoming_transactions_from_can_complete_in_single_remote_call(expected_returned_heights, **kwargs):
 	# Arrange:
 	connector = MockConnector({
-		('foo_address', None): [{'meta': {'height': height}} for height in [175, 125, 101, 100, 99, 75]]
+		('foo_address', None): [_make_transaction_template_from_height(height) for height in [176, 130, 125, 101, 100, 99, 75]],
+		('foo_address', 9): []
 	})
 
 	# Act:
-	transactions = [transaction async for transaction in get_incoming_transactions_from(connector, 'foo_address', 100)]
+	transactions = [transaction async for transaction in get_incoming_transactions_from(connector, 'foo_address', **kwargs)]
 
 	# Assert:
-	assert [{'meta': {'height': height}} for height in [175, 125, 101, 100]] == transactions
+	assert [_make_transaction_template_from_height(height) for height in expected_returned_heights] == transactions
+
+
+async def test_get_incoming_transactions_from_can_complete_in_single_remote_call():
+	await _assert_get_incoming_transactions_from_can_complete_in_single_remote_call([176, 130, 125, 101, 100, 99, 75])
+
+
+async def test_get_incoming_transactions_from_can_complete_in_single_remote_call_with_start_height_filter():
+	await _assert_get_incoming_transactions_from_can_complete_in_single_remote_call([176, 130, 125, 101, 100], start_height=100)
+
+
+async def test_get_incoming_transactions_from_can_complete_in_single_remote_call_with_end_height_filter():
+	await _assert_get_incoming_transactions_from_can_complete_in_single_remote_call([100, 99, 75], end_height=101)
+
+
+async def test_get_incoming_transactions_from_can_complete_in_single_remote_call_with_start_and_end_height_filter():
+	await _assert_get_incoming_transactions_from_can_complete_in_single_remote_call([125, 101, 100], start_height=100, end_height=130)
+
+
+async def _assert_get_incoming_transactions_from_can_complete_in_multiple_remote_calls(expected_returned_heights, **kwargs):
+	# Arrange:
+	connector = MockConnector({
+		('foo_address', None): [_make_transaction_template_from_height(height) for height in [176, 130, 125]],
+		('foo_address', 25): [_make_transaction_template_from_height(height) for height in [101, 100]],
+		('foo_address', 16): [_make_transaction_template_from_height(height) for height in [99, 75]],
+		('foo_address', 9): []
+	})
+
+	# Act:
+	transactions = [transaction async for transaction in get_incoming_transactions_from(connector, 'foo_address', **kwargs)]
+
+	# Assert:
+	assert [_make_transaction_template_from_height(height) for height in expected_returned_heights] == transactions
 
 
 async def test_get_incoming_transactions_from_can_complete_in_multiple_remote_calls():
+	await _assert_get_incoming_transactions_from_can_complete_in_multiple_remote_calls([176, 130, 125, 101, 100, 99, 75])
+
+
+async def test_get_incoming_transactions_from_can_complete_in_multiple_remote_calls_with_start_height_filter():
+	await _assert_get_incoming_transactions_from_can_complete_in_multiple_remote_calls([176, 130, 125, 101, 100], start_height=100)
+
+
+async def test_get_incoming_transactions_from_can_complete_in_multiple_remote_calls_with_end_height_filter():
+	await _assert_get_incoming_transactions_from_can_complete_in_multiple_remote_calls([100, 99, 75], end_height=101)
+
+
+async def test_get_incoming_transactions_from_can_complete_in_multiple_remote_calls_with_start_and_end_height_filter():
+	await _assert_get_incoming_transactions_from_can_complete_in_multiple_remote_calls([125, 101, 100], start_height=100, end_height=130)
+
+
+async def test_get_incoming_transactions_from_supports_string_heights_and_ids():
 	# Arrange:
+	def _make_transaction_template_from_height_str(height):
+		transaction_json = _make_transaction_template_from_height(height)
+		transaction_json['meta']['height'] = str(transaction_json['meta']['height'])
+		if 'id' in transaction_json['meta']:
+			transaction_json['meta']['id'] = str(transaction_json['meta']['id'])
+
+		return transaction_json
+
 	connector = MockConnector({
-		('foo_address', None): [{'meta': {'height': 175}}, {'meta': {'height': 125, 'id': 4}}],
-		('foo_address', 4): [{'meta': {'height': 101}}, {'meta': {'height': 100, 'id': 9}}],
-		('foo_address', 9): [{'meta': {'height': 99}}, {'meta': {'height': 75}}]
+		('foo_address', None): [_make_transaction_template_from_height_str(height) for height in [176, 130, 125, 101, 100, 99, 75]],
+		('foo_address', '9'): []
 	})
 
 	# Act:
-	transactions = [transaction async for transaction in get_incoming_transactions_from(connector, 'foo_address', 100)]
+	transactions = [transaction async for transaction in get_incoming_transactions_from(connector, 'foo_address')]
 
 	# Assert:
-	assert [
-		{'meta': {'height': 175}}, {'meta': {'height': 125, 'id': 4}}, {'meta': {'height': 101}}, {'meta': {'height': 100, 'id': 9}}
-	] == transactions
-
-
-async def test_get_incoming_transactions_from_supports_string_heights():
-	# Arrange:
-	connector = MockConnector({
-		('foo_address', None): [{'meta': {'height': str(height)}} for height in [175, 125, 101, 100, 99, 75]]
-	})
-
-	# Act:
-	transactions = [transaction async for transaction in get_incoming_transactions_from(connector, 'foo_address', 100)]
-
-	# Assert:
-	assert [{'meta': {'height': str(height)}} for height in [175, 125, 101, 100]] == transactions
+	assert [_make_transaction_template_from_height_str(height) for height in [176, 130, 125, 101, 100, 99, 75]] == transactions
 
 # endregion

--- a/lightapi/python/tests/connector/test_SymbolConnector.py
+++ b/lightapi/python/tests/connector/test_SymbolConnector.py
@@ -589,7 +589,7 @@ async def test_incoming_transactions(server):  # pylint: disable=redefined-outer
 
 	# Assert:
 	assert [
-		f'{server.make_url("")}/transactions/confirmed?recipientAddress={Address(SYMBOL_ADDRESSES[0])}&embedded=true&fromHeight=2&pageSize=100'
+		f'{server.make_url("")}/transactions/confirmed?recipientAddress={Address(SYMBOL_ADDRESSES[0])}&embedded=true&pageSize=100&order=desc'
 	] == server.mock.urls
 	assert 4 == len(transactions)
 


### PR DESCRIPTION
 problem: transactions/confirmed does not seem to be returning transactions in desc order
solution: explicitly specify desc order