### PR TITLE
[bridge]: update network facades to support arbitrary mosaics

### DIFF
--- a/bridge/bridge/symbol/SymbolNetworkFacade.py
+++ b/bridge/bridge/symbol/SymbolNetworkFacade.py
@@ -51,16 +51,24 @@ class SymbolNetworkFacade:
 
 		return self.network.is_valid_address_string(address_string)
 
-	def extract_wrap_request_from_transaction(self, is_valid_address, transaction_with_meta_json):  # pylint: disable=invalid-name
+	def extract_wrap_request_from_transaction(self, is_valid_address, transaction_with_meta_json, mosaic_id=None):
+		# pylint: disable=invalid-name
 		"""Extracts a wrap request (or error) from a transaction ."""
 
-		return extract_wrap_request_from_transaction(self.network, is_valid_address, self.is_currency_mosaic_id, transaction_with_meta_json)
+		is_matching_mosaic_id = self.is_currency_mosaic_id
+		if mosaic_id:
+			def is_custom_mosaic_id(test_mosaic_id):
+				return mosaic_id == test_mosaic_id
 
-	async def lookup_account_balance(self, address):
+			is_matching_mosaic_id = is_custom_mosaic_id
+
+		return extract_wrap_request_from_transaction(self.network, is_valid_address, is_matching_mosaic_id, transaction_with_meta_json)
+
+	async def lookup_account_balance(self, address, mosaic_id=None):
 		"""Gets account balance for network currency."""
 
 		connector = self.create_connector()
-		formatted_currency_mosaic_id = hex(self.currency_mosaic_ids[0])[2:].upper()
+		formatted_currency_mosaic_id = hex(mosaic_id or self.currency_mosaic_ids[0])[2:].upper()
 		return await connector.balance(address, formatted_currency_mosaic_id)
 
 	def create_transfer_transaction(self, timestamp, balance_transfer, mosaic_id=None):

--- a/bridge/bridge/symbol/SymbolUtils.py
+++ b/bridge/bridge/symbol/SymbolUtils.py
@@ -6,7 +6,7 @@ from symbolchain.sc import TransactionType
 
 from ..models.WrapRequest import TransactionIdentifier, check_address_and_make_wrap_result, make_wrap_error_result
 
-Predicates = namedtuple('Predicates', ['is_valid_address', 'is_currency_mosaic_id'])
+Predicates = namedtuple('Predicates', ['is_valid_address', 'is_matching_mosaic_id'])
 
 
 # region extract_wrap_address_from_transaction
