### PR TITLE
[explorer/puller] feat: Added beneficiary field in block sync

### DIFF
--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -26,10 +26,11 @@ class NemDatabase(DatabaseConnection):
 				id serial PRIMARY KEY,
 				height bigint NOT NULL UNIQUE,
 				timestamp timestamp NOT NULL,
-				total_fees bigint DEFAULT 0,
+				total_fee bigint DEFAULT 0,
 				total_transactions int DEFAULT 0,
 				difficulty bigint NOT NULL,
 				hash bytea NOT NULL,
+				beneficiary bytea NOT NULL,
 				signer bytea NOT NULL,
 				signature bytea NOT NULL,
 				size bigint DEFAULT 0
@@ -46,16 +47,17 @@ class NemDatabase(DatabaseConnection):
 
 		cursor.execute(
 			'''
-			INSERT INTO blocks (height, timestamp, total_fees, total_transactions, difficulty, hash, signer, signature, size)
-			VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+			INSERT INTO blocks (height, timestamp, total_fee, total_transactions, difficulty, hash, beneficiary, signer, signature, size)
+			VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 			''', (
 				block.height,
 				block.timestamp,
-				block.total_fees,
+				block.total_fee,
 				block.total_transactions,
 				block.difficulty,
 				unhexlify(block.block_hash),
-				unhexlify(block.signer),
+				block.beneficiary.bytes,
+				block.signer.bytes,
 				unhexlify(block.signature),
 				block.size
 			)

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -15,10 +15,11 @@ from puller.db.NemDatabase import NemDatabase
 BlockRecord = namedtuple('BlockRecord', [
 	'height',
 	'timestamp',
-	'total_fees',
+	'total_fee',
 	'total_transactions',
 	'difficulty',
 	'block_hash',
+	'beneficiary',
 	'signer',
 	'signature',
 	'size'
@@ -59,15 +60,15 @@ class NemPuller:
 		"""Process block data."""
 
 		timestamp = self._convert_timestamp_to_datetime(block_data.timestamp)
-		total_fees = sum(transaction.fee for transaction in block_data.transactions)
 
 		block = BlockRecord(
 			block_data.height,
 			timestamp,
-			total_fees,
+			block_data.total_fee,
 			len(block_data.transactions),
 			block_data.difficulty,
 			block_data.block_hash,
+			block_data.beneficiary,
 			block_data.signer,
 			block_data.signature,
 			block_data.size

--- a/explorer/puller/requirements.txt
+++ b/explorer/puller/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp==3.13.3
 psycopg2-binary==2.9.6
-symbol-lightapi~=0.0.8
+symbol-lightapi~=0.0.9
 symbol-sdk-python==3.0.7
 zenlog==1.1

--- a/explorer/puller/tests/db/test_NemDatabase.py
+++ b/explorer/puller/tests/db/test_NemDatabase.py
@@ -3,6 +3,8 @@ import unittest
 
 import psycopg2
 import testing.postgresql
+from symbolchain.CryptoTypes import PublicKey
+from symbolchain.nem.Network import Address
 from test_DatabaseConnection import DatabaseConfig
 
 from puller.db.NemDatabase import NemDatabase
@@ -18,7 +20,8 @@ BLOCKS = [
 		5,
 		100000000000000,
 		'438cf6375dab5a0d32f9b7bf151d4539e00a590f7c022d5572c7d41815a24be4',
-		'8d07f90fb4bbe7715fa327c926770166a11be2e494a970605f2e12557f66c9b9',
+		Address('TBZWVEKB2XMTO4F3RAOEIBWRBMPQ5N23G56ZJM4I'),
+		PublicKey('8d07f90fb4bbe7715fa327c926770166a11be2e494a970605f2e12557f66c9b9'),
 		'2abdd19ad3efab0413b42772a586faa19dedb16d35f665f90d598046a2132c4a'
 		'd1e71001545ceaa44e63c04345591e7aadbfd330af82a0d8a1da5643e791ff0f',
 		100),
@@ -29,7 +32,8 @@ BLOCKS = [
 		3,
 		80000000000000,
 		'1dd9d4d7b6af603d29c082f9aa4e123f07d18154ddbcd7ddc6702491b854c5e4',
-		'f9bd190dd0c364261f5c8a74870cc7f7374e631352293c62ecc437657e5de2cd',
+		Address('TCJLCZSOQ6RGWHTPSV2DW467WZSHK4NBSITND4OF'),
+		PublicKey('f9bd190dd0c364261f5c8a74870cc7f7374e631352293c62ecc437657e5de2cd'),
 		'1b81379847241e45da86b27911e5c9a9192ec04f644d98019657d32838b49c14'
 		'3eaa4815a3028b80f9affdbf0b94cd620f7a925e02783dda67b8627b69ddf70e',
 		200),
@@ -85,10 +89,11 @@ class NemDatabaseTest(unittest.TestCase):
 				SELECT
 					height,
 					timestamp,
-					total_fees,
+					total_fee,
 					total_transactions,
 					difficulty,
 					encode(hash, 'hex'),
+					encode(beneficiary, 'hex'),
 					encode(signer, 'hex'),
 					encode(signature, 'hex'),
 					size
@@ -108,7 +113,8 @@ class NemDatabaseTest(unittest.TestCase):
 			5,
 			100000000000000,
 			BLOCKS[0].block_hash,
-			BLOCKS[0].signer,
+			Address(BLOCKS[0].beneficiary).bytes.hex(),
+			PublicKey(BLOCKS[0].signer).bytes.hex(),
 			BLOCKS[0].signature,
 			BLOCKS[0].size
 		)

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -5,6 +5,8 @@ import unittest
 from unittest.mock import AsyncMock, patch
 
 import testing.postgresql
+from symbolchain.CryptoTypes import PublicKey
+from symbolchain.nem.Network import Address
 from symbollightapi.model.Block import Block
 from symbollightapi.model.Exceptions import NodeException
 from symbollightapi.model.Transaction import TransferTransaction
@@ -35,7 +37,9 @@ NEM_CONNECTOR_RESPONSE_BLOCKS = [
 		],
 		100,
 		'1dd9d4d7b6af603d29c082f9aa4e123f07d18154ddbcd7ddc6702491b854c5e4',
-		'f9bd190dd0c364261f5c8a74870cc7f7374e631352293c62ecc437657e5de2cd',
+		9000000,
+		Address('TBZWVEKB2XMTO4F3RAOEIBWRBMPQ5N23G56ZJM4I'),
+		PublicKey('f9bd190dd0c364261f5c8a74870cc7f7374e631352293c62ecc437657e5de2cd'),
 		(
 			'fdf6a9830e9320af79123f467fcb03d6beab735575ff50eab363d812c5581436'
 			'2ad7be0503db2ee70e60ac3408d83cdbcbd941067a6df703e0c21c7bf389f105'
@@ -48,7 +52,9 @@ NEM_CONNECTOR_RESPONSE_BLOCKS = [
 		[],
 		200,
 		'9708256e8a8dfb76eed41dcfa2e47f4af520b7b3286afb7f60dca02851f8a53e',
-		'45c1553fb1be7f25b6f79278b9ede1129bb9163f3b85883ea90f1c66f497e68b',
+		0,
+		Address('TCJLCZSOQ6RGWHTPSV2DW467WZSHK4NBSITND4OF'),
+		PublicKey('45c1553fb1be7f25b6f79278b9ede1129bb9163f3b85883ea90f1c66f497e68b'),
 		(
 			'919ae66a34119b49812b335827b357f86884ab08b628029fd6e8db3572faeb4f'
 			'323a7bf9488c76ef8faa5b513036bbcce2d949ba3e41086d95a54c0007403c0b'
@@ -109,8 +115,8 @@ class NemPullerTest(unittest.TestCase):
 
 		query = (
 			'SELECT height, timestamp, '
-			'total_fees, total_transactions, difficulty, '
-			'encode(hash, \'hex\'), encode(signer, \'hex\'), encode(signature, \'hex\'), size '
+			'total_fee, total_transactions, difficulty, '
+			'encode(hash, \'hex\'), encode(beneficiary, \'hex\'), encode(signer, \'hex\'), encode(signature, \'hex\'), size '
 			'FROM blocks'
 		)
 
@@ -141,6 +147,7 @@ class NemPullerTest(unittest.TestCase):
 				1,
 				100,
 				'1dd9d4d7b6af603d29c082f9aa4e123f07d18154ddbcd7ddc6702491b854c5e4',
+				'98736a9141d5d93770bb881c4406d10b1f0eb75b377d94b388',
 				'f9bd190dd0c364261f5c8a74870cc7f7374e631352293c62ecc437657e5de2cd',
 				(
 					'fdf6a9830e9320af79123f467fcb03d6beab735575ff50eab363d812c5581436'
@@ -169,6 +176,7 @@ class NemPullerTest(unittest.TestCase):
 				1,
 				100,
 				'1dd9d4d7b6af603d29c082f9aa4e123f07d18154ddbcd7ddc6702491b854c5e4',
+				'98736a9141d5d93770bb881c4406d10b1f0eb75b377d94b388',
 				'f9bd190dd0c364261f5c8a74870cc7f7374e631352293c62ecc437657e5de2cd',
 				(
 					'fdf6a9830e9320af79123f467fcb03d6beab735575ff50eab363d812c5581436'
@@ -183,6 +191,7 @@ class NemPullerTest(unittest.TestCase):
 				0,
 				200,
 				'9708256e8a8dfb76eed41dcfa2e47f4af520b7b3286afb7f60dca02851f8a53e',
+				'9892b1664e87a26b1e6f95743b73dfb6647571a19226d1f1c5',
 				'45c1553fb1be7f25b6f79278b9ede1129bb9163f3b85883ea90f1c66f497e68b',
 				(
 					'919ae66a34119b49812b335827b357f86884ab08b628029fd6e8db3572faeb4f'
@@ -220,8 +229,10 @@ class NemPullerTest(unittest.TestCase):
 					[],
 					100 + i,
 					'a' * 64,  # hash
-					'b' * 64,  # signer
-					'c' * 128,  # signature
+					1000000,  # total_fee
+					Address('T' + 'A' * 39),  # beneficiary
+					PublicKey('A' * 64),  # signer
+					'd' * 128,  # signature
 					200
 				)
 			)


### PR DESCRIPTION
Problem: We added `total fee` and `beneficiary` in symbolLightAPI, update in puller is needed.
Solution: Added beneficiary field in DB and puller logic, updated unit test, also bumped symbolLightAPI to 0.0.9 