### PR TITLE
[faucet/frontend] fix: update discord link

### DIFF
--- a/faucet/frontend/components/nem/config/default.json
+++ b/faucet/frontend/components/nem/config/default.json
@@ -1,7 +1,7 @@
 {
     "URL_GITHUB": "https://github.com/nemproject",
     "URL_TWITTER": "https://twitter.com/NEMofficial",
-    "URL_DISCORD": "https://discord.gg/xymcity",
+    "URL_DISCORD": "https://discord.gg/NMA9YQ55td",
     "URL_EXPLORER": "https://testnet-explorer.nemtool.com",
     "URL_TELEGRAM_CH_HELP_DESK": "https://t.me/nemhelpdesk",
     "TELEGRAM_CH_HELP_DESK": "@nemhelpdesk",

--- a/faucet/frontend/components/symbol/config/default.json
+++ b/faucet/frontend/components/symbol/config/default.json
@@ -1,7 +1,7 @@
 {
     "URL_GITHUB": "https://github.com/symbol",
     "URL_TWITTER": "https://twitter.com/thesymbolchain",
-    "URL_DISCORD": "https://discord.gg/xymcity",
+    "URL_DISCORD": "https://discord.gg/NMA9YQ55td",
     "URL_EXPLORER": "https://testnet.symbol.fyi",
     "URL_TELEGRAM_CH_HELP_DESK": "https://t.me/nemhelpdesk",
     "TELEGRAM_CH_HELP_DESK": "@nemhelpdesk",


### PR DESCRIPTION
Problem: The Discord link is outdated.
Solution: Updated the latest link.