### PR TITLE
[monorepo] feat: add wallet/common-symbol project to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ It includes our optin manager.
 | [@tools/shoestring](tools/shoestring) | [![lint][tools-shoestring-lint]][tools-shoestring-job] | | [![test][tools-shoestring-test]][tools-shoestring-job]| [![][tools-shoestring-cov]][tools-shoestring-cov-link] |
 | [@tools/vanity](tools/vanity) | [![lint][tools-vanity-lint]][tools-vanity-job] | | [![test][tools-vanity-test]][tools-vanity-job]| [![][tools-vanity-cov]][tools-vanity-cov-link] |
 | [@wallet/common-core](wallet/common/core) | [![lint][wallet-common-core-lint]][wallet-common-core-job] | | [![test][wallet-common-core-test]][wallet-common-core-job]| [![][wallet-common-core-cov]][wallet-common-core-cov-link] |
+| [@wallet/common-symbol](wallet/common/symbol) | [![lint][wallet-common-symbol-lint]][wallet-common-symbol-job] | | [![test][wallet-common-symbol-test]][wallet-common-symbol-job]| [![][wallet-common-symbol-cov]][wallet-common-symbol-cov-link] |
 
 ## Full Coverage Report
 
@@ -78,3 +79,9 @@ Detailed version can be seen on [codecov.io][product-cov-link].
 [wallet-common-core-test]: https://jenkins.symbolsyndicate.us/buildStatus/icon?job=Symbol%2Fgenerated%2Fproduct%2Fwallet-common-core%2Fdev%2F&config=wallet-common-core-test
 [wallet-common-core-cov]: https://codecov.io/gh/symbol/product/branch/dev/graph/badge.svg?token=SSYYBMK0M7&flag=wallet-common-core
 [wallet-common-core-cov-link]: https://codecov.io/gh/symbol/product/tree/dev/wallet/common/core
+
+[wallet-common-symbol-job]: https://jenkins.symbolsyndicate.us/blue/organizations/jenkins/Symbol%2Fgenerated%2Fproduct%2Fwallet-common-symbol/activity?branch=dev
+[wallet-common-symbol-lint]: https://jenkins.symbolsyndicate.us/buildStatus/icon?job=Symbol%2Fgenerated%2Fproduct%2Fwallet-common-symbol%2Fdev%2F&config=wallet-common-symbol-lint
+[wallet-common-symbol-test]: https://jenkins.symbolsyndicate.us/buildStatus/icon?job=Symbol%2Fgenerated%2Fproduct%2Fwallet-common-symbol%2Fdev%2F&config=wallet-common-symbol-test
+[wallet-common-symbol-cov]: https://codecov.io/gh/symbol/product/branch/dev/graph/badge.svg?token=SSYYBMK0M7&flag=wallet-common-symbol
+[wallet-common-symbol-cov-link]: https://codecov.io/gh/symbol/product/tree/dev/wallet/common/symbol


### PR DESCRIPTION
## Problem
The wallet/common-symbol project is missing in monorepo readme

## Solution
Add wallet/common-symbol project to monorepo readme
