### PR TITLE
[explorer/nodewatch] fix: refresh height task failing

### DIFF
--- a/explorer/nodewatch/nodewatch/NetworkConnector.py
+++ b/explorer/nodewatch/nodewatch/NetworkConnector.py
@@ -65,7 +65,12 @@ class NetworkConnector:
 
 				if 'finalized_height' in response_json:
 					descriptor.finalized_height = int(response_json['finalized_height'])
-		except (aiohttp.client_exceptions.ClientConnectorError, aiohttp.client_exceptions.ContentTypeError, asyncio.TimeoutError) as ex:
+		except (
+			aiohttp.client_exceptions.ClientConnectorError,
+			aiohttp.client_exceptions.ContentTypeError,
+			aiohttp.client_exceptions.ServerDisconnectedError,
+			asyncio.TimeoutError
+		) as ex:
 			log.warning(f'failed retrieving height from endpoint "{descriptor.endpoint}"\n{ex}')
 			return False
 

--- a/explorer/nodewatch/nodewatch/NetworkConnector.py
+++ b/explorer/nodewatch/nodewatch/NetworkConnector.py
@@ -66,17 +66,19 @@ class NetworkConnector:
 					descriptor.height = int(response_json['height'])
 
 				if 'latestFinalizedBlock' in response_json:
+					latest_finalized_block = response_json['latestFinalizedBlock']
 					descriptor.finalized_info = FinalizedInfo(
-						int(response_json['latestFinalizedBlock'].get('height', 0)),
-						int(response_json['latestFinalizedBlock'].get('finalizedEpoch', 0)),
-						response_json['latestFinalizedBlock'].get('hash', None),
-						int(response_json['latestFinalizedBlock'].get('finalizedPoint', 0))
+						int(latest_finalized_block['height']),
+						int(latest_finalized_block['finalizedEpoch']),
+						latest_finalized_block['hash'],
+						int(latest_finalized_block['finalizedPoint'])
 					)
 		except (
 			aiohttp.client_exceptions.ClientConnectorError,
 			aiohttp.client_exceptions.ContentTypeError,
 			aiohttp.client_exceptions.ServerDisconnectedError,
-			asyncio.TimeoutError
+			asyncio.TimeoutError,
+			KeyError
 		) as ex:
 			log.warning(f'failed retrieving height from endpoint "{descriptor.endpoint}"\n{ex}')
 			return False

--- a/explorer/nodewatch/nodewatch/NetworkConnector.py
+++ b/explorer/nodewatch/nodewatch/NetworkConnector.py
@@ -3,6 +3,8 @@ import asyncio
 import aiohttp
 from zenlog import log
 
+from .NetworkRepository import FinalizedInfo
+
 
 class NetworkConnector:
 	"""Connects to NEM or Symbol networks."""
@@ -63,8 +65,13 @@ class NetworkConnector:
 				if 'height' in response_json:
 					descriptor.height = int(response_json['height'])
 
