### PR TITLE
[lightapi/python]: add `balance`  to NemConnector and SymbolConnector and other fixes

### DIFF
--- a/lightapi/python/symbollightapi/connector/NemConnector.py
+++ b/lightapi/python/symbollightapi/connector/NemConnector.py
@@ -129,7 +129,13 @@ class NemConnector(BasicConnector):
 
 	# endregion
 
-	# region GET (account_info)
+	# region GET (balance, account_info)
+
+	async def balance(self, address):
+		"""Gets account balance for specified mosaic."""
+
+		response_json = await self.get(f'account/get?address={address}')
+		return response_json['account']['balance']
 
 	async def account_info(self, address, forwarded=False):
 		subpath = '/forwarded' if forwarded else ''

--- a/lightapi/python/symbollightapi/connector/NemConnector.py
+++ b/lightapi/python/symbollightapi/connector/NemConnector.py
@@ -90,8 +90,8 @@ class NemConnector(BasicConnector):
 	async def node_info(self):
 		"""Gets node information."""
 
-		node_dict = await self.get('node/info')
-		node_info = self._map_to_node_info(node_dict)
+		node_json = await self.get('node/info')
+		node_info = self._map_to_node_info(node_json)
 
 		# lookup main account public key
 		node_address = self.network.public_key_to_address(node_info.node_public_key)
@@ -105,16 +105,16 @@ class NemConnector(BasicConnector):
 		return node_info
 
 	@staticmethod
-	def _map_to_node_info(node_dict):
-		endpoint_dict = node_dict['endpoint']
+	def _map_to_node_info(node_json):
+		endpoint_json = node_json['endpoint']
 		return NodeInfo(
-			node_dict['metaData']['networkId'],
+			node_json['metaData']['networkId'],
 			None,  # NEM does not have network generation hash seed
 			None,
-			PublicKey(node_dict['identity']['public-key']),
-			Endpoint(endpoint_dict['protocol'], endpoint_dict['host'], endpoint_dict['port']),
-			node_dict['identity']['name'],
-			node_dict['metaData']['version'],
+			PublicKey(node_json['identity']['public-key']),
+			Endpoint(endpoint_json['protocol'], endpoint_json['host'], endpoint_json['port']),
+			node_json['identity']['name'],
+			node_json['metaData']['version'],
 			NodeInfo.API_ROLE_FLAG)
 
 	# endregion
@@ -124,8 +124,8 @@ class NemConnector(BasicConnector):
 	async def peers(self):
 		"""Gets peer nodes information."""
 
-		nodes_dict = await self.get('node/peer-list/reachable', 'data')
-		return [self._map_to_node_info(node_dict) for node_dict in nodes_dict]
+		nodes_json = await self.get('node/peer-list/reachable', 'data')
+		return [self._map_to_node_info(node_json) for node_json in nodes_json]
 
 	# endregion
 
@@ -133,18 +133,18 @@ class NemConnector(BasicConnector):
 
 	async def account_info(self, address, forwarded=False):
 		subpath = '/forwarded' if forwarded else ''
-		response_dict = await self.get(f'account/get{subpath}?address={address}')
+		response_json = await self.get(f'account/get{subpath}?address={address}')
 
-		account_dict = response_dict['account']
-		account_info = NemAccountInfo(Address(account_dict['address']))
-		account_info.vested_balance = account_dict['vestedBalance'] / MICROXEM_PER_XEM
-		account_info.balance = account_dict['balance'] / MICROXEM_PER_XEM
-		account_info.public_key = PublicKey(account_dict['publicKey']) if account_dict['publicKey'] else None
-		account_info.importance = account_dict['importance']
-		account_info.harvested_blocks = account_dict['harvestedBlocks']
+		account_json = response_json['account']
+		account_info = NemAccountInfo(Address(account_json['address']))
+		account_info.vested_balance = account_json['vestedBalance'] / MICROXEM_PER_XEM
+		account_info.balance = account_json['balance'] / MICROXEM_PER_XEM
+		account_info.public_key = PublicKey(account_json['publicKey']) if account_json['publicKey'] else None
+		account_info.importance = account_json['importance']
+		account_info.harvested_blocks = account_json['harvestedBlocks']
 
