### PR TITLE
[bridge]: add workflow for checking completed wrap payout transactions

### DIFF
--- a/bridge/requirements.txt
+++ b/bridge/requirements.txt
@@ -1,3 +1,4 @@
+aiolimiter~=1.2.1 # remove when updating lightapi
 symbol-lightapi~=0.0.7
 symbol-sdk-python==3.2.3
 web3==7.12.0

--- a/bridge/workflows/calculate_conversion.py
+++ b/bridge/workflows/calculate_conversion.py
@@ -29,10 +29,9 @@ async def main_impl(databases, native_network, wrapped_network):
 	print(f'{len(wrap_requests_to_send)} requests need to be sent')
 
 	for wrap_request in wrap_requests_to_send:
-		transaction_hash = await send_wrapped_tokens(wrapped_network.facade, wrap_request, conversion_rate)
-		databases.wrap_request.set_request_status(wrap_request, WrapRequestStatus.SENT, transaction_hash)
-		print(f'sent transaction with hash: {transaction_hash}')
-		break  # temporarily only send a single transaction for easier testing
+		payout_transaction_hash = await send_wrapped_tokens(wrapped_network.facade, wrap_request, conversion_rate)
+		databases.wrap_request.mark_payout_sent(wrap_request, payout_transaction_hash)
+		print(f'sent transaction with hash: {payout_transaction_hash}')
 
 	wrap_requests_sent = databases.wrap_request.requests_by_status(WrapRequestStatus.SENT)
 	print(f'{len(wrap_requests_sent)} requests have been sent')

--- a/bridge/workflows/check_finalized_transactions.py
+++ b/bridge/workflows/check_finalized_transactions.py
@@ -1,0 +1,30 @@
+import asyncio
+
+from symbollightapi.connector.ConnectorExtensions import filter_finalized_transactions, query_block_timestamps
+
+from .main_impl import main_bootstrapper
+
+
+async def main_impl(databases, _native_network, wrapped_network):
+	payout_transaction_hashes = databases.wrap_request.unconfirmed_payout_transaction_hashes()
+	print(f'found {len(payout_transaction_hashes)} unconfirmed payout transaction hashes')
+
+	connector = wrapped_network.facade.create_connector()
+	transaction_hash_height_pairs = await filter_finalized_transactions(connector, payout_transaction_hashes)
+	print(f'found {len(transaction_hash_height_pairs)} finalized payout transactions')
+
+	for hash_height_pair in transaction_hash_height_pairs:
+		databases.wrap_request.mark_payout_completed(*hash_height_pair)
+		print(f'marking payout transaction {hash_height_pair[0]} complete at height {hash_height_pair[1]}')
+
+	heights = {hash_height_pair[1] for hash_height_pair in transaction_hash_height_pairs}
+	print(f'found {len(heights)} block heights')
+
+	block_height_timestamp_pairs = await query_block_timestamps(connector, heights)
+	for height_timestamp_pair in block_height_timestamp_pairs:
+		databases.wrap_request.set_block_timestamp(*height_timestamp_pair)
+		print(f'saving block {height_timestamp_pair[0]} with timestamp {height_timestamp_pair[1]}')
+
+
+if '__main__' == __name__:
+	asyncio.run(main_bootstrapper('check finalized transactions', main_impl))


### PR DESCRIPTION
 problem: after sending payout transactions need to monitor their completion
solution: add workflow for tracking payout transactions
          rework WrapRequestDatabase to store all required information