### PR TITLE
[explorer/puller] feat: process accounts from the blocks

### DIFF
--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -28,13 +28,6 @@ class NemDatabase(DatabaseConnection):
 
 		cursor.execute(
 			'''
-			CREATE INDEX IF NOT EXISTS idx_accounts_importance
-				ON accounts(importance DESC);
-			'''
-		)
-
-		cursor.execute(
-			'''
 			CREATE INDEX IF NOT EXISTS idx_accounts_public_key
 				ON accounts (public_key)
 			'''

--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -1,3 +1,4 @@
+import json
 from binascii import unhexlify
 
 from .DatabaseConnection import DatabaseConnection
@@ -10,6 +11,43 @@ class NemDatabase(DatabaseConnection):
 	def _create_table_indexes(cursor):
 		"""Creates table indexes."""
 
+		# Create indexes for accounts table
+		cursor.execute(
+			'''
+			CREATE INDEX IF NOT EXISTS idx_accounts_address
+				ON accounts (address)
+			'''
+		)
+
+		cursor.execute(
+			'''
+			CREATE INDEX IF NOT EXISTS idx_accounts_balance
+				ON accounts(balance DESC);
+			'''
+		)
+
+		cursor.execute(
+			'''
+			CREATE INDEX IF NOT EXISTS idx_accounts_importance
+				ON accounts(importance DESC);
+			'''
+		)
+
+		cursor.execute(
+			'''
+			CREATE INDEX IF NOT EXISTS idx_accounts_public_key
+				ON accounts (public_key)
+			'''
+		)
+
+		cursor.execute(
+			'''
+			CREATE INDEX IF NOT EXISTS idx_accounts_mosaics_gin
+				ON accounts USING GIN (mosaics)
+			'''
+		)
+
+		# Create indexes for blocks table
 		cursor.execute(
 			'''
 			CREATE INDEX IF NOT EXISTS idx_blocks_height_desc ON blocks(height DESC);
@@ -17,9 +55,36 @@ class NemDatabase(DatabaseConnection):
 		)
 
 	def create_tables(self):
-		"""Creates blocks database tables."""
+		"""Creates database tables."""
 
 		cursor = self.connection.cursor()
+
+		# Create accounts table
+		cursor.execute(
+			'''
+			CREATE TABLE IF NOT EXISTS accounts (
+				id serial PRIMARY KEY,
+				address bytea NOT NULL UNIQUE,
+				public_key bytea,
+				remote_address bytea,
+				importance decimal(20, 10) DEFAULT 0,
+				balance bigint DEFAULT 0,
+				vested_balance bigint DEFAULT 0,
+				mosaics jsonb DEFAULT '[]'::jsonb,
+				harvested_fees bigint DEFAULT 0,
+				harvested_blocks bigint DEFAULT 0,
+				status varchar(8) DEFAULT NULL,
+				remote_status varchar(12) DEFAULT NULL,
+				last_harvested_height bigint DEFAULT 0,
+				min_cosignatories int DEFAULT NULL,
+				cosignatory_of bytea[] DEFAULT NULL,
+				cosignatories bytea[] DEFAULT NULL,
+				updated_at timestamp DEFAULT CURRENT_TIMESTAMP
+			)
+			'''
+		)
+
+		# Create blocks table
 		cursor.execute(
 			'''
 			CREATE TABLE IF NOT EXISTS blocks (
@@ -75,3 +140,55 @@ class NemDatabase(DatabaseConnection):
 		)
 		results = cursor.fetchone()
 		return 0 if results[0] is None else results[0]
+
+	def upsert_account(self, cursor, account_info):  # pylint: disable=no-self-use
+		"""Insert or update account information."""
+
+		cursor.execute(
+			'''
+			INSERT INTO accounts (
+				address,
+				public_key,
+				remote_address,
+				importance,
+				balance,
+				vested_balance,
+				mosaics,
+				harvested_blocks,
+				status,
+				remote_status,
+				min_cosignatories,
+				cosignatory_of,
+				cosignatories
+			)
+			VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+			ON CONFLICT (address)
+			DO UPDATE SET
+				remote_address = EXCLUDED.remote_address,
+				importance = EXCLUDED.importance,
+				balance = EXCLUDED.balance,
+				vested_balance = EXCLUDED.vested_balance,
+				mosaics = EXCLUDED.mosaics,
+				harvested_blocks = EXCLUDED.harvested_blocks,
+				status = EXCLUDED.status,
+				remote_status = EXCLUDED.remote_status,
+				min_cosignatories = EXCLUDED.min_cosignatories,
+				cosignatory_of = EXCLUDED.cosignatory_of,
+				cosignatories = EXCLUDED.cosignatories,
+				updated_at = CURRENT_TIMESTAMP
+			''', (
+				account_info.address.bytes,
+				account_info.public_key.bytes if account_info.public_key else None,
+				account_info.remote_address.bytes if account_info.remote_address else None,
+				account_info.importance,
+				account_info.balance,
+				account_info.vested_balance,
+				json.dumps(account_info.mosaics),
+				account_info.harvested_blocks,
+				account_info.status,
+				account_info.remote_status,
+				account_info.min_cosignatories,
+				[address.bytes for address in account_info.cosignatory_of] if len(account_info.cosignatory_of) > 0 else None,
+				[address.bytes for address in account_info.cosignatories] if len(account_info.cosignatories) > 0 else None,
+			)
+		)

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -307,21 +307,6 @@ class NemPuller:
 
 		log.info(f'Database thread: {processed} blocks inserted')
 
-	async def _retry_get_blocks_after(self, height, retries=3, delay=2):
-		"""Retries fetching blocks after a given height with exponential backoff."""
-
-		for attempt in range(1, retries + 1):
-			try:
-				return await self.nem_connector.get_blocks_after(height)
-			except NodeException as error:
-				if attempt < retries:
-					wait_time = delay * (2 ** (attempt - 1))  # Exponential backoff: 2s, 4s, 8s
-					log.warning(f'Error fetching blocks after height {height} (attempt {attempt}/{retries}): {error}. Retrying in {wait_time}s...')
-					await asyncio.sleep(wait_time)
-				else:
-					log.error(f'Failed to fetch blocks after height {height} after {retries} attempts: {error}')
-					raise
-
 	async def sync_blocks(self, db_height, chain_height, queue_size=200, batch_size=50):
 		"""sync blocks from NEM network."""
 

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -25,6 +25,21 @@ BlockRecord = namedtuple('BlockRecord', [
 	'signature',
 	'size'
 ])
+AccountRecord = namedtuple('AccountRecord', [
+	'address',
+	'public_key',
+	'remote_address',
+	'importance',
+	'balance',
+	'vested_balance',
+	'mosaics',
+	'harvested_blocks',
+	'status',
+	'remote_status',
+	'min_cosignatories',
+	'cosignatory_of',
+	'cosignatories'
+])
 DatabaseConfig = namedtuple('DatabaseConfig', ['database', 'user', 'password', 'host', 'port'])
 
 
@@ -183,6 +198,64 @@ class NemPuller:
 		)
 
 		self.nem_db.insert_block(cursor, block)
+
+	def _convert_mosaics_to_json(self, account_mosaics):  # pylint: disable=no-self-use
+		"""Convert AccountMosaic to Json format."""
+
+		return [
+			{
+				'namespace': f'{mosaic.mosaic_id[0]}.{mosaic.mosaic_id[1]}',
+				'quantity': mosaic.quantity
+			}
+			for mosaic in account_mosaics
+		]
+
+	def _create_account_record(self, account_info, mosaics_json, remote_address=None):  # pylint: disable=no-self-use
+		"""Create AccountRecord from account info and mosaics."""
+
+		return AccountRecord(
+			account_info.address,
+			account_info.public_key,
+			remote_address,
+			account_info.importance,
+			account_info.balance,
+			account_info.vested_balance,
+			mosaics_json,
+			account_info.harvested_blocks,
+			account_info.status,
+			account_info.remote_status,
+			account_info.min_cosignatories,
+			account_info.cosignatory_of,
+			account_info.cosignatories
+		)
+
+	async def _process_account_batch(self, cursor, addresses):
+		"""
+		Process a batch of addresses: fetch account info, mosaics, and upsert.
+		Updates both new and existing accounts with latest information.
+		"""
+
+		log.info(f'Processing batch of {len(addresses)} addresses')
+
+		# Fetch account info for all addresses (both new and existing)
+		for address in addresses:
+			account_info = await self._retry_get_account_info(address)
+			account_mosaics = await self._retry_get_account_mosaics(address)
+
+			mosaics_json = self._convert_mosaics_to_json(account_mosaics)
+			account = self._create_account_record(account_info, mosaics_json)
+
+			self.nem_db.upsert_account(cursor, account)
+
+			if 'REMOTE' == account_info.remote_status:
+				# Try fetching forwarded account info if remote status is REMOTE
+				main_account_info = await self._retry_get_account_info(address, forwarded=True)
+				main_account_mosaics = await self._retry_get_account_mosaics(str(main_account_info.address))
+
+				main_mosaics_json = self._convert_mosaics_to_json(main_account_mosaics)
+				main_account = self._create_account_record(main_account_info, main_mosaics_json, remote_address=account.address)
+
+				self.nem_db.upsert_account(cursor, main_account)
 
 	async def sync_nemesis_block(self):
 		"""Sync and write Nemesis block to database."""

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -45,6 +45,51 @@ class NemPuller:
 		self.nem_connector = NemConnector(node_url, network)
 		self.nem_facade = NemFacade(str(network))
 
+	async def _retry_operation(self, operation, description, retries=3, delay=2):  # pylint: disable=no-self-use
+		"""Retries an async operation with exponential backoff."""
+
+		for attempt in range(1, retries + 1):
+			try:
+				return await operation()
+			except NodeException as error:
+				if attempt < retries:
+					wait_time = delay * (2 ** (attempt - 1))  # Exponential backoff: 2s, 4s, 8s
+					log.warning(f'Error {description} (attempt {attempt}/{retries}): {error}. Retrying in {wait_time}s...')
+					await asyncio.sleep(wait_time)
+				else:
+					log.error(f'Failed {description} after {retries} attempts: {error}')
+					raise
+
+	async def _retry_get_blocks_after(self, height, retries=3, delay=2):
+		"""Retries fetching blocks after a given height with exponential backoff."""
+
+		return await self._retry_operation(
+			lambda: self.nem_connector.get_blocks_after(height),
+			f'fetching blocks after height {height}',
+			retries,
+			delay
+		)
+
+	async def _retry_get_account_info(self, address, forwarded=False, retries=3, delay=2):
+		"""Retries fetching account info with exponential backoff."""
+
+		return await self._retry_operation(
+			lambda: self.nem_connector.account_info(address, forwarded),
+			f'fetching account {address[:16]}...',
+			retries,
+			delay
+		)
+
+	async def _retry_get_account_mosaics(self, address, retries=3, delay=2):
+		"""Retries fetching account mosaics with exponential backoff."""
+
+		return await self._retry_operation(
+			lambda: self.nem_connector.account_mosaics(address),
+			f'fetching mosaics for account {address[:16]}...',
+			retries,
+			delay
+		)
+
 	def _convert_timestamp_to_datetime(self, timestamp):
 		"""Formats a NEM network timestamp to UTC."""
 

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -278,6 +278,7 @@ class NemPuller:
 
 		cursor = self.nem_db.connection.cursor()
 		processed = 0
+		pending_addresses = set()
 
 		log.info('DB writer thread started')
 
@@ -288,6 +289,11 @@ class NemPuller:
 			# Check for sentinel value (None) to stop processing
 			if block is None:
 				log.info('Received stop signal, ending DB writer thread')
+
+				# Process any remaining addresses before exiting
+				if pending_addresses:
+					asyncio.run(self._process_account_batch(cursor, pending_addresses))
+
 				block_queue.task_done()
 				break
 
@@ -295,8 +301,15 @@ class NemPuller:
 			self._process_block(cursor, block)
 			processed += 1
 
+			# Extract addresses for account processing
+			addresses = self._extract_addresses_from_block(block)
+			pending_addresses.update(addresses)
+
 			# Batch commits
 			if processed % batch_size == 0:
+				asyncio.run(self._process_account_batch(cursor, pending_addresses))
+				pending_addresses.clear()
+
 				self._commit_blocks(f'Committed {processed} blocks')
 
 			block_queue.task_done()
@@ -325,6 +338,7 @@ class NemPuller:
 		try:
 			while chain_height > db_height:
 				blocks = await self._retry_get_blocks_after(db_height)
+				# print(vars(blocks[0].transactions[0]))
 
 				for block in blocks:
 					block_queue.put(block)

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -266,6 +266,9 @@ class NemPuller:
 
 		self._process_block(cursor, nemesis_block)
 
+		addresses = self._extract_addresses_from_block(nemesis_block)
+		await self._process_account_batch(cursor, addresses)
+
 		self._commit_blocks('Committed Nemesis block')
 
 	def _db_writer(self, block_queue, batch_size=50):

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -144,24 +144,16 @@ class NemPuller:
 			# Handle multisig signatures
 			if hasattr(transaction, 'signatures'):
 				for signature in transaction.signatures:
-					other_account = getattr(signature, 'other_account', None)
-					sender = getattr(signature, 'sender', None)
-					if other_account:
-						addresses.add(str(Address(other_account)))
-					if sender:
-						addresses.add(str(self._convert_public_key_to_address(sender)))
+					addresses.add(str(Address(signature.other_account)))
+					addresses.add(str(self._convert_public_key_to_address(signature.sender)))
 
 			# Handle multisig modifications
 			if hasattr(transaction, 'modifications'):
 				for modification in transaction.modifications:
-					cosignatory = getattr(modification, 'cosignatory_account', None)
-					if cosignatory:
-						addresses.add(str(self._convert_public_key_to_address(cosignatory)))
+					addresses.add(str(self._convert_public_key_to_address(modification.cosignatory_account)))
 
 		# Block signer
-		block_signer = getattr(block, 'signer', None)
-		if block_signer:
-			addresses.add(str(self._convert_public_key_to_address(block_signer)))
+		addresses.add(str(self._convert_public_key_to_address(block.signer)))
 
 		# Block transactions
 		for transaction in block.transactions:

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -4,8 +4,9 @@ import threading
 from collections import namedtuple
 from queue import Queue
 
+from symbolchain.CryptoTypes import PublicKey
 from symbolchain.facade.NemFacade import NemFacade
-from symbolchain.nem.Network import Network
+from symbolchain.nem.Network import Address, Network
 from symbollightapi.connector.NemConnector import NemConnector
 from symbollightapi.model.Exceptions import NodeException
 from zenlog import log
@@ -48,6 +49,68 @@ class NemPuller:
 		"""Formats a NEM network timestamp to UTC."""
 
 		return self.nem_facade.network.datetime_converter.to_datetime(timestamp).strftime('%Y-%m-%d %H:%M:%S+00:00')
+
+	def _convert_public_key_to_address(self, public_key):
+		"""Convert public key to address."""
+
+		return self.nem_facade.network.public_key_to_address(PublicKey(public_key))
+
+	def _extract_addresses_from_block(self, block):
+		"""Extract address and public key from block and transactions."""
+
+		addresses = set()
+
+		public_key_fields = ['sender', 'remote_account', 'creator']
+		address_fields = ['recipient', 'rental_fee_sink', 'creation_fee_sink']
+
+		def _extract_from_transaction(transaction):
+			# Extract from public key fields
+			for field in public_key_fields:
+				value = getattr(transaction, field, None)
+				if value:
+					addresses.add(str(self._convert_public_key_to_address(value)))
+
+			# Extract from address fields
+			for field in address_fields:
+				value = getattr(transaction, field, None)
+				if value:
+					addresses.add(str(Address(value)))
+
+			# Handle levy recipient
+			levy = getattr(transaction, 'levy', None)
+			if levy:
+				addresses.add(str(Address(levy.recipient)))
+
+			# Handle multisig signatures
+			if hasattr(transaction, 'signatures'):
+				for signature in transaction.signatures:
+					other_account = getattr(signature, 'other_account', None)
+					sender = getattr(signature, 'sender', None)
+					if other_account:
+						addresses.add(str(Address(other_account)))
+					if sender:
+						addresses.add(str(self._convert_public_key_to_address(sender)))
+
+			# Handle multisig modifications
+			if hasattr(transaction, 'modifications'):
+				for modification in transaction.modifications:
+					cosignatory = getattr(modification, 'cosignatory_account', None)
+					if cosignatory:
+						addresses.add(str(self._convert_public_key_to_address(cosignatory)))
+
+		# Block signer
+		block_signer = getattr(block, 'signer', None)
+		if block_signer:
+			addresses.add(str(self._convert_public_key_to_address(block_signer)))
+
+		# Block transactions
+		for transaction in block.transactions:
+			_extract_from_transaction(transaction)
+
+			if hasattr(transaction, 'other_transaction'):
+				_extract_from_transaction(transaction.other_transaction)
+
+		return addresses
 
 	def _commit_blocks(self, message=None):
 		"""Commit blocks to database with error handling."""

--- a/explorer/puller/requirements.txt
+++ b/explorer/puller/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp==3.13.3
 psycopg2-binary==2.9.6
 symbol-lightapi~=0.0.9
-symbol-sdk-python==3.0.7
+symbol-sdk-python==3.3.0
 zenlog==1.1

--- a/explorer/puller/tests/db/test_NemDatabase.py
+++ b/explorer/puller/tests/db/test_NemDatabase.py
@@ -8,7 +8,7 @@ from symbolchain.nem.Network import Address
 from test_DatabaseConnection import DatabaseConfig
 
 from puller.db.NemDatabase import NemDatabase
-from puller.facade.NemPuller import BlockRecord
+from puller.facade.NemPuller import AccountRecord, BlockRecord
 
 # region test data
 
@@ -39,6 +39,22 @@ BLOCKS = [
 		200),
 ]
 
