### PR TITLE
[bridge]: use checksum addresses or eth libraries will not work

### DIFF
--- a/bridge/bridge/ethereum/EthereumAdapters.py
+++ b/bridge/bridge/ethereum/EthereumAdapters.py
@@ -3,6 +3,7 @@ from collections import namedtuple
 
 from eth_account import Account
 from eth_keys import keys
+from eth_utils.address import to_checksum_address
 from symbolchain.ByteArray import ByteArray
 from symbolchain.CryptoTypes import Hash256
 
@@ -27,7 +28,8 @@ class EthereumAddress(ByteArray):
 		super().__init__(self.SIZE, raw_bytes, EthereumAddress)
 
 	def __str__(self):
-		return f'0x{super().__str__()}'
+		# render checksum address representation
+		return str(to_checksum_address(self.bytes))
 
 
 class EthereumPublicKey(ByteArray):

--- a/bridge/tests/ethereum/test_EthereumAdapters.py
+++ b/bridge/tests/ethereum/test_EthereumAdapters.py
@@ -27,7 +27,7 @@ class EthereumAdaptersTest(unittest.TestCase):
 
 		# Assert:
 		self.assertEqual(unhexlify('0FF070994DD3FDB1441433C219A42286EF85290F'), address.bytes)
-		self.assertEqual('0x0FF070994DD3FDB1441433C219A42286EF85290F', str(address))
+		self.assertEqual('0x0ff070994dd3fdB1441433c219A42286ef85290f', str(address))
 
 	def test_can_create_ethereum_address_from_bytes(self):
 		# Act:
@@ -35,7 +35,7 @@ class EthereumAdaptersTest(unittest.TestCase):
 
 		# Assert:
 		self.assertEqual(unhexlify('0FF070994DD3FDB1441433C219A42286EF85290F'), address.bytes)
-		self.assertEqual('0x0FF070994DD3FDB1441433C219A42286EF85290F', str(address))
+		self.assertEqual('0x0ff070994dd3fdB1441433c219A42286ef85290f', str(address))
 
 	def test_ethereum_address_supports_comparisons(self):
 		# Arrange:
@@ -123,8 +123,9 @@ class EthereumAdaptersTest(unittest.TestCase):
 		self.assertEqual(network, facade.network)
 
 	@staticmethod
