### PR TITLE
[wallet/common] feat: create ethereum project

### DIFF
--- a/wallet/common/ethereum/.c8rc.json
+++ b/wallet/common/ethereum/.c8rc.json
@@ -1,0 +1,5 @@
+{
+	"all": "true",
+	"include": ["src/**"],
+	"exclude": ["src/types/**"]
+}

--- a/wallet/common/ethereum/.eslintignore
+++ b/wallet/common/ethereum/.eslintignore
@@ -1,0 +1,4 @@
+node_modules/
+build/
+dist/
+coverage/

--- a/wallet/common/ethereum/.eslintrc.yaml
+++ b/wallet/common/ethereum/.eslintrc.yaml
@@ -1,0 +1,49 @@
+extends:
+  - ../../../linters/javascript/default.eslintrc
+  - plugin:import/recommended
+
+plugins:
+  - jsdoc
+
+parserOptions:
+  ecmaVersion: latest
+  sourceType: module
+  ecmaFeatures:
+    jsx: true
+
+env:
+  browser: true
+  es6: true
+  jest: true
+  node: true
+
+rules:
+  sort-imports:
+    - error
+    - ignoreDeclarationSort: true
+  no-unused-vars: error
+  yoda: off
+  no-underscore-dangle: off
+  jsdoc/no-undefined-types: 1
+  import/named: off
+  import/namespace: off
+  import/no-unresolved:
+    - 2
+    - ignore:
+      - '^symbol-sdk/'
+  prefer-destructuring:
+    - error
+    - VariableDeclarator:
+        array: false
+        object: true
+      AssignmentExpression:
+        array: false
+        object: false
+
+settings:
+  import/resolver:
+    node:
+      extensions:
+        - .js
+
+

--- a/wallet/common/ethereum/.gitignore
+++ b/wallet/common/ethereum/.gitignore
@@ -1,0 +1,20 @@
+# OSX
+#
+.DS_Store
+
+# node.js
+#
+node_modules/
+npm-debug.log
+yarn-error.log
+
+# testing
+/coverage
+
+# Yarn
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions

--- a/wallet/common/ethereum/Jenkinsfile
+++ b/wallet/common/ethereum/Jenkinsfile
@@ -1,0 +1,11 @@
+defaultCiPipeline {
+	operatingSystem = ['ubuntu']
+	instanceSize = 'medium'
+
+	environment = 'javascript'
+
+	packageId = 'wallet-common-ethereum'
+
+	codeCoverageTool = 'c8'
+	minimumCodeCoverage = 90
+}

--- a/wallet/common/ethereum/README.md
+++ b/wallet/common/ethereum/README.md
@@ -1,0 +1,123 @@
+# Wallet Common Ethereum
+
+Protocol-specific layer for Ethereum used by Wallet Common Core. It provides:
+- HTTP API services for Ethereum nodes and ecosystem endpoints.
+- SDK helpers for signing.
+- Utilities mapping, fees, and conversions.
+
+## Project Structure
+
+```
+src/
+├── api/            # Network service clients
+├── constants/      # Ethereum enums and constants
+├── sdk/            # Thin SDK facade
+├── types/          # Local JSDoc typedefs
+└── utils/          # Ethereum-specific utilities
+```
+
+## Requirements
+
+- Node.js v20.11.0
+
+## Installation
+
+This package lives inside the Product monorepo.
+
+1. Clone the repository from GitHub:
+```bash
+git clone https://github.com/symbol/product.git
+```
+
+2. Initialize:
+```bash
+bash init.sh
+```
+
+3. Navigate to the project folder:
+```bash
+cd wallet/common/ethereum
+```
+
+4. Install Node.js dependencies:
+```bash
+npm install
+```
+
+## Running Tests
+
+To run tests, use:
+```bash
+npm run test
+```
+To run tests with coverage via c8, use:
+
+```bash
+npm run test:cov
+```
+
+## Linting
+
+To run lint checks, use:
+```bash
+npm run lint
+```
+
+To fix lint issues, use:
+```bash
+npm run lint:fix
+```
+
+## Package Overview
+
+Main entry: `./src/index.js`
+
+This module contains the key building blocks:
+
+- Protocol network API
+- Protocol wallet SDK
+- Utilities
+- Constants
+
+## Usage
+
+### WalletController
+
+```js
+import { WalletController } from 'wallet-common-core';
+import { 
+   Api as EthereumNetworkApi, 
+   sdk as ethereumWalletSdk
+} from 'wallet-common-ethereum';
+
+const ethereumNetworkApi = new EthereumNetworkApi({
+    makeRequest: async (url, options) => fetch(url, options)
+});
+
+const controller = new WalletController({
+    api: ethereumNetworkApi,
+    sdk: ethereumWalletSdk
+});
+```
+
+### Calling API services directly
+
+```js
+import { Api as EthereumNetworkApi } from 'wallet-common-ethereum';
+
+const api = new EthereumNetworkApi({ makeRequest, config });
+
+// Announce a signed transaction payload
+await api.transaction.announceTransaction(networkProperties, signedTransaction);
+```
+
+### Using SDK helpers
+
+```js
+import { sdk } from 'wallet-common-ethereum';
+
+// Sign a transaction object (already mapped)
+const signedTransaction = sdk.signTransaction(networkIdentifier, transaction, 'PRIVATE_KEY');
+
+```
+

--- a/wallet/common/ethereum/jest.config.js
+++ b/wallet/common/ethereum/jest.config.js
@@ -1,0 +1,15 @@
+export default {
+	clearMocks: true,
+	testMatch: ['<rootDir>/tests/**/*.test.js'],
+	modulePaths: ['<rootDir>'],
+	collectCoverageFrom: ['<rootDir>/src/**/*.js'],
+	coverageDirectory: 'coverage',
+	coverageProvider: 'v8',
+	coverageReporters: ['lcov'],
+	coveragePathIgnorePatterns: [
+		'<rootDir>/tests/',
+		'<rootDir>/coverage/',
+		'<rootDir>/src/types/'
+	],
+	transform: {} // Required for native ESM, even if empty
+};

