### PR TITLE
[lightapi/python]: add a few more needed extensions

### DIFF
--- a/lightapi/python/requirements.txt
+++ b/lightapi/python/requirements.txt
@@ -1,3 +1,4 @@
 aiohttp~=3.12.6
+aiolimiter~=1.2.1
 symbol-sdk-python~=3.2.3
 zenlog~=1.1

--- a/lightapi/python/symbollightapi/connector/ConnectorExtensions.py
+++ b/lightapi/python/symbollightapi/connector/ConnectorExtensions.py
@@ -1,4 +1,11 @@
+import asyncio
+
+from aiolimiter import AsyncLimiter
+
+from ..model.Constants import DEFAULT_ASYNC_LIMITER_ARGUMENTS
+
 # region get_incoming_transactions_from
+
 
 async def get_incoming_transactions_from(connector, address, start_height=None, end_height=None):
 	"""Uses the specified connector to retrieve all transactions sent to an account in the range [start_height, end_height)."""
@@ -34,5 +41,25 @@ async def filter_finalized_transactions(connector, transaction_hashes):
 	return list(filter(
 		lambda transaction_hash_height_pair: transaction_hash_height_pair[1] <= finalized_chain_height,
 		transaction_hash_height_pairs))
+
+# endregion
+
+
+# region query_block_timestamps
+
+async def query_block_timestamps(connector, heights, async_limiter_arguments=DEFAULT_ASYNC_LIMITER_ARGUMENTS):
+	"""Finds the timestamps for all blocks with the specified heights."""
+
+	limiter = AsyncLimiter(*async_limiter_arguments)
+
+	async def get_block_height_timestamp_pair(height):
+		async with limiter:
+			block_json = await connector.block_headers(height)
+			timestamp = connector.extract_block_timestamp(block_json)
+			return (height, timestamp)
+
+	tasks = [get_block_height_timestamp_pair(height) for height in heights]
+	block_height_timestamp_pairs = await asyncio.gather(*tasks)
+	return block_height_timestamp_pairs
 
 # endregion

--- a/lightapi/python/symbollightapi/connector/ConnectorExtensions.py
+++ b/lightapi/python/symbollightapi/connector/ConnectorExtensions.py
@@ -1,3 +1,5 @@
+# region get_incoming_transactions_from
+
 async def get_incoming_transactions_from(connector, address, start_height=None, end_height=None):
 	"""Uses the specified connector to retrieve all transactions sent to an account in the range [start_height, end_height)."""
 
