### PR TITLE
[explorer/frontend] fix: lint error - style variable interpolation

### DIFF
--- a/explorer/frontend/styles/globals.scss
+++ b/explorer/frontend/styles/globals.scss
@@ -159,10 +159,10 @@ a {
 }
 
 :root {
-	--toastify-color-info: $color-info;
-	--toastify-color-success: $color-success;
-	--toastify-color-warning: $color-warning;
-	--toastify-color-error: $color-danger;
+	--toastify-color-info: #{$color-info};
+	--toastify-color-success: #{$color-success};
+	--toastify-color-warning: #{$color-warning};
+	--toastify-color-error: #{$color-danger};
 	--toastify-toast-width: 20rem;
 	--toastify-toast-background: #fff;
 	--toastify-toast-min-height: 2rem;


### PR DESCRIPTION
## Problem
Error on Jenkins:
```
[2025-12-31T10:56:35.210Z] styles/globals.scss

[2025-12-31T10:56:35.210Z]   162:25  ✖  Expected variable $color-info to be interpolated when using it with --toastify-color-info        scss/dollar-variable-no-missing-interpolation

[2025-12-31T10:56:35.210Z]   163:28  ✖  Expected variable $color-success to be interpolated when using it with --toastify-color-success  scss/dollar-variable-no-missing-interpolation

[2025-12-31T10:56:35.210Z]   164:28  ✖  Expected variable $color-warning to be interpolated when using it with --toastify-color-warning  scss/dollar-variable-no-missing-interpolation

[2025-12-31T10:56:35.211Z]   165:26  ✖  Expected variable $color-danger to be interpolated when using it with --toastify-color-error     scss/dollar-variable-no-missing-interpolation

[2025-12-31T10:56:35.211Z] 

[2025-12-31T10:56:35.211Z] ✖ 4 problems (4 errors, 0 warnings)
```
## Solution
Fix stylelint error by wrapping scss variable using `#{}`.