--- a/wallet/common/ethereum/package-lock.json
+++ b/wallet/common/ethereum/package-lock.json
@@ -1,0 +1,7489 @@
+{
+	"name": "wallet-common-ethereum",
+	"version": "0.1.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "wallet-common-ethereum",
+			"version": "0.1.0",
+			"hasInstallScript": true,
+			"dependencies": {
+				"ethers": "^6.15.0",
+				"lodash": "^4.17.21",
+				"resolve-local-dependencies": "^1.0.2",
+				"wallet-common-core": "file:../core"
+			},
+			"devDependencies": {
+				"c8": "~10.1.2",
+				"eslint": "~8.57.0",
+				"eslint-config-airbnb": "~19.0.4",
+				"eslint-plugin-import": "^2.32.0",
+				"eslint-plugin-jsdoc": "^50.1.0",
+				"jest": "^30.0.0"
+			}
+		},
+		"../../../../../../common/core": {
+			"version": "0.1.0",
+			"extraneous": true,
+			"devDependencies": {
+				"c8": "~10.1.2",
+				"eslint": "~8.57.0",
+				"eslint-config-airbnb": "~19.0.4",
+				"eslint-plugin-jsdoc": "^50.1.0",
+				"jest": "^30.0.0"
+			}
+		},
+		"../../../../../../core": {
+			"extraneous": true
+		},
+		"../../../../../core": {
+			"extraneous": true
+		},
+		"../../../../core": {
+			"extraneous": true
+		},
+		"../../../core": {
+			"extraneous": true
+		},
+		"../core": {
+			"name": "wallet-common-core",
+			"version": "0.1.0",
+			"devDependencies": {
+				"c8": "~10.1.2",
+				"eslint": "~8.57.0",
+				"eslint-config-airbnb": "~19.0.4",
+				"eslint-plugin-jsdoc": "^54.1.0",
+				"jest": "^30.0.0"
+			}
+		},
+		"node_modules/@adraffy/ens-normalize": {
+			"version": "1.10.1",
+			"resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+			"integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw=="
+		},
+		"node_modules/@ampproject/remapping": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+			"integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@babel/code-frame": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+			"integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^7.27.1",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/compat-data": {
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
+			"integrity": "sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/core": {
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.3.tgz",
+			"integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
+			"dev": true,
+			"dependencies": {
+				"@ampproject/remapping": "^2.2.0",
+				"@babel/code-frame": "^7.27.1",
+				"@babel/generator": "^7.28.3",
+				"@babel/helper-compilation-targets": "^7.27.2",
+				"@babel/helper-module-transforms": "^7.28.3",
+				"@babel/helpers": "^7.28.3",
+				"@babel/parser": "^7.28.3",
+				"@babel/template": "^7.27.2",
+				"@babel/traverse": "^7.28.3",
+				"@babel/types": "^7.28.2",
+				"convert-source-map": "^2.0.0",
+				"debug": "^4.1.0",
+				"gensync": "^1.0.0-beta.2",
+				"json5": "^2.2.3",
+				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/babel"
+			}
+		},
+		"node_modules/@babel/generator": {
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
+			"integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/parser": "^7.28.3",
+				"@babel/types": "^7.28.2",
+				"@jridgewell/gen-mapping": "^0.3.12",
+				"@jridgewell/trace-mapping": "^0.3.28",
+				"jsesc": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-compilation-targets": {
+			"version": "7.27.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
+			"integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/compat-data": "^7.27.2",
+				"@babel/helper-validator-option": "^7.27.1",
+				"browserslist": "^4.24.0",
+				"lru-cache": "^5.1.1",
+				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-globals": {
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+			"integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-module-imports": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+			"integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+			"dev": true,
+			"dependencies": {
+				"@babel/traverse": "^7.27.1",
+				"@babel/types": "^7.27.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-module-transforms": {
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
+			"integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-module-imports": "^7.27.1",
+				"@babel/helper-validator-identifier": "^7.27.1",
+				"@babel/traverse": "^7.28.3"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
+			}
+		},
+		"node_modules/@babel/helper-plugin-utils": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
+			"integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-string-parser": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-validator-identifier": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+			"integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-validator-option": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+			"integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helpers": {
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.3.tgz",
+			"integrity": "sha512-PTNtvUQihsAsDHMOP5pfobP8C6CM4JWXmP8DrEIt46c3r2bf87Ua1zoqevsMo9g+tWDwgWrFP5EIxuBx5RudAw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/template": "^7.27.2",
+				"@babel/types": "^7.28.2"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/parser": {
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz",
+			"integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/types": "^7.28.2"
+			},
+			"bin": {
+				"parser": "bin/babel-parser.js"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-async-generators": {
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+			"integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-bigint": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+			"integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-class-properties": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+			"integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.12.13"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-class-static-block": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+			"integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-import-attributes": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
+			"integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.27.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-import-meta": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+			"integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-json-strings": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+			"integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-jsx": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
+			"integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.27.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+			"integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+			"integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-numeric-separator": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+			"integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-object-rest-spread": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+			"integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-optional-catch-binding": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+			"integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-optional-chaining": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+			"integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-private-property-in-object": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+			"integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-top-level-await": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+			"integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-typescript": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
+			"integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.27.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/template": {
+			"version": "7.27.2",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+			"integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.27.1",
+				"@babel/parser": "^7.27.2",
+				"@babel/types": "^7.27.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/traverse": {
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.3.tgz",
+			"integrity": "sha512-7w4kZYHneL3A6NP2nxzHvT3HCZ7puDZZjFMqDpBPECub79sTtSO5CGXDkKrTQq8ksAwfD/XI2MRFX23njdDaIQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.27.1",
+				"@babel/generator": "^7.28.3",
+				"@babel/helper-globals": "^7.28.0",
+				"@babel/parser": "^7.28.3",
+				"@babel/template": "^7.27.2",
+				"@babel/types": "^7.28.2",
+				"debug": "^4.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/types": {
+			"version": "7.28.2",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
+			"integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-string-parser": "^7.27.1",
+				"@babel/helper-validator-identifier": "^7.27.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@bcoe/v8-coverage": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+			"integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@emnapi/core": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.5.0.tgz",
+			"integrity": "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==",
+			"dev": true,
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.1.0",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/runtime": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
+			"integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
+			"dev": true,
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/wasi-threads": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
+			"integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+			"dev": true,
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@es-joy/jsdoccomment": {
+			"version": "0.50.2",
+			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.50.2.tgz",
+			"integrity": "sha512-YAdE/IJSpwbOTiaURNCKECdAwqrJuFiZhylmesBcIRawtYKnBR2wxPhoIewMg+Yu+QuYvHfJNReWpoxGBKOChA==",
+			"dev": true,
+			"dependencies": {
+				"@types/estree": "^1.0.6",
+				"@typescript-eslint/types": "^8.11.0",
+				"comment-parser": "1.4.1",
+				"esquery": "^1.6.0",
+				"jsdoc-type-pratt-parser": "~4.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@eslint-community/eslint-utils": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
+			"integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+			"dev": true,
+			"dependencies": {
+				"eslint-visitor-keys": "^3.4.3"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+			}
+		},
+		"node_modules/@eslint-community/regexpp": {
+			"version": "4.12.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+			"integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+			"dev": true,
+			"engines": {
+				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+			}
+		},
+		"node_modules/@eslint/eslintrc": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+			"integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+			"dev": true,
+			"dependencies": {
+				"ajv": "^6.12.4",
+				"debug": "^4.3.2",
+				"espree": "^9.6.0",
+				"globals": "^13.19.0",
+				"ignore": "^5.2.0",
+				"import-fresh": "^3.2.1",
+				"js-yaml": "^4.1.0",
+				"minimatch": "^3.1.2",
+				"strip-json-comments": "^3.1.1"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@eslint/js": {
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+			"integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+			"dev": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/@humanwhocodes/config-array": {
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+			"integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+			"deprecated": "Use @eslint/config-array instead",
+			"dev": true,
+			"dependencies": {
+				"@humanwhocodes/object-schema": "^2.0.3",
+				"debug": "^4.3.1",
+				"minimatch": "^3.0.5"
+			},
+			"engines": {
+				"node": ">=10.10.0"
+			}
+		},
+		"node_modules/@humanwhocodes/module-importer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+			"dev": true,
+			"engines": {
+				"node": ">=12.22"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/nzakas"
+			}
+		},
+		"node_modules/@humanwhocodes/object-schema": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+			"integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+			"deprecated": "Use @eslint/object-schema instead",
+			"dev": true
+		},
+		"node_modules/@isaacs/cliui": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+			"dev": true,
+			"dependencies": {
+				"string-width": "^5.1.2",
+				"string-width-cjs": "npm:string-width@^4.2.0",
+				"strip-ansi": "^7.0.1",
+				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+				"wrap-ansi": "^8.1.0",
+				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.0.tgz",
+			"integrity": "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/@istanbuljs/load-nyc-config": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+			"integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+			"dev": true,
+			"dependencies": {
+				"camelcase": "^5.3.1",
+				"find-up": "^4.1.0",
+				"get-package-type": "^0.1.0",
+				"js-yaml": "^3.13.1",
+				"resolve-from": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
+			"dependencies": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
+		"node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+			"dev": true,
+			"dependencies": {
+				"locate-path": "^5.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+			"version": "3.14.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+			"dev": true,
+			"dependencies": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+			"dev": true,
+			"dependencies": {
+				"p-locate": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+			"dev": true,
+			"dependencies": {
+				"p-try": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+			"dev": true,
+			"dependencies": {
+				"p-limit": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@istanbuljs/schema": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+			"integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@jest/console": {
+			"version": "30.1.2",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-30.1.2.tgz",
+			"integrity": "sha512-BGMAxj8VRmoD0MoA/jo9alMXSRoqW8KPeqOfEo1ncxnRLatTBCpRoOwlwlEMdudp68Q6WSGwYrrLtTGOh8fLzw==",
+			"dev": true,
+			"dependencies": {
+				"@jest/types": "30.0.5",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"jest-message-util": "30.1.0",
+				"jest-util": "30.0.5",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/core": {
+			"version": "30.1.2",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-30.1.2.tgz",
+			"integrity": "sha512-iSLOojkYgM7Lw0FF5egecZh+CiLWe4xICM3WOMjFbewhbWn+ixEoPwY7oK9jSCnLLphMFAjussXp7CE3tHa5EA==",
+			"dev": true,
+			"dependencies": {
+				"@jest/console": "30.1.2",
+				"@jest/pattern": "30.0.1",
+				"@jest/reporters": "30.1.2",
+				"@jest/test-result": "30.1.2",
+				"@jest/transform": "30.1.2",
+				"@jest/types": "30.0.5",
+				"@types/node": "*",
+				"ansi-escapes": "^4.3.2",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"exit-x": "^0.2.2",
+				"graceful-fs": "^4.2.11",
+				"jest-changed-files": "30.0.5",
+				"jest-config": "30.1.2",
+				"jest-haste-map": "30.1.0",
+				"jest-message-util": "30.1.0",
+				"jest-regex-util": "30.0.1",
+				"jest-resolve": "30.1.0",
+				"jest-resolve-dependencies": "30.1.2",
+				"jest-runner": "30.1.2",
+				"jest-runtime": "30.1.2",
+				"jest-snapshot": "30.1.2",
+				"jest-util": "30.0.5",
+				"jest-validate": "30.1.0",
+				"jest-watcher": "30.1.2",
+				"micromatch": "^4.0.8",
+				"pretty-format": "30.0.5",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+			},
+			"peerDependenciesMeta": {
+				"node-notifier": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@jest/diff-sequences": {
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
+			"integrity": "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==",
+			"dev": true,
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/environment": {
+			"version": "30.1.2",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.1.2.tgz",
+			"integrity": "sha512-N8t1Ytw4/mr9uN28OnVf0SYE2dGhaIxOVYcwsf9IInBKjvofAjbFRvedvBBlyTYk2knbJTiEjEJ2PyyDIBnd9w==",
+			"dev": true,
+			"dependencies": {
+				"@jest/fake-timers": "30.1.2",
+				"@jest/types": "30.0.5",
+				"@types/node": "*",
+				"jest-mock": "30.0.5"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/expect": {
+			"version": "30.1.2",
+			"resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.1.2.tgz",
+			"integrity": "sha512-tyaIExOwQRCxPCGNC05lIjWJztDwk2gPDNSDGg1zitXJJ8dC3++G/CRjE5mb2wQsf89+lsgAgqxxNpDLiCViTA==",
+			"dev": true,
+			"dependencies": {
+				"expect": "30.1.2",
+				"jest-snapshot": "30.1.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/expect-utils": {
+			"version": "30.1.2",
+			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.1.2.tgz",
+			"integrity": "sha512-HXy1qT/bfdjCv7iC336ExbqqYtZvljrV8odNdso7dWK9bSeHtLlvwWWC3YSybSPL03Gg5rug6WLCZAZFH72m0A==",
+			"dev": true,
+			"dependencies": {
+				"@jest/get-type": "30.1.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/fake-timers": {
+			"version": "30.1.2",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.1.2.tgz",
+			"integrity": "sha512-Beljfv9AYkr9K+ETX9tvV61rJTY706BhBUtiaepQHeEGfe0DbpvUA5Z3fomwc5Xkhns6NWrcFDZn+72fLieUnA==",
+			"dev": true,
+			"dependencies": {
+				"@jest/types": "30.0.5",
+				"@sinonjs/fake-timers": "^13.0.0",
+				"@types/node": "*",
+				"jest-message-util": "30.1.0",
+				"jest-mock": "30.0.5",
+				"jest-util": "30.0.5"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/get-type": {
+			"version": "30.1.0",
+			"resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+			"integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+			"dev": true,
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/globals": {
+			"version": "30.1.2",
+			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.1.2.tgz",
+			"integrity": "sha512-teNTPZ8yZe3ahbYnvnVRDeOjr+3pu2uiAtNtrEsiMjVPPj+cXd5E/fr8BL7v/T7F31vYdEHrI5cC/2OoO/vM9A==",
+			"dev": true,
+			"dependencies": {
+				"@jest/environment": "30.1.2",
+				"@jest/expect": "30.1.2",
+				"@jest/types": "30.0.5",
+				"jest-mock": "30.0.5"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/pattern": {
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+			"integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*",
+				"jest-regex-util": "30.0.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/reporters": {
+			"version": "30.1.2",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.1.2.tgz",
+			"integrity": "sha512-8Jd7y3DUFBn8dG/bNJ2blmaJmT2Up74WAXkUJsbL0OuEZHDRRMnS4JmRtLArW2d0H5k8RDdhNN7j70Ki16Zr5g==",
+			"dev": true,
+			"dependencies": {
+				"@bcoe/v8-coverage": "^0.2.3",
+				"@jest/console": "30.1.2",
+				"@jest/test-result": "30.1.2",
+				"@jest/transform": "30.1.2",
+				"@jest/types": "30.0.5",
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"collect-v8-coverage": "^1.0.2",
+				"exit-x": "^0.2.2",
+				"glob": "^10.3.10",
+				"graceful-fs": "^4.2.11",
+				"istanbul-lib-coverage": "^3.0.0",
+				"istanbul-lib-instrument": "^6.0.0",
+				"istanbul-lib-report": "^3.0.0",
+				"istanbul-lib-source-maps": "^5.0.0",
+				"istanbul-reports": "^3.1.3",
+				"jest-message-util": "30.1.0",
+				"jest-util": "30.0.5",
+				"jest-worker": "30.1.0",
+				"slash": "^3.0.0",
+				"string-length": "^4.0.2",
+				"v8-to-istanbul": "^9.0.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+			},
+			"peerDependenciesMeta": {
+				"node-notifier": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@jest/reporters/node_modules/@bcoe/v8-coverage": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+			"dev": true
+		},
+		"node_modules/@jest/schemas": {
+			"version": "30.0.5",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+			"integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+			"dev": true,
+			"dependencies": {
+				"@sinclair/typebox": "^0.34.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/snapshot-utils": {
+			"version": "30.1.2",
+			"resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.1.2.tgz",
+			"integrity": "sha512-vHoMTpimcPSR7OxS2S0V1Cpg8eKDRxucHjoWl5u4RQcnxqQrV3avETiFpl8etn4dqxEGarBeHbIBety/f8mLXw==",
+			"dev": true,
+			"dependencies": {
+				"@jest/types": "30.0.5",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"natural-compare": "^1.4.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/source-map": {
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-30.0.1.tgz",
+			"integrity": "sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"callsites": "^3.1.0",
+				"graceful-fs": "^4.2.11"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/test-result": {
+			"version": "30.1.2",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.1.2.tgz",
+			"integrity": "sha512-mpKFr8DEpfG5aAfQYA5+3KneAsRBXhF7zwtwqT4UeYBckoOPD1MzVxU6gDHwx4gRB7I1MKL6owyJzr8QRq402Q==",
+			"dev": true,
+			"dependencies": {
+				"@jest/console": "30.1.2",
+				"@jest/types": "30.0.5",
+				"@types/istanbul-lib-coverage": "^2.0.6",
+				"collect-v8-coverage": "^1.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/test-sequencer": {
+			"version": "30.1.2",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.1.2.tgz",
+			"integrity": "sha512-v3vawuj2LC0XjpzF4q0pI0ZlQvMBDNqfRZZ2yHqcsGt7JEYsDK2L1WwrybEGlnOaEvnDFML/Y9xWLiW47Dda8A==",
+			"dev": true,
+			"dependencies": {
+				"@jest/test-result": "30.1.2",
+				"graceful-fs": "^4.2.11",
+				"jest-haste-map": "30.1.0",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/transform": {
+			"version": "30.1.2",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.1.2.tgz",
+			"integrity": "sha512-UYYFGifSgfjujf1Cbd3iU/IQoSd6uwsj8XHj5DSDf5ERDcWMdJOPTkHWXj4U+Z/uMagyOQZ6Vne8C4nRIrCxqA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/core": "^7.27.4",
+				"@jest/types": "30.0.5",
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"babel-plugin-istanbul": "^7.0.0",
+				"chalk": "^4.1.2",
+				"convert-source-map": "^2.0.0",
+				"fast-json-stable-stringify": "^2.1.0",
+				"graceful-fs": "^4.2.11",
+				"jest-haste-map": "30.1.0",
+				"jest-regex-util": "30.0.1",
+				"jest-util": "30.0.5",
+				"micromatch": "^4.0.8",
+				"pirates": "^4.0.7",
+				"slash": "^3.0.0",
+				"write-file-atomic": "^5.0.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/types": {
+			"version": "30.0.5",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.0.5.tgz",
+			"integrity": "sha512-aREYa3aku9SSnea4aX6bhKn4bgv3AXkgijoQgbYV3yvbiGt6z+MQ85+6mIhx9DsKW2BuB/cLR/A+tcMThx+KLQ==",
+			"dev": true,
+			"dependencies": {
+				"@jest/pattern": "30.0.1",
+				"@jest/schemas": "30.0.5",
+				"@types/istanbul-lib-coverage": "^2.0.6",
+				"@types/istanbul-reports": "^3.0.4",
+				"@types/node": "*",
+				"@types/yargs": "^17.0.33",
+				"chalk": "^4.1.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jridgewell/gen-mapping": {
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+			"integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.0",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
+		"node_modules/@jridgewell/resolve-uri": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+			"dev": true
+		},
+		"node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.30",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz",
+			"integrity": "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
+		},
+		"node_modules/@napi-rs/wasm-runtime": {
+			"version": "0.2.12",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+			"integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+			"dev": true,
+			"optional": true,
+			"dependencies": {
+				"@emnapi/core": "^1.4.3",
+				"@emnapi/runtime": "^1.4.3",
+				"@tybys/wasm-util": "^0.10.0"
+			}
+		},
+		"node_modules/@noble/curves": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+			"integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+			"dependencies": {
+				"@noble/hashes": "1.3.2"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/@noble/hashes": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+			"integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+			"engines": {
+				"node": ">= 16"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/@nodelib/fs.scandir": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+			"dev": true,
+			"dependencies": {
+				"@nodelib/fs.stat": "2.0.5",
+				"run-parallel": "^1.1.9"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@nodelib/fs.stat": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+			"dev": true,
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@nodelib/fs.walk": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+			"dev": true,
+			"dependencies": {
+				"@nodelib/fs.scandir": "2.1.5",
+				"fastq": "^1.6.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@pkgjs/parseargs": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+			"dev": true,
+			"optional": true,
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@pkgr/core": {
+			"version": "0.2.9",
+			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
+			"integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
+			"dev": true,
+			"engines": {
+				"node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/pkgr"
+			}
+		},
+		"node_modules/@rtsao/scc": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
+			"integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+			"dev": true
+		},
+		"node_modules/@sinclair/typebox": {
+			"version": "0.34.41",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz",
+			"integrity": "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==",
+			"dev": true
+		},
+		"node_modules/@sinonjs/commons": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+			"integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+			"dev": true,
+			"dependencies": {
+				"type-detect": "4.0.8"
+			}
+		},
+		"node_modules/@sinonjs/fake-timers": {
+			"version": "13.0.5",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+			"integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+			"dev": true,
+			"dependencies": {
+				"@sinonjs/commons": "^3.0.1"
+			}
+		},
+		"node_modules/@tybys/wasm-util": {
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
+			"integrity": "sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==",
+			"dev": true,
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@types/babel__core": {
+			"version": "7.20.5",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+			"integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/parser": "^7.20.7",
+				"@babel/types": "^7.20.7",
+				"@types/babel__generator": "*",
+				"@types/babel__template": "*",
+				"@types/babel__traverse": "*"
+			}
+		},
+		"node_modules/@types/babel__generator": {
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+			"integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"node_modules/@types/babel__template": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+			"integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+			"dev": true,
+			"dependencies": {
+				"@babel/parser": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"node_modules/@types/babel__traverse": {
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+			"integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+			"dev": true,
+			"dependencies": {
+				"@babel/types": "^7.28.2"
+			}
+		},
+		"node_modules/@types/estree": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+			"dev": true
+		},
+		"node_modules/@types/istanbul-lib-coverage": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+			"integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+			"dev": true
+		},
+		"node_modules/@types/istanbul-lib-report": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+			"integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+			"dev": true,
+			"dependencies": {
+				"@types/istanbul-lib-coverage": "*"
+			}
+		},
+		"node_modules/@types/istanbul-reports": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+			"integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+			"dev": true,
+			"dependencies": {
+				"@types/istanbul-lib-report": "*"
+			}
+		},
+		"node_modules/@types/json5": {
+			"version": "0.0.29",
+			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+			"dev": true
+		},
+		"node_modules/@types/node": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+			"integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+			"dev": true,
+			"dependencies": {
+				"undici-types": "~7.10.0"
+			}
+		},
+		"node_modules/@types/stack-utils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+			"integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+			"dev": true
+		},
+		"node_modules/@types/yargs": {
+			"version": "17.0.33",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+			"integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
+			"dev": true,
+			"dependencies": {
+				"@types/yargs-parser": "*"
+			}
+		},
+		"node_modules/@types/yargs-parser": {
+			"version": "21.0.3",
+			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+			"integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+			"dev": true
+		},
+		"node_modules/@typescript-eslint/types": {
+			"version": "8.42.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.42.0.tgz",
+			"integrity": "sha512-LdtAWMiFmbRLNP7JNeY0SqEtJvGMYSzfiWBSmx+VSZ1CH+1zyl8Mmw1TT39OrtsRvIYShjJWzTDMPWZJCpwBlw==",
+			"dev": true,
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@ungap/structured-clone": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+			"integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+			"dev": true
+		},
+		"node_modules/@unrs/resolver-binding-android-arm-eabi": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+			"integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-android-arm64": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+			"integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-darwin-arm64": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+			"integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-darwin-x64": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+			"integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-freebsd-x64": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+			"integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+			"integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+			"integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+			"integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+			"integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+			"integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+			"integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+			"integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+			"integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+			"integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-x64-musl": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+			"integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-wasm32-wasi": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+			"integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"optional": true,
+			"dependencies": {
+				"@napi-rs/wasm-runtime": "^0.2.11"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+			"integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+			"integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+			"integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/acorn": {
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+			"dev": true,
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/acorn-jsx": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+			"dev": true,
+			"peerDependencies": {
+				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/aes-js": {
+			"version": "4.0.0-beta.5",
+			"resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+			"integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
+		},
+		"node_modules/ajv": {
+			"version": "6.12.6",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"dev": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ansi-escapes": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+			"integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+			"dev": true,
+			"dependencies": {
+				"type-fest": "^0.21.3"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ansi-escapes/node_modules/type-fest": {
+			"version": "0.21.3",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+			"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/anymatch": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+			"integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+			"dev": true,
+			"dependencies": {
+				"normalize-path": "^3.0.0",
+				"picomatch": "^2.0.4"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/are-docs-informative": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+			"integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
+			"dev": true,
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true
+		},
+		"node_modules/aria-query": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+			"integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+			"dev": true,
+			"peer": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/array-buffer-byte-length": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+			"integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+			"dev": true,
+			"dependencies": {
+				"call-bound": "^1.0.3",
+				"is-array-buffer": "^3.0.5"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/array-includes": {
+			"version": "3.1.9",
+			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+			"integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.4",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.24.0",
+				"es-object-atoms": "^1.1.1",
+				"get-intrinsic": "^1.3.0",
+				"is-string": "^1.1.1",
+				"math-intrinsics": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/array.prototype.findlast": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+			"integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.2",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.0.0",
+				"es-shim-unscopables": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/array.prototype.findlastindex": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
+			"integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.4",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.9",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.1.1",
+				"es-shim-unscopables": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/array.prototype.flat": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+			"integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.5",
+				"es-shim-unscopables": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/array.prototype.flatmap": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+			"integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.5",
+				"es-shim-unscopables": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/array.prototype.tosorted": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+			"integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.3",
+				"es-errors": "^1.3.0",
+				"es-shim-unscopables": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/arraybuffer.prototype.slice": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+			"integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+			"dev": true,
+			"dependencies": {
+				"array-buffer-byte-length": "^1.0.1",
+				"call-bind": "^1.0.8",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.5",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.6",
+				"is-array-buffer": "^3.0.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/ast-types-flow": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+			"integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+			"dev": true,
+			"peer": true
+		},
+		"node_modules/async-function": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+			"integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/available-typed-arrays": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+			"integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+			"dev": true,
+			"dependencies": {
+				"possible-typed-array-names": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/axe-core": {
+			"version": "4.10.3",
+			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
+			"integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
+			"dev": true,
+			"peer": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/axobject-query": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+			"integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+			"dev": true,
+			"peer": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/babel-jest": {
+			"version": "30.1.2",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.1.2.tgz",
+			"integrity": "sha512-IQCus1rt9kaSh7PQxLYRY5NmkNrNlU2TpabzwV7T2jljnpdHOcmnYYv8QmE04Li4S3a2Lj8/yXyET5pBarPr6g==",
+			"dev": true,
+			"dependencies": {
+				"@jest/transform": "30.1.2",
+				"@types/babel__core": "^7.20.5",
+				"babel-plugin-istanbul": "^7.0.0",
+				"babel-preset-jest": "30.0.1",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.11.0"
+			}
+		},
+		"node_modules/babel-plugin-istanbul": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.0.tgz",
+			"integrity": "sha512-C5OzENSx/A+gt7t4VH1I2XsflxyPUmXRFPKBxt33xncdOmq7oROVM3bZv9Ysjjkv8OJYDMa+tKuKMvqU/H3xdw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@istanbuljs/load-nyc-config": "^1.0.0",
+				"@istanbuljs/schema": "^0.1.3",
+				"istanbul-lib-instrument": "^6.0.2",
+				"test-exclude": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/babel-plugin-istanbul/node_modules/glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"deprecated": "Glob versions prior to v9 are no longer supported",
+			"dev": true,
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/babel-plugin-istanbul/node_modules/test-exclude": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+			"integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+			"dev": true,
+			"dependencies": {
+				"@istanbuljs/schema": "^0.1.2",
+				"glob": "^7.1.4",
+				"minimatch": "^3.0.4"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/babel-plugin-jest-hoist": {
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.0.1.tgz",
+			"integrity": "sha512-zTPME3pI50NsFW8ZBaVIOeAxzEY7XHlmWeXXu9srI+9kNfzCUTy8MFan46xOGZY8NZThMqq+e3qZUKsvXbasnQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/template": "^7.27.2",
+				"@babel/types": "^7.27.3",
+				"@types/babel__core": "^7.20.5"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/babel-preset-current-node-syntax": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+			"integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/plugin-syntax-async-generators": "^7.8.4",
+				"@babel/plugin-syntax-bigint": "^7.8.3",
+				"@babel/plugin-syntax-class-properties": "^7.12.13",
+				"@babel/plugin-syntax-class-static-block": "^7.14.5",
+				"@babel/plugin-syntax-import-attributes": "^7.24.7",
+				"@babel/plugin-syntax-import-meta": "^7.10.4",
+				"@babel/plugin-syntax-json-strings": "^7.8.3",
+				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+				"@babel/plugin-syntax-numeric-separator": "^7.10.4",
+				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+				"@babel/plugin-syntax-optional-chaining": "^7.8.3",
+				"@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+				"@babel/plugin-syntax-top-level-await": "^7.14.5"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0 || ^8.0.0-0"
+			}
+		},
+		"node_modules/babel-preset-jest": {
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.0.1.tgz",
+			"integrity": "sha512-+YHejD5iTWI46cZmcc/YtX4gaKBtdqCHCVfuVinizVpbmyjO3zYmeuyFdfA8duRqQZfgCAMlsfmkVbJ+e2MAJw==",
+			"dev": true,
+			"dependencies": {
+				"babel-plugin-jest-hoist": "30.0.1",
+				"babel-preset-current-node-syntax": "^1.1.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.11.0"
+			}
+		},
+		"node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true
+		},
+		"node_modules/brace-expansion": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/braces": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+			"dev": true,
+			"dependencies": {
+				"fill-range": "^7.1.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/browserslist": {
+			"version": "4.25.4",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.4.tgz",
+			"integrity": "sha512-4jYpcjabC606xJ3kw2QwGEZKX0Aw7sgQdZCvIK9dhVSPh76BKo+C+btT1RRofH7B+8iNpEbgGNVWiLki5q93yg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"dependencies": {
+				"caniuse-lite": "^1.0.30001737",
+				"electron-to-chromium": "^1.5.211",
+				"node-releases": "^2.0.19",
+				"update-browserslist-db": "^1.1.3"
+			},
+			"bin": {
+				"browserslist": "cli.js"
+			},
+			"engines": {
+				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+			}
+		},
+		"node_modules/bser": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+			"integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+			"dev": true,
+			"dependencies": {
+				"node-int64": "^0.4.0"
+			}
+		},
+		"node_modules/buffer-from": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+			"dev": true
+		},
+		"node_modules/c8": {
+			"version": "10.1.3",
+			"resolved": "https://registry.npmjs.org/c8/-/c8-10.1.3.tgz",
+			"integrity": "sha512-LvcyrOAaOnrrlMpW22n690PUvxiq4Uf9WMhQwNJ9vgagkL/ph1+D4uvjvDA5XCbykrc0sx+ay6pVi9YZ1GnhyA==",
+			"dev": true,
+			"dependencies": {
+				"@bcoe/v8-coverage": "^1.0.1",
+				"@istanbuljs/schema": "^0.1.3",
+				"find-up": "^5.0.0",
+				"foreground-child": "^3.1.1",
+				"istanbul-lib-coverage": "^3.2.0",
+				"istanbul-lib-report": "^3.0.1",
+				"istanbul-reports": "^3.1.6",
+				"test-exclude": "^7.0.1",
+				"v8-to-istanbul": "^9.0.0",
+				"yargs": "^17.7.2",
+				"yargs-parser": "^21.1.1"
+			},
+			"bin": {
+				"c8": "bin/c8.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"monocart-coverage-reports": "^2"
+			},
+			"peerDependenciesMeta": {
+				"monocart-coverage-reports": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/call-bind": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+			"integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+			"dev": true,
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.0",
+				"es-define-property": "^1.0.0",
+				"get-intrinsic": "^1.2.4",
+				"set-function-length": "^1.2.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/call-bind-apply-helpers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+			"dev": true,
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/call-bound": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+			"dev": true,
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"get-intrinsic": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/callsites": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/camelcase": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/caniuse-lite": {
+			"version": "1.0.30001739",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001739.tgz",
+			"integrity": "sha512-y+j60d6ulelrNSwpPyrHdl+9mJnQzHBr08xm48Qno0nSk4h3Qojh+ziv2qE6rXf4k3tadF4o1J/1tAbVm1NtnA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			]
+		},
+		"node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/char-regex": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+			"integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/ci-info": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.0.tgz",
+			"integrity": "sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cjs-module-lexer": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.1.0.tgz",
+			"integrity": "sha512-UX0OwmYRYQQetfrLEZeewIFFI+wSTofC+pMBLNuH3RUuu/xzG1oz84UCEDOSoQlN3fZ4+AzmV50ZYvGqkMh9yA==",
+			"dev": true
+		},
+		"node_modules/cliui": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"dev": true,
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/cliui/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true
+		},
+		"node_modules/cliui/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cliui/node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/co": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+			"integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+			"dev": true,
+			"engines": {
+				"iojs": ">= 1.0.0",
+				"node": ">= 0.12.0"
+			}
+		},
+		"node_modules/collect-v8-coverage": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
+			"integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
+			"dev": true
+		},
+		"node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"node_modules/comment-parser": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
+			"integrity": "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+			"dev": true
+		},
+		"node_modules/confusing-browser-globals": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
+			"integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
+			"dev": true
+		},
+		"node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true
+		},
+		"node_modules/cross-spawn": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+			"dev": true,
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/damerau-levenshtein": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+			"integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+			"dev": true,
+			"peer": true
+		},
+		"node_modules/data-view-buffer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+			"integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bound": "^1.0.3",
+				"es-errors": "^1.3.0",
+				"is-data-view": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/data-view-byte-length": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+			"integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bound": "^1.0.3",
+				"es-errors": "^1.3.0",
+				"is-data-view": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/inspect-js"
+			}
+		},
+		"node_modules/data-view-byte-offset": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+			"integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"is-data-view": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+			"dev": true,
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/dedent": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.6.0.tgz",
+			"integrity": "sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA==",
+			"dev": true,
+			"peerDependencies": {
+				"babel-plugin-macros": "^3.1.0"
+			},
+			"peerDependenciesMeta": {
+				"babel-plugin-macros": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/deep-is": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+			"dev": true
+		},
+		"node_modules/deepmerge": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+			"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/define-data-property": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+			"dev": true,
+			"dependencies": {
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/define-properties": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+			"integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+			"dev": true,
+			"dependencies": {
+				"define-data-property": "^1.0.1",
+				"has-property-descriptors": "^1.0.0",
+				"object-keys": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/detect-newline": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+			"integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/doctrine": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+			"dev": true,
+			"dependencies": {
+				"esutils": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/dunder-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+			"dev": true,
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/eastasianwidth": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+			"dev": true
+		},
+		"node_modules/electron-to-chromium": {
+			"version": "1.5.212",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.212.tgz",
+			"integrity": "sha512-gE7ErIzSW+d8jALWMcOIgf+IB6lpfsg6NwOhPVwKzDtN2qcBix47vlin4yzSregYDxTCXOUqAZjVY/Z3naS7ww==",
+			"dev": true
+		},
+		"node_modules/emittery": {
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+			"integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/emittery?sponsor=1"
+			}
+		},
+		"node_modules/emoji-regex": {
+			"version": "9.2.2",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+			"dev": true
+		},
+		"node_modules/error-ex": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+			"dev": true,
+			"dependencies": {
+				"is-arrayish": "^0.2.1"
+			}
+		},
+		"node_modules/es-abstract": {
+			"version": "1.24.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz",
+			"integrity": "sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==",
+			"dev": true,
+			"dependencies": {
+				"array-buffer-byte-length": "^1.0.2",
+				"arraybuffer.prototype.slice": "^1.0.4",
+				"available-typed-arrays": "^1.0.7",
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.4",
+				"data-view-buffer": "^1.0.2",
+				"data-view-byte-length": "^1.0.2",
+				"data-view-byte-offset": "^1.0.1",
+				"es-define-property": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.1.1",
+				"es-set-tostringtag": "^2.1.0",
+				"es-to-primitive": "^1.3.0",
+				"function.prototype.name": "^1.1.8",
+				"get-intrinsic": "^1.3.0",
+				"get-proto": "^1.0.1",
+				"get-symbol-description": "^1.1.0",
+				"globalthis": "^1.0.4",
+				"gopd": "^1.2.0",
+				"has-property-descriptors": "^1.0.2",
+				"has-proto": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"hasown": "^2.0.2",
+				"internal-slot": "^1.1.0",
+				"is-array-buffer": "^3.0.5",
+				"is-callable": "^1.2.7",
+				"is-data-view": "^1.0.2",
+				"is-negative-zero": "^2.0.3",
+				"is-regex": "^1.2.1",
+				"is-set": "^2.0.3",
+				"is-shared-array-buffer": "^1.0.4",
+				"is-string": "^1.1.1",
+				"is-typed-array": "^1.1.15",
+				"is-weakref": "^1.1.1",
+				"math-intrinsics": "^1.1.0",
+				"object-inspect": "^1.13.4",
+				"object-keys": "^1.1.1",
+				"object.assign": "^4.1.7",
+				"own-keys": "^1.0.1",
+				"regexp.prototype.flags": "^1.5.4",
+				"safe-array-concat": "^1.1.3",
+				"safe-push-apply": "^1.0.0",
+				"safe-regex-test": "^1.1.0",
+				"set-proto": "^1.0.0",
+				"stop-iteration-iterator": "^1.1.0",
+				"string.prototype.trim": "^1.2.10",
+				"string.prototype.trimend": "^1.0.9",
+				"string.prototype.trimstart": "^1.0.8",
+				"typed-array-buffer": "^1.0.3",
+				"typed-array-byte-length": "^1.0.3",
+				"typed-array-byte-offset": "^1.0.4",
+				"typed-array-length": "^1.0.7",
+				"unbox-primitive": "^1.1.0",
+				"which-typed-array": "^1.1.19"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/es-define-property": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-iterator-helpers": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.1.tgz",
+			"integrity": "sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.3",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.6",
+				"es-errors": "^1.3.0",
+				"es-set-tostringtag": "^2.0.3",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.6",
+				"globalthis": "^1.0.4",
+				"gopd": "^1.2.0",
+				"has-property-descriptors": "^1.0.2",
+				"has-proto": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"internal-slot": "^1.1.0",
+				"iterator.prototype": "^1.1.4",
+				"safe-array-concat": "^1.1.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-object-atoms": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+			"dev": true,
+			"dependencies": {
+				"es-errors": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-set-tostringtag": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+			"integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+			"dev": true,
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.6",
+				"has-tostringtag": "^1.0.2",
+				"hasown": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-shim-unscopables": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+			"integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+			"dev": true,
+			"dependencies": {
+				"hasown": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-to-primitive": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+			"integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+			"dev": true,
+			"dependencies": {
+				"is-callable": "^1.2.7",
+				"is-date-object": "^1.0.5",
+				"is-symbol": "^1.0.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/escalade": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/escape-string-regexp": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint": {
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+			"integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+			"deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+			"dev": true,
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.2.0",
+				"@eslint-community/regexpp": "^4.6.1",
+				"@eslint/eslintrc": "^2.1.4",
+				"@eslint/js": "8.57.1",
+				"@humanwhocodes/config-array": "^0.13.0",
+				"@humanwhocodes/module-importer": "^1.0.1",
+				"@nodelib/fs.walk": "^1.2.8",
+				"@ungap/structured-clone": "^1.2.0",
+				"ajv": "^6.12.4",
+				"chalk": "^4.0.0",
+				"cross-spawn": "^7.0.2",
+				"debug": "^4.3.2",
+				"doctrine": "^3.0.0",
+				"escape-string-regexp": "^4.0.0",
+				"eslint-scope": "^7.2.2",
+				"eslint-visitor-keys": "^3.4.3",
+				"espree": "^9.6.1",
+				"esquery": "^1.4.2",
+				"esutils": "^2.0.2",
+				"fast-deep-equal": "^3.1.3",
+				"file-entry-cache": "^6.0.1",
+				"find-up": "^5.0.0",
+				"glob-parent": "^6.0.2",
+				"globals": "^13.19.0",
+				"graphemer": "^1.4.0",
+				"ignore": "^5.2.0",
+				"imurmurhash": "^0.1.4",
+				"is-glob": "^4.0.0",
+				"is-path-inside": "^3.0.3",
+				"js-yaml": "^4.1.0",
+				"json-stable-stringify-without-jsonify": "^1.0.1",
+				"levn": "^0.4.1",
+				"lodash.merge": "^4.6.2",
+				"minimatch": "^3.1.2",
+				"natural-compare": "^1.4.0",
+				"optionator": "^0.9.3",
+				"strip-ansi": "^6.0.1",
+				"text-table": "^0.2.0"
+			},
+			"bin": {
+				"eslint": "bin/eslint.js"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint-config-airbnb": {
+			"version": "19.0.4",
+			"resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-19.0.4.tgz",
+			"integrity": "sha512-T75QYQVQX57jiNgpF9r1KegMICE94VYwoFQyMGhrvc+lB8YF2E/M/PYDaQe1AJcWaEgqLE+ErXV1Og/+6Vyzew==",
+			"dev": true,
+			"dependencies": {
+				"eslint-config-airbnb-base": "^15.0.0",
+				"object.assign": "^4.1.2",
+				"object.entries": "^1.1.5"
+			},
+			"engines": {
+				"node": "^10.12.0 || ^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"peerDependencies": {
+				"eslint": "^7.32.0 || ^8.2.0",
+				"eslint-plugin-import": "^2.25.3",
+				"eslint-plugin-jsx-a11y": "^6.5.1",
+				"eslint-plugin-react": "^7.28.0",
+				"eslint-plugin-react-hooks": "^4.3.0"
+			}
+		},
+		"node_modules/eslint-config-airbnb-base": {
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-15.0.0.tgz",
+			"integrity": "sha512-xaX3z4ZZIcFLvh2oUNvcX5oEofXda7giYmuplVxoOg5A7EXJMrUyqRgR+mhDhPK8LZ4PttFOBvCYDbX3sUoUig==",
+			"dev": true,
+			"dependencies": {
+				"confusing-browser-globals": "^1.0.10",
+				"object.assign": "^4.1.2",
+				"object.entries": "^1.1.5",
+				"semver": "^6.3.0"
+			},
+			"engines": {
+				"node": "^10.12.0 || >=12.0.0"
+			},
+			"peerDependencies": {
+				"eslint": "^7.32.0 || ^8.2.0",
+				"eslint-plugin-import": "^2.25.2"
+			}
+		},
+		"node_modules/eslint-import-resolver-node": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
+			"integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
+			"dev": true,
+			"dependencies": {
+				"debug": "^3.2.7",
+				"is-core-module": "^2.13.0",
+				"resolve": "^1.22.4"
+			}
+		},
+		"node_modules/eslint-import-resolver-node/node_modules/debug": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+			"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+			"dev": true,
+			"dependencies": {
+				"ms": "^2.1.1"
+			}
+		},
+		"node_modules/eslint-module-utils": {
+			"version": "2.12.1",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
+			"integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
+			"dev": true,
+			"dependencies": {
+				"debug": "^3.2.7"
+			},
+			"engines": {
+				"node": ">=4"
+			},
+			"peerDependenciesMeta": {
+				"eslint": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/eslint-module-utils/node_modules/debug": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+			"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+			"dev": true,
+			"dependencies": {
+				"ms": "^2.1.1"
+			}
+		},
+		"node_modules/eslint-plugin-import": {
+			"version": "2.32.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
+			"integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
+			"dev": true,
+			"dependencies": {
+				"@rtsao/scc": "^1.1.0",
+				"array-includes": "^3.1.9",
+				"array.prototype.findlastindex": "^1.2.6",
+				"array.prototype.flat": "^1.3.3",
+				"array.prototype.flatmap": "^1.3.3",
+				"debug": "^3.2.7",
+				"doctrine": "^2.1.0",
+				"eslint-import-resolver-node": "^0.3.9",
+				"eslint-module-utils": "^2.12.1",
+				"hasown": "^2.0.2",
+				"is-core-module": "^2.16.1",
+				"is-glob": "^4.0.3",
+				"minimatch": "^3.1.2",
+				"object.fromentries": "^2.0.8",
+				"object.groupby": "^1.0.3",
+				"object.values": "^1.2.1",
+				"semver": "^6.3.1",
+				"string.prototype.trimend": "^1.0.9",
+				"tsconfig-paths": "^3.15.0"
+			},
+			"engines": {
+				"node": ">=4"
+			},
+			"peerDependencies": {
+				"eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
+			}
+		},
+		"node_modules/eslint-plugin-import/node_modules/debug": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+			"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+			"dev": true,
+			"dependencies": {
+				"ms": "^2.1.1"
+			}
+		},
+		"node_modules/eslint-plugin-import/node_modules/doctrine": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+			"dev": true,
+			"dependencies": {
+				"esutils": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/eslint-plugin-jsdoc": {
+			"version": "50.8.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.8.0.tgz",
+			"integrity": "sha512-UyGb5755LMFWPrZTEqqvTJ3urLz1iqj+bYOHFNag+sw3NvaMWP9K2z+uIn37XfNALmQLQyrBlJ5mkiVPL7ADEg==",
+			"dev": true,
+			"dependencies": {
+				"@es-joy/jsdoccomment": "~0.50.2",
+				"are-docs-informative": "^0.0.2",
+				"comment-parser": "1.4.1",
+				"debug": "^4.4.1",
+				"escape-string-regexp": "^4.0.0",
+				"espree": "^10.3.0",
+				"esquery": "^1.6.0",
+				"parse-imports-exports": "^0.2.4",
+				"semver": "^7.7.2",
+				"spdx-expression-parse": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
+			}
+		},
+		"node_modules/eslint-plugin-jsdoc/node_modules/eslint-visitor-keys": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+			"dev": true,
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint-plugin-jsdoc/node_modules/espree": {
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+			"integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+			"dev": true,
+			"dependencies": {
+				"acorn": "^8.15.0",
+				"acorn-jsx": "^5.3.2",
+				"eslint-visitor-keys": "^4.2.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint-plugin-jsdoc/node_modules/semver": {
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/eslint-plugin-jsx-a11y": {
+			"version": "6.10.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+			"integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"aria-query": "^5.3.2",
+				"array-includes": "^3.1.8",
+				"array.prototype.flatmap": "^1.3.2",
+				"ast-types-flow": "^0.0.8",
+				"axe-core": "^4.10.0",
+				"axobject-query": "^4.1.0",
+				"damerau-levenshtein": "^1.0.8",
+				"emoji-regex": "^9.2.2",
+				"hasown": "^2.0.2",
+				"jsx-ast-utils": "^3.3.5",
+				"language-tags": "^1.0.9",
+				"minimatch": "^3.1.2",
+				"object.fromentries": "^2.0.8",
+				"safe-regex-test": "^1.0.3",
+				"string.prototype.includes": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=4.0"
+			},
+			"peerDependencies": {
+				"eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+			}
+		},
+		"node_modules/eslint-plugin-react": {
+			"version": "7.37.5",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+			"integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"array-includes": "^3.1.8",
+				"array.prototype.findlast": "^1.2.5",
+				"array.prototype.flatmap": "^1.3.3",
+				"array.prototype.tosorted": "^1.1.4",
+				"doctrine": "^2.1.0",
+				"es-iterator-helpers": "^1.2.1",
+				"estraverse": "^5.3.0",
+				"hasown": "^2.0.2",
+				"jsx-ast-utils": "^2.4.1 || ^3.0.0",
+				"minimatch": "^3.1.2",
+				"object.entries": "^1.1.9",
+				"object.fromentries": "^2.0.8",
+				"object.values": "^1.2.1",
+				"prop-types": "^15.8.1",
+				"resolve": "^2.0.0-next.5",
+				"semver": "^6.3.1",
+				"string.prototype.matchall": "^4.0.12",
+				"string.prototype.repeat": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			},
+			"peerDependencies": {
+				"eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+			}
+		},
+		"node_modules/eslint-plugin-react-hooks": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
+			"integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
+			"dev": true,
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+			}
+		},
+		"node_modules/eslint-plugin-react/node_modules/doctrine": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"esutils": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/eslint-plugin-react/node_modules/resolve": {
+			"version": "2.0.0-next.5",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
+			"integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"is-core-module": "^2.13.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/eslint-scope": {
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+			"integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+			"dev": true,
+			"dependencies": {
+				"esrecurse": "^4.3.0",
+				"estraverse": "^5.2.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint-visitor-keys": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+			"dev": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/espree": {
+			"version": "9.6.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+			"integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+			"dev": true,
+			"dependencies": {
+				"acorn": "^8.9.0",
+				"acorn-jsx": "^5.3.2",
+				"eslint-visitor-keys": "^3.4.1"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"dev": true,
+			"bin": {
+				"esparse": "bin/esparse.js",
+				"esvalidate": "bin/esvalidate.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/esquery": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+			"integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+			"dev": true,
+			"dependencies": {
+				"estraverse": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/esrecurse": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+			"dev": true,
+			"dependencies": {
+				"estraverse": "^5.2.0"
+			},
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/esutils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/ethers": {
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ethers/-/ethers-6.15.0.tgz",
+			"integrity": "sha512-Kf/3ZW54L4UT0pZtsY/rf+EkBU7Qi5nnhonjUb8yTXcxH3cdcWrV2cRyk0Xk/4jK6OoHhxxZHriyhje20If2hQ==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/ethers-io/"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@adraffy/ens-normalize": "1.10.1",
+				"@noble/curves": "1.2.0",
+				"@noble/hashes": "1.3.2",
+				"@types/node": "22.7.5",
+				"aes-js": "4.0.0-beta.5",
+				"tslib": "2.7.0",
+				"ws": "8.17.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/ethers/node_modules/@types/node": {
+			"version": "22.7.5",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+			"integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+			"dependencies": {
+				"undici-types": "~6.19.2"
+			}
+		},
+		"node_modules/ethers/node_modules/tslib": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+		},
+		"node_modules/ethers/node_modules/undici-types": {
+			"version": "6.19.8",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+			"integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
+		},
+		"node_modules/execa": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+			"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+			"dev": true,
+			"dependencies": {
+				"cross-spawn": "^7.0.3",
+				"get-stream": "^6.0.0",
+				"human-signals": "^2.1.0",
+				"is-stream": "^2.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^4.0.1",
+				"onetime": "^5.1.2",
+				"signal-exit": "^3.0.3",
+				"strip-final-newline": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
+		"node_modules/execa/node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"dev": true
+		},
+		"node_modules/exit-x": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz",
+			"integrity": "sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/expect": {
+			"version": "30.1.2",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-30.1.2.tgz",
+			"integrity": "sha512-xvHszRavo28ejws8FpemjhwswGj4w/BetHIL8cU49u4sGyXDw2+p3YbeDbj6xzlxi6kWTjIRSTJ+9sNXPnF0Zg==",
+			"dev": true,
+			"dependencies": {
+				"@jest/expect-utils": "30.1.2",
+				"@jest/get-type": "30.1.0",
+				"jest-matcher-utils": "30.1.2",
+				"jest-message-util": "30.1.0",
+				"jest-mock": "30.0.5",
+				"jest-util": "30.0.5"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"dev": true
+		},
+		"node_modules/fast-json-stable-stringify": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+			"dev": true
+		},
+		"node_modules/fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+			"dev": true
+		},
+		"node_modules/fastq": {
+			"version": "1.19.1",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+			"integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+			"dev": true,
+			"dependencies": {
+				"reusify": "^1.0.4"
+			}
+		},
+		"node_modules/fb-watchman": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+			"integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+			"dev": true,
+			"dependencies": {
+				"bser": "2.1.1"
+			}
+		},
+		"node_modules/file-entry-cache": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+			"integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+			"dev": true,
+			"dependencies": {
+				"flat-cache": "^3.0.4"
+			},
+			"engines": {
+				"node": "^10.12.0 || >=12.0.0"
+			}
+		},
+		"node_modules/fill-range": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+			"dev": true,
+			"dependencies": {
+				"to-regex-range": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/find-up": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"dev": true,
+			"dependencies": {
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/flat-cache": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+			"integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+			"dev": true,
+			"dependencies": {
+				"flatted": "^3.2.9",
+				"keyv": "^4.5.3",
+				"rimraf": "^3.0.2"
+			},
+			"engines": {
+				"node": "^10.12.0 || >=12.0.0"
+			}
+		},
+		"node_modules/flatted": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+			"dev": true
+		},
+		"node_modules/for-each": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+			"integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+			"dev": true,
+			"dependencies": {
+				"is-callable": "^1.2.7"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/foreground-child": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+			"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+			"dev": true,
+			"dependencies": {
+				"cross-spawn": "^7.0.6",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+			"dev": true
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/function-bind": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/function.prototype.name": {
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+			"integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.3",
+				"define-properties": "^1.2.1",
+				"functions-have-names": "^1.2.3",
+				"hasown": "^2.0.2",
+				"is-callable": "^1.2.7"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/functions-have-names": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+			"integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/gensync": {
+			"version": "1.0.0-beta.2",
+			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"dev": true,
+			"engines": {
+				"node": "6.* || 8.* || >= 10.*"
+			}
+		},
+		"node_modules/get-intrinsic": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.1.1",
+				"function-bind": "^1.1.2",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"hasown": "^2.0.2",
+				"math-intrinsics": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-package-type": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+			"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/get-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"dev": true,
+			"dependencies": {
+				"dunder-proto": "^1.0.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/get-stream": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/get-symbol-description": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+			"integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+			"dev": true,
+			"dependencies": {
+				"call-bound": "^1.0.3",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.6"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/glob": {
+			"version": "10.4.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+			"integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+			"dev": true,
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/glob-parent": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+			"dev": true,
+			"dependencies": {
+				"is-glob": "^4.0.3"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/glob/node_modules/brace-expansion": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/glob/node_modules/minimatch": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/globals": {
+			"version": "13.24.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+			"dev": true,
+			"dependencies": {
+				"type-fest": "^0.20.2"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/globalthis": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+			"integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+			"dev": true,
+			"dependencies": {
+				"define-properties": "^1.2.1",
+				"gopd": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/gopd": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true
+		},
+		"node_modules/graphemer": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+			"dev": true
+		},
+		"node_modules/has-bigints": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+			"integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/has-property-descriptors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+			"dev": true,
+			"dependencies": {
+				"es-define-property": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-proto": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+			"integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+			"dev": true,
+			"dependencies": {
+				"dunder-proto": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-symbols": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-tostringtag": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+			"dev": true,
+			"dependencies": {
+				"has-symbols": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/hasown": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"dev": true,
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/html-escaper": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+			"dev": true
+		},
+		"node_modules/human-signals": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.17.0"
+			}
+		},
+		"node_modules/ignore": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+			"dev": true,
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/import-fresh": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+			"integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+			"dev": true,
+			"dependencies": {
+				"parent-module": "^1.0.0",
+				"resolve-from": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/import-local": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+			"integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+			"dev": true,
+			"dependencies": {
+				"pkg-dir": "^4.2.0",
+				"resolve-cwd": "^3.0.0"
+			},
+			"bin": {
+				"import-local-fixture": "fixtures/cli.js"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.19"
+			}
+		},
+		"node_modules/inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+			"deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+			"dev": true,
+			"dependencies": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
+		},
+		"node_modules/internal-slot": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+			"integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+			"dev": true,
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"hasown": "^2.0.2",
+				"side-channel": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/is-array-buffer": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+			"integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.3",
+				"get-intrinsic": "^1.2.6"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-arrayish": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+			"dev": true
+		},
+		"node_modules/is-async-function": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+			"integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+			"dev": true,
+			"dependencies": {
+				"async-function": "^1.0.0",
+				"call-bound": "^1.0.3",
+				"get-proto": "^1.0.1",
+				"has-tostringtag": "^1.0.2",
+				"safe-regex-test": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-bigint": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+			"integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+			"dev": true,
+			"dependencies": {
+				"has-bigints": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-boolean-object": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+			"integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+			"dev": true,
+			"dependencies": {
+				"call-bound": "^1.0.3",
+				"has-tostringtag": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-callable": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-core-module": {
+			"version": "2.16.1",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+			"integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+			"dev": true,
+			"dependencies": {
+				"hasown": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-data-view": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+			"integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+			"dev": true,
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"get-intrinsic": "^1.2.6",
+				"is-typed-array": "^1.1.13"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-date-object": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+			"integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+			"dev": true,
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"has-tostringtag": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-finalizationregistry": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+			"integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+			"dev": true,
+			"dependencies": {
+				"call-bound": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-generator-fn": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+			"integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/is-generator-function": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
+			"integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bound": "^1.0.3",
+				"get-proto": "^1.0.0",
+				"has-tostringtag": "^1.0.2",
+				"safe-regex-test": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-glob": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+			"dev": true,
+			"dependencies": {
+				"is-extglob": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-map": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+			"integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-negative-zero": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+			"integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-number": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.12.0"
+			}
+		},
+		"node_modules/is-number-object": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+			"integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+			"dev": true,
+			"dependencies": {
+				"call-bound": "^1.0.3",
+				"has-tostringtag": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-path-inside": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-regex": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+			"integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+			"dev": true,
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"gopd": "^1.2.0",
+				"has-tostringtag": "^1.0.2",
+				"hasown": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-set": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+			"integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-shared-array-buffer": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+			"integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+			"dev": true,
+			"dependencies": {
+				"call-bound": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-string": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+			"integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+			"dev": true,
+			"dependencies": {
+				"call-bound": "^1.0.3",
+				"has-tostringtag": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-symbol": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+			"integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+			"dev": true,
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"has-symbols": "^1.1.0",
+				"safe-regex-test": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-typed-array": {
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+			"integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+			"dev": true,
+			"dependencies": {
+				"which-typed-array": "^1.1.16"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-weakmap": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+			"integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-weakref": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+			"integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+			"dev": true,
+			"dependencies": {
+				"call-bound": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-weakset": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+			"integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bound": "^1.0.3",
+				"get-intrinsic": "^1.2.6"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/isarray": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+			"dev": true
+		},
+		"node_modules/isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"dev": true
+		},
+		"node_modules/istanbul-lib-coverage": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+			"integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/istanbul-lib-instrument": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+			"integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+			"dev": true,
+			"dependencies": {
+				"@babel/core": "^7.23.9",
+				"@babel/parser": "^7.23.9",
+				"@istanbuljs/schema": "^0.1.3",
+				"istanbul-lib-coverage": "^3.2.0",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/istanbul-lib-instrument/node_modules/semver": {
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/istanbul-lib-report": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+			"integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+			"dev": true,
+			"dependencies": {
+				"istanbul-lib-coverage": "^3.0.0",
+				"make-dir": "^4.0.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/istanbul-lib-source-maps": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+			"integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.23",
+				"debug": "^4.1.1",
+				"istanbul-lib-coverage": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/istanbul-reports": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+			"integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+			"dev": true,
+			"dependencies": {
+				"html-escaper": "^2.0.0",
+				"istanbul-lib-report": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/iterator.prototype": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+			"integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"define-data-property": "^1.1.4",
+				"es-object-atoms": "^1.0.0",
+				"get-intrinsic": "^1.2.6",
+				"get-proto": "^1.0.0",
+				"has-symbols": "^1.1.0",
+				"set-function-name": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/jackspeak": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+			"dev": true,
+			"dependencies": {
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			},
+			"optionalDependencies": {
+				"@pkgjs/parseargs": "^0.11.0"
+			}
+		},
+		"node_modules/jest": {
+			"version": "30.1.2",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-30.1.2.tgz",
+			"integrity": "sha512-iLreJmUWdANLD2UIbebrXxQqU9jIxv2ahvrBNfff55deL9DtVxm8ZJBLk/kmn0AQ+FyCTrNSlGbMdTgSasldYA==",
+			"dev": true,
+			"dependencies": {
+				"@jest/core": "30.1.2",
+				"@jest/types": "30.0.5",
+				"import-local": "^3.2.0",
+				"jest-cli": "30.1.2"
+			},
+			"bin": {
+				"jest": "bin/jest.js"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+			},
+			"peerDependenciesMeta": {
+				"node-notifier": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/jest-changed-files": {
+			"version": "30.0.5",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.0.5.tgz",
+			"integrity": "sha512-bGl2Ntdx0eAwXuGpdLdVYVr5YQHnSZlQ0y9HVDu565lCUAe9sj6JOtBbMmBBikGIegne9piDDIOeiLVoqTkz4A==",
+			"dev": true,
+			"dependencies": {
+				"execa": "^5.1.1",
+				"jest-util": "30.0.5",
+				"p-limit": "^3.1.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-circus": {
+			"version": "30.1.2",
+			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.1.2.tgz",
+			"integrity": "sha512-pyqgRv00fPbU3QBjN9I5QRd77eCWA19NA7BLgI1veFvbUIFpeDCKbnG1oyRr6q5/jPEW2zDfqZ/r6fvfE85vrA==",
+			"dev": true,
+			"dependencies": {
+				"@jest/environment": "30.1.2",
+				"@jest/expect": "30.1.2",
+				"@jest/test-result": "30.1.2",
+				"@jest/types": "30.0.5",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"co": "^4.6.0",
+				"dedent": "^1.6.0",
+				"is-generator-fn": "^2.1.0",
+				"jest-each": "30.1.0",
+				"jest-matcher-utils": "30.1.2",
+				"jest-message-util": "30.1.0",
+				"jest-runtime": "30.1.2",
+				"jest-snapshot": "30.1.2",
+				"jest-util": "30.0.5",
+				"p-limit": "^3.1.0",
+				"pretty-format": "30.0.5",
+				"pure-rand": "^7.0.0",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.6"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-cli": {
+			"version": "30.1.2",
+			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.1.2.tgz",
+			"integrity": "sha512-Q7H6GGo/0TBB8Mhm3Ab7KKJHn6GeMVff+/8PVCQ7vXXahvr5sRERnNbxuVJAMiVY2JQm5roA7CHYOYlH+gzmUg==",
+			"dev": true,
+			"dependencies": {
+				"@jest/core": "30.1.2",
+				"@jest/test-result": "30.1.2",
+				"@jest/types": "30.0.5",
+				"chalk": "^4.1.2",
+				"exit-x": "^0.2.2",
+				"import-local": "^3.2.0",
+				"jest-config": "30.1.2",
+				"jest-util": "30.0.5",
+				"jest-validate": "30.1.0",
+				"yargs": "^17.7.2"
+			},
+			"bin": {
+				"jest": "bin/jest.js"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+			},
+			"peerDependenciesMeta": {
+				"node-notifier": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/jest-config": {
+			"version": "30.1.2",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.1.2.tgz",
+			"integrity": "sha512-gCuBeE/cksjQ3e1a8H4YglZJuVPcnLZQK9jC70E6GbkHNQKPasnOO+r9IYdsUbAekb6c7eVRR8laGLMF06gMqg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/core": "^7.27.4",
+				"@jest/get-type": "30.1.0",
+				"@jest/pattern": "30.0.1",
+				"@jest/test-sequencer": "30.1.2",
+				"@jest/types": "30.0.5",
+				"babel-jest": "30.1.2",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"deepmerge": "^4.3.1",
+				"glob": "^10.3.10",
+				"graceful-fs": "^4.2.11",
+				"jest-circus": "30.1.2",
+				"jest-docblock": "30.0.1",
+				"jest-environment-node": "30.1.2",
+				"jest-regex-util": "30.0.1",
+				"jest-resolve": "30.1.0",
+				"jest-runner": "30.1.2",
+				"jest-util": "30.0.5",
+				"jest-validate": "30.1.0",
+				"micromatch": "^4.0.8",
+				"parse-json": "^5.2.0",
+				"pretty-format": "30.0.5",
+				"slash": "^3.0.0",
+				"strip-json-comments": "^3.1.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"@types/node": "*",
+				"esbuild-register": ">=3.4.0",
+				"ts-node": ">=9.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"esbuild-register": {
+					"optional": true
+				},
+				"ts-node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/jest-diff": {
+			"version": "30.1.2",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.1.2.tgz",
+			"integrity": "sha512-4+prq+9J61mOVXCa4Qp8ZjavdxzrWQXrI80GNxP8f4tkI2syPuPrJgdRPZRrfUTRvIoUwcmNLbqEJy9W800+NQ==",
+			"dev": true,
+			"dependencies": {
+				"@jest/diff-sequences": "30.0.1",
+				"@jest/get-type": "30.1.0",
+				"chalk": "^4.1.2",
+				"pretty-format": "30.0.5"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-docblock": {
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.0.1.tgz",
+			"integrity": "sha512-/vF78qn3DYphAaIc3jy4gA7XSAz167n9Bm/wn/1XhTLW7tTBIzXtCJpb/vcmc73NIIeeohCbdL94JasyXUZsGA==",
+			"dev": true,
+			"dependencies": {
+				"detect-newline": "^3.1.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-each": {
+			"version": "30.1.0",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.1.0.tgz",
+			"integrity": "sha512-A+9FKzxPluqogNahpCv04UJvcZ9B3HamqpDNWNKDjtxVRYB8xbZLFuCr8JAJFpNp83CA0anGQFlpQna9Me+/tQ==",
+			"dev": true,
+			"dependencies": {
+				"@jest/get-type": "30.1.0",
+				"@jest/types": "30.0.5",
+				"chalk": "^4.1.2",
+				"jest-util": "30.0.5",
+				"pretty-format": "30.0.5"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-environment-node": {
+			"version": "30.1.2",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.1.2.tgz",
+			"integrity": "sha512-w8qBiXtqGWJ9xpJIA98M0EIoq079GOQRQUyse5qg1plShUCQ0Ek1VTTcczqKrn3f24TFAgFtT+4q3aOXvjbsuA==",
+			"dev": true,
+			"dependencies": {
+				"@jest/environment": "30.1.2",
+				"@jest/fake-timers": "30.1.2",
+				"@jest/types": "30.0.5",
+				"@types/node": "*",
+				"jest-mock": "30.0.5",
+				"jest-util": "30.0.5",
+				"jest-validate": "30.1.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-haste-map": {
+			"version": "30.1.0",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.1.0.tgz",
+			"integrity": "sha512-JLeM84kNjpRkggcGpQLsV7B8W4LNUWz7oDNVnY1Vjj22b5/fAb3kk3htiD+4Na8bmJmjJR7rBtS2Rmq/NEcADg==",
+			"dev": true,
+			"dependencies": {
+				"@jest/types": "30.0.5",
+				"@types/node": "*",
+				"anymatch": "^3.1.3",
+				"fb-watchman": "^2.0.2",
+				"graceful-fs": "^4.2.11",
+				"jest-regex-util": "30.0.1",
+				"jest-util": "30.0.5",
+				"jest-worker": "30.1.0",
+				"micromatch": "^4.0.8",
+				"walker": "^1.0.8"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "^2.3.3"
+			}
+		},
+		"node_modules/jest-leak-detector": {
+			"version": "30.1.0",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.1.0.tgz",
+			"integrity": "sha512-AoFvJzwxK+4KohH60vRuHaqXfWmeBATFZpzpmzNmYTtmRMiyGPVhkXpBqxUQunw+dQB48bDf4NpUs6ivVbRv1g==",
+			"dev": true,
+			"dependencies": {
+				"@jest/get-type": "30.1.0",
+				"pretty-format": "30.0.5"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-matcher-utils": {
+			"version": "30.1.2",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.1.2.tgz",
+			"integrity": "sha512-7ai16hy4rSbDjvPTuUhuV8nyPBd6EX34HkBsBcBX2lENCuAQ0qKCPb/+lt8OSWUa9WWmGYLy41PrEzkwRwoGZQ==",
+			"dev": true,
+			"dependencies": {
+				"@jest/get-type": "30.1.0",
+				"chalk": "^4.1.2",
+				"jest-diff": "30.1.2",
+				"pretty-format": "30.0.5"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-message-util": {
+			"version": "30.1.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.1.0.tgz",
+			"integrity": "sha512-HizKDGG98cYkWmaLUHChq4iN+oCENohQLb7Z5guBPumYs+/etonmNFlg1Ps6yN9LTPyZn+M+b/9BbnHx3WTMDg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.27.1",
+				"@jest/types": "30.0.5",
+				"@types/stack-utils": "^2.0.3",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"micromatch": "^4.0.8",
+				"pretty-format": "30.0.5",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.6"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-mock": {
+			"version": "30.0.5",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.0.5.tgz",
+			"integrity": "sha512-Od7TyasAAQX/6S+QCbN6vZoWOMwlTtzzGuxJku1GhGanAjz9y+QsQkpScDmETvdc9aSXyJ/Op4rhpMYBWW91wQ==",
+			"dev": true,
+			"dependencies": {
+				"@jest/types": "30.0.5",
+				"@types/node": "*",
+				"jest-util": "30.0.5"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-pnp-resolver": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+			"integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			},
+			"peerDependencies": {
+				"jest-resolve": "*"
+			},
+			"peerDependenciesMeta": {
+				"jest-resolve": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/jest-regex-util": {
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+			"integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+			"dev": true,
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-resolve": {
+			"version": "30.1.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.1.0.tgz",
+			"integrity": "sha512-hASe7D/wRtZw8Cm607NrlF7fi3HWC5wmA5jCVc2QjQAB2pTwP9eVZILGEi6OeSLNUtE1zb04sXRowsdh5CUjwA==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"jest-haste-map": "30.1.0",
+				"jest-pnp-resolver": "^1.2.3",
+				"jest-util": "30.0.5",
+				"jest-validate": "30.1.0",
+				"slash": "^3.0.0",
+				"unrs-resolver": "^1.7.11"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-resolve-dependencies": {
+			"version": "30.1.2",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.1.2.tgz",
+			"integrity": "sha512-HJjyoaedY4wrwda+eqvgjbwFykrAnQEmhuT0bMyOV3GQIyLPcunZcjfkm77Zr11ujwl34ySdc4qYnm7SG75TjA==",
+			"dev": true,
+			"dependencies": {
+				"jest-regex-util": "30.0.1",
+				"jest-snapshot": "30.1.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-runner": {
+			"version": "30.1.2",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.1.2.tgz",
+			"integrity": "sha512-eu9AzpDY/QV+7NuMg6fZMpQ7M24cBkl5dyS1Xj7iwDPDriOmLUXR8rLojESibcIX+sCDTO4KvUeaxWCH1fbTvg==",
+			"dev": true,
+			"dependencies": {
+				"@jest/console": "30.1.2",
+				"@jest/environment": "30.1.2",
+				"@jest/test-result": "30.1.2",
+				"@jest/transform": "30.1.2",
+				"@jest/types": "30.0.5",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"emittery": "^0.13.1",
+				"exit-x": "^0.2.2",
+				"graceful-fs": "^4.2.11",
+				"jest-docblock": "30.0.1",
+				"jest-environment-node": "30.1.2",
+				"jest-haste-map": "30.1.0",
+				"jest-leak-detector": "30.1.0",
+				"jest-message-util": "30.1.0",
+				"jest-resolve": "30.1.0",
+				"jest-runtime": "30.1.2",
+				"jest-util": "30.0.5",
+				"jest-watcher": "30.1.2",
+				"jest-worker": "30.1.0",
+				"p-limit": "^3.1.0",
+				"source-map-support": "0.5.13"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-runtime": {
+			"version": "30.1.2",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.1.2.tgz",
+			"integrity": "sha512-zU02si+lAITgyRmVRgJn/AB4cnakq8+o7bP+5Z+N1A4r2mq40zGbmrg3UpYQWCkeim17tx8w1Tnmt6tQ6y9PGA==",
+			"dev": true,
+			"dependencies": {
+				"@jest/environment": "30.1.2",
+				"@jest/fake-timers": "30.1.2",
+				"@jest/globals": "30.1.2",
+				"@jest/source-map": "30.0.1",
+				"@jest/test-result": "30.1.2",
+				"@jest/transform": "30.1.2",
+				"@jest/types": "30.0.5",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"cjs-module-lexer": "^2.1.0",
+				"collect-v8-coverage": "^1.0.2",
+				"glob": "^10.3.10",
+				"graceful-fs": "^4.2.11",
+				"jest-haste-map": "30.1.0",
+				"jest-message-util": "30.1.0",
+				"jest-mock": "30.0.5",
+				"jest-regex-util": "30.0.1",
+				"jest-resolve": "30.1.0",
+				"jest-snapshot": "30.1.2",
+				"jest-util": "30.0.5",
+				"slash": "^3.0.0",
+				"strip-bom": "^4.0.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-snapshot": {
+			"version": "30.1.2",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.1.2.tgz",
+			"integrity": "sha512-4q4+6+1c8B6Cy5pGgFvjDy/Pa6VYRiGu0yQafKkJ9u6wQx4G5PqI2QR6nxTl43yy7IWsINwz6oT4o6tD12a8Dg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/core": "^7.27.4",
+				"@babel/generator": "^7.27.5",
+				"@babel/plugin-syntax-jsx": "^7.27.1",
+				"@babel/plugin-syntax-typescript": "^7.27.1",
+				"@babel/types": "^7.27.3",
+				"@jest/expect-utils": "30.1.2",
+				"@jest/get-type": "30.1.0",
+				"@jest/snapshot-utils": "30.1.2",
+				"@jest/transform": "30.1.2",
+				"@jest/types": "30.0.5",
+				"babel-preset-current-node-syntax": "^1.1.0",
+				"chalk": "^4.1.2",
+				"expect": "30.1.2",
+				"graceful-fs": "^4.2.11",
+				"jest-diff": "30.1.2",
+				"jest-matcher-utils": "30.1.2",
+				"jest-message-util": "30.1.0",
+				"jest-util": "30.0.5",
+				"pretty-format": "30.0.5",
+				"semver": "^7.7.2",
+				"synckit": "^0.11.8"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-snapshot/node_modules/semver": {
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/jest-util": {
+			"version": "30.0.5",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.0.5.tgz",
+			"integrity": "sha512-pvyPWssDZR0FlfMxCBoc0tvM8iUEskaRFALUtGQYzVEAqisAztmy+R8LnU14KT4XA0H/a5HMVTXat1jLne010g==",
+			"dev": true,
+			"dependencies": {
+				"@jest/types": "30.0.5",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-util/node_modules/picomatch": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/jest-validate": {
+			"version": "30.1.0",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.1.0.tgz",
+			"integrity": "sha512-7P3ZlCFW/vhfQ8pE7zW6Oi4EzvuB4sgR72Q1INfW9m0FGo0GADYlPwIkf4CyPq7wq85g+kPMtPOHNAdWHeBOaA==",
+			"dev": true,
+			"dependencies": {
+				"@jest/get-type": "30.1.0",
+				"@jest/types": "30.0.5",
+				"camelcase": "^6.3.0",
+				"chalk": "^4.1.2",
+				"leven": "^3.1.0",
+				"pretty-format": "30.0.5"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-validate/node_modules/camelcase": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/jest-watcher": {
+			"version": "30.1.2",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.1.2.tgz",
+			"integrity": "sha512-MtoGuEgqsBM8Jkn52oEj+mXLtF94+njPlHI5ydfduZL5MHrTFr14ZG1CUX1xAbY23dbSZCCEkEPhBM3cQd12Jg==",
+			"dev": true,
+			"dependencies": {
+				"@jest/test-result": "30.1.2",
+				"@jest/types": "30.0.5",
+				"@types/node": "*",
+				"ansi-escapes": "^4.3.2",
+				"chalk": "^4.1.2",
+				"emittery": "^0.13.1",
+				"jest-util": "30.0.5",
+				"string-length": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-worker": {
+			"version": "30.1.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.1.0.tgz",
+			"integrity": "sha512-uvWcSjlwAAgIu133Tt77A05H7RIk3Ho8tZL50bQM2AkvLdluw9NG48lRCl3Dt+MOH719n/0nnb5YxUwcuJiKRA==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*",
+				"@ungap/structured-clone": "^1.3.0",
+				"jest-util": "30.0.5",
+				"merge-stream": "^2.0.0",
+				"supports-color": "^8.1.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-worker/node_modules/supports-color": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
+			}
+		},
+		"node_modules/js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true
+		},
+		"node_modules/js-yaml": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"dev": true,
+			"dependencies": {
+				"argparse": "^2.0.1"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/jsdoc-type-pratt-parser": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.1.0.tgz",
+			"integrity": "sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/jsesc": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+			"integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+			"dev": true,
+			"bin": {
+				"jsesc": "bin/jsesc"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/json-buffer": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+			"dev": true
+		},
+		"node_modules/json-parse-even-better-errors": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+			"dev": true
+		},
+		"node_modules/json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true
+		},
+		"node_modules/json-stable-stringify-without-jsonify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+			"dev": true
+		},
+		"node_modules/json5": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+			"dev": true,
+			"bin": {
+				"json5": "lib/cli.js"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/jsx-ast-utils": {
+			"version": "3.3.5",
+			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+			"integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"array-includes": "^3.1.6",
+				"array.prototype.flat": "^1.3.1",
+				"object.assign": "^4.1.4",
+				"object.values": "^1.1.6"
+			},
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/keyv": {
+			"version": "4.5.4",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+			"integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+			"dev": true,
+			"dependencies": {
+				"json-buffer": "3.0.1"
+			}
+		},
+		"node_modules/language-subtag-registry": {
+			"version": "0.3.23",
+			"resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+			"integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
+			"dev": true,
+			"peer": true
+		},
+		"node_modules/language-tags": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+			"integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"language-subtag-registry": "^0.3.20"
+			},
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/leven": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/levn": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+			"dev": true,
+			"dependencies": {
+				"prelude-ls": "^1.2.1",
+				"type-check": "~0.4.0"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/lines-and-columns": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+			"dev": true
+		},
+		"node_modules/locate-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"dev": true,
+			"dependencies": {
+				"p-locate": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/lodash": {
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+		},
+		"node_modules/lodash.merge": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+			"dev": true
+		},
+		"node_modules/loose-envify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"js-tokens": "^3.0.0 || ^4.0.0"
+			},
+			"bin": {
+				"loose-envify": "cli.js"
+			}
+		},
+		"node_modules/lru-cache": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+			"dev": true,
+			"dependencies": {
+				"yallist": "^3.0.2"
+			}
+		},
+		"node_modules/make-dir": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+			"integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+			"dev": true,
+			"dependencies": {
+				"semver": "^7.5.3"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/make-dir/node_modules/semver": {
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/makeerror": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+			"integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+			"dev": true,
+			"dependencies": {
+				"tmpl": "1.0.5"
+			}
+		},
+		"node_modules/math-intrinsics": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/merge-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+			"dev": true
+		},
+		"node_modules/micromatch": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+			"dev": true,
+			"dependencies": {
+				"braces": "^3.0.3",
+				"picomatch": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=8.6"
+			}
+		},
+		"node_modules/mimic-fn": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/minimist": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/minipass": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+			"dev": true,
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true
+		},
+		"node_modules/napi-postinstall": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.3.tgz",
+			"integrity": "sha512-uTp172LLXSxuSYHv/kou+f6KW3SMppU9ivthaVTXian9sOt3XM/zHYHpRZiLgQoxeWfYUnslNWQHF1+G71xcow==",
+			"dev": true,
+			"bin": {
+				"napi-postinstall": "lib/cli.js"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/napi-postinstall"
+			}
+		},
+		"node_modules/natural-compare": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+			"dev": true
+		},
+		"node_modules/node-int64": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+			"integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+			"dev": true
+		},
+		"node_modules/node-releases": {
+			"version": "2.0.19",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+			"integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+			"dev": true
+		},
+		"node_modules/normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npm-run-path": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+			"dev": true,
+			"dependencies": {
+				"path-key": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"dev": true,
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/object-inspect": {
+			"version": "1.13.4",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+			"integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/object-keys": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/object.assign": {
+			"version": "4.1.7",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+			"integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.3",
+				"define-properties": "^1.2.1",
+				"es-object-atoms": "^1.0.0",
+				"has-symbols": "^1.1.0",
+				"object-keys": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/object.entries": {
+			"version": "1.1.9",
+			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+			"integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.4",
+				"define-properties": "^1.2.1",
+				"es-object-atoms": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/object.fromentries": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+			"integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.2",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/object.groupby": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
+			"integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/object.values": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+			"integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.3",
+				"define-properties": "^1.2.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"dev": true,
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/onetime": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+			"dev": true,
+			"dependencies": {
+				"mimic-fn": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/optionator": {
+			"version": "0.9.4",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+			"integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+			"dev": true,
+			"dependencies": {
+				"deep-is": "^0.1.3",
+				"fast-levenshtein": "^2.0.6",
+				"levn": "^0.4.1",
+				"prelude-ls": "^1.2.1",
+				"type-check": "^0.4.0",
+				"word-wrap": "^1.2.5"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/own-keys": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+			"integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+			"dev": true,
+			"dependencies": {
+				"get-intrinsic": "^1.2.6",
+				"object-keys": "^1.1.1",
+				"safe-push-apply": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/p-limit": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"dev": true,
+			"dependencies": {
+				"yocto-queue": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-locate": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"dev": true,
+			"dependencies": {
+				"p-limit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-try": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/package-json-from-dist": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+			"dev": true
+		},
+		"node_modules/parent-module": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+			"dev": true,
+			"dependencies": {
+				"callsites": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/parse-imports-exports": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/parse-imports-exports/-/parse-imports-exports-0.2.4.tgz",
+			"integrity": "sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==",
+			"dev": true,
+			"dependencies": {
+				"parse-statements": "1.0.11"
+			}
+		},
+		"node_modules/parse-json": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+			"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.0.0",
+				"error-ex": "^1.3.1",
+				"json-parse-even-better-errors": "^2.3.0",
+				"lines-and-columns": "^1.1.6"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/parse-statements": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz",
+			"integrity": "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==",
+			"dev": true
+		},
+		"node_modules/path-exists": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/path-parse": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+			"dev": true
+		},
+		"node_modules/path-scurry": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^10.2.0",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/path-scurry/node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true
+		},
+		"node_modules/picocolors": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true
+		},
+		"node_modules/picomatch": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"dev": true,
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/pirates": {
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+			"integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/pkg-dir": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+			"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+			"dev": true,
+			"dependencies": {
+				"find-up": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/pkg-dir/node_modules/find-up": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+			"dev": true,
+			"dependencies": {
+				"locate-path": "^5.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/pkg-dir/node_modules/locate-path": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+			"dev": true,
+			"dependencies": {
+				"p-locate": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/pkg-dir/node_modules/p-limit": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+			"dev": true,
+			"dependencies": {
+				"p-try": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/pkg-dir/node_modules/p-locate": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+			"dev": true,
+			"dependencies": {
+				"p-limit": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/possible-typed-array-names": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+			"integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/prelude-ls": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/pretty-format": {
+			"version": "30.0.5",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.5.tgz",
+			"integrity": "sha512-D1tKtYvByrBkFLe2wHJl2bwMJIiT8rW+XA+TiataH79/FszLQMrpGEvzUVkzPau7OCO0Qnrhpe87PqtOAIB8Yw==",
+			"dev": true,
+			"dependencies": {
+				"@jest/schemas": "30.0.5",
+				"ansi-styles": "^5.2.0",
+				"react-is": "^18.3.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/pretty-format/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/prop-types": {
+			"version": "15.8.1",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"loose-envify": "^1.4.0",
+				"object-assign": "^4.1.1",
+				"react-is": "^16.13.1"
+			}
+		},
+		"node_modules/prop-types/node_modules/react-is": {
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+			"dev": true,
+			"peer": true
+		},
+		"node_modules/punycode": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/pure-rand": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+			"integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/dubzzz"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fast-check"
+				}
+			]
+		},
+		"node_modules/queue-microtask": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
+		"node_modules/react-is": {
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+			"dev": true
+		},
+		"node_modules/reflect.getprototypeof": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+			"integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.9",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.0.0",
+				"get-intrinsic": "^1.2.7",
+				"get-proto": "^1.0.1",
+				"which-builtin-type": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/regexp.prototype.flags": {
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+			"integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"define-properties": "^1.2.1",
+				"es-errors": "^1.3.0",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"set-function-name": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/resolve": {
+			"version": "1.22.10",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+			"integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+			"dev": true,
+			"dependencies": {
+				"is-core-module": "^2.16.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/resolve-cwd": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+			"integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+			"dev": true,
+			"dependencies": {
+				"resolve-from": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/resolve-cwd/node_modules/resolve-from": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/resolve-from": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/resolve-local-dependencies": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/resolve-local-dependencies/-/resolve-local-dependencies-1.0.2.tgz",
+			"integrity": "sha512-ANEmzd1J6qGbaxXwCOQBAMXZ1p10+jA3gnZ0DcLz2DgQId//GFpY33PQazspZSLpTMVdpJhNuD6agszcCUlWIg==",
+			"bin": {
+				"resolve-local-dependencies": "bin/cli.js"
+			}
+		},
+		"node_modules/reusify": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+			"integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+			"dev": true,
+			"engines": {
+				"iojs": ">=1.0.0",
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/rimraf": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"deprecated": "Rimraf versions prior to v4 are no longer supported",
+			"dev": true,
+			"dependencies": {
+				"glob": "^7.1.3"
+			},
+			"bin": {
+				"rimraf": "bin.js"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/rimraf/node_modules/glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"deprecated": "Glob versions prior to v9 are no longer supported",
+			"dev": true,
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/run-parallel": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"queue-microtask": "^1.2.2"
+			}
+		},
+		"node_modules/safe-array-concat": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+			"integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.2",
+				"get-intrinsic": "^1.2.6",
+				"has-symbols": "^1.1.0",
+				"isarray": "^2.0.5"
+			},
+			"engines": {
+				"node": ">=0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/safe-push-apply": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+			"integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+			"dev": true,
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"isarray": "^2.0.5"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/safe-regex-test": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+			"integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+			"dev": true,
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"is-regex": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/set-function-length": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+			"dev": true,
+			"dependencies": {
+				"define-data-property": "^1.1.4",
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.4",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/set-function-name": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+			"integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+			"dev": true,
+			"dependencies": {
+				"define-data-property": "^1.1.4",
+				"es-errors": "^1.3.0",
+				"functions-have-names": "^1.2.3",
+				"has-property-descriptors": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/set-proto": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+			"integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+			"dev": true,
+			"dependencies": {
+				"dunder-proto": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/side-channel": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+			"integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+			"dev": true,
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.3",
+				"side-channel-list": "^1.0.0",
+				"side-channel-map": "^1.0.1",
+				"side-channel-weakmap": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-list": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+			"integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+			"dev": true,
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-map": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+			"integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+			"dev": true,
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-weakmap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+			"integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+			"dev": true,
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3",
+				"side-channel-map": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/slash": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/source-map-support": {
+			"version": "0.5.13",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+			"integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+			"dev": true,
+			"dependencies": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			}
+		},
+		"node_modules/spdx-exceptions": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+			"integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+			"dev": true
+		},
+		"node_modules/spdx-expression-parse": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+			"integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+			"dev": true,
+			"dependencies": {
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"node_modules/spdx-license-ids": {
+			"version": "3.0.22",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
+			"integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
+			"dev": true
+		},
+		"node_modules/sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+			"dev": true
+		},
+		"node_modules/stack-utils": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+			"integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+			"dev": true,
+			"dependencies": {
+				"escape-string-regexp": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/stack-utils/node_modules/escape-string-regexp": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+			"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/stop-iteration-iterator": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+			"integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+			"dev": true,
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"internal-slot": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/string-length": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+			"integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+			"dev": true,
+			"dependencies": {
+				"char-regex": "^1.0.2",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/string-width": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+			"dev": true,
+			"dependencies": {
+				"eastasianwidth": "^0.2.0",
+				"emoji-regex": "^9.2.2",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/string-width-cjs": {
+			"name": "string-width",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width-cjs/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true
+		},
+		"node_modules/string-width/node_modules/ansi-regex": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.0.tgz",
+			"integrity": "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/string-width/node_modules/strip-ansi": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/string.prototype.includes": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
+			"integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/string.prototype.matchall": {
+			"version": "4.0.12",
+			"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+			"integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.3",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.6",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.0.0",
+				"get-intrinsic": "^1.2.6",
+				"gopd": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"internal-slot": "^1.1.0",
+				"regexp.prototype.flags": "^1.5.3",
+				"set-function-name": "^2.0.2",
+				"side-channel": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/string.prototype.repeat": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+			"integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.5"
+			}
+		},
+		"node_modules/string.prototype.trim": {
+			"version": "1.2.10",
+			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+			"integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.2",
+				"define-data-property": "^1.1.4",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.5",
+				"es-object-atoms": "^1.0.0",
+				"has-property-descriptors": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/string.prototype.trimend": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+			"integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.2",
+				"define-properties": "^1.2.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/string.prototype.trimstart": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+			"integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi-cjs": {
+			"name": "strip-ansi",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-bom": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+			"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-final-newline": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/strip-json-comments": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/synckit": {
+			"version": "0.11.11",
+			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
+			"integrity": "sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==",
+			"dev": true,
+			"dependencies": {
+				"@pkgr/core": "^0.2.9"
+			},
+			"engines": {
+				"node": "^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/synckit"
+			}
+		},
+		"node_modules/test-exclude": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
+			"integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
+			"dev": true,
+			"dependencies": {
+				"@istanbuljs/schema": "^0.1.2",
+				"glob": "^10.4.1",
+				"minimatch": "^9.0.4"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/test-exclude/node_modules/brace-expansion": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/test-exclude/node_modules/minimatch": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/text-table": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+			"dev": true
+		},
+		"node_modules/tmpl": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+			"integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+			"dev": true
+		},
+		"node_modules/to-regex-range": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+			"dev": true,
+			"dependencies": {
+				"is-number": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=8.0"
+			}
+		},
+		"node_modules/tsconfig-paths": {
+			"version": "3.15.0",
+			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+			"integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+			"dev": true,
+			"dependencies": {
+				"@types/json5": "^0.0.29",
+				"json5": "^1.0.2",
+				"minimist": "^1.2.6",
+				"strip-bom": "^3.0.0"
+			}
+		},
+		"node_modules/tsconfig-paths/node_modules/json5": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+			"integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+			"dev": true,
+			"dependencies": {
+				"minimist": "^1.2.0"
+			},
+			"bin": {
+				"json5": "lib/cli.js"
+			}
+		},
+		"node_modules/tsconfig-paths/node_modules/strip-bom": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+			"integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true,
+			"optional": true
+		},
+		"node_modules/type-check": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+			"dev": true,
+			"dependencies": {
+				"prelude-ls": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/type-detect": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/type-fest": {
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/typed-array-buffer": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+			"integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+			"dev": true,
+			"dependencies": {
+				"call-bound": "^1.0.3",
+				"es-errors": "^1.3.0",
+				"is-typed-array": "^1.1.14"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/typed-array-byte-length": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+			"integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"for-each": "^0.3.3",
+				"gopd": "^1.2.0",
+				"has-proto": "^1.2.0",
+				"is-typed-array": "^1.1.14"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/typed-array-byte-offset": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+			"integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+			"dev": true,
+			"dependencies": {
+				"available-typed-arrays": "^1.0.7",
+				"call-bind": "^1.0.8",
+				"for-each": "^0.3.3",
+				"gopd": "^1.2.0",
+				"has-proto": "^1.2.0",
+				"is-typed-array": "^1.1.15",
+				"reflect.getprototypeof": "^1.0.9"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/typed-array-length": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+			"integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"for-each": "^0.3.3",
+				"gopd": "^1.0.1",
+				"is-typed-array": "^1.1.13",
+				"possible-typed-array-names": "^1.0.0",
+				"reflect.getprototypeof": "^1.0.6"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/unbox-primitive": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+			"integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+			"dev": true,
+			"dependencies": {
+				"call-bound": "^1.0.3",
+				"has-bigints": "^1.0.2",
+				"has-symbols": "^1.1.0",
+				"which-boxed-primitive": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/undici-types": {
+			"version": "7.10.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+			"integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+			"dev": true
+		},
+		"node_modules/unrs-resolver": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
+			"integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+			"dev": true,
+			"hasInstallScript": true,
+			"dependencies": {
+				"napi-postinstall": "^0.3.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/unrs-resolver"
+			},
+			"optionalDependencies": {
+				"@unrs/resolver-binding-android-arm-eabi": "1.11.1",
+				"@unrs/resolver-binding-android-arm64": "1.11.1",
+				"@unrs/resolver-binding-darwin-arm64": "1.11.1",
+				"@unrs/resolver-binding-darwin-x64": "1.11.1",
+				"@unrs/resolver-binding-freebsd-x64": "1.11.1",
+				"@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
+				"@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
+				"@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
+				"@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
+				"@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-x64-musl": "1.11.1",
+				"@unrs/resolver-binding-wasm32-wasi": "1.11.1",
+				"@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
+				"@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
+				"@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+			}
+		},
+		"node_modules/update-browserslist-db": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+			"integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"dependencies": {
+				"escalade": "^3.2.0",
+				"picocolors": "^1.1.1"
+			},
+			"bin": {
+				"update-browserslist-db": "cli.js"
+			},
+			"peerDependencies": {
+				"browserslist": ">= 4.21.0"
+			}
+		},
+		"node_modules/uri-js": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"dev": true,
+			"dependencies": {
+				"punycode": "^2.1.0"
+			}
+		},
+		"node_modules/v8-to-istanbul": {
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+			"integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.12",
+				"@types/istanbul-lib-coverage": "^2.0.1",
+				"convert-source-map": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10.12.0"
+			}
+		},
+		"node_modules/walker": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+			"integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+			"dev": true,
+			"dependencies": {
+				"makeerror": "1.0.12"
+			}
+		},
+		"node_modules/wallet-common-core": {
+			"resolved": "../core",
+			"link": true
+		},
+		"node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/which-boxed-primitive": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+			"integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+			"dev": true,
+			"dependencies": {
+				"is-bigint": "^1.1.0",
+				"is-boolean-object": "^1.2.1",
+				"is-number-object": "^1.1.1",
+				"is-string": "^1.1.1",
+				"is-symbol": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/which-builtin-type": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+			"integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+			"dev": true,
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"function.prototype.name": "^1.1.6",
+				"has-tostringtag": "^1.0.2",
+				"is-async-function": "^2.0.0",
+				"is-date-object": "^1.1.0",
+				"is-finalizationregistry": "^1.1.0",
+				"is-generator-function": "^1.0.10",
+				"is-regex": "^1.2.1",
+				"is-weakref": "^1.0.2",
+				"isarray": "^2.0.5",
+				"which-boxed-primitive": "^1.1.0",
+				"which-collection": "^1.0.2",
+				"which-typed-array": "^1.1.16"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/which-collection": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+			"integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+			"dev": true,
+			"dependencies": {
+				"is-map": "^2.0.3",
+				"is-set": "^2.0.3",
+				"is-weakmap": "^2.0.2",
+				"is-weakset": "^2.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/which-typed-array": {
+			"version": "1.1.19",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+			"integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+			"dev": true,
+			"dependencies": {
+				"available-typed-arrays": "^1.0.7",
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.4",
+				"for-each": "^0.3.5",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-tostringtag": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/word-wrap": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/wrap-ansi": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^6.1.0",
+				"string-width": "^5.0.1",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs": {
+			"name": "wrap-ansi",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/ansi-regex": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.0.tgz",
+			"integrity": "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/ansi-styles": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+			"integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/strip-ansi": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"dev": true
+		},
+		"node_modules/write-file-atomic": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+			"integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+			"dev": true,
+			"dependencies": {
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/ws": {
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+			"integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yallist": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+			"dev": true
+		},
+		"node_modules/yargs": {
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"dev": true,
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/yargs-parser": {
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/yargs/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true
+		},
+		"node_modules/yargs/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		}
+	}
+}

--- a/wallet/common/ethereum/package.json
+++ b/wallet/common/ethereum/package.json
@@ -1,0 +1,27 @@
+{
+	"name": "wallet-common-ethereum",
+	"version": "0.1.0",
+	"main": "./src/index.js",
+	"type": "module",
+	"scripts": {
+		"lint": "eslint .",
+		"lint:fix": "eslint . --fix --color",
+		"test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
+		"test:cov": "c8 --reporter=lcov --reporter=text --report-dir=coverage npm run test",
+		"postinstall": "resolve-local-dependencies"
+	},
+	"dependencies": {
+		"ethers": "^6.15.0",
+		"lodash": "^4.17.21",
+		"resolve-local-dependencies": "^1.0.2",
+		"wallet-common-core": "file:../core"
+	},
+	"devDependencies": {
+		"c8": "~10.1.2",
+		"eslint": "~8.57.0",
+		"eslint-config-airbnb": "~19.0.4",
+		"eslint-plugin-import": "^2.32.0",
+		"eslint-plugin-jsdoc": "^50.1.0",
+		"jest": "^30.0.0"
+	}
+}

--- a/wallet/common/ethereum/src/api/AccountService.js
+++ b/wallet/common/ethereum/src/api/AccountService.js
@@ -1,0 +1,79 @@
+import { NETWORK_CURRENCY_DIVISIBILITY, NETWORK_CURRENCY_ID, NETWORK_CURRENCY_NAME } from '../constants';
+import { ethers } from 'ethers';
+import { absoluteToRelativeAmount } from 'wallet-common-core';
+
+/** @typedef {import('../types/Account').AccountInfo} AccountInfo */
+/** @typedef {import('../types/Network').NetworkProperties} NetworkProperties */
+
+export class AccountService {
+	#config;
+
+	constructor(options) {
+		this.#config = options.config;
+	}
+
+	/**
+     * Fetches account information from the node.
+     * @param {NetworkProperties} networkProperties - Network properties.
+     * @param {string} address - The address of the account to fetch information for.
+     * @returns {Promise<AccountInfo>} - The account information.
+     */
+	fetchAccountInfo = async (networkProperties, address) => {
+		const provider = new ethers.JsonRpcProvider(networkProperties.nodeUrl);
+		const erc20TokensAddresses = this.#config.erc20TokensAddresses[networkProperties.networkIdentifier] || [];
+		const erc20Abi = [
+			'function balanceOf(address) view returns (uint256)',
+			'function decimals() view returns (uint8)',
+			'function symbol() view returns (string)'
+		];
+		const erc20TokensFetches = erc20TokensAddresses.map(async tokenAddress => {
+			const contract = new ethers.Contract(tokenAddress, erc20Abi, provider);
+			const [balanceRaw, decimals, symbol] = await Promise.all([
+				contract.balanceOf(address),
+				contract.decimals(),
+				contract.symbol()
+			]);
+			const divisibility = Number(decimals);
+			const amount = absoluteToRelativeAmount(balanceRaw.toString(), divisibility);
+            
+			return {
+				id: tokenAddress,
+				amount,
+				name: symbol,
+				divisibility
+			};
+		});
+
+		const [balance, ...tokens] = await Promise.all([
+			this.fetchAccountBalance(networkProperties, address),
+			...erc20TokensFetches
+		]);
+
+		return {
+			address,
+			balance,
+			tokens: [
+				{
+					id: NETWORK_CURRENCY_ID,
+					name: NETWORK_CURRENCY_NAME,
+					amount: balance,
+					divisibility: NETWORK_CURRENCY_DIVISIBILITY
+				},
+				...tokens
+			]
+		};
+	};
+
+	/**
+     * Fetches the native currency balance of an account from the node.
+     * @param {NetworkProperties} networkProperties - Network properties.
+     * @param {string} address - Requested account address.
+     * @returns {Promise<number>} - The account balance.
+     */
+	fetchAccountBalance = async (networkProperties, address) => {
+		const provider = new ethers.JsonRpcProvider(networkProperties.nodeUrl);
+		const balance = await provider.getBalance(address);
+
+		return absoluteToRelativeAmount(balance.toString(), NETWORK_CURRENCY_DIVISIBILITY);
+	};
+}

--- a/wallet/common/ethereum/src/api/Listener.js
+++ b/wallet/common/ethereum/src/api/Listener.js
@@ -1,0 +1,19 @@
+export class Listener {
+	constructor() {}
+
+	open() {}
+
+	close() {}
+
+	listenAddedTransactions() {}
+
+	listenRemovedTransactions() {}
+
+	listenNewBlock() {}
+
+	listenFinalizedBlock() {}
+
+	listenTransactionCosignature() {}
+
+	listenTransactionError() {}
+}

--- a/wallet/common/ethereum/src/api/ListenerService.js
+++ b/wallet/common/ethereum/src/api/ListenerService.js
@@ -1,0 +1,18 @@
+import { Listener } from './Listener';
+
+/** @typedef {import('../types/Account').PublicAccount} PublicAccount */
+/** @typedef {import('../types/Network').NetworkProperties} NetworkProperties */
+
+export class ListenerService {
+	constructor() {}
+
+	/**
+	 * Creates a new Listener instance.
+	 * @param {NetworkProperties} networkProperties - The network properties.
+	 * @param {string} accountAddress - The address of the account to listen for events.
+	 * @returns {Listener} - The Listener instance.
+	 */
+	createListener = (networkProperties, accountAddress) => {
+		return new Listener(networkProperties, accountAddress);
+	};
+}

--- a/wallet/common/ethereum/src/api/NetworkService.js
+++ b/wallet/common/ethereum/src/api/NetworkService.js
@@ -1,0 +1,66 @@
+import { NETWORK_CURRENCY_DIVISIBILITY, NETWORK_CURRENCY_ID, NETWORK_CURRENCY_NAME } from '../constants';
+import { chainIdToNetworkIdentifier, createTransactionFeeMultipliers } from '../utils';
+import { ethers } from 'ethers';
+
+/** @typedef {import('../types/Network').NetworkInfo} NetworkInfo */
+/** @typedef {import('../types/Network').NetworkProperties} NetworkProperties */
+/** @typedef {import('../types/Network').RentalFees} RentalFees */
+
+export class NetworkService {
+	#config;
+
+	constructor(options) {
+		this.#config = options.config;
+	}
+
+	/**
+	 * Returns network nodes from the config.
+	 * @param {string} networkIdentifier - Network identifier.
+	 * @returns {Promise<string[]>} The node list.
+	 */
+	fetchNodeList = async networkIdentifier => {
+		return this.#config.nodeList[networkIdentifier];
+	};
+
+	/**
+	 * Fetches the network info.
+	 * @param {string} nodeUrl - Node URL.
+	 * @returns {Promise<NetworkInfo>} Network info.
+	 */
+	fetchNetworkInfo = async nodeUrl => {
+		const provider = new ethers.JsonRpcProvider(nodeUrl);
+		const { chainId } = await provider.getNetwork();
+		const [feeHistory, chainHeight] = await Promise.all([
+			provider.send('eth_feeHistory', [
+				ethers.toQuantity(10),
+				'latest',
+				[25, 50, 75]
+			]),
+			provider.getBlockNumber()
+		]);
+
+		return {
+			nodeUrl,
+			wsUrl: nodeUrl.replace(/^http/, 'ws').replace(':8545', ':8546'),
+			networkIdentifier: chainIdToNetworkIdentifier(Number(chainId.toString())),
+			chainHeight: chainHeight,
+			transactionFees: createTransactionFeeMultipliers(NETWORK_CURRENCY_DIVISIBILITY, feeHistory),
+			networkCurrency: {
+				name: NETWORK_CURRENCY_NAME,
+				id: NETWORK_CURRENCY_ID,
+				divisibility: NETWORK_CURRENCY_DIVISIBILITY
+			}
+		};
+	};
+
+	/**
+	 * Pings the node and returns the chain height.
+	 * @param {string} nodeUrl - Node URL.
+	 * @returns {Promise<number>} Chain height.
+	 */
+	pingNode = async nodeUrl => {
+		const provider = new ethers.JsonRpcProvider(nodeUrl);
+		
+		return provider.getBlockNumber();
+	};
+}

--- a/wallet/common/ethereum/src/api/TransactionService.js
+++ b/wallet/common/ethereum/src/api/TransactionService.js
@@ -1,0 +1,79 @@
+import { transactionToEthereum } from '../utils';
+import { ethers } from 'ethers';
+import { ApiError } from 'wallet-common-core';
+
+/** @typedef {import('../types/Account').PublicAccount} PublicAccount */
+/** @typedef {import('../types/Mosaic').MosaicInfo} MosaicInfo */
+/** @typedef {import('../types/Network').NetworkProperties} NetworkProperties */
+/** @typedef {import('../types/SearchCriteria').TransactionSearchCriteria} TransactionSearchCriteria */
+/** @typedef {import('../types/Transaction').Transaction} Transaction */
+/** @typedef {import('../types/Transaction').SignedTransactionDTO} SignedTransactionDTO */
+
+export class TransactionService {
+	constructor() { }
+
+	fetchAccountTransactions = () => {
+		throw new ApiError('fetchAccountTransactions is not implemented for Ethereum');
+	};
+
+	/**
+	 * Send transaction to the network.
+	 * @param {NetworkProperties} networkProperties - Network properties.
+	 * @param {SignedTransactionDTO} dto - The signed transaction DTO.
+	 * @returns {Promise<void>} - A promise that resolves when the transaction is announced.
+	 * @throws {ApiError} - If the transaction is not accepted by any node.
+	 */
+	announceTransaction = async (networkProperties, dto) => {
+		const { nodeUrl } = networkProperties;
+		const provider = new ethers.JsonRpcProvider(nodeUrl);
+
+		try {
+			const response = await provider.broadcastTransaction(dto);
+
+			return response.hash;
+		} catch (error) {
+			throw new ApiError(`Transaction announce failed: ${error.message}`);
+		}
+	};
+
+	/**
+	 * Estimates the gas limit for a transaction.
+	 * @param {NetworkProperties} networkProperties - Network properties.
+	 * @param {Transaction} transaction - The transaction to estimate gas for.
+	 * @returns {Promise<string>} - The estimated gas limit amount.
+	 */
+	estimateTransactionGasLimit = async (networkProperties, transaction) => {
+		const { nodeUrl } = networkProperties;
+		const provider = new ethers.JsonRpcProvider(nodeUrl);
+		const ethereumTransaction = transactionToEthereum(transaction, {
+			networkIdentifier: networkProperties.networkIdentifier 
+		});
+
+		try {
+			const gasLimit = await provider.estimateGas(ethereumTransaction);
+			
+			return gasLimit.toString();
+		} catch (error) {
+			throw new ApiError(`Gas limit estimation failed: ${error.message}`);
+		}
+	};
+
+	/**
+	 * Fetches the transaction nonce for an account.
+	 * @param {NetworkProperties} networkProperties - Network properties.
+	 * @param {string} address - The account address.
+	 * @returns {Promise<number>} - The transaction nonce.
+	 */
+	fetchTransactionNonce = async (networkProperties, address) => {
+		const { nodeUrl } = networkProperties;
+		const provider = new ethers.JsonRpcProvider(nodeUrl);
+
+		try {
+			const nonce = await provider.getTransactionCount(address, 'pending');
+			
+			return nonce;
+		} catch (error) {
+			throw new ApiError(`Nonce fetching failed: ${error.message}`);
+		}
+	};
+}

--- a/wallet/common/ethereum/src/api/index.js
+++ b/wallet/common/ethereum/src/api/index.js
@@ -1,0 +1,50 @@
+import { AccountService } from './AccountService';
+import { ListenerService } from './ListenerService';
+import { NetworkService } from './NetworkService';
+import { TransactionService } from './TransactionService';
+
+/**
+ * @typedef {object} Config
+ * @property {Object.<string,string[]>} erc20TokensAddresses -  Map of networkIdentifier (key) to node the list of ERC-20 token addresses.
+ * @property {Object.<string, string[]>} nodeList - Map of networkIdentifier (key) to node URLs array (values).
+ */
+
+export class Api {
+	/**
+     * @type {AccountService}
+     */
+	account;
+
+	/**
+     * @type {ListenerService}
+     */
+	listener;
+
+	/**
+     * @type {NetworkService}
+     */
+	network;
+
+	/**
+     * @type {TransactionService}
+     */
+	transaction;
+
+
+	/**
+     * Creates an instance of SymbolApi.
+     * @param {object} options - Options for the API.
+     * @param {(url: string, config?: object) => Promise<any>} options.makeRequest - Function to make HTTP requests.
+     * @param {Config} options.config - Configuration object.
+     */
+	constructor(options) {
+		const propagatedOptions = {
+			...options,
+			api: this
+		};
+		this.account = new AccountService(propagatedOptions);
+		this.listener = new ListenerService(propagatedOptions);
+		this.network = new NetworkService(propagatedOptions);
+		this.transaction = new TransactionService(propagatedOptions);
+	}
+}

--- a/wallet/common/ethereum/src/constants/index.js
+++ b/wallet/common/ethereum/src/constants/index.js
@@ -1,0 +1,30 @@
+export const TransactionGroup = {
+	CONFIRMED: 'confirmed',
+	UNCONFIRMED: 'unconfirmed'
+};
+
+export const TransactionAnnounceGroup = {
+	DEFAULT: 'default'
+};
+
+export const TransactionType = {
+	RESERVED: 0,
+	TRANSFER: 1,
+	ERC_20_TRANSFER: 2
+};
+
+export const ChainId = {
+	MAIN_NET: 1,
+	ERIGON_LOCAL: 3151908,
+	SEPOLIA: 11155111
+};
+
+export const NetworkIdentifier = {
+	MAIN_NET: 'mainnet',
+	ERIGON_LOCAL: 'erigon_local',
+	SEPOLIA: 'sepolia'
+};
+
+export const NETWORK_CURRENCY_NAME = 'ETH';
+export const NETWORK_CURRENCY_ID = 'ETH';
+export const NETWORK_CURRENCY_DIVISIBILITY = 18;

--- a/wallet/common/ethereum/src/index.js
+++ b/wallet/common/ethereum/src/index.js
@@ -1,0 +1,10 @@
+import { Api } from './api';
+import * as sdk from './sdk';
+
+export {
+	Api,
+	sdk
+};
+
+export * from './modules';
+export * from './utils';

--- a/wallet/common/ethereum/src/modules/TransferModule.js
+++ b/wallet/common/ethereum/src/modules/TransferModule.js
@@ -1,0 +1,50 @@
+import { NETWORK_CURRENCY_ID, TransactionType } from '../constants';
+
+/** @typedef {import('../types/Transaction').Transaction} Transaction */
+
+export class TransferModule {
+	static name = 'transfer';
+	#root;
+	#api;
+
+	constructor() {}
+
+	init = options => {
+		this.#root = options.root;
+		this.#api = options.api;
+	};
+
+	loadCache = async () => {};
+
+	resetState = () => {};
+
+	clear = () => {};
+
+	/**
+     * Prepares a transfer transaction.
+     * @param {object} options - The transfer options.
+     * @param {string} options.recipientAddress - The recipient address or alias.
+     * @param {object[]} options.tokens - The tokens to transfer.
+	 * @param {object} options.fee - The transaction fee.
+     * @param {string} [password] - The wallet password.
+     * @returns {Transaction} The transfer transaction.
+     */
+	createTransaction = async options => {
+		const { recipientAddress, tokens, fee } = options;
+		const { currentAccount, networkProperties } = this.#root;
+
+		const nonce = await this.#api.transaction.fetchTransactionNonce(networkProperties, currentAccount.address);
+
+		const transaction = {
+			type: tokens[0].id === NETWORK_CURRENCY_ID ? TransactionType.TRANSFER : TransactionType.ERC_20_TRANSFER,
+			signerPublicKey: currentAccount.publicKey,
+			signerAddress: currentAccount.address,
+			recipientAddress,
+			tokens,
+			nonce,
+			fee
+		};
+
+		return transaction;
+	};
+}

--- a/wallet/common/ethereum/src/modules/index.js
+++ b/wallet/common/ethereum/src/modules/index.js
@@ -1,0 +1,1 @@
+export * from './TransferModule';

--- a/wallet/common/ethereum/src/sdk/index.js
+++ b/wallet/common/ethereum/src/sdk/index.js
@@ -1,0 +1,19 @@
+import { SdkError } from 'wallet-common-core';
+
+export { 
+	signTransaction, 
+	createPrivateAccount, 
+	createPrivateKeysFromMnemonic 
+} from '../utils';
+
+export const cosignTransaction = () => {
+	throw new SdkError('cosignTransaction is not implemented for Ethereum');
+};
+
+export const encryptMessage = () => {
+	throw new SdkError('encryptMessage is not implemented for Ethereum');
+};
+
+export const decryptMessage = () => {
+	throw new SdkError('decryptMessage is not implemented for Ethereum');
+};

--- a/wallet/common/ethereum/src/types/Account.js
+++ b/wallet/common/ethereum/src/types/Account.js
@@ -1,0 +1,47 @@
+/** @typedef {import('./Token').Token} Token */
+
+/**
+ * @typedef {Object} KeyPair
+ * @property {string} privateKey - The private key as a string.
+ * @property {string} publicKey - The public key as a string.
+ */
+
+/**
+ * @typedef {Object} PublicAccount
+ * @property {string} address - Account address.
+ * @property {string} publicKey - Account public key.
+ * @property {string} networkIdentifier - Network identifier the account belongs to.
+ * @property {string} [accountType] - Account type 'mnemonic' or 'external'
+ * @property {number} [index] - Seed account index
+ */
+
+/**
+ * @typedef {PublicAccount} PrivateAccount
+ * @property {string} privateKey - Account private key.
+ */
+
+/**
+ * @typedef {PublicAccount} WalletAccount
+ * @property {string} name - Account name.
+ * @property {string} accountType - Account type 'mnemonic' or 'external'
+ */
+
+/**
+ * @typedef {Object} LinkedKeys
+ * @property {string} linkedPublicKey - Linked public key.
+ * @property {string} nodePublicKey - Node public key.
+ * @property {string} vrfPublicKey - VRF public key.
+ */
+
+/**
+ * @typedef {Object} BaseAccountInfo
+ * @property {string} address - Account address.
+ * @property {Token[]} tokens - Account owned tokens (e.g. ETH, ERC-20).
+ * @property {number} balance - Account native currency balance (ETH).
+ */
+
+/**
+ * @typedef {BaseAccountInfo} AccountInfo
+ */
+
+export default {};

--- a/wallet/common/ethereum/src/types/Network.js
+++ b/wallet/common/ethereum/src/types/Network.js
@@ -1,0 +1,37 @@
+/**
+ * @typedef {Object} TransactionFeeMultiplier
+ * @property {string} maxFeePerGas - The maximum fee per gas for the transaction. Relative amount string in Ethers.
+ * @property {string} maxPriorityFeePerGas - The maximum priority fee per gas for the transaction. Relative amount string in Ethers.
+ */
+
+/**
+ * @typedef {Object} TransactionFeeMultipliers
+ * @property {TransactionFeeMultiplier} fast - Highest fee multiplier.
+ * @property {TransactionFeeMultiplier} medium - Median fee multiplier.
+ * @property {TransactionFeeMultiplier} slow - Lowest fee multiplier.
+ */
+
+/**
+ * @typedef {Object} NetworkCurrency
+ * @property {string} name - Token symbol ('ETH').
+ * @property {string} id - Token identifier ('ETH').
+ * @property {number} divisibility - Token divisibility (18).
+ */
+
+/**
+ * @typedef {Object} NetworkInfo
+ * @property {string} nodeUrl - API node URL.
+ * @property {string} wsUrl - Websocket connection URL.
+ * @property {string} networkIdentifier - Network identifier.
+ * @property {number} chainHeight - Chain height at the time of the request.
+ * @property {TransactionFeeMultipliers} transactionFees - Transaction fee multipliers.
+ * @property {NetworkCurrency} networkCurrency - Network currency token.
+ */
+
+/**
+ * @typedef {NetworkInfo} NetworkProperties
+ * @property {string[]} nodeUrls - List of the network node URLs.
+ */
+
+
+export default {};

--- a/wallet/common/ethereum/src/types/SearchCriteria.js
+++ b/wallet/common/ethereum/src/types/SearchCriteria.js
@@ -1,0 +1,29 @@
+/**
+ * @typedef {Object} SearchCriteria
+ * @property {number} pageNumber - The page number.
+ * @property {number} pageSize - The page size.
+ */
+
+/**
+ * @typedef {SearchCriteria} SortableSearchCriteria
+ * @property {"asc" | "desc"} order - The sort order.
+ */
+
+/**
+ * @typedef {Object} TransactionFiler
+ * @property {string} [from] - The sender address.
+ * @property {string} [to] - The recipient address.
+ * @property {string} [type] - The transaction type.
+ */
+
+/**
+ * @typedef {SortableSearchCriteria} TransactionSearchCriteria
+ * @property {"confirmed" | "partial" | "unconfirmed"} group - The transaction group.
+ * @property {TransactionFiler} [filter] - The transaction filter.
+ */
+
+/**
+ * @typedef {SortableSearchCriteria} HarvestedBlockSearchCriteria
+ */
+
+export default {};

--- a/wallet/common/ethereum/src/types/Token.js
+++ b/wallet/common/ethereum/src/types/Token.js
@@ -1,0 +1,10 @@
+/**
+ * @typedef {Object} Token
+ * @property {string} id - 'ETH' or ERC-20 contract address.
+ * @property {string} name - Token symbol.
+ * @property {string} amount - The token relative amount.
+ * @property {number} divisibility - Token divisibility. 18 for ETH or decimals for ERC-20 tokens.
+ */
+
+
+export default {};

--- a/wallet/common/ethereum/src/types/Transaction.js
+++ b/wallet/common/ethereum/src/types/Transaction.js
@@ -1,0 +1,49 @@
+/** @typedef {import('./Token').Token} Token */
+
+/**
+ * @typedef {Object} TransactionFee
+ * @property {string} gasLimit - The gas limit for the transaction. BigInt string.
+ * @property {string} maxFeePerGas - The maximum fee per gas for the transaction. Relative amount string in Ethers.
+ * @property {string} maxPriorityFeePerGas - The maximum priority fee per gas for the transaction. Relative amount string in Ethers.
+ * @property {string} totalAmount - The total fee amount to pay for a transaction (maxFeePerGas * gasLimit).
+ * Relative amount string in Ethers.
+ */
+
+/**
+ * @typedef {Object} Transaction
+ * @property {string} type - The transaction type.
+ * @property {string} signerPublicKey - The public key of the transaction signer.
+ * @property {string} signerAddress - The address of the transaction signer.
+ * @property {string} recipientAddress - The address of the transaction recipient.
+ * @property {Token[]} tokens - The tokens involved in the transaction (e.g. ETH, ERC-20).
+ * @property {TransactionFee} [fee] - The transaction fee.
+ * @property {number} [timestamp] - Timestamp the transaction is confirmed.
+ * @property {number} [height] - The block height the transaction is included in.
+ * @property {string} [hash] - The transaction hash.
+ */
+
+/**
+ * @typedef {Object} SignedTransactionDTO
+ * @property {string} payload - The transaction payload.
+ */
+
+/**
+ * @typedef {Object} SignedTransaction
+ * @property {SignedTransactionDTO} dto - Transaction data transfer object.
+ * @property {string} hash - The transaction hash.
+ */
+
+/**
+ * @typedef {Object} EthersTransaction
+ * @property {string} from - The sender's address.
+ * @property {string} to - The recipient's address or contract address.
+ * @property {string} value - The amount of Ether to send.transaction.
+ * @property {string} nonce - The transaction nonce.
+ * @property {string} chainId - The ID of the Ethereum chain.
+ * @property {string} [data] - The function call data.
+ * @property {string} [gasLimit] - The maximum amount of gas to use for the transaction.
+ * @property {string} [maxFeePerGas] - The maximum fee per gas for the transaction.
+ * @property {string} [maxPriorityFeePerGas] - The maximum priority fee per gas for the transaction.
+ */
+
+export default {};

--- a/wallet/common/ethereum/src/utils/account.js
+++ b/wallet/common/ethereum/src/utils/account.js
@@ -1,0 +1,176 @@
+import { SigningKey, Wallet, computeAddress, isAddress } from 'ethers';
+
+/** @typedef {import('../types/Account').KeyPair} KeyPair */
+/** @typedef {import('../types/Account').PublicAccount} PublicAccount */
+/** @typedef {import('../types/Account').PrivateAccount} PrivateAccount */
+/** @typedef {import('../types/Account').WalletAccount} WalletAccount */
+
+const to0x = hex => (typeof hex === 'string' && hex.startsWith('0x') ? hex : `0x${hex}`);
+
+/**
+ * Generates an Ethereum key pair consisting of a private key and a public key.
+ * @returns {KeyPair} An object containing the generated private key and public key.
+ */
+export const generateKeyPair = () => {
+	const wallet = Wallet.createRandom();
+
+	return {
+		privateKey: wallet.privateKey,
+		publicKey: wallet.publicKey
+	};
+};
+
+/**
+ * Get the Ethereum account address from a given private key.
+ * @param {string} privateKey - The private key.
+ * @returns {string} The account address.
+ */
+export const addressFromPrivateKey = privateKey => {
+	return computeAddress(to0x(privateKey));
+};
+
+/**
+ * Get the Ethereum account address from a given public key.
+ * @param {string} publicKey - The public key.
+ * @returns {string} The account address.
+ */
+export const addressFromPublicKey = publicKey => {
+	return computeAddress(to0x(publicKey));
+};
+
+/**
+ * Creates the public account from a given public key.
+ * @param {string} publicKey - The public key.
+ * @param {string} networkIdentifier - The network identifier.
+ * @param {string} [accountType] - The account type (optional).
+ * @param {number} [index] - The account index (optional).
+ * @returns {PublicAccount} The public account.
+ */
+export const publicAccountFromPublicKey = (publicKey, networkIdentifier, accountType, index) => {
+	const address = computeAddress(to0x(publicKey));
+
+	const account = {
+		address,
+		publicKey,
+		networkIdentifier
+	};
+
+	if (index !== null && index !== undefined)
+		account.index = index;
+
+	if (accountType)
+		account.accountType = accountType;
+
+	return account;
+};
+
+/**
+ * Creates the public account from a given private key.
+ * @param {string} privateKey - The private key.
+ * @param {string} networkIdentifier - The network identifier.
+ * @param {string} [accountType] - The account type (optional).
+ * @param {number} [index] - The account index (optional).
+ * @returns {PublicAccount} The public account.
+ */
+export const publicAccountFromPrivateKey = (privateKey, networkIdentifier, accountType, index) => {
+	const sk = new SigningKey(to0x(privateKey));
+	const {publicKey} = sk;
+
+	return publicAccountFromPublicKey(publicKey, networkIdentifier, accountType, index);
+};
+
+/**
+ * Creates a wallet storage account object. This object includes the private key.
+ * @param {string} privateKey - The private key.
+ * @param {string} networkIdentifier - The network identifier.
+ * @param {string} [accountType] - The account type (optional).
+ * @param {number} [index] - The account index (optional).
+ * @returns {PrivateAccount} The wallet storage account object.
+ */
+export const createPrivateAccount = (privateKey, networkIdentifier, accountType, index) => {
+	const publicAccount = publicAccountFromPrivateKey(privateKey, networkIdentifier, accountType, index);
+
+	return {
+		...publicAccount,
+		privateKey
+	};
+};
+
+/**
+ * Creates a wallet account object.
+ * @param {string} privateKey - The private key.
+ * @param {string} networkIdentifier - The network identifier.
+ * @param {string} name - The account name.
+ * @param {string} accountType - The account type.
+ * @param {number} [index] - The account index.
+ * @returns {WalletAccount} The wallet account object.
+ */
+export const createWalletAccount = (privateKey, networkIdentifier, name, accountType, index) => {
+	const publicAccount = publicAccountFromPrivateKey(privateKey, networkIdentifier, accountType, index);
+
+	return {
+		...publicAccount,
+		name,
+		accountType
+	};
+};
+
+/**
+ * Checks if a given string looks like an Ethereum private key.
+ * Accepts:
+ * - private key: 32 bytes (64 hex, with or without 0x)
+ * @param {string} stringToTest - The string to test.
+ * @returns {boolean} A boolean indicating if the string is a valid-looking key.
+ */
+export const isPrivateKey = stringToTest => {
+	if (typeof stringToTest !== 'string') 
+		return false;
+
+	const hex = stringToTest.startsWith('0x') ? stringToTest.slice(2) : stringToTest;
+	
+	if (!/^[0-9a-fA-F]+$/.test(hex)) 
+		return false;
+
+	const privateKeyLength = 32 * 2;
+	const acceptedLength = [
+		privateKeyLength
+	];
+
+	return acceptedLength.includes(hex.length);
+};
+
+/**
+ * Checks if a given string looks like an Ethereum public key.
+ * Accepts:
+ * - public key (compressed): 33 bytes (66 hex)
+ * - public key (uncompressed): 65 bytes (130 hex)
+ * @param {string} stringToTest - The string to test.
+ * @returns {boolean} A boolean indicating if the string is a valid-looking key.
+ */
+export const isPublicKey = stringToTest => {
+	if (typeof stringToTest !== 'string') 
+		return false;
+
+	const hex = stringToTest.startsWith('0x') ? stringToTest.slice(2) : stringToTest;
+	
+	if (!/^[0-9a-fA-F]+$/.test(hex)) 
+		return false;
+
+	const publicKeyCompressedLength = 33 * 2;
+	const publicKeyUncompressedLength = 65 * 2;
+	const acceptedLength = [
+		publicKeyCompressedLength,
+		publicKeyUncompressedLength
+	];
+
+	return acceptedLength.includes(hex.length);
+};
+
+/**
+ * Checks if a given string is a valid Ethereum address (with or without checksum).
+ * @param {string} address - The address to test.
+ * @returns {boolean} A boolean indicating if the string is a valid Ethereum address.
+ */
+export const isEthereumAddress = address => {
+	return typeof address === 'string' && isAddress(address);
+};

--- a/wallet/common/ethereum/src/utils/fee.js
+++ b/wallet/common/ethereum/src/utils/fee.js
@@ -1,0 +1,124 @@
+import { NETWORK_CURRENCY_DIVISIBILITY } from '../constants';
+import { ethers } from 'ethers';
+import { absoluteToRelativeAmount, safeOperationWithRelativeAmounts } from 'wallet-common-core';
+
+/** @typedef {import('../types/Network').TransactionFeeMultiplier} TransactionFeeMultiplier */
+/** @typedef {import('../types/Network').TransactionFeeMultipliers} TransactionFeeMultipliers */
+/** @typedef {import('../types/Transaction').TransactionFee} TransactionFee */
+
+/**
+ * Fixed fallback priority fee values (EIP-1559 tip) in wei.
+ * Chosen as 1, 2, 3 gwei — a safe baseline for low network load.
+ * These are used only if `eth_feeHistory` data is unavailable.
+ */
+const FALLBACK_PRIORITY_FEES_WEI = {
+	slow: 1_000_000_000n,  // 1 gwei
+	medium: 2_000_000_000n, // 2 gwei
+	fast: 3_000_000_000n    // 3 gwei
+};
+
+/**
+ * Base fee multipliers for EIP-1559 headroom.
+ * Covers several blocks of potential baseFee increases.
+ */
+const BASE_FEE_MULTIPLIERS = {
+	slow: 1.2,
+	medium: 1.5,
+	fast: 2.0
+};
+
+const parseHexToBigInt = hexString => {
+	if (!hexString) 
+		return 0n;
+
+	try {
+		return ethers.getBigInt(hexString);
+	} catch {
+		return 0n;
+	}
+};
+
+const medianBigInt = values => {
+	if (!values.length) 
+		return 0n;
+
+	const sorted = [...values].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+	const mid = Math.floor(sorted.length / 2);
+    
+	return sorted.length % 2
+		? sorted[mid]
+		: (sorted[mid - 1] + sorted[mid]) / 2n;
+};
+
+/**
+ * Creates gas fee tiers (slow/medium/fast) using EIP-1559 rules.
+ * @param {number} currencyDivisibility - e.g. 18 for ETH
+ * @param {{ baseFeePerGas?: string[], reward?: string[][] }} feeHistory - from eth_feeHistory
+ * @returns {TransactionFeeMultipliers} The transaction fee multipliers.
+ */
+export const createTransactionFeeMultipliers = (currencyDivisibility, feeHistory) => {
+	const baseFees = Array.isArray(feeHistory?.baseFeePerGas) ? feeHistory.baseFeePerGas : [];
+	const rewards = Array.isArray(feeHistory?.reward) ? feeHistory.reward : [];
+
+	const nextBaseFee = baseFees.length
+		? parseHexToBigInt(baseFees[baseFees.length - 1])
+		: 0n;
+
+	// Percentiles → [slow, medium, fast]
+	const slowSamples = rewards.map(p => parseHexToBigInt(p?.[0]));
+	const mediumSamples = rewards.map(p => parseHexToBigInt(p?.[1]));
+	const fastSamples = rewards.map(p => parseHexToBigInt(p?.[2]));
+
+	// Pick median or fallback
+	const priorityFeesWei = {
+		slow: slowSamples.length ? medianBigInt(slowSamples) : FALLBACK_PRIORITY_FEES_WEI.slow,
+		medium: mediumSamples.length ? medianBigInt(mediumSamples) : FALLBACK_PRIORITY_FEES_WEI.medium,
+		fast: fastSamples.length ? medianBigInt(fastSamples) : FALLBACK_PRIORITY_FEES_WEI.fast
+	};
+
+	// Ensure non-decreasing order
+	if (priorityFeesWei.medium < priorityFeesWei.slow) 
+		priorityFeesWei.medium = priorityFeesWei.slow;
+    
+	if (priorityFeesWei.fast < priorityFeesWei.medium) 
+		priorityFeesWei.fast = priorityFeesWei.medium;
+    
+
+	// Helper to build fee tier
+	const buildTier = (priorityFeeWei, multiplier) => {
+		const maxFeeWei = BigInt(Math.floor(Number(nextBaseFee) * multiplier)) + priorityFeeWei;
+		return {
+			maxPriorityFeePerGas: absoluteToRelativeAmount(priorityFeeWei.toString(), currencyDivisibility),
+			maxFeePerGas: absoluteToRelativeAmount(maxFeeWei.toString(), currencyDivisibility)
+		};
+	};
+
+	return {
+		slow: buildTier(priorityFeesWei.slow, BASE_FEE_MULTIPLIERS.slow),
+		medium: buildTier(priorityFeesWei.medium, BASE_FEE_MULTIPLIERS.medium),
+		fast: buildTier(priorityFeesWei.fast, BASE_FEE_MULTIPLIERS.fast)
+	};
+};
+
+
+/**
+ * Creates a fee object for transaction.
+ * @param {TransactionFeeMultiplier} feeMultiplier - The fee multiplier object.
+ * @param {string} gasLimit - The gas limit.
+ * @param {number} [divisibility=18] - The currency divisibility.
+ * @returns {TransactionFee} The fee object.
+ */
+export const createFee = (feeMultiplier, gasLimit, divisibility = NETWORK_CURRENCY_DIVISIBILITY) => {
+	const { maxFeePerGas, maxPriorityFeePerGas } = feeMultiplier;
+
+	return {
+		gasLimit,
+		maxFeePerGas,
+		maxPriorityFeePerGas,
+		totalAmount: safeOperationWithRelativeAmounts(
+			divisibility,
+			[maxFeePerGas],
+			maxFeePerGas => maxFeePerGas * BigInt(gasLimit)
+		)
+	};
+};

--- a/wallet/common/ethereum/src/utils/index.js
+++ b/wallet/common/ethereum/src/utils/index.js
@@ -1,0 +1,6 @@
+export * from './account';
+export * from './fee';
+export * from './network';
+export * from './transaction';
+export * from './transaction-to-ethereum';
+export * from './wallet';

--- a/wallet/common/ethereum/src/utils/network.js
+++ b/wallet/common/ethereum/src/utils/network.js
@@ -1,0 +1,37 @@
+import { ChainId, NetworkIdentifier } from '../constants';
+
+/**
+ * Converts a network type to a network identifier.
+ * @param {number} networkType - The network type.
+ * @returns {string} The network identifier.
+ */
+export const chainIdToNetworkIdentifier = chainId => {
+	if (chainId === ChainId.MAIN_NET) 
+		return NetworkIdentifier.MAIN_NET;
+
+	if (chainId === ChainId.ERIGON_LOCAL) 
+		return NetworkIdentifier.ERIGON_LOCAL;
+
+	if (chainId === ChainId.SEPOLIA) 
+		return NetworkIdentifier.SEPOLIA;
+
+	throw new Error(`Unsupported chain ID "${chainId}"`);
+};
+
+/**
+ * Converts a network identifier to a network type.
+ * @param {string} networkIdentifier - The network identifier.
+ * @returns {number} The network type.
+ */
+export const networkIdentifierToChainId = networkIdentifier => {
+	if (networkIdentifier === NetworkIdentifier.MAIN_NET) 
+		return ChainId.MAIN_NET;
+
+	if (networkIdentifier === NetworkIdentifier.ERIGON_LOCAL) 
+		return ChainId.ERIGON_LOCAL;
+
+	if (networkIdentifier === NetworkIdentifier.SEPOLIA) 
+		return ChainId.SEPOLIA;
+
+	throw new Error(`Unsupported network identifier "${networkIdentifier}"`);
+};

--- a/wallet/common/ethereum/src/utils/transaction-to-ethereum.js
+++ b/wallet/common/ethereum/src/utils/transaction-to-ethereum.js
@@ -1,0 +1,74 @@
+import { networkIdentifierToChainId } from './network';
+import { TransactionType } from '../constants';
+import { ethers } from 'ethers';
+
+/** @typedef {import('../types/Transaction').Transaction} Transaction */
+/** @typedef {import('../types/Transaction').EthersTransaction} EthersTransaction */
+
+/**
+ * Converts a transaction to the ethers format.
+ * @param {Transaction} transaction - The transaction to convert.
+ * @param {object} config - The configuration object.
+ * @param {string} config.networkIdentifier - The network identifier.
+ * @returns {EthersTransaction} The ethers format transaction.
+ */
+export const transactionToEthereum = (transaction, config) => {
+	switch (transaction.type) {
+	case TransactionType.TRANSFER:
+		return transferTransactionToEthereum(transaction, config);
+	case TransactionType.ERC_20_TRANSFER:
+		return erc20TransferTransactionToEthereum(transaction, config);
+	}
+
+	return null;
+};
+
+const createBaseEthereumTransaction = (transaction, networkIdentifier) => {
+	const baseTransaction = {
+		from: transaction.signerAddress,
+		chainId: networkIdentifierToChainId(networkIdentifier),
+		nonce: transaction.nonce
+	};
+
+	if (transaction.fee) {
+		const { gasLimit, maxFeePerGas, maxPriorityFeePerGas} = transaction.fee;
+
+		baseTransaction.gasLimit = BigInt(gasLimit);
+		baseTransaction.maxFeePerGas = ethers.parseUnits(maxFeePerGas);
+		baseTransaction.maxPriorityFeePerGas = ethers.parseUnits(maxPriorityFeePerGas);
+	}
+
+	return baseTransaction;
+};
+
+const transferTransactionToEthereum = (transaction, config) => {
+	const { recipientAddress, tokens } = transaction;
+	const { amount } = tokens[0];
+	const baseTransaction = createBaseEthereumTransaction(transaction, config.networkIdentifier);
+
+	return {
+		...baseTransaction,
+		to: recipientAddress,
+		value: ethers.parseEther(amount)
+	};
+};
+
+const erc20TransferTransactionToEthereum = (transaction, config) => {
+	const { recipientAddress, tokens } = transaction;
+	const token = tokens[0];
+	const baseTransaction = createBaseEthereumTransaction(transaction, config.networkIdentifier);
+
+	const erc20Interface = new ethers.Interface([
+		'function transfer(address to, uint256 value) public returns (bool)'
+	]);
+
+	return {
+		...baseTransaction,
+		to: token.id,
+		value: 0n,
+		data: erc20Interface.encodeFunctionData('transfer', [
+			recipientAddress,
+			ethers.parseUnits(token.amount, token.divisibility)
+		])
+	};
+};

--- a/wallet/common/ethereum/src/utils/transaction.js
+++ b/wallet/common/ethereum/src/utils/transaction.js
@@ -1,0 +1,47 @@
+import { transactionToEthereum } from './transaction-to-ethereum';
+import { ethers } from 'ethers';
+
+/** @typedef {import('../types/Account').PublicAccount} PublicAccount */
+/** @typedef {import('../types/Network').NetworkProperties} NetworkProperties */
+/** @typedef {import('../types/Network').TransactionFees} TransactionFees */
+/** @typedef {import('../types/Transaction').Transaction} Transaction */
+/** @typedef {import('../types/Transaction').SignedTransaction} SignedTransaction */
+
+
+/**
+ * Checks if a transaction is an outgoing transaction.
+ * @param {Transaction} transaction - Transaction.
+ * @param {PublicAccount} currentAccount - Current account.
+ * @returns {boolean} A boolean indicating whether the transaction is an outgoing transaction.
+ */
+export const isOutgoingTransaction = (transaction, currentAccount) => transaction.signerAddress === currentAccount.address;
+
+/**
+ * Checks if a transaction is an incoming transaction.
+ * @param {Transaction} transaction - Transaction.
+ * @param {PublicAccount} currentAccount - Current account.
+ * @returns {boolean} A boolean indicating whether the transaction is an incoming transaction.
+ */
+export const isIncomingTransaction = (transaction, currentAccount) => transaction.recipientAddress === currentAccount.address;
+
+
+/**
+ * Signs an Ethereum transaction with a private key (EIP-155/EIP-1559).
+ * @param {string} networkIdentifier - The network identifier.
+ * @param {Transaction} transaction - App transaction object.
+ * @param {string} privateKey - The signer account private key.
+ * @returns {Promise<SignedTransaction>} The signed transaction.
+ */
+export const signTransaction = async (networkIdentifier, transaction, privateKey) => {
+	const ethereumTransaction = transactionToEthereum(transaction, { networkIdentifier });
+
+	const wallet = new ethers.Wallet(privateKey);
+	const signedTransactionString = await wallet.signTransaction(ethereumTransaction);
+	const hash = ethers.keccak256(signedTransactionString);
+
+	return {
+		dto: signedTransactionString,
+		hash
+	};
+};
+

--- a/wallet/common/ethereum/src/utils/wallet.js
+++ b/wallet/common/ethereum/src/utils/wallet.js
@@ -1,0 +1,30 @@
+import { ethers } from 'ethers';
+
+const BASE_PATH = 'm/44\'/60\'/0\'/0';
+
+/**
+ * Generates a random Ethereum mnemonic phrase.
+ * @returns {string} The generated mnemonic phrase.
+ */
+export const generateMnemonic = () => {
+	const entropy = ethers.randomBytes(32);
+	const mnemonic = ethers.Mnemonic.fromEntropy(entropy);
+
+	return mnemonic.phrase;
+};
+
+/**
+ * Creates an array of Ethereum private keys from a given mnemonic phrase.
+ * Derives using BIP44 path: m/44'/60'/0'/0/index
+ * @param {string} mnemonic - The mnemonic phrase used to generate the private keys.
+ * @param {number[]} indexes - An array of indexes to derive the private keys from.
+ * @returns {string[]} An array of private keys derived from the mnemonic and indexes.
+ */
+export const createPrivateKeysFromMnemonic = (mnemonic, indexes) => {
+	return indexes.map(index => {
+		const path = `${BASE_PATH}/${index}`;
+		const wallet = ethers.HDNodeWallet.fromPhrase(mnemonic, undefined, path);
+		
+		return wallet.privateKey;
+	});
+};

--- a/wallet/common/ethereum/tests/__fixtures__/local/transactions.js
+++ b/wallet/common/ethereum/tests/__fixtures__/local/transactions.js
@@ -1,0 +1,88 @@
+/* eslint-disable max-len */
+import { ethers } from 'ethers';
+
+const erc20Interface = new ethers.Interface([
+	'function transfer(address to, uint256 value) public returns (bool)'
+]);
+const signerPublicKey = '0x04d180bfa90bb100d21df55b10cc535b392e87d595593afa9de219f4bd006bd2893d80827f43c47794029a8b4218699e65d837a6beb95b5b2f95a31b52f3e93b13';
+const signerAddress = '0xb1b2145b7d2ba5AB20Ee0Bcb0F7FAd08a1BfC7A4';
+const recipientAddress1 = '0xC5D9cF0eE687e357Aea5d26592F8bC9fe32aBAA2';
+const recipientAddress2 = '0xE61c8ba605B4A808dD8138c990e941feAe532307';
+const erc20ContractAddress = '0x6fE1f90116fd1225c4B713a6EFb3f87DCe77b445';
+const chainId = 3151908;
+const baseFee = {
+	gasLimit: 21000,
+	maxFeePerGas: '3',
+	maxPriorityFeePerGas: '1'
+};
+
+export const walletTransactions = [
+	{
+		type: 1,
+		signerPublicKey,
+		signerAddress,
+		recipientAddress: recipientAddress1,
+		tokens: [
+			{
+				id: 'ETH',
+				amount: '1.5',
+				divisibility: 18
+			}
+		],
+		nonce: 0,
+		fee: baseFee
+	},
+	{
+		type: 2,
+		signerPublicKey,
+		signerAddress,
+		recipientAddress: recipientAddress2,
+		tokens: [
+			{
+				id: erc20ContractAddress,
+				amount: '10',
+				divisibility: 6
+			}
+		],
+		nonce: 1,
+		fee: baseFee
+	}
+];
+
+export const ethereumTransactions = [
+	{
+		from: signerAddress,
+		to: recipientAddress1,
+		value: 1500000000000000000n,
+		gasLimit: 21000n,
+		maxFeePerGas: 3000000000000000000n,
+		maxPriorityFeePerGas: 1000000000000000000n,
+		chainId,
+		nonce: 0
+	},
+	{
+		from: signerAddress,
+		to: erc20ContractAddress,
+		value: 0n,
+		data: erc20Interface.encodeFunctionData('transfer', [
+			recipientAddress2,
+			10000000n
+		]),
+		gasLimit: 21000n,
+		maxFeePerGas: 3000000000000000000n,
+		maxPriorityFeePerGas: 1000000000000000000n,
+		chainId,
+		nonce: 1
+	}
+];
+
+export const signedTransactions = [
+	{
+		'dto': '0x02f87d8330182480880de0b6b3a76400008829a2241af62c000082520894c5d9cf0ee687e357aea5d26592f8bc9fe32abaa28814d1120d7b16000080c001a0d4d10f0e5c6f6b95e1afd7bbddae6d5e33c3000be1c147024547ca7341566294a00b216cdaceb421f13c9e7978f00d6271695311aeced9e2ba3ad64f1783fe37ea',
+		'hash': '0x4707b91a2cddee42b96caf2de66a8b0645d02b96b4e44ba81dffffd198b8cff8'
+	},
+	{
+		'dto': '0x02f8ba8330182401880de0b6b3a76400008829a2241af62c0000825208946fe1f90116fd1225c4b713a6efb3f87dce77b44580b844a9059cbb000000000000000000000000e61c8ba605b4a808dd8138c990e941feae5323070000000000000000000000000000000000000000000000000000000000989680c001a06d702fcdc50ae678e0e9017f1391fd3858d27c60d1b5bc45955d24c678f81989a05586df7919671215ac17c05b75f6a937fae826c5dbcc2d46b6d376d5427c667e',
+		'hash': '0xd0c31e56e3e73cf88aab09a5ddff5f4536f7b907e81d7ad5a4f72a717dbc65ba'
+	}
+];

--- a/wallet/common/ethereum/tests/__fixtures__/local/wallet.js
+++ b/wallet/common/ethereum/tests/__fixtures__/local/wallet.js
@@ -1,0 +1,96 @@
+/* eslint-disable max-len */
+export const mnemonic =
+    'valve blossom bright away room lady assume always oven belt family when pride wild sort earn bicycle galaxy practice drink rely divide puzzle dune';
+
+export const walletStorageAccounts = {
+	mainnet: [
+		{
+			address: '0xb1b2145b7d2ba5AB20Ee0Bcb0F7FAd08a1BfC7A4',
+			publicKey: '0x04d180bfa90bb100d21df55b10cc535b392e87d595593afa9de219f4bd006bd2893d80827f43c47794029a8b4218699e65d837a6beb95b5b2f95a31b52f3e93b13',
+			networkIdentifier: 'mainnet',
+			index: 0,
+			accountType: 'mnemonic',
+			privateKey: '0x91181700f2f82f5e42444a9e80dc067d1675ba6cc4507cd225dcd7eba49dcc27'
+		},
+		{
+			address: '0x38F3fa5dfb5359F8425bC90B4ebDEaf96d0670C4',
+			publicKey: '0x04a172ab918fac698c5792c9a467f1323e522cef6ac42bf64798fa397e8153cf67bb4abb9a6fdb67024cbb64775c391b3168dbcd2fb3736085ec4e3a059caaecd4',
+			networkIdentifier: 'mainnet',
+			index: 1,
+			accountType: 'mnemonic',
+			privateKey: '0x17bf8d4fadf6e9f0bffefaa94f13068bae2f9521176008baa4892ac8345a453b'
+		},
+		{
+			address: '0xC5D9cF0eE687e357Aea5d26592F8bC9fe32aBAA2',
+			publicKey: '0x04e9b65ffc96c359d93d9b4cd956e3e823cff31fe20697f2d82b279eb492352211738c1c1fc91ceafcf9f175be1c0ab9112c426feb6989dd11a296ae681e9fb0a3',
+			networkIdentifier: 'mainnet',
+			index: 2,
+			accountType: 'mnemonic',
+			privateKey: '0x28f5122129ba513e4dc6cab5eede6675eda0f2e6a3283a14c085981fc5089388'
+		},
+		{
+			address: '0xE61c8ba605B4A808dD8138c990e941feAe532307',
+			publicKey: '0x04564f21add19960bac1dc859da23e037d9436fee8e8dc5aa6a993a102528f5f8824093e5b06ac383be415cb1f533a082b5372c762ab74eed7b9240080b873930a',
+			networkIdentifier: 'mainnet',
+			index: 3,
+			accountType: 'mnemonic',
+			privateKey: '0xf3890a0e4292269fa16950f48ccb031f30a5f0b2a75e65c9388fe45542d85961'
+		},
+		{
+			address: '0x6fE1f90116fd1225c4B713a6EFb3f87DCe77b445',
+			publicKey: '0x0440b16472b032c0b659cdb0e4a3cd016441849fd4b765b294a2098ae958fce685327d7ef687d07985f6c6ff590039a7adb651fb8412c2606feebd6c5b660d1d7e',
+			networkIdentifier: 'mainnet',
+			index: 4,
+			accountType: 'mnemonic',
+			privateKey: '0xec880a6bdd3150dc8e6a7b9c3ca5fe1edb6ba34e9b05b7522f7567480cfe004f'
+		}
+	],
+	erigon_local: [
+		{
+			address: '0xb1b2145b7d2ba5AB20Ee0Bcb0F7FAd08a1BfC7A4',
+			publicKey: '0x04d180bfa90bb100d21df55b10cc535b392e87d595593afa9de219f4bd006bd2893d80827f43c47794029a8b4218699e65d837a6beb95b5b2f95a31b52f3e93b13',
+			networkIdentifier: 'erigon_local',
+			index: 0,
+			accountType: 'mnemonic',
+			privateKey: '0x91181700f2f82f5e42444a9e80dc067d1675ba6cc4507cd225dcd7eba49dcc27'
+		},
+		{
+			address: '0x38F3fa5dfb5359F8425bC90B4ebDEaf96d0670C4',
+			publicKey: '0x04a172ab918fac698c5792c9a467f1323e522cef6ac42bf64798fa397e8153cf67bb4abb9a6fdb67024cbb64775c391b3168dbcd2fb3736085ec4e3a059caaecd4',
+			networkIdentifier: 'erigon_local',
+			index: 1,
+			accountType: 'mnemonic',
+			privateKey: '0x17bf8d4fadf6e9f0bffefaa94f13068bae2f9521176008baa4892ac8345a453b'
+		},
+		{
+			address: '0xC5D9cF0eE687e357Aea5d26592F8bC9fe32aBAA2',
+			publicKey: '0x04e9b65ffc96c359d93d9b4cd956e3e823cff31fe20697f2d82b279eb492352211738c1c1fc91ceafcf9f175be1c0ab9112c426feb6989dd11a296ae681e9fb0a3',
+			networkIdentifier: 'erigon_local',
+			index: 2,
+			accountType: 'mnemonic',
+			privateKey: '0x28f5122129ba513e4dc6cab5eede6675eda0f2e6a3283a14c085981fc5089388'
+		},
+		{
+			address: '0xE61c8ba605B4A808dD8138c990e941feAe532307',
+			publicKey: '0x04564f21add19960bac1dc859da23e037d9436fee8e8dc5aa6a993a102528f5f8824093e5b06ac383be415cb1f533a082b5372c762ab74eed7b9240080b873930a',
+			networkIdentifier: 'erigon_local',
+			index: 3,
+			accountType: 'mnemonic',
+			privateKey: '0xf3890a0e4292269fa16950f48ccb031f30a5f0b2a75e65c9388fe45542d85961'
+		},
+		{
+			address: '0x6fE1f90116fd1225c4B713a6EFb3f87DCe77b445',
+			publicKey: '0x0440b16472b032c0b659cdb0e4a3cd016441849fd4b765b294a2098ae958fce685327d7ef687d07985f6c6ff590039a7adb651fb8412c2606feebd6c5b660d1d7e',
+			networkIdentifier: 'erigon_local',
+			index: 4,
+			accountType: 'mnemonic',
+			privateKey: '0xec880a6bdd3150dc8e6a7b9c3ca5fe1edb6ba34e9b05b7522f7567480cfe004f'
+		}
+	]
+};
+
+export const networkIdentifiers = ['mainnet', 'erigon_local'];
+
+export const currentNetworkIdentifier = 'erigon_local';
+
+export const currentAccount = walletStorageAccounts[currentNetworkIdentifier][0];

--- a/wallet/common/ethereum/tests/modules/TransferModule.test.js
+++ b/wallet/common/ethereum/tests/modules/TransferModule.test.js
@@ -1,0 +1,107 @@
+import { TransferModule } from '../../src/modules/TransferModule';
+import { currentAccount as currentAccountFixture } from '../__fixtures__/local/wallet';
+import { expect, jest } from '@jest/globals';
+
+const createFee = () => ({
+	key: 'value'
+});
+
+const createEthereumToken = () => ({
+	id: 'ETH',
+	name: 'ETH',
+	amount: '1.0',
+	divisibility: 18
+});
+
+const createERC20Token = () => ({
+	id: '0xERC20',
+	name: 'ERC20',
+	amount: '1.0',
+	divisibility: 6
+});
+
+describe('TransferModule', () => {
+	let transferModule;
+	let root;
+	let api;
+
+	const currentAccount = { ...currentAccountFixture };
+	const recipientAddress = '0xRecipientAddress';
+
+	beforeEach(() => {
+		root = {
+			currentAccount,
+			networkProperties: { networkIdentifier: 'erigon_local' }
+		};
+		api = {
+			transaction: {
+				fetchTransactionNonce: jest.fn(async () => 10)
+			}
+		};
+		transferModule = new TransferModule();
+		transferModule.init({ root, api });
+
+		jest.clearAllMocks();
+	});
+
+	it('has correct static name', () => {
+		// Assert:
+		expect(TransferModule.name).toBe('transfer');
+	});
+
+	describe('createTransaction()', () => {
+		const runCreateTransactionTest = async (tokens, expectedResult) => {
+			// Arrange:
+			const options = {
+				recipientAddress,
+				tokens,
+				fee: createFee()
+			};
+
+			// Act:
+			const result = await transferModule.createTransaction(options);
+
+			// Assert:
+			expect(result).toStrictEqual(expectedResult);
+			expect(api.transaction.fetchTransactionNonce).toHaveBeenCalledWith(
+				root.networkProperties,
+				currentAccount.address
+			);
+		};
+		
+		it('creates a ETH transfer transaction', async () => {
+			// Arrange:
+			const tokens = [createEthereumToken()];
+			const expectedResult = {
+				type: 1,
+				recipientAddress,
+				signerAddress: currentAccount.address,
+				signerPublicKey: currentAccount.publicKey,
+				fee: createFee(),
+				tokens,
+				nonce: 10
+			};
+
+			// Act & Assert:
+			await runCreateTransactionTest(tokens, expectedResult);
+		});
+
+		it('creates a ERC20 transfer transaction', async () => {
+			// Arrange:
+			const tokens = [createERC20Token()];
+
+			const expectedResult = {
+				type: 2,
+				recipientAddress,
+				signerAddress: currentAccount.address,
+				signerPublicKey: currentAccount.publicKey,
+				fee: createFee(),
+				tokens,
+				nonce: 10
+			};
+
+			// Act & Assert:
+			await runCreateTransactionTest(tokens, expectedResult);
+		});
+	});
+});

--- a/wallet/common/ethereum/tests/modules/index.test.js
+++ b/wallet/common/ethereum/tests/modules/index.test.js
@@ -1,0 +1,21 @@
+import { expect, jest } from '@jest/globals';
+
+const mockShuffle = jest.fn(arr => arr);
+jest.unstable_mockModule('lodash', () => ({
+	shuffle: mockShuffle,
+	default: { shuffle: mockShuffle }
+}));
+
+const { TransferModule } = await import('../../src/modules');
+
+describe('modules/index.js re-exports', () => {
+	it('re-exports TransferModule and HarvestingModule', () => {
+		// Assert:
+		expect(typeof TransferModule).toBe('function');
+
+		// Instances can be created without args and then initialized
+		const transfer = new TransferModule();
+
+		expect(transfer).toBeInstanceOf(TransferModule);
+	});
+});

--- a/wallet/common/ethereum/tests/test-utils.js
+++ b/wallet/common/ethereum/tests/test-utils.js
@@ -1,0 +1,69 @@
+import { networkIdentifiers } from './__fixtures__/local/wallet';
+import fs from 'fs';
+
+export const writeFileJSON = (fileName, data) => {
+	fs.writeFileSync(`./${fileName}.json`, JSON.stringify(data, null, 4));
+};
+
+export const createNetworkMap = (networkIdentifiers, callback) => {
+	const maps = networkIdentifiers.map(networkIdentifier => [networkIdentifier, callback(networkIdentifier)]);
+
+	return Object.fromEntries(maps);
+};
+
+/**
+ * Run a test function by iterating over all network related accounts.
+ * @template ItemType
+ * @param {object<string, ItemType[]>} networkMap - The network map.
+ * @param {function(string, ItemType, number)} testFunction - The test function.
+ */
+export const forEachNetwork = (networkMap, testFunction) => {
+	createNetworkMap(networkIdentifiers, networkIdentifier => {
+		networkMap[networkIdentifier].map((item, index) => {
+			testFunction(networkIdentifier, item, index);
+		});
+	});
+};
+
+/**
+ * Runs a test for a function that makes API calls.
+ * @param {jest.Mock} mockFetch - The mocked fetch function.
+ * @param {function} functionToTest - The function to test.
+ * @param {Array<{url: string, options: object, response: any}>}expectedCalls - The expected API calls.
+ * @param {object} [expectedResult] - Optional checks if the result matches the expected calls; if an object, compares the result with it.
+ */
+export const runApiTest = async (mockFetch, functionToTest, expectedCalls, expectedResult) => {
+	// Arrange:
+	mockFetch.mockImplementation(async (url, options) => {
+		const matchingCall = expectedCalls.find(call => {
+			if (call.url !== url) 
+				return false;
+
+			// If options are not specified in the expected call, ensure no options were passed
+			if (!call.options)
+				return !options;
+
+			// Otherwise, compare options
+			return JSON.stringify(call.options) === JSON.stringify(options);
+		});
+		
+		if (matchingCall)
+			return Promise.resolve(matchingCall.response);
+		
+		return Promise.reject(new Error(`[Test error] Unexpected API call. URL: ${url}, Options: ${JSON.stringify(options)}`));
+	});
+
+	// Act:
+	const result = await functionToTest();
+
+	// Assert:
+	expectedCalls.forEach(call => {
+		if (call.options)
+			expect(mockFetch).toHaveBeenCalledWith(call.url, call.options);
+		else
+			expect(mockFetch).toHaveBeenCalledWith(call.url);
+	});
+
+	if (expectedResult) 
+		expect(result).toStrictEqual(expectedResult);
+};

--- a/wallet/common/ethereum/tests/utils/account.test.js
+++ b/wallet/common/ethereum/tests/utils/account.test.js
@@ -1,0 +1,264 @@
+import {
+	addressFromPrivateKey,
+	addressFromPublicKey,
+	createPrivateAccount,
+	createWalletAccount,
+	generateKeyPair,
+	isEthereumAddress,
+	isPrivateKey,
+	isPublicKey,
+	publicAccountFromPrivateKey,
+	publicAccountFromPublicKey
+} from '../../src/utils';
+import { currentNetworkIdentifier, walletStorageAccounts } from '../__fixtures__/local/wallet';
+import { forEachNetwork } from '../test-utils';
+
+
+describe('utils/account', () => {
+	describe('generateKeyPair', () => {
+		it('generates a random key pair', () => {
+			// Arrange:
+			const privateKeyLength = 66;
+			const publicKeyLength = 68;
+			// Act:
+			const result = generateKeyPair();
+
+			// Assert:
+			expect(result).toHaveProperty('privateKey');
+			expect(typeof result.privateKey).toBe('string');
+			expect(result.privateKey.length).toBe(privateKeyLength);
+
+			expect(result).toHaveProperty('publicKey');
+			expect(typeof result.publicKey).toBe('string');
+			expect(result.publicKey.length).toBe(publicKeyLength);
+		});
+	});
+
+	describe('addressFromPrivateKey', () => {
+		it('generates the account address from a given private key', () => {
+			forEachNetwork(walletStorageAccounts, (networkIdentifier, account) => {
+				// Arrange:
+				const expectedResult = account.address;
+
+				// Act:
+				const result = addressFromPrivateKey(account.privateKey, networkIdentifier);
+
+				// Assert:
+				expect(result).toBe(expectedResult);
+			});
+		});
+	});
+
+	describe('addressFromPublicKey', () => {
+		it('generates the account address from a given public key', () => {
+			forEachNetwork(walletStorageAccounts, (networkIdentifier, account) => {
+				// Arrange:
+				const expectedResult = account.address;
+
+				// Act:
+				const result = addressFromPublicKey(account.publicKey, networkIdentifier);
+
+				// Assert:
+				expect(result).toBe(expectedResult);
+			});
+		});
+	});
+
+	describe('publicAccountFromPrivateKey', () => {
+		it('creates the public account from a given private key', () => {
+			forEachNetwork(walletStorageAccounts, (networkIdentifier, account) => {
+				// Arrange:
+				const expectedResult = {
+					address: account.address,
+					publicKey: account.publicKey,
+					networkIdentifier
+				};
+
+				// Act:
+				const result = publicAccountFromPrivateKey(account.privateKey, networkIdentifier);
+
+				// Assert:
+				expect(result).toStrictEqual(expectedResult);
+			});
+		});
+	});
+
+	describe('publicAccountFromPublicKey', () => {
+		it('creates the public account from a given public key', () => {
+			forEachNetwork(walletStorageAccounts, (networkIdentifier, account) => {
+				// Arrange:
+				const expectedResult = {
+					address: account.address,
+					publicKey: account.publicKey,
+					networkIdentifier
+				};
+
+				// Act:
+				const result = publicAccountFromPublicKey(account.publicKey, networkIdentifier);
+
+				// Assert:
+				expect(result).toStrictEqual(expectedResult);
+			});
+		});
+	});
+
+	describe('createWalletAccount', () => {
+		it('creates wallet account object', () => {
+			forEachNetwork(walletStorageAccounts, (networkIdentifier, account) => {
+				// Arrange:
+				const expectedResult = {
+					address: account.address,
+					publicKey: account.publicKey,
+					name: account.name,
+					networkIdentifier,
+					accountType: account.accountType,
+					index: account.index
+				};
+
+				// Act:
+				const result = createWalletAccount(account.privateKey, networkIdentifier, account.name, account.accountType, account.index);
+
+				// Assert:
+				expect(result).toStrictEqual(expectedResult);
+			});
+		});
+	});
+
+	describe('createPrivateAccount', () => {
+		it('creates wallet account object which contains private key', () => {
+			forEachNetwork(walletStorageAccounts, (networkIdentifier, account) => {
+				// Arrange:
+				const expectedResult = {
+					address: account.address,
+					publicKey: account.publicKey,
+					networkIdentifier,
+					accountType: account.accountType,
+					index: account.index,
+					privateKey: account.privateKey
+				};
+
+				// Act:
+				const result = createPrivateAccount(
+					account.privateKey,
+					networkIdentifier,
+					account.accountType,
+					account.index
+				);
+
+				// Assert:
+				expect(result).toStrictEqual(expectedResult);
+			});
+		});
+	});
+
+	describe('isPrivateKey', () => {
+		const runIsPublicOrPrivateKeyTest = (input, expectedResult) => {
+			// Act:
+			const result = isPrivateKey(input);
+
+			// Assert:
+			expect(result).toBe(expectedResult);
+		};
+
+		it('returns true if the input is a private key', () => {
+			// Arrange:
+			const {privateKey} = walletStorageAccounts[currentNetworkIdentifier][0];
+			const expectedResult = true;
+
+			// Act & Assert:
+			runIsPublicOrPrivateKeyTest(privateKey, expectedResult);
+		});
+
+		it('returns false if the input is not a string', () => {
+			// Arrange:
+			const inputs = [123, null, undefined, [], {}, () => {}, true];
+			const expectedResult = false;
+
+			// Act & Assert:
+			inputs.forEach(input => runIsPublicOrPrivateKeyTest(input, expectedResult));
+		});
+
+		it('returns false if the input is not a private key', () => {
+			// Arrange:
+			const input = 'invalid';
+			const expectedResult = false;
+
+			// Act & Assert:
+			runIsPublicOrPrivateKeyTest(input, expectedResult);
+		});
+	});
+
+	describe('isPublicKey', () => {
+		const runIsPublicKeyTest = (input, expectedResult) => {
+			// Act:
+			const result = isPublicKey(input);
+
+			// Assert:
+			expect(result).toBe(expectedResult);
+		};
+
+		it('returns true if the input is a public key', () => {
+			// Arrange:
+			const {publicKey} = walletStorageAccounts[currentNetworkIdentifier][0];
+			const expectedResult = true;
+
+			// Act & Assert:
+			runIsPublicKeyTest(publicKey, expectedResult);
+		});
+
+		it('returns false if the input is not a string', () => {
+			// Arrange:
+			const inputs = [123, null, undefined, [], {}, () => {}, true];
+			const expectedResult = false;
+
+			// Act & Assert:
+			inputs.forEach(input => runIsPublicKeyTest(input, expectedResult));
+		});
+
+		it('returns false if the input is not a public key', () => {
+			// Arrange:
+			const input = 'invalid';
+			const expectedResult = false;
+
+			// Act & Assert:
+			runIsPublicKeyTest(input, expectedResult);
+		});
+	});
+
+	describe('isEthereumAddress', () => {
+		const runIsEthereumAddressTest = (input, expectedResult) => {
+			// Act:
+			const result = isEthereumAddress(input);
+
+			// Assert:
+			expect(result).toBe(expectedResult);
+		};
+
+		it('returns true if the input is a Ethereum address', () => {
+			// Arrange:
+			const address = '0xb1b2145b7d2ba5AB20Ee0Bcb0F7FAd08a1BfC7A4';
+			const expectedResult = true;
+
+			// Act & Assert:
+			runIsEthereumAddressTest(address, expectedResult);
+		});
+
+		it('returns false if the input is not a string', () => {
+			// Arrange:
+			const inputs = [123, null, undefined, [], {}, () => {}, true];
+			const expectedResult = false;
+
+			// Act & Assert:
+			inputs.forEach(input => runIsEthereumAddressTest(input, expectedResult));
+		});
+
+		it('returns false if the input is not a Ethereum address', () => {
+			// Arrange:
+			const input = 'invalid';
+			const expectedResult = false;
+
+			// Act & Assert:
+			runIsEthereumAddressTest(input, expectedResult);
+		});
+	});
+});

--- a/wallet/common/ethereum/tests/utils/network.test.js
+++ b/wallet/common/ethereum/tests/utils/network.test.js
@@ -1,0 +1,54 @@
+import { chainIdToNetworkIdentifier, networkIdentifierToChainId } from '../../src/utils';
+
+
+describe('utils/network', () => {
+	describe('networkIdentifierToChainId', () => {
+		it('returns the chain ID from a given network identifier', () => {
+			// Arrange:
+			const networkIdentifiersAndExpectedChainIds = [
+				{ networkIdentifier: 'mainnet', expectedChainId: 1 },
+				{ networkIdentifier: 'erigon_local', expectedChainId: 3151908 },
+				{ networkIdentifier: 'sepolia', expectedChainId: 11155111 }
+			];
+
+			networkIdentifiersAndExpectedChainIds.map(({ networkIdentifier, expectedChainId }) => {
+				// Act:
+				const result = networkIdentifierToChainId(networkIdentifier);
+
+				// Assert:
+				expect(result).toBe(expectedChainId);
+			});
+		});
+
+		it('throws for unsupported network identifier', () => {
+			expect(() => networkIdentifierToChainId('custom')).toThrow('Unsupported network identifier');
+			expect(() => networkIdentifierToChainId('devnet')).toThrow('Unsupported network identifier');
+		});
+	});
+
+	describe('chainIdToNetworkIdentifier', () => {
+		it('returns the network identifier from a given chain ID', () => {
+			// Arrange:
+			const chainIdsAndExpectedIdentifiers = [
+				{ chainId: 1, expectedIdentifier: 'mainnet' },
+				{ chainId: 3151908, expectedIdentifier: 'erigon_local' },
+				{ chainId: 11155111, expectedIdentifier: 'sepolia' }
+			];
+
+			chainIdsAndExpectedIdentifiers.map(({ chainId, expectedIdentifier }) => {
+				// Act:
+				const result = chainIdToNetworkIdentifier(chainId);
+
+				// Assert:
+				expect(result).toBe(expectedIdentifier);
+			});
+		});
+
+		it('throws for unsupported chain ID', () => {
+			expect(() => chainIdToNetworkIdentifier(0)).toThrow('Unsupported chain ID');
+			expect(() => chainIdToNetworkIdentifier(999)).toThrow('Unsupported chain ID');
+		});
+	});
+});
+
+		

--- a/wallet/common/ethereum/tests/utils/transaction-to-ethereum.test.js
+++ b/wallet/common/ethereum/tests/utils/transaction-to-ethereum.test.js
@@ -1,0 +1,19 @@
+import { transactionToEthereum } from '../../src/utils/transaction-to-ethereum';
+import { ethereumTransactions, walletTransactions } from '../__fixtures__/local/transactions';
+import { currentNetworkIdentifier } from '../__fixtures__/local/wallet';
+
+describe('utils/transaction-to-ethereum', () => {
+	it('converts transactions to ethers format (array-driven, no mocks)', () => {
+		// Arrange:
+		const networkIdentifier = currentNetworkIdentifier;
+		const inputs = walletTransactions;
+		const expected = ethereumTransactions;
+
+		// Act & Assert:
+		inputs.forEach((tx, index) => {
+			const result = transactionToEthereum(tx, { networkIdentifier });
+			expect(result).toStrictEqual(expected[index]);
+		});
+	});
+});
+

--- a/wallet/common/ethereum/tests/utils/transaction.test.js
+++ b/wallet/common/ethereum/tests/utils/transaction.test.js
@@ -1,0 +1,86 @@
+import {
+	createFee,
+	isIncomingTransaction,
+	isOutgoingTransaction,
+	signTransaction
+} from '../../src/utils';
+import { signedTransactions, walletTransactions } from '../__fixtures__/local/transactions';
+import { currentNetworkIdentifier, walletStorageAccounts } from '../__fixtures__/local/wallet';
+
+describe('utils/transaction', () => {
+	describe('isOutgoingTransaction', () => {
+		it('returns true when signer matches current account', () => {
+			const account = walletStorageAccounts[currentNetworkIdentifier][0];
+			const tx = {
+				signerAddress: account.address,
+				recipientAddress: walletStorageAccounts[currentNetworkIdentifier][1].address
+			};
+
+			expect(isOutgoingTransaction(tx, { address: account.address })).toBe(true);
+		});
+
+		it('returns false when signer differs from current account', () => {
+			const account = walletStorageAccounts[currentNetworkIdentifier][0];
+			const tx = {
+				signerAddress: walletStorageAccounts[currentNetworkIdentifier][1].address,
+				recipientAddress: account.address
+			};
+
+			expect(isOutgoingTransaction(tx, { address: account.address })).toBe(false);
+		});
+	});
+
+	describe('isIncomingTransaction', () => {
+		it('returns true when recipient matches current account', () => {
+			const account = walletStorageAccounts[currentNetworkIdentifier][0];
+			const tx = {
+				signerAddress: walletStorageAccounts[currentNetworkIdentifier][1].address,
+				recipientAddress: account.address
+			};
+
+			expect(isIncomingTransaction(tx, { address: account.address })).toBe(true);
+		});
+
+		it('returns false when recipient differs from current account', () => {
+			const account = walletStorageAccounts[currentNetworkIdentifier][0];
+			const tx = {
+				signerAddress: account.address,
+				recipientAddress: walletStorageAccounts[currentNetworkIdentifier][1].address
+			};
+
+			expect(isIncomingTransaction(tx, { address: account.address })).toBe(false);
+		});
+	});
+
+	describe('createFee', () => {
+		it('creates fee object and computes totalAmount via helper', () => {
+			const feeMultiplier = { maxFeePerGas: '3', maxPriorityFeePerGas: '1' };
+			const gasLimit = '1000';
+
+			const fee = createFee(feeMultiplier, gasLimit);
+
+			expect(fee).toEqual({
+				gasLimit,
+				maxFeePerGas: '3',
+				maxPriorityFeePerGas: '1',
+				totalAmount: '3000'
+			});
+		});
+	});
+
+	describe('signTransaction', () => {
+		it('signs transaction and returns dto + hash', async () => {
+			const { privateKey } = walletStorageAccounts[currentNetworkIdentifier][0];
+			const inputs = walletTransactions;
+			const expectedOutputs = signedTransactions;
+
+			// Act & Assert:
+			for (let i = 0; i < inputs.length; i++) {
+				const result = await signTransaction(currentNetworkIdentifier, inputs[i], privateKey);
+
+				expect(result).toStrictEqual(expectedOutputs[i]);
+			}
+		});
+	});
+});
+

--- a/wallet/common/ethereum/tests/utils/wallet.test.js
+++ b/wallet/common/ethereum/tests/utils/wallet.test.js
@@ -1,0 +1,35 @@
+import { createPrivateKeysFromMnemonic, generateMnemonic } from '../../src/utils';
+import { mnemonic, networkIdentifiers, walletStorageAccounts } from '../__fixtures__/local/wallet';
+
+describe('utils/wallet', () => {
+	describe('generateMnemonic', () => {
+		it('generates a random mnemonic phrase string of 24 words', () => {
+			// Arrange:
+			const expectedWordsCount = 24;
+
+			// Act:
+			const result = generateMnemonic();
+			const mnemonicWords = result.split(' ');
+
+			// Assert:
+			expect(typeof result).toBe('string');
+			expect(mnemonicWords.length).toBe(expectedWordsCount);
+		});
+	});
+
+	describe('createPrivateKeysFromMnemonic', () => {
+		it('derives private keys from a given mnemonic phrase', () => {
+			networkIdentifiers.forEach(networkIdentifier => {
+				// Arrange:
+				const indexes = [0, 1, 2, 3, 4];
+				const expectedPrivateKeys = walletStorageAccounts[networkIdentifier].map(account => account.privateKey);
+
+				// Act:
+				const result = createPrivateKeysFromMnemonic(mnemonic, indexes, networkIdentifier);
+
+				// Assert:
+				expect(result).toEqual(expectedPrivateKeys);
+			});
+		});
+	});
+});


### PR DESCRIPTION
## Problem
There is no Ethereum-specific wallet logic (API calls, signing, transfer flows) that is needed for Bridge feature.

## Solution
1. Introduced wallet-common-ethereum (wallet/common/ethereum/) as the Ethereum protocol layer designed to work with wallet-common-core.
2. Exposed a clean injection surface for WalletController:

- Ethereum Protocol Network API
Fetches account info, tokens, network data and announce signed transactions.
Injected into WalletController as api.

- Symbol Protocol Wallet SDK
Transaction signing helpers.
Injected into WalletController as sdk.

- Feature Modules
TransferModule: direct and ERC-20 transfers.

- Utilities
Transaction mapping to ethers, fee calculation, helpers.

3. Added tests
4. Added README 