-	def _create_test_transaction_descriptor():
+	def _create_test_transaction_descriptor(public_key):
 		return {
+			'from': str(public_key.address),
 			'to': '0xF0109fC8DF283027b6285cc889F5aA624EaC1F55',
 			'value': 1000000000,
 			'gas': 2000000,
@@ -140,7 +141,7 @@ class EthereumAdaptersTest(unittest.TestCase):
 		key_pair = EthereumSdkFacade.KeyPair(private_key)
 
 		# Act:
-		signed_transaction = facade.sign_transaction(key_pair, self._create_test_transaction_descriptor())
+		signed_transaction = facade.sign_transaction(key_pair, self._create_test_transaction_descriptor(key_pair.public_key))
 
 		# Assert:
 		self.assertEqual(unhexlify(''.join([
@@ -156,7 +157,7 @@ class EthereumAdaptersTest(unittest.TestCase):
 		private_key = PrivateKey('0999a20d4fdda8d7273e8a24f70e1105f9dcfcae2fba55e9a08f6e752411ed7a')
 		key_pair = EthereumSdkFacade.KeyPair(private_key)
 
-		transaction = self._create_test_transaction_descriptor()
+		transaction = self._create_test_transaction_descriptor(key_pair.public_key)
 		signed_transaction = facade.sign_transaction(key_pair, transaction)
 
 		# Act:
@@ -171,7 +172,7 @@ class EthereumAdaptersTest(unittest.TestCase):
 		private_key = PrivateKey('0999a20d4fdda8d7273e8a24f70e1105f9dcfcae2fba55e9a08f6e752411ed7a')
 		key_pair = EthereumSdkFacade.KeyPair(private_key)
 
-		transaction = self._create_test_transaction_descriptor()
+		transaction = self._create_test_transaction_descriptor(key_pair.public_key)
 		signed_transaction = facade.sign_transaction(key_pair, transaction)
 		facade.transaction_factory.attach_signature(transaction, signed_transaction)
 

--- a/bridge/tests/ethereum/test_EthereumConnector.py
+++ b/bridge/tests/ethereum/test_EthereumConnector.py
@@ -140,7 +140,7 @@ async def _assert_can_query_balance(server, block_identifier, expected_block_ide
 	assert [
 		make_rpc_request_json('eth_call', [
 			{
-				'data': '0x70a08231000000000000000000000000D8DA6BF26964AF9D7EED9E03E53415D37AA96045',
+				'data': '0x70a08231000000000000000000000000d8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
 				'to': '0x0D8775F648430679A709E98d2b0Cb6250d2887EF'
 			},
 			expected_block_identifier
@@ -173,7 +173,7 @@ async def _assert_can_query_nonce(server, block_identifier, expected_block_ident
 	# Assert:
 	assert [f'{server.make_url("")}/'] == server.mock.urls
 	assert [
-		make_rpc_request_json('eth_getTransactionCount', ['0xD8DA6BF26964AF9D7EED9E03E53415D37AA96045', expected_block_identifier])
+		make_rpc_request_json('eth_getTransactionCount', ['0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045', expected_block_identifier])
 	] == server.mock.request_json_payloads
 	assert 11 == nonce
 
@@ -262,7 +262,7 @@ async def _assert_can_query_incoming_transactions(server, start_id, expected_sta
 	# Assert:
 	assert [f'{server.make_url("")}/'] == server.mock.urls
 	assert [
-		make_rpc_request_json('ots_searchTransactionsBefore', ['0xB668A7CDC62108FAC00F65E1690591B67A1EF7C9', expected_start_id, 25])
+		make_rpc_request_json('ots_searchTransactionsBefore', ['0xB668a7Cdc62108fAC00F65E1690591B67A1eF7c9', expected_start_id, 25])
 	] == server.mock.request_json_payloads
 	assert [
 		{'meta': {'height': 29}, 'transaction': {'blockNumber': '0x1d', 'nonce': '0x2'}},

--- a/bridge/tests/ethereum/test_EthereumNetworkFacade.py
+++ b/bridge/tests/ethereum/test_EthereumNetworkFacade.py
@@ -236,7 +236,7 @@ async def test_cannot_create_transfer_transaction_from_account_with_unknown_nonc
 	await facade.init()
 
 	# Act + Assert:
-	signer_address = '0xC3B280FA8E521B3263BD6DB705ACE0B309306A73'
+	signer_address = '0xC3B280FA8E521B3263bD6db705ACe0B309306A73'
 	signer_public_key = ''.join([
 		'0x',
 		'B2B454118618A6D3E79FEDE753F60824C4D7E5EA15B4282D847801C8246A5A7C',
@@ -262,12 +262,12 @@ async def test_can_create_transfer_transaction(server):  # pylint: disable=redef
 
 	# Assert:
 	assert {
-		'from': '0xB5368C39EFB0DBA28C082733FE3F9463A215CC3D',
+		'from': '0xb5368c39Efb0DbA28C082733FE3F9463A215CC3D',
 		'to': '0x67b1d87101671b127f5f8714789C7192f7ad340e',
 		'data': ''.join([
 			'0x',
 			'a9059cbb000000000000000000000000',
-			'F0109FC8DF283027B6285CC889F5AA624EAC1F55',
+			'F0109fC8DF283027b6285cc889F5aA624EaC1F55',
 			hexlify(int(88888_000000).to_bytes(32, 'big')).decode('utf8')
 		]),
 		'nonce': 11,

--- a/bridge/tests/test/MockEthereumServer.py
+++ b/bridge/tests/test/MockEthereumServer.py
@@ -89,7 +89,7 @@ async def create_simple_ethereum_client(aiohttp_client):
 
 		async def _handle_eth_call(self, request, data):
 			# balanceOf(address) [d8dA6BF26964aF9D7eEd9e03E53415D37aA96045]
-			if '0x70a08231000000000000000000000000D8DA6BF26964AF9D7EED9E03E53415D37AA96045' == data:
+			if '0x70a08231000000000000000000000000d8dA6BF26964aF9D7eEd9e03E53415D37aA96045' == data:
 				return await self._process(request, {'result': '0x123456'})
 
 			# decimals()


### PR DESCRIPTION
 problem: prior to signing, eth_account checks if (string) address matches checksum address
          since string representation used is uppercase, it will not match and signing fails
solution: change EthereumAddress str to return checksum address