### PR TITLE
[explorer/nodewatch] fix: update version colors

### DIFF
--- a/explorer/nodewatch/nodewatch/RoutesFacade.py
+++ b/explorer/nodewatch/nodewatch/RoutesFacade.py
@@ -231,9 +231,10 @@ class SymbolRoutesFacade(BasicRoutesFacade):
 		"""Creates a facade."""
 
 		super().__init__(network, explorer_endpoint, 'symbol', 'Symbol', self._version_to_css_class, {
-			'1.0.3.8': (COMPATIBLE_VERSION_COLORS[0], 11),
-			'1.0.3.7': (COMPATIBLE_VERSION_COLORS[1], 10),
-			'delegating / updating': (AMBIGUOUS_COLORS[0], 9),
+			'1.0.3.9': (COMPATIBLE_VERSION_COLORS[0], 12),
+			'delegating / updating': (AMBIGUOUS_COLORS[0], 11),
+			'1.0.3.8': (INCOMPATIBLE_VERSION_COLORS[1], 10),
+			'1.0.3.7': (INCOMPATIBLE_VERSION_COLORS[1], 9),
 			'1.0.3.6': (INCOMPATIBLE_VERSION_COLORS[1], 8),
 			'1.0.3.5': (INCOMPATIBLE_VERSION_COLORS[1], 7),
 			'1.0.3.4': (INCOMPATIBLE_VERSION_COLORS[1], 6),

--- a/explorer/nodewatch/nodewatch/RoutesFacade.py
+++ b/explorer/nodewatch/nodewatch/RoutesFacade.py
@@ -292,7 +292,7 @@ class SymbolRoutesFacade(BasicRoutesFacade):
 		tag = 'danger'
 		if not version:
 			tag = 'warning'
-		if version.startswith('1.0.3.') and not any(version.endswith(f'.{build}') for build in range(7)):
+		if version.startswith('1.0.3.') and not any(version.endswith(f'.{build}') for build in range(9)):
 			tag = 'success'
 
 		return tag

--- a/explorer/nodewatch/tests/test_RoutesFacade.py
+++ b/explorer/nodewatch/tests/test_RoutesFacade.py
@@ -636,12 +636,12 @@ class SymbolRoutesFacadeTest(unittest.TestCase):  # pylint: disable=too-many-pub
 	# region utils
 
 	def test_can_map_version_to_css_class(self):
-		for version in ['1.0.3.7', '1.0.3.8']:
+		for version in ['1.0.3.9']:
 			self.assertEqual('success', _map_version_to_css_class(SymbolRoutesFacade, version))
 
 		self.assertEqual('warning', _map_version_to_css_class(SymbolRoutesFacade, ''))
 
-		for version in ['1.0.3.6', '1.0.3.5', '1.0.3.4', '1.0.3.3', '1.0.3.1', '1.0.3.0', '1.0.2.0', '1.0.1.0', '0.0.0.0']:
+		for version in ['1.0.3.8', '1.0.3.7', '1.0.3.6', '1.0.3.5', '1.0.3.4', '1.0.3.3', '1.0.3.1', '1.0.3.0', '1.0.2.0', '1.0.1.0', '0.0.0.0']:
 			self.assertEqual('danger', _map_version_to_css_class(SymbolRoutesFacade, version))
 
 	# endregion


### PR DESCRIPTION
Problem: the latest client version turns to red.
Solution: update the version list