@@ -18,3 +20,19 @@ async def get_incoming_transactions_from(connector, address, start_height=None, 
 			yield transaction_json
 
 		start_id = connector.extract_transaction_id(transactions_json[-1])
+
+# endregion
+
+
+# region filter_finalized_transactions
+
+async def filter_finalized_transactions(connector, transaction_hashes):
+	"""Filters transaction hashes and returns only finalized ones with heights."""
+
+	finalized_chain_height = await connector.finalized_chain_height()
+	transaction_hash_height_pairs = await connector.filter_confirmed_transactions(transaction_hashes)
+	return list(filter(
+		lambda transaction_hash_height_pair: transaction_hash_height_pair[1] <= finalized_chain_height,
+		transaction_hash_height_pairs))
+
+# endregion

--- a/lightapi/python/symbollightapi/connector/NemConnector.py
+++ b/lightapi/python/symbollightapi/connector/NemConnector.py
@@ -45,13 +45,19 @@ class NemConnector(BasicConnector):
 		super().__init__(endpoint)
 		self.network = network
 
-	# region extract_transaction_id
+	# region extract_transaction_id, extract_block_timestamp
 
 	@staticmethod
 	def extract_transaction_id(transaction):
 		"""Extracts the transaction id from a REST transaction JSON object."""
 
 		return transaction['meta']['id']
+
+	@staticmethod
+	def extract_block_timestamp(block):
+		"""Extracts the block timestamp from a REST block header JSON object."""
+
+		return block['timeStamp']
 
 	# endregion
 

--- a/lightapi/python/symbollightapi/connector/NemConnector.py
+++ b/lightapi/python/symbollightapi/connector/NemConnector.py
@@ -140,11 +140,19 @@ class NemConnector(BasicConnector):
 
 	# region GET (balance, account_info)
 
-	async def balance(self, address):
+	async def balance(self, address, mosaic_id=None):
 		"""Gets account balance for specified mosaic."""
 
-		response_json = await self.get(f'account/get?address={address}')
-		return response_json['account']['balance']
+		if not mosaic_id:
+			response_json = await self.get(f'account/get?address={address}')
+			return response_json['account']['balance']
+
+		mosaics_json = await self.get(f'account/mosaic/owned?address={address}', 'data')
+		mosaic_json = next((
+			mosaic_json for mosaic_json in mosaics_json
+			if (mosaic_json['mosaicId']['namespaceId'], mosaic_json['mosaicId']['name']) == mosaic_id
+		), None)
+		return mosaic_json['quantity'] if mosaic_json else 0
 
 	async def account_info(self, address, forwarded=False):
 		subpath = '/forwarded' if forwarded else ''

--- a/lightapi/python/symbollightapi/connector/SymbolConnector.py
+++ b/lightapi/python/symbollightapi/connector/SymbolConnector.py
@@ -205,13 +205,23 @@ class SymbolConnector(BasicConnector):
 
 	# endregion
 
-	# region POST (transaction_statuses)
+	# region POST (transaction_statuses, filter_confirmed_transactions)
 
 	async def transaction_statuses(self, transaction_hashes):
 		"""Gets the statuses of the specified transactions."""
 
 		request = {'hashes': [str(transaction_hash) for transaction_hash in transaction_hashes]}
 		return await self.post('transactionStatus', request)
+
+	async def filter_confirmed_transactions(self, transaction_hashes):
+		"""Filters transaction hashes and returns only confirmed ones with (confirmed) heights."""
+
+		transaction_statuses = await self.transaction_statuses(transaction_hashes)
+		return [
+			(Hash256(transaction_status['hash']), int(transaction_status['height']))
+			for transaction_status in transaction_statuses
+			if 'confirmed' == transaction_status['group']
+		]
 
 	# endregion
 

--- a/lightapi/python/symbollightapi/connector/SymbolConnector.py
+++ b/lightapi/python/symbollightapi/connector/SymbolConnector.py
@@ -40,13 +40,19 @@ class SymbolConnector(BasicConnector):
 		super().__init__(endpoint)
 		self._network_properties = None
 
-	# region extract_transaction_id
+	# region extract_transaction_id, extract_block_timestamp
 
 	@staticmethod
 	def extract_transaction_id(transaction):
 		"""Extracts the transaction id from a REST transaction JSON object."""
 
 		return transaction['id']
+
+	@staticmethod
+	def extract_block_timestamp(block):
+		"""Extracts the block timestamp from a REST block header JSON object."""
+
+		return int(block['block']['timestamp'])
 
 	# endregion
 
@@ -96,6 +102,16 @@ class SymbolConnector(BasicConnector):
 
 		timestamps = await self.get('node/time')
 		return NetworkTimestamp(int(timestamps['communicationTimestamps']['sendTimestamp']))
+
+	# endregion
+
+	# region GET (block_headers)
+
+	async def block_headers(self, height):
+		"""Gets block headers."""
+
+		block = await self.get(f'blocks/{height}')
+		return block
 
 	# endregion
 

--- a/lightapi/python/symbollightapi/connector/SymbolConnector.py
+++ b/lightapi/python/symbollightapi/connector/SymbolConnector.py
@@ -160,9 +160,9 @@ class SymbolConnector(BasicConnector):
 	async def balance(self, account_id, mosaic_id):
 		"""Gets account balance for specified mosaic."""
 
-		json_account = await self.get(f'accounts/{account_id}', 'account')
-		json_mosaic = next((json_mosaic for json_mosaic in json_account['mosaics'] if json_mosaic['id'] == mosaic_id), None)
-		return int(json_mosaic['amount']) if json_mosaic else 0
+		account_json = await self.get(f'accounts/{account_id}', 'account')
+		mosaic_json = next((mosaic_json for mosaic_json in account_json['mosaics'] if mosaic_json['id'] == mosaic_id), None)
+		return int(mosaic_json['amount']) if mosaic_json else 0
 
 	# endregion
 

--- a/lightapi/python/symbollightapi/model/Constants.py
+++ b/lightapi/python/symbollightapi/model/Constants.py
@@ -1,0 +1,1 @@
+DEFAULT_ASYNC_LIMITER_ARGUMENTS = (20, 0.1)  # allow up to 20 requests every 0.1 seconds

--- a/lightapi/python/tests/connector/test_NemConnector.py
+++ b/lightapi/python/tests/connector/test_NemConnector.py
@@ -300,7 +300,7 @@ async def server(aiohttp_client):
 # pylint: disable=invalid-name
 
 
-# region extract_transaction_id
+# region extract_transaction_id, extract_block_timestamp
 
 def test_can_extract_transaction_id():
 	# Act:
@@ -311,6 +311,17 @@ def test_can_extract_transaction_id():
 
 	# Assert:
 	assert 5577 == transaction_id
+
+
+def test_can_extract_block_timestamp():
+	# Act:
+	timestamp = NemConnector.extract_block_timestamp({
+		'timeStamp': 1234,
+		'meta': {'timeStamp': 5577}
+	})
+
+	# Assert:
+	assert 1234 == timestamp
 
 # endregion
 
@@ -365,8 +376,8 @@ async def test_can_get_block_headers(server):  # pylint: disable=redefined-outer
 	headers = await connector.block_headers(1000)
 
 	# Assert:
-	assert {'type': 1, 'signer': PUBLIC_KEYS[0], 'timeStamp': 201000} == headers
 	assert [f'{server.make_url("")}/block/at/public'] == server.mock.urls
+	assert {'type': 1, 'signer': PUBLIC_KEYS[0], 'timeStamp': 201000} == headers
 
 # endregion
 

--- a/lightapi/python/tests/connector/test_SymbolConnector.py
+++ b/lightapi/python/tests/connector/test_SymbolConnector.py
@@ -575,7 +575,7 @@ async def test_can_query_account_multisig_information_for_known_account(server):
 # endregion
 
 
-# region POST (transaction_statuses)
+# region POST (transaction_statuses, filter_confirmed_transactions)
 
 async def test_can_query_transaction_statuses(server):  # pylint: disable=redefined-outer-name
 	# Arrange:
@@ -602,6 +602,21 @@ async def test_can_query_transaction_statuses(server):  # pylint: disable=redefi
 	assert 'Success' == transaction_statuses[2]['code']
 	assert str(HASHES[1]) == transaction_statuses[2]['hash']
 	assert '111003' == transaction_statuses[2]['height']
+
+
+async def test_can_filter_confirmed_transactions(server):  # pylint: disable=redefined-outer-name
+	# Arrange:
+	connector = SymbolConnector(server.make_url(''))
+
+	# Act:
+	transaction_hash_height_pairs = await connector.filter_confirmed_transactions([HASHES[0], HASHES[2], HASHES[1]])
+
+	# Assert:
+	assert [f'{server.make_url("")}/transactionStatus'] == server.mock.urls
+	assert 2 == len(transaction_hash_height_pairs)
+
+	assert (Hash256(HASHES[0]), 111001) == transaction_hash_height_pairs[0]
+	assert (Hash256(HASHES[1]), 111003) == transaction_hash_height_pairs[1]
 
 # endregion
 


### PR DESCRIPTION
    [lightapi/python]: add query_block_timestamps
    
     problem: need to lookup timestamps of block heights
    solution: add query_block_timestamps extension
              add block_headers to SymbolConnector

    [lightapi/python]: add filter_finalized_transactions
    
     problem: need to select finalized transactions from a group of transactions
    solution: add filter_finalized_transactions extension
              add filter_confirmed_transactions to SymbolConnector and NemConnector
