### PR TITLE
[bridge]: check Ethereum transaction status

### DIFF
--- a/bridge/bridge/ethereum/EthereumUtils.py
+++ b/bridge/bridge/ethereum/EthereumUtils.py
@@ -32,6 +32,9 @@ def extract_wrap_request_from_transaction(is_valid_address, target_search_addres
 	if DESTINATION_ADDRESS_OFFSET == len(input_data):
 		return make_wrap_error_result(transaction_identifier, 'required message is missing')
 
+	if not transaction_with_meta_json['meta']['isSuccess']:
+		return make_wrap_error_result(transaction_identifier, 'ethereum transaction failed on ethereum blockchain')
+
 	amount = int.from_bytes(input_data[AMOUNT_OFFSET:DESTINATION_ADDRESS_OFFSET], 'big')
 	destination_address = input_data[DESTINATION_ADDRESS_OFFSET:]
 	return check_address_and_make_wrap_result(is_valid_address, transaction_identifier, amount, destination_address)

--- a/bridge/tests/ethereum/test_EthereumConnector.py
+++ b/bridge/tests/ethereum/test_EthereumConnector.py
@@ -317,10 +317,16 @@ async def _assert_can_query_incoming_transactions(server, start_id, expected_sta
 	assert [
 		make_rpc_request_json('ots_searchTransactionsBefore', ['0xB668a7Cdc62108fAC00F65E1690591B67A1eF7c9', expected_start_id, 25])
 	] == server.mock.request_json_payloads
+
+	hashes = [
+		'0x12dfb8047ec57ba5a34a4ce8b8206e5020da409e06cdcf4ad02cc1034aa178ed',
+		'0x7a184ca95fadc36f35bde72b4f042b281664c9db16e83a8d9ac10ee5b0491f77',
+		'0x6f246476cff6570f9153cd4a463d4a25e6bf9ef1a1fc7b740523362fb391a45c'
+	]
 	assert [
-		{'meta': {'height': 29}, 'transaction': {'blockNumber': '0x1d', 'nonce': '0x2'}},
-		{'meta': {'height': 26}, 'transaction': {'blockNumber': '0x1a', 'nonce': '0x3'}},
-		{'meta': {'height': 7}, 'transaction': {'blockNumber': '0x7', 'nonce': '0x1'}}
+		{'meta': {'height': 29, 'isSuccess': False}, 'transaction': {'blockNumber': '0x1d', 'nonce': '0x2', 'hash': hashes[0]}},
+		{'meta': {'height': 26, 'isSuccess': True}, 'transaction': {'blockNumber': '0x1a', 'nonce': '0x3', 'hash': hashes[1]}},
+		{'meta': {'height': 7, 'isSuccess': False}, 'transaction': {'blockNumber': '0x7', 'nonce': '0x1', 'hash': hashes[2]}}
 	] == transactions
 
 

--- a/bridge/tests/ethereum/test_EthereumNetworkFacade.py
+++ b/bridge/tests/ethereum/test_EthereumNetworkFacade.py
@@ -208,7 +208,8 @@ def _extract_wrap_request_from_transaction(is_valid_address, receipient_address)
 	# Act:
 	results = facade.extract_wrap_request_from_transaction(lambda address: (is_valid_address, hexlify(address).decode('utf8').upper()), {
 		'meta': {
-			'height': 1234
+			'height': 1234,
+			'isSuccess': True
 		},
 		'transaction': {
 			'from': '0x4838b106fce9647bdf1e7877bf73ce8b0bad5f97',

--- a/bridge/tests/ethereum/test_EthereumUtils.py
+++ b/bridge/tests/ethereum/test_EthereumUtils.py
@@ -55,7 +55,8 @@ class EthereumUtilsTest(unittest.TestCase):
 
 		transaction_with_meta_json = {
 			'meta': {
-				'height': request.transaction_height
+				'height': request.transaction_height,
+				'isSuccess': True
 			},
 			'transaction': {
 				'from': str(request.sender_address),
@@ -150,6 +151,19 @@ class EthereumUtilsTest(unittest.TestCase):
 
 		# Assert:
 		expected_error_message = 'destination address 983678467BDE6B234D8DDE673914A407AAB7287F244835 is invalid'
+		assert_wrap_request_failure(self, result, make_wrap_error_from_request(request, expected_error_message))
+
+	def test_cannot_extract_wrap_request_from_transfer_with_failed_ethereum_transaction(self):
+		# Arrange:
+		request = self._create_simple_wrap_request()
+		transaction_with_meta_json = self._create_transfer_json(request)
+		transaction_with_meta_json['meta']['isSuccess'] = False
+
+		# Act:
+		result = self._extract_wrap_request_from_transaction(transaction_with_meta_json)
+
+		# Assert:
+		expected_error_message = 'ethereum transaction failed on ethereum blockchain'
 		assert_wrap_request_failure(self, result, make_wrap_error_from_request(request, expected_error_message))
 
 	# endregion

--- a/bridge/tests/test/MockEthereumServer.py
+++ b/bridge/tests/test/MockEthereumServer.py
@@ -162,12 +162,21 @@ async def create_simple_ethereum_client(aiohttp_client):
 			raise ValueError(f'unknown eth_call data: {data}')
 
 		async def handle_ots_search_transaction_before(self, request):
+			hashes = [
+				'0x12dfb8047ec57ba5a34a4ce8b8206e5020da409e06cdcf4ad02cc1034aa178ed',
+				'0x7a184ca95fadc36f35bde72b4f042b281664c9db16e83a8d9ac10ee5b0491f77',
+				'0x6f246476cff6570f9153cd4a463d4a25e6bf9ef1a1fc7b740523362fb391a45c'
+			]
 			return await self._process(request, {
 				'result': {
 					'txs': [
-						{'blockNumber': '0x1d', 'nonce': '0x2'},
-						{'blockNumber': '0x1a', 'nonce': '0x3'},
-						{'blockNumber': '0x7', 'nonce': '0x1'}
+						{'blockNumber': '0x1d', 'nonce': '0x2', 'hash': hashes[0]},
+						{'blockNumber': '0x1a', 'nonce': '0x3', 'hash': hashes[1]},
+						{'blockNumber': '0x7', 'nonce': '0x1', 'hash': hashes[2]}
+					],
+					'receipts': [
+						{'transactionHash': hashes[1], 'status': '0x1'},
+						{'transactionHash': hashes[2], 'status': '0x0'}
 					]
 				}
 			})


### PR DESCRIPTION
 problem: ethereum processing assumes only successful transactions are returned
solution: check ethereum transaction status and create wrap_error entry for failures