+ACCOUNTS = [
+	AccountRecord(
+		Address('TBZWVEKB2XMTO4F3RAOEIBWRBMPQ5N23G56ZJM4I'),
+		PublicKey('5451f450416d214b14f0375ce06c3451eeb784f7bcd25ae1072ba7e403940a58'),
+		None,
+		0.123456,
+		1000000,
+		99999,
+		[],
+		10,
+		'LOCKED',
+		'INACTIVE',
+		None,
+		[],
+		[])
+]
 # endregion
 
 
@@ -52,6 +68,32 @@ class NemDatabaseTest(unittest.TestCase):
 		# Destroy the temporary PostgreSQL database
 		self.postgresql.stop()
 
+	def _fetch_account_from_db(self, cursor, address):
+		"""Helper method to fetch account data from database."""
+
+		cursor.execute(
+			'''
+			SELECT
+				encode(address, 'hex'),
+				encode(public_key, 'hex'),
+				encode(remote_address, 'hex'),
+				importance::TEXT,
+				balance,
+				vested_balance,
+				mosaics,
+				harvested_blocks,
+				status,
+				remote_status,
+				min_cosignatories,
+				cosignatory_of,
+				cosignatories
+			FROM accounts
+			WHERE address = %s
+			''',
+			(address.bytes,)
+		)
+		return cursor.fetchone()
+
 	def test_can_create_tables(self):
 		# Arrange:
 		with NemDatabase(self.db_config) as nem_database:
