### PR TITLE
[bridge]: update strategy mode names

### DIFF
--- a/bridge/bridge/WorkflowUtils.py
+++ b/bridge/bridge/WorkflowUtils.py
@@ -62,7 +62,7 @@ class NativeConversionRateCalculatorFactory:
 # endregion
 
 
-# region is_native_to_native_conversion, validate_strategy_configuration
+# region is_native_to_native_conversion, validate_global_configuration
 
 def is_native_to_native_conversion(wrapped_facade):
 	"""Determines if a native to native conversion is configured."""
@@ -70,14 +70,14 @@ def is_native_to_native_conversion(wrapped_facade):
 	return not wrapped_facade.extract_mosaic_id().id
 
 
-def validate_strategy_configuration(strategy_config, wrapped_facade):
-	is_native_strategy = 'native' == strategy_config.mode
+def validate_global_configuration(global_config, wrapped_facade):
+	is_swap_strategy = 'swap' == global_config.mode
 	if is_native_to_native_conversion(wrapped_facade):
-		if not is_native_strategy:
-			raise ValueError('wrapped token is native but native mode is not selected')
+		if not is_swap_strategy:
+			raise ValueError('wrapped token is native but swap mode is not selected')
 	else:
-		if is_native_strategy:
-			raise ValueError('wrapped token is not native but native mode is selected')
+		if is_swap_strategy:
+			raise ValueError('wrapped token is not native but swap mode is selected')
 
 # endregion
 
@@ -94,7 +94,7 @@ def create_conversion_rate_calculator_factory(execution_context, databases, nati
 
 		return NativeConversionRateCalculatorFactory(databases, fee_multiplier)
 
-	if 'wrapped' == execution_context.strategy_mode:
+	if 'wrap' == execution_context.strategy_mode:
 		return NativeConversionRateCalculatorFactory(databases, Decimal(1))  # wrapped mode (1:1) uses fixed unity multiplier (1)
 
 	return ConversionRateCalculatorFactory(databases, native_facade.extract_mosaic_id().formatted, execution_context.is_unwrap_mode)

--- a/bridge/bridge/api/__init__.py
+++ b/bridge/bridge/api/__init__.py
@@ -232,7 +232,7 @@ class BridgeContext:  # pylint: disable=too-many-instance-attributes
 		self._semaphore = asyncio.Semaphore(1)
 		self._is_loaded = False
 
-		self.strategy_mode = self._config.strategy.mode
+		self.strategy_mode = self._config.global_.mode
 		self.native_facade = None
 		self.wrapped_facade = None
 		self.database_params = None

--- a/bridge/bridge/models/BridgeConfiguration.py
+++ b/bridge/bridge/models/BridgeConfiguration.py
@@ -3,11 +3,11 @@ from collections import namedtuple
 
 MachineConfiguration = namedtuple('MachineConfiguration', ['database_directory', 'log_filename', 'log_backup_count', 'max_log_size'])
 PriceOracleConfiguration = namedtuple('PriceOracle', ['url', 'access_token'])
-StrategyConfiguration = namedtuple('StrategyConfiguration', ['mode'])
+GlobalConfiguration = namedtuple('GlobalConfiguration', ['mode'])
 NetworkConfiguration = namedtuple('NetworkConfiguration', [
 	'blockchain', 'network', 'endpoint', 'bridge_address', 'mosaic_id', 'extensions'
 ])
-BridgeConfiguration = namedtuple('BridgeConfiguration', ['machine', 'price_oracle', 'strategy', 'native_network', 'wrapped_network'])
+BridgeConfiguration = namedtuple('BridgeConfiguration', ['machine', 'global_', 'price_oracle', 'native_network', 'wrapped_network'])
 
 
 def _camel_case_to_snake_case(value):
@@ -37,14 +37,14 @@ def parse_price_oracle_configuration(config):
 	return PriceOracleConfiguration(config['url'], config['accessToken'])
 
 
-def parse_strategy_configuration(config):
-	"""Parses strategy configuration."""
+def parse_global_configuration(config):
+	"""Parses global configuration."""
 
 	mode = config['mode']
-	if mode not in ('staked', 'wrapped', 'native'):
+	if mode not in ('stake', 'wrap', 'swap'):
 		raise ValueError(f'mode "{mode}" is not supported')
 
-	return StrategyConfiguration(mode)
+	return GlobalConfiguration(mode)
 
 
 def parse_network_configuration(config):
@@ -71,7 +71,7 @@ def parse_bridge_configuration(filename):
 
 	return BridgeConfiguration(
 		parse_machine_configuration(parser['machine']),
+		parse_global_configuration(parser['global']),
 		parse_price_oracle_configuration(parser['price_oracle']),
-		parse_strategy_configuration(parser['strategy']),
 		parse_network_configuration(parser['native_network']),
 		parse_network_configuration(parser['wrapped_network']))

--- a/bridge/tests/models/test_BridgeConfiguration.py
+++ b/bridge/tests/models/test_BridgeConfiguration.py
@@ -4,10 +4,10 @@ from pathlib import Path
 
 from bridge.models.BridgeConfiguration import (
 	parse_bridge_configuration,
+	parse_global_configuration,
 	parse_machine_configuration,
 	parse_network_configuration,
-	parse_price_oracle_configuration,
-	parse_strategy_configuration
+	parse_price_oracle_configuration
 )
 
 
@@ -21,13 +21,13 @@ class BridgeConfigurationTest(unittest.TestCase):
 		'maxLogSize': '12345'
 	}
 
