### PR TITLE
[bridge]: add ETH fee calculation and convert fees into wrapped token units

### DIFF
--- a/bridge/bridge/CoinGeckoConnector.py
+++ b/bridge/bridge/CoinGeckoConnector.py
@@ -1,0 +1,20 @@
+from decimal import Decimal
+
+from symbollightapi.connector.BasicConnector import BasicConnector
+
+
+class CoinGeckoConnector(BasicConnector):
+	"""Async connector for interacting with CoinGecko."""
+
+	async def price(self, ticker):
+		"""Gets spot price for ticker."""
+
+		result_json = await self.get(f'api/v3/simple/price?vs_currencies=usd&ids={ticker}')
+		return Decimal(result_json[ticker]['usd'])
+
+	async def conversion_rate(self, ticker1, ticker2):
+		"""Gets spot conversion rate between two tickers."""
+
+		price1 = await self.price(ticker1)
+		price2 = await self.price(ticker2)
+		return price1 / price2

--- a/bridge/bridge/ConversionRateCalculatorFactory.py
+++ b/bridge/bridge/ConversionRateCalculatorFactory.py
@@ -14,7 +14,6 @@ class ConversionRateCalculatorFactory:
 		# when calculating rate at height H, timestamp T, use sums from height H-1, timestamp T-1
 		# only the lookups for the network corresponding to `height` should be adjusted
 		self._native_adjustment = 0 if self._is_unwrap_mode else -1
-		self._wrapped_adjustment = -1 if self._is_unwrap_mode else 0
 
 	def _lookup_native_balance(self, native_height):
 		return self._databases.balance_change.balance_at(native_height + self._native_adjustment, self._mosaic_id)
@@ -27,7 +26,7 @@ class ConversionRateCalculatorFactory:
 		))
 
 	def _lookup_unwrapped_balance(self, native_height, timestamp):