@@ -15,7 +15,7 @@ Predicates = namedtuple('Predicates', ['is_valid_address', 'is_currency_mosaic_i
 def _process_transfer_transaction(predicates, transaction_identifier, transaction_json):
 	amount = 0
 	for mosaic_json in transaction_json['mosaics']:
-		if predicates.is_currency_mosaic_id(int(mosaic_json['id'], 16)):
+		if predicates.is_matching_mosaic_id(int(mosaic_json['id'], 16)):
 			amount = int(mosaic_json['amount'])
 
 	if 'message' not in transaction_json:
@@ -34,11 +34,11 @@ def _process_transaction(predicates, transaction_identifier, transaction_json):
 	return make_wrap_error_result(transaction_identifier, error_message)
 
 
-def extract_wrap_request_from_transaction(network, is_valid_address, is_currency_mosaic_id, transaction_with_meta_json):
+def extract_wrap_request_from_transaction(network, is_valid_address, is_matching_mosaic_id, transaction_with_meta_json):
 	# pylint: disable=invalid-name
 	"""Extracts a wrap request (or error) from a transaction given a network."""
 
-	predicates = Predicates(is_valid_address, is_currency_mosaic_id)
+	predicates = Predicates(is_valid_address, is_matching_mosaic_id)
 
 	transaction_json = transaction_with_meta_json['transaction']
 	transaction_type = transaction_json['type']

--- a/bridge/tests/nem/test_NemUtils.py
+++ b/bridge/tests/nem/test_NemUtils.py
@@ -67,7 +67,7 @@ class NemUtilsTest(unittest.TestCase):
 		}
 
 		transaction_version = kwargs.get('transaction_version', TransferTransactionV1.TRANSACTION_VERSION)
-		transaction_meta_json = {
+		transaction_with_meta_json = {
 			'meta': {
 				'height': request.transaction_height,
 				'hash': {
@@ -87,70 +87,70 @@ class NemUtilsTest(unittest.TestCase):
 		}
 
 		if 1 < transaction_version:
-			transaction_meta_json['transaction']['mosaics'] = []
+			transaction_with_meta_json['transaction']['mosaics'] = []
 
-		return transaction_meta_json
+		return transaction_with_meta_json
 
-	def _assert_can_create_wrap_request_from_simple_transfer(self, **kwargs):
+	def _assert_can_extract_wrap_request_from_simple_transfer(self, **kwargs):
 		# Arrange:
 		request = self._create_simple_wrap_request()
-		transaction_meta_json = self._create_transfer_json(request, **kwargs)
+		transaction_with_meta_json = self._create_transfer_json(request, **kwargs)
 
 		# Act:
-		result = self._extract_wrap_request_from_transaction(transaction_meta_json)
+		result = self._extract_wrap_request_from_transaction(transaction_with_meta_json)
 
 		# Assert:
 		assert_wrap_request_success(self, result, request)
 
-	def test_can_create_wrap_request_from_simple_transfer_v1(self):
-		self._assert_can_create_wrap_request_from_simple_transfer(transaction_version=TransferTransactionV1.TRANSACTION_VERSION)
+	def test_can_extract_wrap_request_from_simple_transfer_v1(self):
+		self._assert_can_extract_wrap_request_from_simple_transfer(transaction_version=TransferTransactionV1.TRANSACTION_VERSION)
 
-	def test_can_create_wrap_request_from_simple_transfer_v2(self):
-		self._assert_can_create_wrap_request_from_simple_transfer(transaction_version=TransferTransactionV2.TRANSACTION_VERSION)
+	def test_can_extract_wrap_request_from_simple_transfer_v2(self):
+		self._assert_can_extract_wrap_request_from_simple_transfer(transaction_version=TransferTransactionV2.TRANSACTION_VERSION)
 
 	@staticmethod
 	def _create_transfer_json_with_single_bag(request, amount, mosaic_amount):
-		transaction_meta_json = NemUtilsTest._create_transfer_json(request, transaction_version=TransferTransactionV2.TRANSACTION_VERSION)
-		transaction_meta_json['transaction']['amount'] = amount  # override amount from request
-		transaction_meta_json['transaction']['mosaics'] = [
+		transaction_with_meta_json = NemUtilsTest._create_transfer_json(request, transaction_version=TransferTransactionV2.TRANSACTION_VERSION)
+		transaction_with_meta_json['transaction']['amount'] = amount  # override amount from request
+		transaction_with_meta_json['transaction']['mosaics'] = [
 			{
 				'mosaicId': {'namespaceId': 'nem', 'name': 'xem'},
 				'quantity': mosaic_amount
 			}
 		]
 
-		return transaction_meta_json
+		return transaction_with_meta_json
 
-	def _assert_can_create_wrap_request_from_single_xem_mosaic_in_bag(self, amount, mosaic_amount, expected_amount):
+	def _assert_can_extract_wrap_request_from_single_xem_mosaic_in_bag(self, amount, mosaic_amount, expected_amount):
 		# Arrange:
 		request = self._create_simple_wrap_request()
-		transaction_meta_json = self._create_transfer_json_with_single_bag(request, amount, mosaic_amount)
+		transaction_with_meta_json = self._create_transfer_json_with_single_bag(request, amount, mosaic_amount)
 
 		# Act:
-		result = self._extract_wrap_request_from_transaction(transaction_meta_json)
+		result = self._extract_wrap_request_from_transaction(transaction_with_meta_json)
 
 		# Assert:
 		assert_wrap_request_success(self, result, change_request_amount(request, expected_amount))
 
-	def test_can_create_wrap_request_from_single_bag_transfer_v2(self):
-		self._assert_can_create_wrap_request_from_single_xem_mosaic_in_bag(2_000000, 12345_000000, 24690_000000)
+	def test_can_extract_wrap_request_from_single_bag_transfer_v2(self):
+		self._assert_can_extract_wrap_request_from_single_xem_mosaic_in_bag(2_000000, 12345_000000, 24690_000000)
 
-	def test_can_create_wrap_request_from_single_bag_transfer_v2_large_amount(self):
+	def test_can_extract_wrap_request_from_single_bag_transfer_v2_large_amount(self):
 		# notice that amount * mosaicAmount > Number.MAX_SAFE_INTEGER
-		self._assert_can_create_wrap_request_from_single_xem_mosaic_in_bag(1_000000, 14570747_490000, 14570747_490000)
+		self._assert_can_extract_wrap_request_from_single_xem_mosaic_in_bag(1_000000, 14570747_490000, 14570747_490000)
 
-	def test_can_create_wrap_request_from_single_bag_transfer_v2_fractional_1(self):
-		self._assert_can_create_wrap_request_from_single_xem_mosaic_in_bag(50000, 34_152375, 1_707618)
+	def test_can_extract_wrap_request_from_single_bag_transfer_v2_fractional_1(self):
+		self._assert_can_extract_wrap_request_from_single_xem_mosaic_in_bag(50000, 34_152375, 1_707618)
 
-	def test_can_create_wrap_request_from_single_bag_transfer_v2_fractional_2(self):
-		self._assert_can_create_wrap_request_from_single_xem_mosaic_in_bag(32_495622, 1_000000, 32_495622)
+	def test_can_extract_wrap_request_from_single_bag_transfer_v2_fractional_2(self):
+		self._assert_can_extract_wrap_request_from_single_xem_mosaic_in_bag(32_495622, 1_000000, 32_495622)
 
-	def test_can_create_wrap_request_from_multi_bag_transfer_v2_with_xem(self):
+	def test_can_extract_wrap_request_from_multi_bag_transfer_v2_with_xem(self):
 		# Arrange:
 		request = self._create_simple_wrap_request()
-		transaction_meta_json = self._create_transfer_json(request, transaction_version=TransferTransactionV2.TRANSACTION_VERSION)
-		transaction_meta_json['transaction']['amount'] = 2_000000
-		transaction_meta_json['transaction']['mosaics'] = [
+		transaction_with_meta_json = self._create_transfer_json(request, transaction_version=TransferTransactionV2.TRANSACTION_VERSION)
+		transaction_with_meta_json['transaction']['amount'] = 2_000000
+		transaction_with_meta_json['transaction']['mosaics'] = [
 			{
 				'mosaicId': {'namespaceId': 'baz', 'name': 'baz'},
 				'quantity': 7733_000000
@@ -166,17 +166,17 @@ class NemUtilsTest(unittest.TestCase):
 		]
 
 		# Act:
-		result = self._extract_wrap_request_from_transaction(transaction_meta_json)
+		result = self._extract_wrap_request_from_transaction(transaction_with_meta_json)
 
 		# Assert:
 		assert_wrap_request_success(self, result, change_request_amount(request, 2222_000000))
 
-	def test_can_create_wrap_request_from_multi_bag_transfer_v2_without_xem(self):
+	def test_can_extract_wrap_request_from_multi_bag_transfer_v2_without_xem(self):
 		# Arrange:
 		request = self._create_simple_wrap_request()
-		transaction_meta_json = self._create_transfer_json(request, transaction_version=TransferTransactionV2.TRANSACTION_VERSION)
-		transaction_meta_json['transaction']['amount'] = 2_000000
-		transaction_meta_json['transaction']['mosaics'] = [
+		transaction_with_meta_json = self._create_transfer_json(request, transaction_version=TransferTransactionV2.TRANSACTION_VERSION)
+		transaction_with_meta_json['transaction']['amount'] = 2_000000
+		transaction_with_meta_json['transaction']['mosaics'] = [
 			{
 				'mosaicId': {'namespaceId': 'baz', 'name': 'baz'},
 				'quantity': 7733_000000
@@ -188,7 +188,7 @@ class NemUtilsTest(unittest.TestCase):
 		]
 
 		# Act:
-		result = self._extract_wrap_request_from_transaction(transaction_meta_json)
+		result = self._extract_wrap_request_from_transaction(transaction_with_meta_json)
 
 		# Assert:
 		assert_wrap_request_success(self, result, change_request_amount(request, 0))
@@ -197,43 +197,43 @@ class NemUtilsTest(unittest.TestCase):
 
 	# region extract_wrap_request_from_transaction - transfer (failure)
 
-	def _assert_cannot_create_wrap_request_from_simple_transfer(self, expected_error_message, **kwargs):
+	def _assert_cannot_extract_wrap_request_from_simple_transfer(self, expected_error_message, **kwargs):
 		# Arrange:
 		request = self._create_simple_wrap_request()
-		transaction_meta_json = self._create_transfer_json(request, **kwargs)
+		transaction_with_meta_json = self._create_transfer_json(request, **kwargs)
 
 		if kwargs.get('clear_message', False):
-			transaction_meta_json['transaction']['message'] = {}
+			transaction_with_meta_json['transaction']['message'] = {}
 
 		# Act:
-		result = self._extract_wrap_request_from_transaction(transaction_meta_json)
+		result = self._extract_wrap_request_from_transaction(transaction_with_meta_json)
 
 		# Assert:
 		assert_wrap_request_failure(self, result, make_wrap_error_from_request(request, expected_error_message))
 
-	def test_cannot_create_wrap_request_from_simple_transfer_with_invalid_message_type(self):
-		self._assert_cannot_create_wrap_request_from_simple_transfer(
+	def test_cannot_extract_wrap_request_from_simple_transfer_with_invalid_message_type(self):
+		self._assert_cannot_extract_wrap_request_from_simple_transfer(
 			'message type 2 is not supported',
 			message_type=MessageType.ENCRYPTED.value)
 
-	def test_cannot_create_wrap_request_from_simple_transfer_without_message(self):
-		self._assert_cannot_create_wrap_request_from_simple_transfer(
+	def test_cannot_extract_wrap_request_from_simple_transfer_without_message(self):
+		self._assert_cannot_extract_wrap_request_from_simple_transfer(
 			'required message is missing',
 			clear_message=True)
 
-	def test_cannot_create_wrap_request_from_other_transaction(self):
-		self._assert_cannot_create_wrap_request_from_simple_transfer(
+	def test_cannot_extract_wrap_request_from_other_transaction(self):
+		self._assert_cannot_extract_wrap_request_from_simple_transfer(
 			'transaction type 8193 is not supported',
 			transaction_type=TransactionType.NAMESPACE_REGISTRATION.value)
 
-	def test_cannot_create_wrap_request_from_transfer_with_invalid_message(self):
+	def test_cannot_extract_wrap_request_from_transfer_with_invalid_message(self):
 		# Arrange:
 		request = self._create_simple_wrap_request()
 		request = change_request_destination_address(request, '0x4838b106fce9647bdf1e7877bf73ce8b0bad5f')  # too short
-		transaction_meta_json = self._create_transfer_json(request)
+		transaction_with_meta_json = self._create_transfer_json(request)
 
 		# Act:
-		result = self._extract_wrap_request_from_transaction(transaction_meta_json)
+		result = self._extract_wrap_request_from_transaction(transaction_with_meta_json)
 
 		# Assert:
 		expected_error_message = 'destination address 0x4838b106fce9647bdf1e7877bf73ce8b0bad5f is invalid'
@@ -243,11 +243,11 @@ class NemUtilsTest(unittest.TestCase):
 
 	# region extract_wrap_request_from_transaction - aggregate (success)
 
-	def test_can_create_wrap_request_from_aggregate_with_transfer(self):
+	def test_can_extract_wrap_request_from_aggregate_with_transfer(self):
 		# Arrange:
 		request = self._create_simple_wrap_request(transaction_subindex=0)
-		transaction_meta_json = self._create_transfer_json(request)
-		transaction_meta_json = {
+		transaction_with_meta_json = self._create_transfer_json(request)
+		transaction_with_meta_json = {
 			'meta': self._create_transfer_json(request)['meta'],
 			'transaction': {
 				'type': TransactionType.MULTISIG.value,
@@ -259,7 +259,7 @@ class NemUtilsTest(unittest.TestCase):
 		}
 
 		# Act:
-		result = self._extract_wrap_request_from_transaction(transaction_meta_json)
+		result = self._extract_wrap_request_from_transaction(transaction_with_meta_json)
 
 		# Assert:
 		assert_wrap_request_success(self, result, request)
@@ -268,11 +268,11 @@ class NemUtilsTest(unittest.TestCase):
 
 	# region extract_wrap_request_from_transaction - aggregate (failure)
 
-	def test_can_create_wrap_request_from_aggregate_with_other_transaction(self):
+	def test_can_extract_wrap_request_from_aggregate_with_other_transaction(self):
 		# Arrange:
 		request = self._create_simple_wrap_request(transaction_subindex=0)
-		transaction_meta_json = self._create_transfer_json(request)
-		transaction_meta_json = {
+		transaction_with_meta_json = self._create_transfer_json(request)
+		transaction_with_meta_json = {
 			'meta': self._create_transfer_json(request)['meta'],
 			'transaction': {
 				'type': TransactionType.MULTISIG.value,
@@ -286,7 +286,7 @@ class NemUtilsTest(unittest.TestCase):
 		}
 
 		# Act:
-		result = self._extract_wrap_request_from_transaction(transaction_meta_json)
+		result = self._extract_wrap_request_from_transaction(transaction_with_meta_json)
 
 		# Assert:
 		expected_error_message = 'inner transaction type 8193 is not supported'

--- a/bridge/tests/symbol/test_SymbolUtils.py
+++ b/bridge/tests/symbol/test_SymbolUtils.py
@@ -49,7 +49,7 @@ class SymbolUtilsTest(unittest.TestCase):
 			Address('TA6MYQRFJI24C2Y2WPX7QKAPMUDIS5FWZOBIBEA'): '4B7E7A084005D2149B44F6A782D9E597C0FABE56F4FEEC1738FE5152C69D55C3'
 		}
 
-		transaction_meta_json = {
+		transaction_with_meta_json = {
 			'meta': {
 				'height': str(request.transaction_height),
 				'hash': str(request.transaction_hash),
@@ -62,42 +62,42 @@ class SymbolUtilsTest(unittest.TestCase):
 			}
 		}
 
-		return transaction_meta_json
+		return transaction_with_meta_json
 
-	def _assert_can_create_wrap_request_from_simple_transfer(self, mosaics, **kwargs):
+	def _assert_can_extract_wrap_request_from_simple_transfer(self, mosaics, **kwargs):
 		# Arrange:
 		request = self._create_simple_wrap_request()
-		transaction_meta_json = self._create_transfer_json(request, mosaics, **kwargs)
+		transaction_with_meta_json = self._create_transfer_json(request, mosaics, **kwargs)
 
 		# Act:
-		results = self._extract_wrap_request_from_transaction(transaction_meta_json)
+		results = self._extract_wrap_request_from_transaction(transaction_with_meta_json)
 
 		# Assert:
 		self.assertEqual(1, len(results))
 		assert_wrap_request_success(self, results[0], request)
 
-	def test_can_create_wrap_request_from_transfer_with_single_mosaic(self):
-		self._assert_can_create_wrap_request_from_simple_transfer([
+	def test_can_extract_wrap_request_from_transfer_with_single_mosaic(self):
+		self._assert_can_extract_wrap_request_from_simple_transfer([
 			{'id': 'FAF0EBED913FA202', 'amount': '7777000000'}
 		])
 
-	def test_can_create_wrap_request_from_transfer_with_multiple_mosaics(self):
-		self._assert_can_create_wrap_request_from_simple_transfer([
+	def test_can_extract_wrap_request_from_transfer_with_multiple_mosaics(self):
+		self._assert_can_extract_wrap_request_from_simple_transfer([
 			{'id': 'F9F0EBED913FA202', 'amount': '5555000000'},
 			{'id': 'FAF0EBED913FA202', 'amount': '7777000000'},
 			{'id': 'FBF0EBED913FA202', 'amount': '8888000000'},
 		])
 
-	def test_can_create_wrap_request_from_transfer_with_multiple_mosaics_without_currency_mosaic(self):
+	def test_can_extract_wrap_request_from_transfer_with_multiple_mosaics_without_currency_mosaic(self):
 		# Arrange:
 		request = self._create_simple_wrap_request()
-		transaction_meta_json = self._create_transfer_json(request, [
+		transaction_with_meta_json = self._create_transfer_json(request, [
 			{'id': 'F9F0EBED913FA202', 'amount': '5555000000'},
 			{'id': 'FBF0EBED913FA202', 'amount': '8888000000'},
 		])
 
 		# Act:
-		results = self._extract_wrap_request_from_transaction(transaction_meta_json)
+		results = self._extract_wrap_request_from_transaction(transaction_with_meta_json)
 
 		# Assert:
 		self.assertEqual(1, len(results))
@@ -107,43 +107,43 @@ class SymbolUtilsTest(unittest.TestCase):
 
 	# region extract_wrap_request_from_transaction - transfer (failure)
 
-	def _assert_cannot_create_wrap_request_from_simple_transfer(self, expected_error_message, **kwargs):
+	def _assert_cannot_extract_wrap_request_from_simple_transfer(self, expected_error_message, **kwargs):
 		# Arrange:
 		request = self._create_simple_wrap_request()
-		transaction_meta_json = self._create_transfer_json(request, [
+		transaction_with_meta_json = self._create_transfer_json(request, [
 			{'id': 'FAF0EBED913FA202', 'amount': '7777000000'}
 		], **kwargs)
 
 		if kwargs.get('clear_message', False):
-			del transaction_meta_json['transaction']['message']
+			del transaction_with_meta_json['transaction']['message']
 
 		# Act:
-		results = self._extract_wrap_request_from_transaction(transaction_meta_json)
+		results = self._extract_wrap_request_from_transaction(transaction_with_meta_json)
 
 		# Assert:
 		self.assertEqual(1, len(results))
 		assert_wrap_request_failure(self, results[0], make_wrap_error_from_request(request, expected_error_message))
 
-	def test_cannot_create_wrap_request_from_simple_transfer_without_message(self):
-		self._assert_cannot_create_wrap_request_from_simple_transfer(
+	def test_cannot_extract_wrap_request_from_simple_transfer_without_message(self):
+		self._assert_cannot_extract_wrap_request_from_simple_transfer(
 			'required message is missing',
 			clear_message=True)
 
-	def test_cannot_create_wrap_request_from_other_transaction(self):
-		self._assert_cannot_create_wrap_request_from_simple_transfer(
+	def test_cannot_extract_wrap_request_from_other_transaction(self):
+		self._assert_cannot_extract_wrap_request_from_simple_transfer(
 			'transaction type 16718 is not supported',
 			transaction_type=TransactionType.NAMESPACE_REGISTRATION.value)
 
-	def test_cannot_create_wrap_request_from_transfer_with_invalid_message(self):
+	def test_cannot_extract_wrap_request_from_transfer_with_invalid_message(self):
 		# Arrange:
 		request = self._create_simple_wrap_request()
 		request = change_request_destination_address(request, '0x4838b106fce9647bdf1e7877bf73ce8b0bad5f')  # too short
-		transaction_meta_json = self._create_transfer_json(request, [
+		transaction_with_meta_json = self._create_transfer_json(request, [
 			{'id': 'FAF0EBED913FA202', 'amount': '7777000000'}
 		])
 
 		# Act:
-		results = self._extract_wrap_request_from_transaction(transaction_meta_json)
+		results = self._extract_wrap_request_from_transaction(transaction_with_meta_json)
 
 		# Assert:
 		self.assertEqual(1, len(results))
@@ -156,13 +156,13 @@ class SymbolUtilsTest(unittest.TestCase):
 	# region extract_wrap_request_from_transaction - aggregate (success)
 
 	@staticmethod
-	def _create_aggregate_transaction_meta_json(aggregate_transaction_type, embedded_transaction_meta_jsons):
+	def _create_aggregate_transaction_with_meta_json(aggregate_transaction_type, embedded_transaction_with_meta_jsons):
 		return {
 			'meta': {'height': '23456', 'hash': 'C0B52BE17C2F41539E50857855A226A24AFE8B23B51E42F3186FBC725EA63550'},
 			'transaction': {
 				'type': aggregate_transaction_type.value,
 				'signerPublicKey': '167F2FFDAFE27B6A8DCEFB4A12F0D8A2DB8908FC93D69B09A2E9237E55D7043E',
-				'transactions': embedded_transaction_meta_jsons
+				'transactions': embedded_transaction_with_meta_jsons
 			}
 		}
 
@@ -190,14 +190,14 @@ class SymbolUtilsTest(unittest.TestCase):
 			}
 		}
 
-	def _assert_can_create_wrap_request_from_aggregate_with_single_transfer(self, aggregate_transaction_type):
+	def _assert_can_extract_wrap_request_from_aggregate_with_single_transfer(self, aggregate_transaction_type):
 		# Arrange:
-		transaction_meta_json = self._create_aggregate_transaction_meta_json(aggregate_transaction_type, [
+		transaction_with_meta_json = self._create_aggregate_transaction_with_meta_json(aggregate_transaction_type, [
 			self._create_embedded_transaction_transfer_json(2, PUBLIC_KEYS[0], 1111, '0x4838b106fce9647bdf1e7877bf73ce8b0bad5f90')
 		])
 
 		# Act:
-		results = self._extract_wrap_request_from_transaction(transaction_meta_json)
+		results = self._extract_wrap_request_from_transaction(transaction_with_meta_json)
 
 		# Assert:
 		self.assertEqual(1, len(results))
@@ -211,23 +211,23 @@ class SymbolUtilsTest(unittest.TestCase):
 			'0x4838b106fce9647bdf1e7877bf73ce8b0bad5f90')
 		assert_wrap_request_success(self, results[0], expected_request)
 
-	def test_can_create_wrap_request_from_aggregate_complete_with_single_transfer(self):
-		self._assert_can_create_wrap_request_from_aggregate_with_single_transfer(TransactionType.AGGREGATE_COMPLETE)
+	def test_can_extract_wrap_request_from_aggregate_complete_with_single_transfer(self):
+		self._assert_can_extract_wrap_request_from_aggregate_with_single_transfer(TransactionType.AGGREGATE_COMPLETE)
 
-	def test_can_create_wrap_request_from_aggregate_bonded_with_single_transfer(self):
-		self._assert_can_create_wrap_request_from_aggregate_with_single_transfer(TransactionType.AGGREGATE_BONDED)
+	def test_can_extract_wrap_request_from_aggregate_bonded_with_single_transfer(self):
+		self._assert_can_extract_wrap_request_from_aggregate_with_single_transfer(TransactionType.AGGREGATE_BONDED)
 
-	def _assert_can_create_wrap_request_from_aggregate_with_multiple_transfers(self, aggregate_transaction_type):
+	def _assert_can_extract_wrap_request_from_aggregate_with_multiple_transfers(self, aggregate_transaction_type):
 		# Arrange:
 		destination_addresses = [f'0x4838b106fce9647bdf1e7877bf73ce8b0bad5f{digit}0' for digit in ['9', 'a', 'b']]
-		transaction_meta_json = self._create_aggregate_transaction_meta_json(aggregate_transaction_type, [
+		transaction_with_meta_json = self._create_aggregate_transaction_with_meta_json(aggregate_transaction_type, [
 			self._create_embedded_transaction_transfer_json(2, PUBLIC_KEYS[0], 1111, destination_addresses[0]),
 			self._create_embedded_transaction_transfer_json(4, PUBLIC_KEYS[1], 3333, destination_addresses[1]),
 			self._create_embedded_transaction_transfer_json(5, PUBLIC_KEYS[2], 2222, destination_addresses[2])
 		])
 
 		# Act:
-		results = self._extract_wrap_request_from_transaction(transaction_meta_json)
+		results = self._extract_wrap_request_from_transaction(transaction_with_meta_json)
 
 		# Assert:
 		self.assertEqual(3, len(results))
@@ -242,19 +242,19 @@ class SymbolUtilsTest(unittest.TestCase):
 		assert_wrap_request_success(self, results[1], expected_requests[1])
 		assert_wrap_request_success(self, results[2], expected_requests[2])
 
-	def test_can_create_wrap_request_from_aggregate_complete_with_multiple_transfers(self):
-		self._assert_can_create_wrap_request_from_aggregate_with_multiple_transfers(TransactionType.AGGREGATE_COMPLETE)
+	def test_can_extract_wrap_request_from_aggregate_complete_with_multiple_transfers(self):
+		self._assert_can_extract_wrap_request_from_aggregate_with_multiple_transfers(TransactionType.AGGREGATE_COMPLETE)
 
-	def test_can_create_wrap_request_from_aggregate_bonded_with_multiple_transfers(self):
-		self._assert_can_create_wrap_request_from_aggregate_with_multiple_transfers(TransactionType.AGGREGATE_BONDED)
+	def test_can_extract_wrap_request_from_aggregate_bonded_with_multiple_transfers(self):
+		self._assert_can_extract_wrap_request_from_aggregate_with_multiple_transfers(TransactionType.AGGREGATE_BONDED)
 
-	def _assert_can_create_wrap_request_from_aggregate_with_mix_of_transfers_and_non_transfers(self, aggregate_transaction_type):
+	def _assert_can_extract_wrap_request_from_aggregate_with_mix_of_transfers_and_non_transfers(self, aggregate_transaction_type):
 		# Arrange:
 		def make_error_message(value):
 			return f'transaction type {value} is not supported'
 
 		destination_addresses = [f'0x4838b106fce9647bdf1e7877bf73ce8b0bad5f{digit}0' for digit in ['9', 'b']]
-		transaction_meta_json = self._create_aggregate_transaction_meta_json(aggregate_transaction_type, [
+		transaction_with_meta_json = self._create_aggregate_transaction_with_meta_json(aggregate_transaction_type, [
 			self._create_embedded_transaction_transfer_json(2, PUBLIC_KEYS[0], 1111, destination_addresses[0]),
 			self._create_embedded_transaction_other_json(4, PUBLIC_KEYS[1], TransactionType.NAMESPACE_REGISTRATION),
 			self._create_embedded_transaction_transfer_json(5, PUBLIC_KEYS[2], 2222, destination_addresses[1]),
@@ -262,7 +262,7 @@ class SymbolUtilsTest(unittest.TestCase):
 		])
 
 		# Act:
-		results = self._extract_wrap_request_from_transaction(transaction_meta_json)
+		results = self._extract_wrap_request_from_transaction(transaction_with_meta_json)
 
 		# Assert:
 		self.assertEqual(4, len(results))
@@ -283,24 +283,24 @@ class SymbolUtilsTest(unittest.TestCase):
 		assert_wrap_request_success(self, results[2], expected_requests[1])
 		assert_wrap_request_failure(self, results[3], expected_errors[1])
 
-	def test_can_create_wrap_request_from_aggregate_complete_with_mix_of_transfers_and_non_transfers(self):
-		self._assert_can_create_wrap_request_from_aggregate_with_mix_of_transfers_and_non_transfers(TransactionType.AGGREGATE_COMPLETE)
+	def test_can_extract_wrap_request_from_aggregate_complete_with_mix_of_transfers_and_non_transfers(self):
+		self._assert_can_extract_wrap_request_from_aggregate_with_mix_of_transfers_and_non_transfers(TransactionType.AGGREGATE_COMPLETE)
 
-	def test_can_create_wrap_request_from_aggregate_bonded_with_mix_of_transfers_and_non_transfers(self):
-		self._assert_can_create_wrap_request_from_aggregate_with_mix_of_transfers_and_non_transfers(TransactionType.AGGREGATE_BONDED)
+	def test_can_extract_wrap_request_from_aggregate_bonded_with_mix_of_transfers_and_non_transfers(self):
+		self._assert_can_extract_wrap_request_from_aggregate_with_mix_of_transfers_and_non_transfers(TransactionType.AGGREGATE_BONDED)
 
-	def _assert_can_create_wrap_request_from_aggregate_with_no_transfers(self, aggregate_transaction_type):
+	def _assert_can_extract_wrap_request_from_aggregate_with_no_transfers(self, aggregate_transaction_type):
 		# Arrange:
 		def make_error_message(value):
 			return f'transaction type {value} is not supported'
 
-		transaction_meta_json = self._create_aggregate_transaction_meta_json(aggregate_transaction_type, [
+		transaction_with_meta_json = self._create_aggregate_transaction_with_meta_json(aggregate_transaction_type, [
 			self._create_embedded_transaction_other_json(4, PUBLIC_KEYS[1], TransactionType.NAMESPACE_REGISTRATION),
 			self._create_embedded_transaction_other_json(6, PUBLIC_KEYS[3], TransactionType.ADDRESS_ALIAS)
 		])
 
 		# Act:
-		results = self._extract_wrap_request_from_transaction(transaction_meta_json)
+		results = self._extract_wrap_request_from_transaction(transaction_with_meta_json)
 
 		# Assert:
 		self.assertEqual(2, len(results))
@@ -314,10 +314,10 @@ class SymbolUtilsTest(unittest.TestCase):
 		assert_wrap_request_failure(self, results[0], expected_errors[0])
 		assert_wrap_request_failure(self, results[1], expected_errors[1])
 
-	def test_can_create_wrap_request_from_aggregate_complete_with_no_transfers(self):
-		self._assert_can_create_wrap_request_from_aggregate_with_no_transfers(TransactionType.AGGREGATE_COMPLETE)
+	def test_can_extract_wrap_request_from_aggregate_complete_with_no_transfers(self):
+		self._assert_can_extract_wrap_request_from_aggregate_with_no_transfers(TransactionType.AGGREGATE_COMPLETE)
 
-	def test_can_create_wrap_request_from_aggregate_bonded_with_no_transfers(self):
-		self._assert_can_create_wrap_request_from_aggregate_with_no_transfers(TransactionType.AGGREGATE_BONDED)
+	def test_can_extract_wrap_request_from_aggregate_bonded_with_no_transfers(self):
+		self._assert_can_extract_wrap_request_from_aggregate_with_no_transfers(TransactionType.AGGREGATE_BONDED)
 
 	# endregion


### PR DESCRIPTION
    [bridge]: update network facades to support arbitrary mosaics
    
     problem: network facades primarily support currency mosaic operations
    solution: generalize to supporting arbitrary mosaics


    [bridge]: fix some naming issues in tests
    
     problem: inconsistent namings should be fixed
    solution: rename can_create_wrap_request_*
              * can(not)_create_wrap_request_* => can(not)_extract_wrap_request_*
              * transaction_meta_json => transaction_with_meta_json

