### PR TITLE
shoestring: add gettext fallback=True to avoid missing messages error

### DIFF
--- a/tools/shoestring/shoestring/__main__.py
+++ b/tools/shoestring/shoestring/__main__.py
@@ -41,7 +41,7 @@ def parse_args(args):
 
 async def main(args):
 	lang_directory = Path(__file__).resolve().parent / 'lang'
-	lang = gettext.translation('messages', localedir=lang_directory, languages=(os.environ.get('LC_MESSAGES', 'en'), 'en'))
+	lang = gettext.translation('messages', localedir=lang_directory, languages=(os.environ.get('LC_MESSAGES', 'en'), 'en'), fallback=True)
 	lang.install()
 
 	args = parse_args(args)


### PR DESCRIPTION
Fixes missing translation files by adding fallback=True to gettext.translation calls in both the main CLI and the wizard.