-				if 'finalized_height' in response_json:
-					descriptor.finalized_height = int(response_json['finalized_height'])
+				if 'latestFinalizedBlock' in response_json:
+					descriptor.finalized_info = FinalizedInfo(
+						int(response_json['latestFinalizedBlock'].get('height', 0)),
+						int(response_json['latestFinalizedBlock'].get('finalizedEpoch', 0)),
+						response_json['latestFinalizedBlock'].get('hash', None),
+						int(response_json['latestFinalizedBlock'].get('finalizedPoint', 0))
+					)
 		except (
 			aiohttp.client_exceptions.ClientConnectorError,
 			aiohttp.client_exceptions.ContentTypeError,

--- a/explorer/nodewatch/tests/test_NetworkConnector.py
+++ b/explorer/nodewatch/tests/test_NetworkConnector.py
@@ -39,7 +39,14 @@ async def server(aiohttp_client):
 			finalized_height = request.match_info['finalized_height']
 			response_json = {'height': height}
 			if finalized_height:
-				response_json = {**response_json, 'latestFinalizedBlock': {'height': finalized_height}}
+				response_json = {
+					**response_json,
+					'latestFinalizedBlock': {
+						'height': finalized_height, 'finalizedEpoch': 3,
+						'hash': 'E29E5695EB269B7DD1D76DBF05FDA1731AB24F561D2032248434FA36A27AFB4C',
+						'finalizedPoint': 2
+					}
+				}
 
 			return await self._process(request, response_json)
 
@@ -196,5 +203,24 @@ async def test_can_update_symbol_heights_with_some_errors(server):  # pylint: di
 	_assert_node_descriptor(node_descriptors[2], 0)  # not updated on failure
 	_assert_node_descriptor(node_descriptors[3], 0)  # not updated on failure
 	_assert_node_descriptor(node_descriptors[4], 1236, 1005)
+
+
+async def test_can_update_symbol_height_and_finalization_info(server):  # pylint: disable=redefined-outer-name
+	# Arrange:
+	connector = NetworkConnector('symbol', 10)
+	node_descriptors = [
+		NodeDescriptor(f'{server.make_url("")}/1234/98765')
+	]
+
+	# Act:
+	await connector.update_heights(node_descriptors)
+
+	# Assert:
+	assert f'{server.make_url("")}/1234/98765/chain/info' in server.mock.urls
+	assert 1234 == node_descriptors[0].height
+	assert 98765 == node_descriptors[0].finalized_info.height
+	assert 'E29E5695EB269B7DD1D76DBF05FDA1731AB24F561D2032248434FA36A27AFB4C' == node_descriptors[0].finalized_info.hash
+	assert 3 == node_descriptors[0].finalized_info.epoch
+	assert 2 == node_descriptors[0].finalized_info.point
 
 # endregion

--- a/explorer/nodewatch/tests/test_NetworkConnector.py
+++ b/explorer/nodewatch/tests/test_NetworkConnector.py
@@ -4,7 +4,7 @@ import pytest
 from aiohttp import web
 
 from nodewatch.NetworkConnector import NetworkConnector
-
+from nodewatch.NetworkRepository import FinalizedInfo
 
 class NodeDescriptor:
 	def __init__(self, endpoint, has_api=True):
@@ -12,12 +12,12 @@ class NodeDescriptor:
 		self.name = endpoint
 		self.has_api = has_api
 		self.height = 0
-		self.finalized_height = 0
+		self.finalized_info = FinalizedInfo(0, 0, None, 0)
 
 
 def _assert_node_descriptor(descriptor, height, finalized_height=0):
 	assert height == descriptor.height
-	assert finalized_height == descriptor.finalized_height
+	assert finalized_height == descriptor.finalized_info.height
 
 
 # region server fixture
@@ -38,7 +38,7 @@ async def server(aiohttp_client):
 			finalized_height = request.match_info['finalized_height']
 			response_json = {'height': height}
 			if finalized_height:
-				response_json = {**response_json, 'finalized_height': finalized_height}
+				response_json = {**response_json, 'latestFinalizedBlock': {'height': finalized_height}}
 
 			return await self._process(request, response_json)
 

--- a/explorer/nodewatch/tests/test_NetworkConnector.py
+++ b/explorer/nodewatch/tests/test_NetworkConnector.py
@@ -6,6 +6,7 @@ from aiohttp import web
 from nodewatch.NetworkConnector import NetworkConnector
 from nodewatch.NetworkRepository import FinalizedInfo
 
+
 class NodeDescriptor:
 	def __init__(self, endpoint, has_api=True):
 		self.endpoint = endpoint

--- a/explorer/nodewatch/tests/test_NetworkConnector.py
+++ b/explorer/nodewatch/tests/test_NetworkConnector.py
@@ -42,7 +42,8 @@ async def server(aiohttp_client):
 				response_json = {
 					**response_json,
 					'latestFinalizedBlock': {
-						'height': finalized_height, 'finalizedEpoch': 3,
+						'height': finalized_height,
+						'finalizedEpoch': 3,
 						'hash': 'E29E5695EB269B7DD1D76DBF05FDA1731AB24F561D2032248434FA36A27AFB4C',
 						'finalizedPoint': 2
 					}
@@ -218,9 +219,6 @@ async def test_can_update_symbol_height_and_finalization_info(server):  # pylint
 	# Assert:
 	assert f'{server.make_url("")}/1234/98765/chain/info' in server.mock.urls
 	assert 1234 == node_descriptors[0].height
-	assert 98765 == node_descriptors[0].finalized_info.height
-	assert 'E29E5695EB269B7DD1D76DBF05FDA1731AB24F561D2032248434FA36A27AFB4C' == node_descriptors[0].finalized_info.hash
-	assert 3 == node_descriptors[0].finalized_info.epoch
-	assert 2 == node_descriptors[0].finalized_info.point
+	assert FinalizedInfo(98765, 3, 'E29E5695EB269B7DD1D76DBF05FDA1731AB24F561D2032248434FA36A27AFB4C', 2) == node_descriptors[0].finalized_info
 
 # endregion


### PR DESCRIPTION
problem: some nodes are failing with ServerDisconnectedError, which is not handled
solution: handle the ServerDisconnectedError exception
                 also, fix finalized info not getting handled in the refresh task