### PR TITLE
[tools/shoestring] fix: show tabs test failing

### DIFF
--- a/tools/shoestring/tests/wizard/test_TabbedView.py
+++ b/tools/shoestring/tests/wizard/test_TabbedView.py
@@ -106,6 +106,6 @@ async def test_can_show_tabs():
 	assert '│ * alpha │' in output
 	assert '   beta ' in output
 	assert '    gamma ' in output
-	assert '    delta ' in output
+	assert '    delta' in output
 
 # endregion


### PR DESCRIPTION
problem: latest prompt_toolkit removed extra space at the end of output
solution: remove extra space after the last tab