-		meta_dict = response_dict['meta']
-		account_info.remote_status = meta_dict['remoteStatus']
+		meta_json = response_json['meta']
+		account_info.remote_status = meta_json['remoteStatus']
 		return account_info
 
 	# endregion

--- a/lightapi/python/symbollightapi/connector/SymbolConnector.py
+++ b/lightapi/python/symbollightapi/connector/SymbolConnector.py
@@ -139,6 +139,17 @@ class SymbolConnector(BasicConnector):
 
 	# endregion
 
+	# region GET (balance)
+
+	async def balance(self, account_id, mosaic_id):
+		"""Gets account balance for specified mosaic."""
+
+		json_account = await self.get(f'accounts/{account_id}', 'account')
+		json_mosaic = next((json_mosaic for json_mosaic in json_account['mosaics'] if json_mosaic['id'] == mosaic_id), None)
+		return int(json_mosaic['amount']) if json_mosaic else 0
+
+	# endregion
+
 	# region GET (account_links)
 
 	async def account_links(self, account_id):

--- a/lightapi/python/tests/connector/test_NemConnector.py
+++ b/lightapi/python/tests/connector/test_NemConnector.py
@@ -434,7 +434,19 @@ async def test_can_query_peers(server):  # pylint: disable=redefined-outer-name
 # endregion
 
 
-# region GET (account_info)
+# region GET (balance, account_info)
+
+async def test_can_query_balance(server):  # pylint: disable=redefined-outer-name
+	# Arrange:
+	connector = NemConnector(server.make_url(''))
+
+	# Act:
+	balance = await connector.balance(Address('NCXIQA4FF5JB6AMQ53NQ3ZMRD3X3PJEWDJJJIGHT'))
+
+	# Assert:
+	assert [f'{server.make_url("")}/account/get?address=NCXIQA4FF5JB6AMQ53NQ3ZMRD3X3PJEWDJJJIGHT'] == server.mock.urls
+	assert 20612823_531967 == balance
+
 
 def _assert_account_info_1(account_info):
 	assert Address('NCXIQA4FF5JB6AMQ53NQ3ZMRD3X3PJEWDJJJIGHT') == account_info.address

--- a/lightapi/python/tests/connector/test_SymbolPeerConnector.py
+++ b/lightapi/python/tests/connector/test_SymbolPeerConnector.py
@@ -95,7 +95,8 @@ async def server():  # pylint: disable=too-many-statements
 			packet_header = PacketHeader.deserialize_from_buffer(header)
 
 			if server.simulate_long_operation:
-				await asyncio.sleep(0.25)
+				server.sleep_task = asyncio.create_task(asyncio.sleep(0.25))
+				await server.sleep_task
 
 			response_header = PacketHeader()
 			response_buffer_writer = BufferWriter()
@@ -143,9 +144,13 @@ async def server():  # pylint: disable=too-many-statements
 	server.simulate_long_operation = False
 	server.simulate_corrupt_packet = False
 	server.simulate_corrupt_packet_type = False
+	server.sleep_task = None
 	server.host = '127.0.0.1'
 	server.port = 8888
 	yield server
+
+	if server.sleep_task:
+		server.sleep_task.cancel()
 
 	server.close()
 


### PR DESCRIPTION
    [lightapi/python]: add `balance`  to NemConnector and SymbolConnector
    
     problem: need to retrieve balance of an account
    solution: add balance function in connectors

    [lightapi/python]: standardize naming convention to use *_json
    
     problem: inconsistent naming is being used - *_json json_* _dict* dict_*
    solution: standardize on *_json

    [lightapi/python]: fix race condition in test_can_handle_timeout
    
     problem: sleep task can be destroyed while sleeping leading to a warning
    solution: explicitly cancel the sleep task at the end of the test