-		transaction_hashes = list(self._databases.unwrap_request.payout_transaction_hashes_at(timestamp + self._wrapped_adjustment))
+		transaction_hashes = list(self._databases.unwrap_request.payout_transaction_hashes_at(timestamp))
 		filtered_transaction_hashes = list(self._databases.balance_change.filter_transactions_if_present(
 			native_height + self._native_adjustment,
 			self._mosaic_id,

--- a/bridge/bridge/ethereum/EthereumConnector.py
+++ b/bridge/bridge/ethereum/EthereumConnector.py
@@ -135,6 +135,24 @@ class EthereumConnector(BasicConnector):
 
 	# endregion
 
+	# region gas_price, estimate_gas
+
+	async def gas_price(self):
+		"""Gets the current estimated gas price."""
+
+		request_json = make_rpc_request_json('eth_gasPrice', [])
+		result_json = await self.post('', request_json)
+		return parse_rpc_response_hex_value(result_json['result'])
+
+	async def estimate_gas(self, transaction_object):
+		"""Gets the current estimated amount of gas for the specified transaction."""
+
+		request_json = make_rpc_request_json('eth_estimateGas', [transaction_object])
+		result_json = await self.post('', request_json)
+		return parse_rpc_response_hex_value(result_json['result'])
+
+	# endregion
+
 	# region filter_confirmed_transactions
 
 	async def _transaction_status_and_height_by_hash(self, transaction_hash):

--- a/bridge/bridge/ethereum/EthereumNetworkFacade.py
+++ b/bridge/bridge/ethereum/EthereumNetworkFacade.py
@@ -34,7 +34,7 @@ class EthereumNetworkFacade:  # pylint: disable=too-many-instance-attributes
 
 		signer_public_key = EthereumSdkFacade.KeyPair(PrivateKey(self.config.extensions['signing_private_key'])).public_key
 		signer_address = signer_public_key.address
-		self.address_to_nonce_map[signer_address] = await connector.nonce(signer_address)
+		self.address_to_nonce_map[signer_address] = await connector.nonce(signer_address, 'pending')
 
 	def extract_mosaic_id(self):
 		"""

--- a/bridge/bridge/models/BridgeConfiguration.py
+++ b/bridge/bridge/models/BridgeConfiguration.py
@@ -2,8 +2,9 @@ import configparser
 from collections import namedtuple
 
 MachineConfiguration = namedtuple('MachineConfiguration', ['database_directory', 'log_filename'])
+PriceOracleConfiguration = namedtuple('PriceOracle', ['url'])
 NetworkConfiguration = namedtuple('NetworkConfiguration', ['blockchain', 'network', 'endpoint', 'bridge_address', 'extensions'])
-BridgeConfiguration = namedtuple('BridgeConfiguration', ['machine', 'native_network', 'wrapped_network'])
+BridgeConfiguration = namedtuple('BridgeConfiguration', ['machine', 'price_oracle', 'native_network', 'wrapped_network'])
 
 
 def _camel_case_to_snake_case(value):
@@ -21,6 +22,12 @@ def parse_machine_configuration(config):
 	"""Parses machine configuration."""
 
 	return MachineConfiguration(config['databaseDirectory'], config['logFilename'])
+
+
+def parse_price_oracle_configuration(config):
+	"""Parses price oracle configuration."""
+
+	return PriceOracleConfiguration(config['url'])
 
 
 def parse_network_configuration(config):
@@ -47,5 +54,6 @@ def parse_bridge_configuration(filename):
 
 	return BridgeConfiguration(
 		parse_machine_configuration(parser['machine']),
+		parse_price_oracle_configuration(parser['price_oracle']),
 		parse_network_configuration(parser['native_network']),
 		parse_network_configuration(parser['wrapped_network']))

--- a/bridge/bridge/symbol/SymbolNetworkFacade.py
+++ b/bridge/bridge/symbol/SymbolNetworkFacade.py
@@ -106,7 +106,7 @@ class SymbolNetworkFacade:
 		transaction.fee = Amount(int(self.config.extensions['transaction_fee_multiplier']) * transaction.size)
 		return transaction
 
-	def calculate_transfer_transaction_fee(self, balance_transfer):
+	def calculate_transfer_transaction_fee(self, balance_transfer, mosaic_id=None):
 		"""Calculates a transfer transaction fee."""
 
-		return self.create_transfer_transaction(NetworkTimestamp(0), balance_transfer).fee.value
+		return self.create_transfer_transaction(NetworkTimestamp(0), balance_transfer, mosaic_id).fee.value

--- a/bridge/tests/ethereum/test_EthereumConnector.py
+++ b/bridge/tests/ethereum/test_EthereumConnector.py
@@ -161,7 +161,8 @@ async def test_can_query_balance_with_custom_block_identifier(server):  # pylint
 
 # region nonce
 
-async def _assert_can_query_nonce(server, block_identifier, expected_block_identifier):  # pylint: disable=redefined-outer-name
+async def _assert_can_query_nonce(server, block_identifier, expected_block_identifier, expected_nonce):
+	# pylint: disable=redefined-outer-name
 	# Arrange:
 	connector = EthereumConnector(server.make_url(''))
 
@@ -175,15 +176,15 @@ async def _assert_can_query_nonce(server, block_identifier, expected_block_ident
 	assert [
 		make_rpc_request_json('eth_getTransactionCount', ['0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045', expected_block_identifier])
 	] == server.mock.request_json_payloads
-	assert 11 == nonce
+	assert expected_nonce == nonce
 
 
 async def test_can_query_nonce(server):  # pylint: disable=redefined-outer-name
-	await _assert_can_query_nonce(server, None, 'latest')
+	await _assert_can_query_nonce(server, None, 'latest', 11)
 
 
 async def test_can_query_nonce_with_custom_block_identifier(server):  # pylint: disable=redefined-outer-name
-	await _assert_can_query_nonce(server, 0xAABBCC, '0xAABBCC')
+	await _assert_can_query_nonce(server, 0xAABBCC, '0xAABBCC', 9)
 
 # endregion
 

--- a/bridge/tests/ethereum/test_EthereumConnector.py
+++ b/bridge/tests/ethereum/test_EthereumConnector.py
@@ -224,6 +224,44 @@ async def test_can_query_token_precision_with_custom_block_identifier(server):  
 # endregion
 
 
+# region gas_price, estimate_gas
+
+async def test_can_query_gas_price(server):  # pylint: disable=redefined-outer-name
+	# Arrange:
+	connector = EthereumConnector(server.make_url(''))
+
+	# Act:
+	gas_price = await connector.gas_price()
+
+	# Assert:
+	assert [f'{server.make_url("")}/'] == server.mock.urls
+	assert [make_rpc_request_json('eth_gasPrice', [])] == server.mock.request_json_payloads
+	assert 0x1DFD14000 == gas_price
+
+
+async def test_can_estimate_gas(server):  # pylint: disable=redefined-outer-name
+	# Arrange:
+	connector = EthereumConnector(server.make_url(''))
+
+	# Act:
+	gas = await connector.estimate_gas({
+		'from': '0x4838b106fce9647bdf1e7877bf73ce8b0bad5f97',
+		'to': '0xb5368c39Efb0DbA28C082733FE3F9463A215CC3D'
+	})
+
+	# Assert:
+	assert [f'{server.make_url("")}/'] == server.mock.urls
+	assert [make_rpc_request_json('eth_estimateGas', [
+		{
+			'from': '0x4838b106fce9647bdf1e7877bf73ce8b0bad5f97',
+			'to': '0xb5368c39Efb0DbA28C082733FE3F9463A215CC3D'
+		}
+	])] == server.mock.request_json_payloads
+	assert 0x5208 == gas
+
+# endregion
+
+
 # region filter_confirmed_transactions
 
 async def test_can_filter_confirmed_transactions(server):  # pylint: disable=redefined-outer-name

--- a/bridge/tests/ethereum/test_EthereumNetworkFacade.py
+++ b/bridge/tests/ethereum/test_EthereumNetworkFacade.py
@@ -57,7 +57,7 @@ async def test_can_initialize_facade(server):  # pylint: disable=redefined-outer
 
 	# Assert:
 	assert 3 == facade.token_precision
-	assert {EthereumAddress('0xb5368c39Efb0DbA28C082733FE3F9463A215CC3D'): 11} == facade.address_to_nonce_map
+	assert {EthereumAddress('0xb5368c39Efb0DbA28C082733FE3F9463A215CC3D'): 14} == facade.address_to_nonce_map
 
 # endregion
 
@@ -270,7 +270,7 @@ async def test_can_create_transfer_transaction(server):  # pylint: disable=redef
 			'F0109fC8DF283027b6285cc889F5aA624EaC1F55',
 			hexlify(int(88888_000000).to_bytes(32, 'big')).decode('utf8')
 		]),
-		'nonce': 11,
+		'nonce': 14,
 		'chainId': 8876,
 
 		'gas': 210000,
@@ -294,7 +294,7 @@ async def test_can_create_multiple_transfer_transactions_with_autoincrementing_n
 	]
 
 	# Assert:
-	assert [11, 12, 13, 14] == [transaction['nonce'] for transaction in transactions]
+	assert [14, 15, 16, 17] == [transaction['nonce'] for transaction in transactions]
 
 # endregion
 

--- a/bridge/tests/test/MockEthereumServer.py
+++ b/bridge/tests/test/MockEthereumServer.py
@@ -23,6 +23,12 @@ async def create_simple_ethereum_client(aiohttp_client):
 			if 'eth_blockNumber' == method:
 				return await self._handle_eth_block_number(request)
 
+			if 'eth_estimateGas' == method:
+				return await self._handle_eth_estimate_gas(request)
+
+			if 'eth_gasPrice' == method:
+				return await self._handle_eth_gas_price(request)
+
 			if 'eth_getBlockByNumber' == method:
 				return await self._handle_eth_get_block_by_number(request, request_json['params'][0])
 
@@ -46,6 +52,16 @@ async def create_simple_ethereum_client(aiohttp_client):
 		async def _handle_eth_block_number(self, request):
 			return await self._process(request, {
 				'result': '0xAB123'
+			})
+
+		async def _handle_eth_estimate_gas(self, request):
+			return await self._process(request, {
+				'result': '0x5208'
+			})
+
+		async def _handle_eth_gas_price(self, request):
+			return await self._process(request, {
+				'result': '0x1DFD14000'
 			})
 
 		async def _handle_eth_get_block_by_number(self, request, block_identifier):

--- a/bridge/tests/test/MockEthereumServer.py
+++ b/bridge/tests/test/MockEthereumServer.py
@@ -30,7 +30,7 @@ async def create_simple_ethereum_client(aiohttp_client):
 				return await self._handle_eth_get_transaction_by_hash(request, request_json['params'][0])
 
 			if 'eth_getTransactionCount' == method:
-				return await self._handle_eth_get_transaction_count(request)
+				return await self._handle_eth_get_transaction_count(request, request_json['params'][1])
 
 			if 'eth_sendRawTransaction' == method:
 				return await self._handle_eth_send_raw_transaction(request)
@@ -72,9 +72,15 @@ async def create_simple_ethereum_client(aiohttp_client):
 
 			return await self._process(request, {'result': None})  # unknown
 
-		async def _handle_eth_get_transaction_count(self, request):
+		async def _handle_eth_get_transaction_count(self, request, block_identifier):
+			block_identifier_to_count_map = {
+				'0xAABBCC': '0x9',
+				'latest': '0xB',
+				'pending': '0xE'
+			}
+
 			return await self._process(request, {
-				'result': '0xB'
+				'result': block_identifier_to_count_map[block_identifier]
 			})
 
 		async def _handle_eth_send_raw_transaction(self, request):

--- a/bridge/tests/test_CoinGeckoConnector.py
+++ b/bridge/tests/test_CoinGeckoConnector.py
@@ -1,0 +1,69 @@
+import json
+from decimal import Decimal
+
+import pytest
+from aiohttp import web
+
+from bridge.CoinGeckoConnector import CoinGeckoConnector
+
+
+@pytest.fixture
+async def server(aiohttp_client):
+	class MockCoinGeckoServer:
+		def __init__(self):
+			self.urls = []
+
+		async def price(self, request):
+			ticker = request.url.query['ids']
+
+			price = {
+				'symbol': 0.0877,
+				'nem': 0.0199
+			}[ticker]
+
+			return await self._process(request, {ticker: {'usd': price}})
+
+		async def _process(self, request, response_body, status_code=200):
+			self.urls.append(str(request.url))
+			return web.Response(body=json.dumps(response_body), headers={'Content-Type': 'application/json'}, status=status_code)
+
+	# create a mock server
+	mock_server = MockCoinGeckoServer()
+
+	# create an app using the server
+	app = web.Application()
+	app.router.add_get('/api/v3/simple/price', mock_server.price)
+	server = await aiohttp_client(app)  # pylint: disable=redefined-outer-name
+
+	server.mock = mock_server
+	return server
+
+
+# pylint: disable=invalid-name
+
+
+async def test_can_query_price(server):  # pylint: disable=redefined-outer-name
+	# Arrange:
+	connector = CoinGeckoConnector(server.make_url(''))
+
+	# Act:
+	price = await connector.price('symbol')
+
+	# Assert:
+	assert [f'{server.make_url("")}/api/v3/simple/price?vs_currencies=usd&ids=symbol'] == server.mock.urls
+	assert Decimal(0.0877) == price
+
+
+async def test_can_query_conversion_rate(server):  # pylint: disable=redefined-outer-name
+	# Arrange:
+	connector = CoinGeckoConnector(server.make_url(''))
+
+	# Act:
+	conversion_rate = await connector.conversion_rate('symbol', 'nem')
+
+	# Assert:
+	assert [
+		f'{server.make_url("")}/api/v3/simple/price?vs_currencies=usd&ids=symbol',
+		f'{server.make_url("")}/api/v3/simple/price?vs_currencies=usd&ids=nem',
+	] == server.mock.urls
+	assert Decimal(0.0877) / Decimal(0.0199) == conversion_rate

--- a/bridge/tests/test_NetworkFacadeLoader.py
+++ b/bridge/tests/test_NetworkFacadeLoader.py
@@ -54,8 +54,7 @@ async def test_can_load_nem_network_facade(nem_server):  # pylint: disable=redef
 	assert isinstance(facade, NemNetworkFacade)
 	assert 'testnet' == facade.network.name
 
-	assert 123000000 == facade.mosaic_fee_information.supply
-	assert 3 == facade.mosaic_fee_information.divisibility
+	assert 1 == len(facade.mosaic_id_to_fee_information_map)
 
 
 async def test_can_load_symbol_network_facade(symbol_server):  # pylint: disable=redefined-outer-name

--- a/bridge/workflows/check_finalized_transactions.py
+++ b/bridge/workflows/check_finalized_transactions.py
@@ -26,7 +26,7 @@ async def _check_finalized_transactions(database, network):
 		database.set_payout_block_timestamp(*height_timestamp_pair)
 
 
-async def main_impl(is_unwrap_mode, databases, native_facade, wrapped_facade):
+async def main_impl(is_unwrap_mode, databases, native_facade, wrapped_facade, _price_oracle):
 	if is_unwrap_mode:
 		await _check_finalized_transactions(databases.unwrap_request, native_facade)
 	else:

--- a/bridge/workflows/download_balance_changes.py
+++ b/bridge/workflows/download_balance_changes.py
@@ -68,7 +68,7 @@ async def download_balance_changes(database, network):
 	])
 
 
-async def main_impl(is_unwrap_mode, databases, native_facade, _wrapped_facade):
+async def main_impl(is_unwrap_mode, databases, native_facade, _wrapped_facade, _price_oracle):
 	if is_unwrap_mode:
 		raise ValueError('this workflow is not compatible with unwrap mode')
 

--- a/bridge/workflows/download_wrap_requests.py
+++ b/bridge/workflows/download_wrap_requests.py
@@ -63,7 +63,7 @@ async def _download_all(database, network, is_valid_address):
 	await _download_block_timestamps(database, connector, heights)
 
 
-async def main_impl(is_unwrap_mode, databases, native_facade, wrapped_facade):
+async def main_impl(is_unwrap_mode, databases, native_facade, wrapped_facade, _price_oracle):
 	if is_unwrap_mode:
 		await _download_all(databases.unwrap_request, wrapped_facade, native_facade.is_valid_address)
 	else:

--- a/bridge/workflows/main_impl.py
+++ b/bridge/workflows/main_impl.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
 
+from bridge.CoinGeckoConnector import CoinGeckoConnector
 from bridge.db.Databases import Databases
 from bridge.models.BridgeConfiguration import parse_bridge_configuration
 from bridge.NetworkFacadeLoader import load_network_facade
@@ -27,8 +28,10 @@ async def main_bootstrapper(program_description, main_impl):
 	native_facade = await load_network_facade(config.native_network)
 	wrapped_facade = await load_network_facade(config.wrapped_network)
 
+	price_oracle = CoinGeckoConnector(config.price_oracle.url)
+
 	with Databases(config.machine.database_directory, native_facade, wrapped_facade) as databases:
 		databases.create_tables()
 
 		print(f'running in unwrap mode? {args.unwrap}')
-		await main_impl(args.unwrap, databases, native_facade, wrapped_facade)
+		await main_impl(args.unwrap, databases, native_facade, wrapped_facade, price_oracle)


### PR DESCRIPTION
    [bridge]: add price oracle for fee conversions
    
     problem: when sending transactions on wrapped network fees need to be from native currency to wrapped token
    solution: add and integrate CoinGecko connector (price oracle)

    [bridge]: add ethereum transaction fee calculation
    
     problem: ethereum fees are hardcoded
    solution: calculate fees dynamically
