### PR TITLE
[bridge]: resolve OpenAPI spec URL dynamically based on current path

### DIFF
--- a/bridge/bridge/api/static/openapi/index.html
+++ b/bridge/bridge/api/static/openapi/index.html
@@ -19,8 +19,12 @@
 <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.10.3/swagger-ui-standalone-preset.js"></script>
 <script>
   window.onload = function() {
+
+    const path = window.location.pathname.replace(/\/openapi\/?$/, "");
+    const specUrl = `${path}/static/openapi/openapi.yaml`;
+
     const ui = SwaggerUIBundle({
-      url: "/static/openapi/openapi.yaml",  // Path to your OpenAPI spec file
+      url: specUrl,  // Path to your OpenAPI spec file
       dom_id: '#swagger-ui',
       deepLinking: true,
       presets: [


### PR DESCRIPTION
## Problem

Swagger UI was failing to load the OpenAPI spec when served under prefixed paths (e.g. /testnet/ethereum-wrapped/openapi).
Relative paths like ../static/... were resolved incorrectly, resulting in 404 Not Found.

## Solution

The OpenAPI spec URL is now derived dynamically from window.location.pathname by removing the /openapi suffix and appending the expected static spec location.

This allows the same index.html to work correctly under:
- /openapi
- /testnet/ethereum-wrapped/openapi

without any environment-specific configuration.