### PR TITLE
[wallet/common/core] fix: update bridge estimation url

### DIFF
--- a/wallet/common/core/src/lib/bridge/BridgeApi.js
+++ b/wallet/common/core/src/lib/bridge/BridgeApi.js
@@ -32,7 +32,7 @@ export class BridgeApi {
 	}
 
 	async estimateRequest(mode, amount, recipientAddress) {
-		return this.#makeBridgePostRequest(`/${mode}/prepare`, {
+		return this.#makeBridgePostRequest(`/${mode}/estimate`, {
 			amount,
 			recipientAddress
 		});

--- a/wallet/common/core/tests/lib/BridgeManager.test.js
+++ b/wallet/common/core/tests/lib/BridgeManager.test.js
@@ -982,7 +982,7 @@ describe('BridgeManager', () => {
 				expect(thrown).toBeTruthy();
 				expect(thrown.message).toBe(expected.errorMessage);
 			} else {
-				const url = `${BRIDGE_URL}/${mode}/prepare`;
+				const url = `${BRIDGE_URL}/${mode}/estimate`;
 				const recipientAddress = mode === 'wrap'
 					? wrappedWalletController.currentAccount.address
 					: nativeWalletController.currentAccount.address;


### PR DESCRIPTION
## Problem
There was a change in the Bridge API. The `/wrap/prepare` and `/unwrap/prepare endpoints` have been changed to `/wrap/estimate` and `/unwrap/estimate`. A wallet should use these new endpoints.

## Solution
Updated the URL path from `/prepare` to `/estimate` in BridgeApi class and in the test.