+	VALID_GLOBAL_CONFIGURATION = {
+		'mode': 'stake'
+	}
+
 	VALID_PRICE_ORACLE_CONFIGURATION = {
 		'url': 'https:/oracle.foo/price/v3',
 		'accessToken': 'D864696403D4DED92F2C82C3BEE33C41E90304B521F86E6CD37A7C808C9BDF80'
-	}
-
-	VALID_STRATEGY_CONFIGURATION = {
-		'mode': 'staked'
 	}
 
 	VALID_NETWORK_CONFIGURATION = {
@@ -79,6 +79,27 @@ class BridgeConfigurationTest(unittest.TestCase):
 
 	# endregion
 
+	# region global configuration
+
+	def test_can_parse_valid_global_configuration(self):
+		# Arrange:
+		for mode in ('stake', 'wrap', 'swap'):
+			# Act:
+			global_config = parse_global_configuration({'mode': mode})
+
+			# Assert:
+			self.assertEqual(mode, global_config.mode)
+
+	def test_cannot_parse_global_configuration_incomplete(self):
+		self._assert_cannot_parse_incomplete_configuration(parse_global_configuration, self.VALID_GLOBAL_CONFIGURATION)
+
+	def test_cannot_parse_global_configuration_invalid(self):
+		for mode in ('foo', 'bar'):
+			with self.assertRaisesRegex(ValueError, f'mode "{mode}" is not supported'):
+				parse_global_configuration({'mode': mode})
+
+	# endregion
+
 	# region price oracle configuration
 
 	def test_can_parse_valid_price_oracle_configuration(self):
@@ -91,27 +112,6 @@ class BridgeConfigurationTest(unittest.TestCase):
 
 	def test_cannot_parse_price_oracle_configuration_incomplete(self):
 		self._assert_cannot_parse_incomplete_configuration(parse_price_oracle_configuration, self.VALID_PRICE_ORACLE_CONFIGURATION)
-
-	# endregion
-
-	# region strategy configuration
-
-	def test_can_parse_valid_strategy_configuration(self):
-		# Arrange:
-		for mode in ('staked', 'wrapped', 'native'):
-			# Act:
-			strategy_config = parse_strategy_configuration({'mode': mode})
-
-			# Assert:
-			self.assertEqual(mode, strategy_config.mode)
-
-	def test_cannot_parse_strategy_configuration_incomplete(self):
-		self._assert_cannot_parse_incomplete_configuration(parse_strategy_configuration, self.VALID_STRATEGY_CONFIGURATION)
-
-	def test_cannot_parse_strategy_configuration_invalid(self):
-		for mode in ('foo', 'bar'):
-			with self.assertRaisesRegex(ValueError, f'mode "{mode}" is not supported'):
-				parse_strategy_configuration({'mode': mode})
 
 	# endregion
 
@@ -168,8 +168,8 @@ class BridgeConfigurationTest(unittest.TestCase):
 
 			with open(configuration_file, 'wt', encoding='utf8') as outfile:
 				self._write_section(outfile, '[machine]', self.VALID_MACHINE_CONFIGURATION)
+				self._write_section(outfile, '\n[global]', self.VALID_GLOBAL_CONFIGURATION)
 				self._write_section(outfile, '\n[price_oracle]', self.VALID_PRICE_ORACLE_CONFIGURATION)
-				self._write_section(outfile, '\n[strategy]', self.VALID_STRATEGY_CONFIGURATION)
 				self._write_section(outfile, '\n[native_network]', self.VALID_NETWORK_CONFIGURATION)
 				self._write_section(outfile, '\n[wrapped_network]', self.VALID_NETWORK_CONFIGURATION_2)
 
@@ -182,10 +182,10 @@ class BridgeConfigurationTest(unittest.TestCase):
 			self.assertEqual(7, config.machine.log_backup_count)
 			self.assertEqual(12345, config.machine.max_log_size)
 
+			self.assertEqual('stake', config.global_.mode)
+
 			self.assertEqual('https:/oracle.foo/price/v3', config.price_oracle.url)
 			self.assertEqual('D864696403D4DED92F2C82C3BEE33C41E90304B521F86E6CD37A7C808C9BDF80', config.price_oracle.access_token)
-
-			self.assertEqual('staked', config.strategy.mode)
 
 			self.assertEqual('foo', config.native_network.blockchain)
 			self.assertEqual('bar', config.native_network.network)
@@ -202,7 +202,7 @@ class BridgeConfigurationTest(unittest.TestCase):
 
 	def test_cannot_parse_bridge_configuration_incomplete(self):
 		# Arrange:
-		for section_id in range(3):
+		for section_id in range(5):
 			with tempfile.TemporaryDirectory() as temp_directory:
 				configuration_file = Path(temp_directory) / 'foo.properties'
 
@@ -211,9 +211,15 @@ class BridgeConfigurationTest(unittest.TestCase):
 						self._write_section(outfile, '[machine]', self.VALID_MACHINE_CONFIGURATION)
 
 					if 1 != section_id:
-						self._write_section(outfile, '\n[native_network]', self.VALID_NETWORK_CONFIGURATION)
+						self._write_section(outfile, '\n[global]', self.VALID_GLOBAL_CONFIGURATION)
 
 					if 2 != section_id:
+						self._write_section(outfile, '\n[price_oracle]', self.VALID_PRICE_ORACLE_CONFIGURATION)
+
+					if 3 != section_id:
+						self._write_section(outfile, '\n[native_network]', self.VALID_NETWORK_CONFIGURATION)
+
+					if 4 != section_id:
 						self._write_section(outfile, '\n[wrapped_network]', self.VALID_NETWORK_CONFIGURATION_2)
 
 				# Act + Assert:

--- a/bridge/tests/resources/sample.config.properties
+++ b/bridge/tests/resources/sample.config.properties
@@ -4,12 +4,12 @@ logFilename =
 logBackupCount = 10
 maxLogSize = 26214400
 
+[global]
+mode = stake
+
 [price_oracle]
 url =
 accessToken =
-
-[strategy]
-mode = staked
 
 [native_network]
 blockchain = nem

--- a/bridge/workflows/main_impl.py
+++ b/bridge/workflows/main_impl.py
@@ -9,7 +9,7 @@ from bridge.models.BridgeConfiguration import parse_bridge_configuration
 from bridge.models.Constants import ExecutionContext
 from bridge.NetworkFacadeLoader import load_network_facade
 from bridge.price_oracle.PriceOracleLoader import load_price_oracle
-from bridge.WorkflowUtils import validate_strategy_configuration
+from bridge.WorkflowUtils import validate_global_configuration
 
 
 def parse_args(description):
@@ -51,14 +51,14 @@ async def main_bootstrapper(program_description, main_impl):
 	native_facade = await load_network_facade(config.native_network)
 	wrapped_facade = await load_network_facade(config.wrapped_network)
 
-	validate_strategy_configuration(config.strategy, wrapped_facade)
+	validate_global_configuration(config.global_, wrapped_facade)
 
 	price_oracle = load_price_oracle(config.price_oracle)
 
 	with Databases(config.machine.database_directory, native_facade, wrapped_facade) as databases:
 		databases.create_tables()
 
-		execution_context = ExecutionContext(args.unwrap, config.strategy.mode)
+		execution_context = ExecutionContext(args.unwrap, config.global_.mode)
 		logger.info('         strategy mode: %s', execution_context.strategy_mode)
 		logger.info('running in unwrap mode? %s', execution_context.is_unwrap_mode)
 		await main_impl(execution_context, databases, native_facade, wrapped_facade, price_oracle)


### PR DESCRIPTION
 problem: strategy names are misleading
solution: rename to { 'stake', 'wrap', 'swap' } and rename section to 'global'