@@ -64,14 +106,15 @@ class NemDatabaseTest(unittest.TestCase):
 				SELECT table_name
 				FROM information_schema.tables
 				WHERE table_schema = 'public'
-				AND table_name = 'blocks'
+				ORDER BY table_name
 				'''
 			)
-			result = cursor.fetchone()
+			results = cursor.fetchall()
 
 		# Assert:
-		self.assertIsNotNone(result)
-		self.assertEqual(result[0], 'blocks')
+		self.assertEqual(len(results), 2)
+		self.assertEqual(results[0][0], 'accounts')
+		self.assertEqual(results[1][0], 'blocks')
 
 	def test_can_insert_block(self):
 		# Arrange:
@@ -161,3 +204,77 @@ class NemDatabaseTest(unittest.TestCase):
 
 		# Assert:
 		self.assertEqual(result, 0)
+
+	def test_can_insert_account(self):
+		# Arrange:
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+
+			cursor = nem_database.connection.cursor()
+
+			# Act:
+			nem_database.upsert_account(
+				cursor,
+				ACCOUNTS[0]
+			)
+
+			nem_database.connection.commit()
+			result = self._fetch_account_from_db(cursor, ACCOUNTS[0].address)
+
+		# Assert:
+		self.assertIsNotNone(result)
+		self.assertEqual(result, (
+			ACCOUNTS[0].address.bytes.hex(),
+			ACCOUNTS[0].public_key.bytes.hex(),
+			None,
+			'0.1234560000',
+			1000000,
+			99999,
+			[],
+			10,
+			'LOCKED',
+			'INACTIVE',
+			None,
+			None,
+			None)
+		)
+
+	def test_can_update_account_by_address_conflict(self):
+		# Arrange:
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+
+			cursor = nem_database.connection.cursor()
+
+			# insert initial account
+			nem_database.upsert_account(
+				cursor,
+				ACCOUNTS[0]
+			)
+
+			# Act:
+			nem_database.upsert_account(
+				cursor,
+				ACCOUNTS[0]._replace(balance=2000000)
+			)
+
+			nem_database.connection.commit()
+			result = self._fetch_account_from_db(cursor, ACCOUNTS[0].address)
+
+		# Assert:
+		self.assertIsNotNone(result)
+		self.assertEqual(result, (
+			ACCOUNTS[0].address.bytes.hex(),
+			ACCOUNTS[0].public_key.bytes.hex(),
+			None,
+			'0.1234560000',
+			2000000,
+			99999,
+			[],
+			10,
+			'LOCKED',
+			'INACTIVE',
+			None,
+			None,
+			None)
+		)

--- a/explorer/puller/tests/db/test_NemDatabase.py
+++ b/explorer/puller/tests/db/test_NemDatabase.py
@@ -68,7 +68,7 @@ class NemDatabaseTest(unittest.TestCase):
 		# Destroy the temporary PostgreSQL database
 		self.postgresql.stop()
 
-	def _fetch_account_from_db(self, cursor, address):
+	def _fetch_account_from_db(self, cursor, address):  # pylint: disable=no-self-use
 		"""Helper method to fetch account data from database."""
 
 		cursor.execute(

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -2,7 +2,7 @@ import asyncio
 import datetime
 import tempfile
 import unittest
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import testing.postgresql
 from symbolchain.CryptoTypes import PublicKey
@@ -23,7 +23,7 @@ from symbollightapi.model.Transaction import (
 	TransferTransaction
 )
 
-from puller.facade.NemPuller import DatabaseConfig, NemPuller
+from puller.facade.NemPuller import DatabaseConfig, NemPuller, AccountRecord
 
 # region test data
 
@@ -569,3 +569,100 @@ class NemPullerTest(unittest.TestCase):
 			'TBEM6SFOHU5PORIGAVG3NNJIMCG73R2TWH35O2VF',
 			'TADMEHCFJD45GPTDL4HZP2LJLZVAZRLYWY2K4OOH'
 		})
+
+	@patch('puller.facade.NemPuller.NemConnector.account_info')
+	@patch('puller.facade.NemPuller.NemConnector.account_mosaics')
+	@patch('puller.facade.NemPuller.NemDatabase.upsert_account')
+	def test_can_process_account_batch(self, mock_upsert_account, mock_account_mosaics, mock_account_info):
+		# Arrange:
+		mock_account_info.return_value = NEM_CONNECTOR_RESPONSE_ACCOUNT_INFO
+		mock_account_mosaics.return_value = [
+			AccountMosaic(('nem', 'xem'), 8000000),
+		]
+
+		cursor = Mock()
+		addresses = {
+			str(NEM_CONNECTOR_RESPONSE_ACCOUNT_INFO.address),
+		}
+
+		# Act:
+		asyncio.run(self.puller._process_account_batch(cursor, addresses))  # pylint: disable=protected-access
+
+		# Assert:
+		mock_account_info.assert_called_once_with(str(NEM_CONNECTOR_RESPONSE_ACCOUNT_INFO.address), False)
+		mock_account_mosaics.assert_called_once_with(str(NEM_CONNECTOR_RESPONSE_ACCOUNT_INFO.address))
+		mock_upsert_account.assert_called_once_with(
+			cursor,
+			AccountRecord(
+				mosaics=[{
+					'namespace': 'nem.xem',
+					'quantity': 8000000
+				}],
+				remote_address=None,
+				**vars(NEM_CONNECTOR_RESPONSE_ACCOUNT_INFO)
+			)
+		)
+
+	@patch('puller.facade.NemPuller.NemConnector.account_info')
+	@patch('puller.facade.NemPuller.NemConnector.account_mosaics')
+	@patch('puller.facade.NemPuller.NemDatabase.upsert_account')
+	def test_can_process_account_batch_with_remote_status(self, mock_upsert_account, mock_account_mosaics, mock_account_info):
+		# Arrange:
+		account = NEM_CONNECTOR_RESPONSE_ACCOUNT_INFO
+		account.remote_status = 'REMOTE'
+
+		remote_account = NemAccountInfo(Address('TBKQWJJGPOHL462DBVMTYOAERXGG2BOS5XRFO2P6'))
+
+		mock_account_info.side_effect = [
+			account,
+			remote_account
+		]
+
+		mock_account_mosaics.side_effect = [
+			[AccountMosaic(('nem', 'xem'), 0)],
+			[AccountMosaic(('nem', 'xem'), 1000000)]  # for remote account
+		]
+
+		cursor = Mock()
+		addresses = {
+			str(account.address),
+		}
+
+		# Act:
+		asyncio.run(self.puller._process_account_batch(cursor, addresses))  # pylint: disable=protected-access
+
+		# Assert:
+		account_info_calls = mock_account_info.call_args_list
+		self.assertEqual(len(account_info_calls), 2)
+		self.assertEqual(account_info_calls[0][0], (str(account.address), False))
+		self.assertEqual(account_info_calls[1][0], (str(account.address), True))
+
+		account_mosaics_calls = mock_account_mosaics.call_args_list
+		self.assertEqual(len(account_mosaics_calls), 2)
+		self.assertEqual(account_mosaics_calls[0][0], (str(account.address),))
+		self.assertEqual(account_mosaics_calls[1][0], (str(remote_account.address),))
+
+		upsert_account_calls = mock_upsert_account.call_args_list
+		self.assertEqual(len(upsert_account_calls), 2)
+		self.assertEqual(upsert_account_calls[0][0], (
+			cursor,
+			AccountRecord(
+				mosaics=[{
+					'namespace': 'nem.xem',
+					'quantity': 0
+				}],
+				remote_address=None,
+				**vars(account)
+			),
+		))
+		self.assertEqual(upsert_account_calls[1][0], (
+			cursor,
+			AccountRecord(
+				mosaics=[{
+					'namespace': 'nem.xem',
+					'quantity': 1000000
+				}],
+				remote_address=account.address,
+				**vars(remote_account)
+			),
+		))

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -340,9 +340,11 @@ class NemPullerTest(unittest.TestCase):
 			)
 
 	@patch('puller.facade.NemPuller.NemConnector.get_blocks_after')
-	def test_can_sync_blocks(self, mock_get_blocks_after):
+	@patch('puller.facade.NemPuller.NemPuller._process_account_batch')
+	def test_can_sync_blocks(self, mock_process_account_batch, mock_get_blocks_after):
 		# Arrange:
 		mock_get_blocks_after.return_value = NEM_CONNECTOR_RESPONSE_BLOCKS
+		mock_process_account_batch.return_value = AsyncMock()
 
 		with self.puller.nem_db as databases:
 			databases.create_tables()
@@ -396,6 +398,10 @@ class NemPullerTest(unittest.TestCase):
 				),
 				2052
 			))
+
+			call_args = mock_process_account_batch.call_args_list[0]
+			addresses = call_args[0][1]
+			self.assertEqual(len(addresses), 19)
 
 	@patch('puller.facade.NemPuller.NemPuller._retry_get_blocks_after')
 	@patch('puller.facade.NemPuller.log')

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -382,6 +382,20 @@ class NemPullerTest(unittest.TestCase):
 				),
 				168
 			))
+			self.assertEqual(results[2], (
+				3,
+				datetime.datetime(2015, 3, 29, 20, 39, 21),
+				57950000,
+				7,
+				300,
+				'1dd9d4d7b6af603d29c082f9aa4e123f07d18154ddbcd7ddc6702491b854c5e4',
+				'f9bd190dd0c364261f5c8a74870cc7f7374e631352293c62ecc437657e5de2cd',
+				(
+					'fdf6a9830e9320af79123f467fcb03d6beab735575ff50eab363d812c5581436'
+					'2ad7be0503db2ee70e60ac3408d83cdbcbd941067a6df703e0c21c7bf389f105'
+				),
+				2052
+			))
 
 	@patch('puller.facade.NemPuller.NemPuller._retry_get_blocks_after')
 	@patch('puller.facade.NemPuller.log')

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import testing.postgresql
 from symbolchain.CryptoTypes import PublicKey
 from symbolchain.nem.Network import Address
+from symbollightapi.connector.NemConnector import AccountMosaic, NemAccountInfo
 from symbollightapi.model.Block import Block
 from symbollightapi.model.Exceptions import NodeException
 from symbollightapi.model.Transaction import (
@@ -201,7 +202,9 @@ NEM_CONNECTOR_RESPONSE_BLOCKS = [
 		],
 		300,
 		'1dd9d4d7b6af603d29c082f9aa4e123f07d18154ddbcd7ddc6702491b854c5e4',
-		'f9bd190dd0c364261f5c8a74870cc7f7374e631352293c62ecc437657e5de2cd',
+		57950000,
+		Address('TCJLCZSOQ6RGWHTPSV2DW467WZSHK4NBSITND4OF'),
+		PublicKey('f9bd190dd0c364261f5c8a74870cc7f7374e631352293c62ecc437657e5de2cd'),
 		(
 			'fdf6a9830e9320af79123f467fcb03d6beab735575ff50eab363d812c5581436'
 			'2ad7be0503db2ee70e60ac3408d83cdbcbd941067a6df703e0c21c7bf389f105'
@@ -391,6 +394,7 @@ class NemPullerTest(unittest.TestCase):
 				7,
 				300,
 				'1dd9d4d7b6af603d29c082f9aa4e123f07d18154ddbcd7ddc6702491b854c5e4',
+				'9892b1664e87a26b1e6f95743b73dfb6647571a19226d1f1c5',
 				'f9bd190dd0c364261f5c8a74870cc7f7374e631352293c62ecc437657e5de2cd',
 				(
 					'fdf6a9830e9320af79123f467fcb03d6beab735575ff50eab363d812c5581436'

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -9,7 +9,19 @@ from symbolchain.CryptoTypes import PublicKey
 from symbolchain.nem.Network import Address
 from symbollightapi.model.Block import Block
 from symbollightapi.model.Exceptions import NodeException
-from symbollightapi.model.Transaction import TransferTransaction
+from symbollightapi.model.Transaction import (
+	AccountKeyLinkTransaction,
+	CosignSignatureTransaction,
+	Modification,
+	MosaicDefinitionTransaction,
+	MosaicLevy,
+	MosaicProperties,
+	MosaicSupplyChangeTransaction,
+	MultisigAccountModificationTransaction,
+	MultisigTransaction,
+	NamespaceRegistrationTransaction,
+	TransferTransaction
+)
 
 from puller.facade.NemPuller import DatabaseConfig, NemPuller
 
@@ -61,6 +73,141 @@ NEM_CONNECTOR_RESPONSE_BLOCKS = [
 		),
 		168
 	),
+	Block(
+		3,
+		73976,
+		[
+			AccountKeyLinkTransaction(
+				'306f20260a1b7af692834809d3e7d53edd41616d5076ac0fac6cfa75982185df',
+				2,
+				'22df5f43ee3739a10c346b3ec2d3878668c5514696be425f9067d3a11c777f1d',
+				8000000,
+				73397,
+				83397,
+				'1b81379847241e45da86b27911e5c9a9192ec04f644d98019657d32838b49c14'
+				'3eaa4815a3028b80f9affdbf0b94cd620f7a925e02783dda67b8627b69ddf70e',
+				1,
+				'7195f4d7a40ad7e31958ae96c4afed002962229675a4cae8dc8a18e290618981'
+			),
+			TransferTransaction(
+				'd6c9902cfa23dbbdd212d720f86391dd91d215bf77d806f03a6c2dd2e730628a',
+				2,
+				'8d07f90fb4bbe7715fa327c926770166a11be2e494a970605f2e12557f66c9b9',
+				9000000,
+				73397,
+				83397,
+				'e0cc7f71e353ca0aaf2f009d74aeac5f97d4796b0f08c009058fb33d93c2e8ca'
+				'68c0b63e46ff125f43314014d324ac032d2c82996a6e47068b251f1d71fdd001',
+				180000040000000,
+				'NCOPERAWEWCD4A34NP5UQCCKEX44MW4SL3QYJYS5',
+				('476f6f64206c75636b21', 1),
+				None
+			),
+			MultisigAccountModificationTransaction(
+				'cc64ca69bfa95db2ff7ac1e21fe6d27ece189c603200ebc9778d8bb80ca25c3c',
+				2,
+				'f41b99320549741c5cce42d9e4bb836d98c50ed5415d0c3c2912d1bb50e6a0e5',
+				40000000,
+				73397,
+				83397,
+				'81ff2235f9ad6f3f8adbc16051bf8691a45ee5ddcace4d6260ce9a2ae63dba59'
+				'4f2b486f25451a1f90da7f0e312d9e8570e4bc03798e58d19dec86feb4152307',
+				2,
+				[
+					Modification(1, '1fbdbdde28daf828245e4533765726f0b7790e0b7146e2ce205df3e86366980b'),
+					Modification(1, 'f94e8702eb1943b23570b1b83be1b81536df35538978820e98bfce8f999e2d37')
+				]
+			),
+			NamespaceRegistrationTransaction(
+				'7e547e45cfc9c34809ce184db6ae7b028360c0f1492cc37b7b4d31c22af07dc3',
+				2,
+				'a700809530e5428066807ec0d34859c52e260fc60634aaac13e3972dcfc08736',
+				150000,
+				73397,
+				83397,
+				'9fc70720d0333d7d8f9eb14ef45ce45a846d37e79cf7a4244b4db36dcb0d3dfe'
+				'0170daefbf4d30f92f343110a6f03a14aedcf7913e465a4a1cc199639169410a',
+				'NAMESPACEWH4MKFMBCVFERDPOOP4FK7MTBXDPZZA',
+				100000000,
+				None,
+				'namespace'
+			),
+			MosaicDefinitionTransaction(
+				'4725e523e5d5a562121f38953d6da3ae695060533fc0c5634b31de29c3b766e1',
+				2,
+				'a700809530e5428066807ec0d34859c52e260fc60634aaac13e3972dcfc08736',
+				150000,
+				73397,
+				83397,
+				'a80ccd44955ded7d35ee3aa011bfafd3f30cc746f63cb59a9d02171f908a0f4a'
+				'0294fcbba0b2838acd184daf1d9ae3c0f645308b442547156364192cd3d2d605',
+				10000000,
+				'NBMOSAICOD4F54EE5CDMR23CCBGOAM2XSIUX6TRS',
+				'a700809530e5428066807ec0d34859c52e260fc60634aaac13e3972dcfc08736',
+				'NEM namespace test',
+				MosaicProperties(4, 3100000, False, True),
+				MosaicLevy(500, 'NBRYCNWZINEVNITUESKUMFIENWKYCRUGNFZV25AV', 1, 'nem.xem'),
+				'namespace.test'
+			),
+			MosaicSupplyChangeTransaction(
+				'cb805b4499479135934e70452d12ad9ecc26c46a111fe0cdda8e09741d257708',
+				2,
+				'da04b4a1d64add6c70958d383f9d247af1aaa957cb89f15b2d059b278e0594d5',
+				150000,
+				73397,
+				83397,
+				'7fef5a89a1c6c98347b8d488a8dd28902e8422680f917c28f3ef0100d394b91c'
+				'd85f7cdfd7bdcd6f0cb8089ae9d4e6ef24a8caca35d1cfec7e33c9ccab5e1503',
+				2,
+				500000,
+				'namespace.test'
+			),
+			MultisigTransaction(
+				'3375969dbc2aaae1cad0d89854d4f41b4fef553dbe9c7d39bdf72e3c538f98fe',
+				2,
+				'aa455d831430872feb0c6ae14265209182546c985a321c501be7fdc96ed04757',
+				500000,
+				73397,
+				83397,
+				'0e7112b029e030d2d1c7dff79c88a29812f7254422d80e37a7aac5228fff5706'
+				'133500b0119a1327cab8787416b5873cc873e3181066c46cb2b108c5da10d90f',
+				[
+					CosignSignatureTransaction(
+						261593985,
+						'edcc8d1c48165f5b771087fbe3c4b4d41f5f8f6c4ce715e050b86fb4e7fdeb64',
+						'NAGJG3QFWYZ37LMI7IQPSGQNYADGSJZGJRD2DIYA',
+						'ae6754c70b7e3ba0c51617c8f9efd462d0bf680d45e09c3444e817643d277826',
+						500000,
+						261680385,
+						'249bc2dbad96e827eabc991b59dff7f12cc27f3e0da8ab3db6a3201169431786'
+						'72f712ba14ed7a3b890e161357a163e7408aa22e1d6d1382ebada57973862706'
+					)
+				],
+				TransferTransaction(
+					None,
+					None,
+					'fbae41931de6a0cc25153781321f3de0806c7ba9a191474bb9a838118c8de4d3',
+					750000,
+					73397,
+					83397,
+					None,
+					150000000000,
+					'NBUH72UCGBIB64VYTAAJ7QITJ62BLISFFQOHVP65',
+					None,
+					None
+				),
+				'edcc8d1c48165f5b771087fbe3c4b4d41f5f8f6c4ce715e050b86fb4e7fdeb64'
+			)
+		],
+		300,
+		'1dd9d4d7b6af603d29c082f9aa4e123f07d18154ddbcd7ddc6702491b854c5e4',
+		'f9bd190dd0c364261f5c8a74870cc7f7374e631352293c62ecc437657e5de2cd',
+		(
+			'fdf6a9830e9320af79123f467fcb03d6beab735575ff50eab363d812c5581436'
+			'2ad7be0503db2ee70e60ac3408d83cdbcbd941067a6df703e0c21c7bf389f105'
+		),
+		2052
+	)
 ]
 
 # endregion
@@ -168,7 +315,7 @@ class NemPullerTest(unittest.TestCase):
 			asyncio.run(self.puller.sync_blocks(0, 2))
 			# Assert:
 			results = self._query_fetch_blocks(self.puller)
-			self.assertEqual(len(results), 2)
+			self.assertEqual(len(results), 3)
 			self.assertEqual(results[0], (
 				1,
 				datetime.datetime(2015, 3, 29, 22, 2, 41),
@@ -331,3 +478,42 @@ class NemPullerTest(unittest.TestCase):
 		self.assertEqual(str(context.exception), 'Connection refused')
 		self.assertEqual(mock_get_blocks_after.call_count, 3)
 		self.assertEqual(mock_sleep.call_count, 2)
+
+	def test_can_extract_addresses_from_block_with_only_signer(self):
+		# Arrange:
+		block = NEM_CONNECTOR_RESPONSE_BLOCKS[1]
+
+		# Act:
+		addresses = self.puller._extract_addresses_from_block(block)  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual(addresses, {'TALICE6XEEEOBFJVY3ZCENZ7WBG6LB4KB7P7KMQX'})
+
+	def test_can_extract_addresses_from_block(self):
+		# Arrange:
+		block = NEM_CONNECTOR_RESPONSE_BLOCKS[2]
+
+		# Act:
+		addresses = self.puller._extract_addresses_from_block(block)  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual(addresses, {
+			'TBKQWJJGPOHL462DBVMTYOAERXGG2BOS5XRFO2P6',
+			'TCC4NPREMOSTSKVODMW3T7OWDL4SRBT5BPVDTUSZ',
+			'TCMARKECQXP3SQZSJPCBKOQWIXRRI7LIS66LNC4X',
+			'TAGJG3QFWYZ37LMI7IQPSGQNYADGSJZGJROECHCG',
+			'TANEMOABLAGR72AZ2RV3V4ZHDCXW25XQ7YP7HX57',
+			'NCOPERAWEWCD4A34NP5UQCCKEX44MW4SL3QYJYS5',
+			'NAMESPACEWH4MKFMBCVFERDPOOP4FK7MTBXDPZZA',
+			'NBUH72UCGBIB64VYTAAJ7QITJ62BLISFFQOHVP65',
+			'TCTWKWGD564GIQQCZ5X5TC4YM46VXWLT3QPGJBHA',
+			'NBMOSAICOD4F54EE5CDMR23CCBGOAM2XSIUX6TRS',
+			'TBRYCNWZINEVNITUESKUMFIENWKYCRUGNE63PMQQ',
+			'NAGJG3QFWYZ37LMI7IQPSGQNYADGSJZGJRD2DIYA',
+			'TBRFW5P3FIXAWV7AOXE6EOEZLZWCBIWHPXVD4V2J',
+			'TALICEPFLZQRZGPRIJTMJOCPWDNECXTNNFEN6XWA',
+			'NBRYCNWZINEVNITUESKUMFIENWKYCRUGNFZV25AV',
+			'TANIBAXPVLBP37YXSGREVD77NXIFZML5FANIVEXX',
+			'TBEM6SFOHU5PORIGAVG3NNJIMCG73R2TWH35O2VF',
+			'TADMEHCFJD45GPTDL4HZP2LJLZVAZRLYWY2K4OOH'
+		})

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -210,6 +210,8 @@ NEM_CONNECTOR_RESPONSE_BLOCKS = [
 	)
 ]
 
+NEM_CONNECTOR_RESPONSE_ACCOUNT_INFO = NemAccountInfo(Address('TALICE6XEEEOBFJVY3ZCENZ7WBG6LB4KB7P7KMQX'))
+
 # endregion
 
 
@@ -408,8 +410,87 @@ class NemPullerTest(unittest.TestCase):
 			actual_calls = [call[0][0] if call[0] else None for call in mock_commit_blocks.call_args_list]
 			self.assertEqual(actual_calls, expected_calls)
 
+	def _assert_retry_operation_successful(self, mock_connector_method, operation, expected_result):
+		# Arrange:
+		mock_connector_method.return_value = expected_result
+
+		# Act:
+		result = asyncio.run(operation(1))  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual(result, expected_result)
+		mock_connector_method.assert_called_once_with(1)
+
+	def test_retry_operation_succeeds_on_first_attempt(self):
+		# Arrange:
+		mock_operation = AsyncMock()
+		mock_operation.return_value = 'success'
+
+		# Act:
+		result = asyncio.run(self.puller._retry_operation(mock_operation, 'testing'))  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual(result, 'success')
+		mock_operation.assert_called_once()
+
+	@patch('asyncio.sleep')
+	def test_retry_operation_succeeds_on_second_attempt(self, mock_sleep):
+		# Arrange:
+		mock_operation = AsyncMock()
+		mock_operation.side_effect = [
+			NodeException('Connection refused'),
+			'success'
+		]
+		mock_sleep.return_value = AsyncMock()
+
+		# Act:
+		result = asyncio.run(self.puller._retry_operation(mock_operation, 'testing'))  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual(result, 'success')
+		self.assertEqual(mock_operation.call_count, 2)
+		self.assertEqual(mock_sleep.call_count, 1)
+		sleep_calls = [call[0][0] for call in mock_sleep.call_args_list]
+		self.assertEqual(sleep_calls, [2])
+
+	@patch('asyncio.sleep')
+	def test_retry_operation_succeeds_on_last_attempt(self, mock_sleep):
+		# Arrange:
+		mock_operation = AsyncMock()
+		mock_operation.side_effect = [
+			NodeException('Connection refused'),
+			NodeException('Connection refused'),
+			'success'
+		]
+		mock_sleep.return_value = AsyncMock()
+
+		# Act:
+		result = asyncio.run(self.puller._retry_operation(mock_operation, 'testing'))  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual(result, 'success')
+		self.assertEqual(mock_operation.call_count, 3)
+		self.assertEqual(mock_sleep.call_count, 2)
+		sleep_calls = [call[0][0] for call in mock_sleep.call_args_list]
+		self.assertEqual(sleep_calls, [2, 4])
+
+	@patch('asyncio.sleep')
+	def test_retry_operation_raises_error_after_max_retries(self, mock_sleep):
+		# Arrange:
+		mock_operation = AsyncMock()
+		mock_operation.side_effect = NodeException('Connection refused')
+		mock_sleep.return_value = AsyncMock()
+
+		# Act & Assert:
+		with self.assertRaises(NodeException) as context:
+			asyncio.run(self.puller._retry_operation(mock_operation, 'testing'))  # pylint: disable=protected-access
+
+		self.assertEqual(str(context.exception), 'Connection refused')
+		self.assertEqual(mock_operation.call_count, 3)
+		self.assertEqual(mock_sleep.call_count, 2)
+
 	@patch('puller.facade.NemPuller.NemConnector.get_blocks_after')
-	def test_retry_get_blocks_after_succeeds_on_first_attempt(self, mock_get_blocks_after):
+	def test_retry_get_blocks_after(self, mock_get_blocks_after):
 		# Arrange:
 		mock_get_blocks_after.return_value = NEM_CONNECTOR_RESPONSE_BLOCKS
 
@@ -420,64 +501,35 @@ class NemPullerTest(unittest.TestCase):
 		self.assertEqual(result, NEM_CONNECTOR_RESPONSE_BLOCKS)
 		mock_get_blocks_after.assert_called_once_with(1)
 
-	@patch('puller.facade.NemPuller.NemConnector.get_blocks_after')
-	@patch('asyncio.sleep')
-	def _assert_retry_with_failures(self, mock_sleep, mock_get_blocks_after, side_effects, expected_sleep_calls):
+	@patch('puller.facade.NemPuller.NemConnector.account_info')
+	def test_retry_get_account_info(self, mock_account_info):
 		# Arrange:
-		mock_get_blocks_after.side_effect = side_effects
-		mock_sleep.return_value = AsyncMock()
+		mock_account_info.return_value = NEM_CONNECTOR_RESPONSE_ACCOUNT_INFO
+		address = str(NEM_CONNECTOR_RESPONSE_ACCOUNT_INFO.address)
 
 		# Act:
-		result = asyncio.run(self.puller._retry_get_blocks_after(1))  # pylint: disable=protected-access
+		result = asyncio.run(self.puller._retry_get_account_info(address))  # pylint: disable=protected-access
 
 		# Assert:
-		self.assertEqual(result, NEM_CONNECTOR_RESPONSE_BLOCKS)
-		self.assertEqual(mock_get_blocks_after.call_count, len(side_effects))  # Call count = number of attempts
-		self.assertEqual(mock_sleep.call_count, len(expected_sleep_calls))
-		sleep_calls = [call[0][0] for call in mock_sleep.call_args_list]
-		self.assertEqual(sleep_calls, expected_sleep_calls)
+		self.assertEqual(result, NEM_CONNECTOR_RESPONSE_ACCOUNT_INFO)
+		mock_account_info.assert_called_once_with(address, False)
 
-	def test_retry_get_blocks_after_succeeds_on_second_attempt(self):
+	@patch('puller.facade.NemPuller.NemConnector.account_mosaics')
+	def test_retry_get_account_mosaics(self, mock_account_mosaics):
 		# Arrange:
-		side_effects = [
-			NodeException('Connection timeout'),
-			NEM_CONNECTOR_RESPONSE_BLOCKS
+		mosaics = [
+			AccountMosaic(('nem', 'xem'), 8000000),
+			AccountMosaic(('foo', 'bar'), 500)
 		]
+		mock_account_mosaics.return_value = mosaics
+		address = str(NEM_CONNECTOR_RESPONSE_ACCOUNT_INFO.address)
 
-		# pylint: disable=no-value-for-parameter
-		self._assert_retry_with_failures(
-			side_effects=side_effects,
-			expected_sleep_calls=[2]
-		)
+		# Act:
+		result = asyncio.run(self.puller._retry_get_account_mosaics(address))  # pylint: disable=protected-access
 
-	def test_retry_get_blocks_after_succeeds_on_last_attempt(self):
-		# Arrange:
-		side_effects = [
-			NodeException('Connection timeout'),
-			NodeException('Connection timeout'),
-			NEM_CONNECTOR_RESPONSE_BLOCKS
-		]
-
-		# pylint: disable=no-value-for-parameter
-		self._assert_retry_with_failures(
-			side_effects=side_effects,
-			expected_sleep_calls=[2, 4]
-		)
-
-	@patch('puller.facade.NemPuller.NemConnector.get_blocks_after')
-	@patch('asyncio.sleep')
-	def test_retry_get_blocks_after_raises_error_after_max_retries(self, mock_sleep, mock_get_blocks_after):
-		# Arrange: Always fail
-		mock_get_blocks_after.side_effect = NodeException('Connection refused')
-		mock_sleep.return_value = AsyncMock()
-
-		# Act & Assert:
-		with self.assertRaises(NodeException) as context:
-			asyncio.run(self.puller._retry_get_blocks_after(1))  # pylint: disable=protected-access
-
-		self.assertEqual(str(context.exception), 'Connection refused')
-		self.assertEqual(mock_get_blocks_after.call_count, 3)
-		self.assertEqual(mock_sleep.call_count, 2)
+		# Assert:
+		self.assertEqual(result, mosaics)
+		mock_account_mosaics.assert_called_once_with(address)
 
 	def test_can_extract_addresses_from_block_with_only_signer(self):
 		# Arrange:

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -420,7 +420,8 @@ class NemPullerTest(unittest.TestCase):
 
 	@patch('puller.facade.NemPuller.NemConnector.get_blocks_after')
 	@patch('puller.facade.NemPuller.NemPuller._commit_blocks')
-	def test_db_writer_can_commits_in_batches(self, mock_commit_blocks, mock_get_blocks_after):
+	@patch('puller.facade.NemPuller.NemPuller._process_account_batch')
+	def test_db_writer_can_commits_in_batches(self, mock_process_account_batch, mock_commit_blocks, mock_get_blocks_after):
 		# Arrange:
 		# Create 5 blocks to test batch commit (batch_size=2 means 2 commits + 1 final)
 		test_blocks = []
@@ -441,6 +442,7 @@ class NemPullerTest(unittest.TestCase):
 			)
 
 		mock_get_blocks_after.return_value = test_blocks
+		mock_process_account_batch.return_value = AsyncMock()
 
 		with self.puller.nem_db as databases:
 			databases.create_tables()

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -23,7 +23,7 @@ from symbollightapi.model.Transaction import (
 	TransferTransaction
 )
 
-from puller.facade.NemPuller import DatabaseConfig, NemPuller, AccountRecord
+from puller.facade.NemPuller import AccountRecord, DatabaseConfig, NemPuller
 
 # region test data
 
@@ -277,10 +277,38 @@ class NemPullerTest(unittest.TestCase):
 
 		return results
 
+	def _query_fetch_accounts(self, facade, where_clause='', params=None):  # pylint: disable=no-self-use
+		cursor = facade.nem_db.connection.cursor()
+
+		query = (
+			'SELECT encode(address, \'hex\') '
+			'FROM accounts'
+		)
+
+		if where_clause:
+			query += f' {where_clause}'
+
+		cursor.execute(query, params or ())
+		results = cursor.fetchall()
+
+		return results
+
 	@patch('puller.facade.NemPuller.NemConnector.get_block')
-	def test_can_sync_nemesis_block(self, mock_get_block):
+	@patch('puller.facade.NemPuller.NemConnector.account_info')
+	@patch('puller.facade.NemPuller.NemConnector.account_mosaics')
+	def test_can_sync_nemesis_block(self, mock_account_mosaics, mock_account_info, mock_get_block):
 		# Arrange:
+		sender_address = Address('TALICE6XEEEOBFJVY3ZCENZ7WBG6LB4KB7P7KMQX')
+		recipient_address = Address('NCOPERAWEWCD4A34NP5UQCCKEX44MW4SL3QYJYS5')
+		signer_address = Address('TBEM6SFOHU5PORIGAVG3NNJIMCG73R2TWH35O2VF')
+
 		mock_get_block.return_value = NEM_CONNECTOR_RESPONSE_BLOCKS[0]
+		mock_account_info.side_effect = [
+			NemAccountInfo(sender_address),
+			NemAccountInfo(recipient_address),
+			NemAccountInfo(signer_address)
+		]
+		mock_account_mosaics.return_value = [AccountMosaic(('nem', 'xem'), 0), ]
 
 		with self.puller.nem_db as databases:
 			databases.create_tables()
@@ -288,8 +316,8 @@ class NemPullerTest(unittest.TestCase):
 			asyncio.run(self.puller.sync_nemesis_block())
 
 			# Assert:
-			results = self._query_fetch_blocks(self.puller, 'WHERE height = %s', (1, ))
-			self.assertEqual(results[0], (
+			block_results = self._query_fetch_blocks(self.puller, 'WHERE height = %s', (1, ))
+			self.assertEqual(block_results[0], (
 				1,
 				datetime.datetime(2015, 3, 29, 22, 2, 41),
 				9000000,
@@ -304,6 +332,12 @@ class NemPullerTest(unittest.TestCase):
 				),
 				345
 			))
+
+			account_results = self._query_fetch_accounts(self.puller)
+			self.assertCountEqual(
+				[sender_address.bytes.hex(), recipient_address.bytes.hex(), signer_address.bytes.hex()],
+				[row[0] for row in account_results],
+			)
 
 	@patch('puller.facade.NemPuller.NemConnector.get_blocks_after')
 	def test_can_sync_blocks(self, mock_get_blocks_after):


### PR DESCRIPTION
Problems: Explorer puller missing process accounts from blocks.
Solution: 
- Added database account tables and upsert account.
- Implemented account info and mosaic query.
- Extract the address from transactions and block signer.
- Query account information and owned mosaics.
