### PR TITLE
[explorer/rest] feat: Added accounts endpoint 

### DIFF
--- a/explorer/rest/rest/__init__.py
+++ b/explorer/rest/rest/__init__.py
@@ -10,6 +10,8 @@ from zenlog import log
 from rest.facade.NemRestFacade import NemRestFacade
 
 DatabaseConfig = namedtuple('DatabaseConfig', ['database', 'user', 'password', 'host', 'port'])
+Pagination = namedtuple('Pagination', ['limit', 'offset'])
+Sorting = namedtuple('Sorting', ['field', 'order'])
 
 
 def create_app():
@@ -47,7 +49,7 @@ def setup_nem_facade(app):
 	return NemRestFacade(db_params, network_name)
 
 
-def setup_nem_routes(app, nem_api_facade):
+def setup_nem_routes(app, nem_api_facade):  # pylint: disable=too-many-statements
 	@app.route('/api/nem/block/<height>')
 	def api_get_nem_block_by_height(height):
 		try:
@@ -107,6 +109,35 @@ def setup_nem_routes(app, nem_api_facade):
 			abort(404)
 
 		return jsonify(result)
+
+	@app.route('/api/nem/accounts')
+	def api_get_nem_accounts():
+		try:
+			limit = int(request.args.get('limit', 10))
+			offset = int(request.args.get('offset', 0))
+			sort_field = request.args.get('sort_field', 'BALANCE').upper()
+			sort_order = request.args.get('sort_order', 'DESC').upper()
+			is_harvesting = request.args.get('is_harvesting', 'false').lower() == 'true'
+
+			if limit < 0 or offset < 0:
+				raise ValueError()
+
+			if sort_order not in ['ASC', 'DESC']:
+				raise ValueError()
+
+			if sort_field not in ['BALANCE']:
+				raise ValueError()
+
+		except ValueError:
+			abort(400)
+
+		results = nem_api_facade.get_accounts(
+			pagination=Pagination(limit, offset),
+			sorting=Sorting(sort_field, sort_order),
+			is_harvesting=is_harvesting
+		)
+
+		return jsonify(results)
 
 
 def setup_error_handlers(app):

--- a/explorer/rest/rest/__init__.py
+++ b/explorer/rest/rest/__init__.py
@@ -80,7 +80,13 @@ def setup_nem_routes(app, nem_api_facade):  # pylint: disable=too-many-statement
 		except ValueError:
 			abort(400)
 
-		return jsonify(nem_api_facade.get_blocks(limit=limit, offset=offset, min_height=min_height, sort=sort))
+		result = nem_api_facade.get_blocks(
+			pagination=Pagination(limit, offset),
+			min_height=min_height,
+			sort=sort
+		)
+
+		return jsonify(result)
 
 	@app.route('/api/nem/account')
 	def api_get_nem_account():

--- a/explorer/rest/rest/__init__.py
+++ b/explorer/rest/rest/__init__.py
@@ -55,10 +55,10 @@ def setup_nem_routes(app, nem_api_facade):  # pylint: disable=too-many-statement
 		try:
 			height = int(height)
 			if height < 1:
-				raise ValueError()
+				raise ValueError('Height must be greater than or equal to 1')
 
-		except ValueError:
-			abort(400)
+		except ValueError as error:
+			abort(400, error)
 
 		result = nem_api_facade.get_block(height)
 		if not result:
@@ -74,11 +74,15 @@ def setup_nem_routes(app, nem_api_facade):  # pylint: disable=too-many-statement
 			min_height = int(request.args.get('min_height', 1))
 			sort = request.args.get('sort', 'DESC')
 
-			if limit < 0 or offset < 0 or min_height < 1 or sort.upper() not in ['ASC', 'DESC']:
-				raise ValueError()
+			if limit < 0 or offset < 0:
+				raise ValueError('Limit and offset must be greater than or equal to 0')
+			if min_height < 1:
+				raise ValueError('Minimum height must be greater than or equal to 1')
+			if sort.upper() not in ['ASC', 'DESC']:
+				raise ValueError('Sort must be either ASC or DESC')
 
-		except ValueError:
-			abort(400)
+		except ValueError as error:
+			abort(400, error)
 
 		result = nem_api_facade.get_blocks(
 			pagination=Pagination(limit, offset),
@@ -95,16 +99,16 @@ def setup_nem_routes(app, nem_api_facade):  # pylint: disable=too-many-statement
 
 		# Validate that exactly one of address or public_key is provided
 		if bool(address) == bool(public_key):
-			abort(400)
+			abort(400, 'Exactly one of address or publicKey must be provided')
 
 		if address and not nem_api_facade.nem_db.network.is_valid_address_string(address):
-			abort(400)
+			abort(400, 'Invalid address format')
 
 		if public_key:
 			try:
 				PublicKey(public_key)
 			except ValueError:
-				abort(400)
+				abort(400, 'Invalid public key format')
 
 		if address:
 			result = nem_api_facade.get_account_by_address(address)
@@ -126,16 +130,14 @@ def setup_nem_routes(app, nem_api_facade):  # pylint: disable=too-many-statement
 			is_harvesting = request.args.get('is_harvesting', 'false').lower() == 'true'
 
 			if limit < 0 or offset < 0:
-				raise ValueError()
-
+				raise ValueError('Limit and offset must be greater than or equal to 0')
 			if sort_order not in ['ASC', 'DESC']:
-				raise ValueError()
-
+				raise ValueError('Sort order must be either ASC or DESC')
 			if sort_field not in ['BALANCE']:
-				raise ValueError()
+				raise ValueError('Sort field must be BALANCE')
 
-		except ValueError:
-			abort(400)
+		except ValueError as error:
+			abort(400, error)
 
 		results = nem_api_facade.get_accounts(
 			pagination=Pagination(limit, offset),
@@ -156,9 +158,9 @@ def setup_error_handlers(app):
 		return jsonify(response), 404
 
 	@app.errorhandler(400)
-	def bad_request(_):
+	def bad_request(error):
 		response = {
 			'status': 400,
-			'message': 'Bad request'
+			'message': str(error.description) if error.description else 'Bad request'
 		}
 		return jsonify(response), 400

--- a/explorer/rest/rest/db/NemDatabase.py
+++ b/explorer/rest/rest/db/NemDatabase.py
@@ -163,16 +163,11 @@ class NemDatabase(DatabaseConnectionPool):
 	def get_accounts(self, pagination, sorting, is_harvesting):
 		"""Gets accounts pagination in database."""
 
-		params = []
-
-		where_condition = ''
-		if is_harvesting:
-			where_condition = " WHERE remote_status = 'ACTIVE' "
-
+		where_condition = " WHERE remote_status = 'ACTIVE' " if is_harvesting else ''
 		order_condition = f' ORDER BY {sorting.field} {sorting.order} '
 		limit_condition = ' LIMIT %s OFFSET %s'
 
-		params.extend([pagination.limit, pagination.offset])
+		params = [pagination.limit, pagination.offset]
 
 		sql = self._generate_account_query(limit_condition=limit_condition, order_condition=order_condition, where_condition=where_condition)
 

--- a/explorer/rest/rest/db/NemDatabase.py
+++ b/explorer/rest/rest/db/NemDatabase.py
@@ -78,7 +78,7 @@ class NemDatabase(DatabaseConnectionPool):
 			cosignatories=[str(Address(address)) for address in cosignatories] if cosignatories else None
 		)
 
-	def _generate_account_query(self, where_condition):  # pylint: disable=no-self-use
+	def _generate_account_query(self, where_condition, order_condition='', limit_condition=''):  # pylint: disable=no-self-use
 		"""Base account query."""
 
 		return f'''
@@ -99,13 +99,15 @@ class NemDatabase(DatabaseConnectionPool):
 				cosignatory_of,
 				cosignatories
 			FROM accounts
-			WHERE {where_condition}
+			{where_condition}
+			{order_condition}
+			{limit_condition}
 		'''
 
-	def _get_account(self, where_clause, query_bytes):
+	def _get_account(self, where_condition, query_bytes):
 		"""Gets account by where clause."""
 
-		sql = self._generate_account_query(where_clause)
+		sql = self._generate_account_query(where_condition=where_condition)
 
 		with self.connection() as connection:
 			cursor = connection.cursor()
@@ -147,13 +149,36 @@ class NemDatabase(DatabaseConnectionPool):
 	def get_account_by_address(self, address):
 		"""Gets account by address."""
 
-		where_clause = 'address = %s'
+		where_condition = 'WHERE address = %s'
 
-		return self._get_account(where_clause, address.bytes)
+		return self._get_account(where_condition, address.bytes)
 
 	def get_account_by_public_key(self, public_key):
 		"""Gets account by public key."""
 
-		where_clause = 'public_key = %s'
+		where_condition = 'WHERE public_key = %s'
 
-		return self._get_account(where_clause, public_key.bytes)
+		return self._get_account(where_condition, public_key.bytes)
+
+	def get_accounts(self, pagination, sorting, is_harvesting):
+		"""Gets accounts pagination in database."""
+
+		params = []
+
+		where_condition = ''
+		if is_harvesting:
+			where_condition = " WHERE remote_status = 'ACTIVE' "
+
+		order_condition = f' ORDER BY {sorting.field} {sorting.order} '
+		limit_condition = ' LIMIT %s OFFSET %s'
+
+		params.extend([pagination.limit, pagination.offset])
+
+		sql = self._generate_account_query(limit_condition=limit_condition, order_condition=order_condition, where_condition=where_condition)
+
+		with self.connection() as connection:
+			cursor = connection.cursor()
+			cursor.execute(sql, params)
+			results = cursor.fetchall()
+
+			return [self._create_account_view(result) for result in results]

--- a/explorer/rest/rest/db/NemDatabase.py
+++ b/explorer/rest/rest/db/NemDatabase.py
@@ -130,7 +130,7 @@ class NemDatabase(DatabaseConnectionPool):
 
 			return self._create_block_view(result) if result else None
 
-	def get_blocks(self, limit, offset, min_height, sort):
+	def get_blocks(self, pagination, min_height, sort):
 		"""Gets blocks pagination in database."""
 
 		with self.connection() as connection:
@@ -141,7 +141,7 @@ class NemDatabase(DatabaseConnectionPool):
 				WHERE height >= %s
 				ORDER BY id {sort}
 				LIMIT %s OFFSET %s
-			''', (min_height, limit, offset,))
+			''', (min_height, pagination.limit, pagination.offset,))
 			results = cursor.fetchall()
 
 			return [self._create_block_view(result) for result in results]

--- a/explorer/rest/rest/facade/NemRestFacade.py
+++ b/explorer/rest/rest/facade/NemRestFacade.py
@@ -41,3 +41,10 @@ class NemRestFacade:
 		account = self.nem_db.get_account_by_public_key(PublicKey(public_key))
 
 		return account.to_dict() if account else None
+
+	def get_accounts(self, pagination, sorting, is_harvesting):
+		"""Gets accounts pagination."""
+
+		accounts = self.nem_db.get_accounts(pagination, sorting, is_harvesting)
+
+		return [account.to_dict() for account in accounts]

--- a/explorer/rest/rest/facade/NemRestFacade.py
+++ b/explorer/rest/rest/facade/NemRestFacade.py
@@ -21,10 +21,10 @@ class NemRestFacade:
 
 		return block.to_dict() if block else None
 
-	def get_blocks(self, limit, offset, min_height, sort):
+	def get_blocks(self, pagination, min_height, sort):
 		"""Gets blocks pagination."""
 
-		blocks = self.nem_db.get_blocks(limit, offset, min_height, sort)
+		blocks = self.nem_db.get_blocks(pagination, min_height, sort)
 
 		return [block.to_dict() for block in blocks]
 

--- a/explorer/rest/tests/db/test_NemDatabase.py
+++ b/explorer/rest/tests/db/test_NemDatabase.py
@@ -22,24 +22,22 @@ EXPECTED_ACCOUNT_VIEW_2 = ACCOUNT_VIEWS[1]
 
 class NemDatabaseTest(DatabaseTestBase):
 
+	def setUp(self):
+		super().setUp()
+		self.nem_db = NemDatabase(self.db_config, self.network)
+
 	# region block
 
 	def _assert_can_query_block_by_height(self, height, expected_block):
-		# Arrange:
-		nem_db = NemDatabase(self.db_config, self.network)
-
 		# Act:
-		block_view = nem_db.get_block(height)
+		block_view = self.nem_db.get_block(height)
 
 		# Assert:
 		self.assertEqual(expected_block, block_view)
 
 	def _assert_can_query_blocks_with_filter(self, query_params, expected_blocks):
-		# Arrange:
-		nem_db = NemDatabase(self.db_config, self.network)
-
 		# Act:
-		blocks_view = nem_db.get_blocks(query_params.limit, query_params.offset, query_params.min_height, query_params.sort)
+		blocks_view = self.nem_db.get_blocks(query_params.limit, query_params.offset, query_params.min_height, query_params.sort)
 
 		# Assert:
 		self.assertEqual(expected_blocks, blocks_view)
@@ -79,22 +77,14 @@ class NemDatabaseTest(DatabaseTestBase):
 	# region account
 
 	def test_can_query_account_by_address(self):
-		# Arrange:
-		nem_db = NemDatabase(self.db_config, self.network)
-
 		# Act:
-		account_view = nem_db.get_account_by_address(address=ACCOUNTS[0].address)
-
+		account_view = self.nem_db.get_account_by_address(address=ACCOUNTS[0].address)
 		# Assert:
 		self.assertEqual(EXPECTED_ACCOUNT_VIEW_1, account_view)
 
 	def test_can_query_account_by_public_key(self):
-		# Arrange:
-		nem_db = NemDatabase(self.db_config, self.network)
-
 		# Act:
-		account_view = nem_db.get_account_by_public_key(public_key=ACCOUNTS[0].public_key)
-
+		account_view = self.nem_db.get_account_by_public_key(public_key=ACCOUNTS[0].public_key)
 		# Assert:
 		self.assertEqual(EXPECTED_ACCOUNT_VIEW_1, account_view)
 
@@ -102,12 +92,8 @@ class NemDatabaseTest(DatabaseTestBase):
 
 	# region accounts
 	def _assert_can_query_accounts(self, pagination, sorting, expected_accounts, is_harvesting=False):
-		# Arrange:
-		nem_db = NemDatabase(self.db_config, self.network)
-
 		# Act:
-		accounts_view = nem_db.get_accounts(pagination, sorting, is_harvesting)
-
+		accounts_view = self.nem_db.get_accounts(pagination, sorting, is_harvesting)
 		# Assert:
 		self.assertEqual(expected_accounts, accounts_view)
 

--- a/explorer/rest/tests/db/test_NemDatabase.py
+++ b/explorer/rest/tests/db/test_NemDatabase.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 
+from rest import Pagination, Sorting
 from rest.db.NemDatabase import NemDatabase
 
 from ..test.DatabaseTestUtils import ACCOUNT_VIEWS, ACCOUNTS, BLOCK_VIEWS, DatabaseTestBase
@@ -13,6 +14,8 @@ EXPECTED_BLOCK_VIEW_1 = BLOCK_VIEWS[0]
 EXPECTED_BLOCK_VIEW_2 = BLOCK_VIEWS[1]
 
 EXPECTED_ACCOUNT_VIEW_1 = ACCOUNT_VIEWS[0]
+
+EXPECTED_ACCOUNT_VIEW_2 = ACCOUNT_VIEWS[1]
 
 # endregion
 
@@ -94,5 +97,33 @@ class NemDatabaseTest(DatabaseTestBase):
 
 		# Assert:
 		self.assertEqual(EXPECTED_ACCOUNT_VIEW_1, account_view)
+
+	# endregion
+
+	# region accounts
+	def _assert_can_query_accounts(self, pagination, sorting, expected_accounts, is_harvesting=False):
+		# Arrange:
+		nem_db = NemDatabase(self.db_config, self.network)
+
+		# Act:
+		accounts_view = nem_db.get_accounts(pagination, sorting, is_harvesting)
+
+		# Assert:
+		self.assertEqual(expected_accounts, accounts_view)
+
+	def test_can_query_accounts_filtered_limit(self):
+		self._assert_can_query_accounts(Pagination(1, 0), Sorting('BALANCE', 'desc'), [EXPECTED_ACCOUNT_VIEW_2])
+
+	def test_can_query_accounts_filtered_offset(self):
+		self._assert_can_query_accounts(Pagination(1, 1), Sorting('BALANCE', 'desc'), [EXPECTED_ACCOUNT_VIEW_1])
+
+	def test_can_query_accounts_filtered_is_harvesting(self):
+		self._assert_can_query_accounts(Pagination(10, 0), Sorting('BALANCE', 'desc'), [EXPECTED_ACCOUNT_VIEW_2], is_harvesting=True)
+
+	def test_can_query_accounts_sorted_by_balance_asc(self):
+		self._assert_can_query_accounts(Pagination(10, 0), Sorting('BALANCE', 'asc'), [EXPECTED_ACCOUNT_VIEW_1, EXPECTED_ACCOUNT_VIEW_2])
+
+	def test_can_query_accounts_sorted_by_balance_desc(self):
+		self._assert_can_query_accounts(Pagination(10, 0), Sorting('BALANCE', 'desc'), [EXPECTED_ACCOUNT_VIEW_2, EXPECTED_ACCOUNT_VIEW_1])
 
 	# endregion

--- a/explorer/rest/tests/db/test_NemDatabase.py
+++ b/explorer/rest/tests/db/test_NemDatabase.py
@@ -1,11 +1,7 @@
-from collections import namedtuple
-
 from rest import Pagination, Sorting
 from rest.db.NemDatabase import NemDatabase
 
 from ..test.DatabaseTestUtils import ACCOUNT_VIEWS, ACCOUNTS, BLOCK_VIEWS, DatabaseTestBase
-
-BlockQueryParams = namedtuple('BlockQueryParams', ['limit', 'offset', 'min_height', 'sort'])
 
 # region test data
 
@@ -35,9 +31,9 @@ class NemDatabaseTest(DatabaseTestBase):
 		# Assert:
 		self.assertEqual(expected_block, block_view)
 
-	def _assert_can_query_blocks_with_filter(self, query_params, expected_blocks):
+	def _assert_can_query_blocks_with_filter(self, pagination, min_height, sort, expected_blocks):
 		# Act:
-		blocks_view = self.nem_db.get_blocks(query_params.limit, query_params.offset, query_params.min_height, query_params.sort)
+		blocks_view = self.nem_db.get_blocks(pagination, min_height, sort)
 
 		# Assert:
 		self.assertEqual(expected_blocks, blocks_view)
@@ -49,28 +45,28 @@ class NemDatabaseTest(DatabaseTestBase):
 		self._assert_can_query_block_by_height(3, None)
 
 	def test_can_query_blocks_filtered_limit(self):
-		self._assert_can_query_blocks_with_filter(BlockQueryParams(1, 0, 1, 'desc'), [EXPECTED_BLOCK_VIEW_2])
+		self._assert_can_query_blocks_with_filter(Pagination(1, 0), 1, 'desc', [EXPECTED_BLOCK_VIEW_2])
 
 	def test_can_query_blocks_filtered_offset_0(self):
-		self._assert_can_query_blocks_with_filter(BlockQueryParams(1, 0, 0, 'desc'), [EXPECTED_BLOCK_VIEW_2])
+		self._assert_can_query_blocks_with_filter(Pagination(1, 0), 0, 'desc', [EXPECTED_BLOCK_VIEW_2])
 
 	def test_can_query_blocks_filtered_offset_1(self):
-		self._assert_can_query_blocks_with_filter(BlockQueryParams(1, 1, 0, 'desc'), [EXPECTED_BLOCK_VIEW_1])
+		self._assert_can_query_blocks_with_filter(Pagination(1, 1), 0, 'desc', [EXPECTED_BLOCK_VIEW_1])
 
 	def test_can_query_blocks_filtered_min_height_1(self):
-		self._assert_can_query_blocks_with_filter(BlockQueryParams(10, 0, 1, 'desc'), [EXPECTED_BLOCK_VIEW_2, EXPECTED_BLOCK_VIEW_1])
+		self._assert_can_query_blocks_with_filter(Pagination(10, 0), 1, 'desc', [EXPECTED_BLOCK_VIEW_2, EXPECTED_BLOCK_VIEW_1])
 
 	def test_can_query_blocks_filtered_min_height_2(self):
-		self._assert_can_query_blocks_with_filter(BlockQueryParams(10, 0, 2, 'desc'), [EXPECTED_BLOCK_VIEW_2])
+		self._assert_can_query_blocks_with_filter(Pagination(10, 0), 2, 'desc', [EXPECTED_BLOCK_VIEW_2])
 
 	def test_can_query_blocks_filtered_min_height_3(self):
-		self._assert_can_query_blocks_with_filter(BlockQueryParams(10, 0, 3, 'desc'), [])
+		self._assert_can_query_blocks_with_filter(Pagination(10, 0), 3, 'desc', [])
 
 	def test_can_query_blocks_sorted_by_height_asc(self):
-		self._assert_can_query_blocks_with_filter(BlockQueryParams(10, 0, 0, 'asc'), [EXPECTED_BLOCK_VIEW_1, EXPECTED_BLOCK_VIEW_2])
+		self._assert_can_query_blocks_with_filter(Pagination(10, 0), 0, 'asc', [EXPECTED_BLOCK_VIEW_1, EXPECTED_BLOCK_VIEW_2])
 
 	def test_can_query_blocks_sorted_by_height_desc(self):
-		self._assert_can_query_blocks_with_filter(BlockQueryParams(10, 0, 0, 'desc'), [EXPECTED_BLOCK_VIEW_2, EXPECTED_BLOCK_VIEW_1])
+		self._assert_can_query_blocks_with_filter(Pagination(10, 0), 0, 'desc', [EXPECTED_BLOCK_VIEW_2, EXPECTED_BLOCK_VIEW_1])
 
 	# endregion
 

--- a/explorer/rest/tests/facade/test_NemRestFacade.py
+++ b/explorer/rest/tests/facade/test_NemRestFacade.py
@@ -1,3 +1,4 @@
+from rest import Pagination, Sorting
 from rest.facade.NemRestFacade import NemRestFacade
 
 from ..db.test_NemDatabase import BlockQueryParams
@@ -10,6 +11,8 @@ EXPECTED_BLOCK_1 = BLOCK_VIEWS[0].to_dict()
 EXPECTED_BLOCK_2 = BLOCK_VIEWS[1].to_dict()
 
 EXPECTED_ACCOUNT_1 = ACCOUNT_VIEWS[0].to_dict()
+
+EXPECTED_ACCOUNT_2 = ACCOUNT_VIEWS[1].to_dict()
 
 # endregion
 
@@ -92,4 +95,46 @@ class TestNemRestFacade(DatabaseTestBase):
 		# Assert:
 		self.assertIsNone(account)
 
+	def _assert_can_retrieve_accounts(self, pagination, sorting, expected_accounts, is_harvesting=False):
+		# Act:
+		accounts = self.nem_rest_facade.get_accounts(pagination, sorting, is_harvesting)
+
+		# Assert:
+		self.assertEqual(expected_accounts, accounts)
+
+	def test_can_retrieve_accounts_filtered_by_limit(self):
+		self._assert_can_retrieve_accounts(
+			pagination=Pagination(limit=1, offset=0),
+			sorting=Sorting(field='BALANCE', order='DESC'),
+			expected_accounts=[EXPECTED_ACCOUNT_2]
+		)
+
+	def test_can_retrieve_accounts_filtered_by_offset(self):
+		self._assert_can_retrieve_accounts(
+			pagination=Pagination(limit=1, offset=1),
+			sorting=Sorting(field='BALANCE', order='DESC'),
+			expected_accounts=[EXPECTED_ACCOUNT_1]
+		)
+
+	def test_can_retrieve_accounts_sorted_by_balance_asc(self):
+		self._assert_can_retrieve_accounts(
+			pagination=Pagination(limit=10, offset=0),
+			sorting=Sorting(field='BALANCE', order='ASC'),
+			expected_accounts=[EXPECTED_ACCOUNT_1, EXPECTED_ACCOUNT_2]
+		)
+
+	def test_can_retrieve_accounts_sorted_by_balance_desc(self):
+		self._assert_can_retrieve_accounts(
+			pagination=Pagination(limit=10, offset=0),
+			sorting=Sorting(field='BALANCE', order='DESC'),
+			expected_accounts=[EXPECTED_ACCOUNT_2, EXPECTED_ACCOUNT_1]
+		)
+
+	def test_can_retrieve_harvesting_accounts(self):
+		self._assert_can_retrieve_accounts(
+			pagination=Pagination(limit=10, offset=0),
+			sorting=Sorting(field='BALANCE', order='DESC'),
+			expected_accounts=[EXPECTED_ACCOUNT_2],
+			is_harvesting=True
+		)
 	# endregion

--- a/explorer/rest/tests/facade/test_NemRestFacade.py
+++ b/explorer/rest/tests/facade/test_NemRestFacade.py
@@ -1,7 +1,6 @@
 from rest import Pagination, Sorting
 from rest.facade.NemRestFacade import NemRestFacade
 
-from ..db.test_NemDatabase import BlockQueryParams
 from ..test.DatabaseTestUtils import ACCOUNT_VIEWS, BLOCK_VIEWS, DatabaseTestBase
 
 # region test data
@@ -32,36 +31,40 @@ class TestNemRestFacade(DatabaseTestBase):
 		# Assert:
 		self.assertEqual(expected_block, block)
 
-	def _assert_can_retrieve_blocks(self, query_params, expected_blocks):
-		# Act:
-		blocks = self.nem_rest_facade.get_blocks(query_params.limit, query_params.offset, query_params.min_height, query_params.sort)
-
-		# Assert:
-		self.assertEqual(expected_blocks, blocks)
-
 	def test_retrieve_block_by_height(self):
 		self._assert_can_retrieve_block(1, EXPECTED_BLOCK_1)
 
 	def test_returns_none_for_nonexistent_block(self):
 		self._assert_can_retrieve_block(3, None)
 
+	# endregion
+
+	# region blocks
+
+	def _assert_can_retrieve_blocks(self, pagination, min_height, sort, expected_blocks):
+		# Act:
+		blocks = self.nem_rest_facade.get_blocks(pagination=pagination, min_height=min_height, sort=sort)
+
+		# Assert:
+		self.assertEqual(expected_blocks, blocks)
+
 	def test_blocks_filtered_by_limit(self):
-		self._assert_can_retrieve_blocks(BlockQueryParams(1, 0, 0, 'desc'), [EXPECTED_BLOCK_2])
+		self._assert_can_retrieve_blocks(Pagination(1, 0), 0, 'desc', [EXPECTED_BLOCK_2])
 
 	def test_blocks_filtered_by_offset(self):
-		self._assert_can_retrieve_blocks(BlockQueryParams(1, 1, 0, 'desc'), [EXPECTED_BLOCK_1])
+		self._assert_can_retrieve_blocks(Pagination(1, 1), 0, 'desc', [EXPECTED_BLOCK_1])
 
 	def test_blocks_filtered_by_min_height(self):
-		self._assert_can_retrieve_blocks(BlockQueryParams(10, 0, 2, 'desc'), [EXPECTED_BLOCK_2])
+		self._assert_can_retrieve_blocks(Pagination(10, 0), 2, 'desc', [EXPECTED_BLOCK_2])
 
 	def test_returns_empty_list_on_no_matches(self):
-		self._assert_can_retrieve_blocks(BlockQueryParams(10, 0, 3, 'desc'), [])
+		self._assert_can_retrieve_blocks(Pagination(10, 0), 3, 'desc', [])
 
 	def test_blocks_sorted_by_height_asc(self):
-		self._assert_can_retrieve_blocks(BlockQueryParams(10, 0, 0, 'asc'), [EXPECTED_BLOCK_1, EXPECTED_BLOCK_2])
+		self._assert_can_retrieve_blocks(Pagination(10, 0), 0, 'asc', [EXPECTED_BLOCK_1, EXPECTED_BLOCK_2])
 
 	def test_blocks_sorted_by_height_desc(self):
-		self._assert_can_retrieve_blocks(BlockQueryParams(10, 0, 0, 'desc'), [EXPECTED_BLOCK_2, EXPECTED_BLOCK_1])
+		self._assert_can_retrieve_blocks(Pagination(10, 0), 0, 'desc', [EXPECTED_BLOCK_2, EXPECTED_BLOCK_1])
 
 	# endregion
 
@@ -95,6 +98,10 @@ class TestNemRestFacade(DatabaseTestBase):
 		# Assert:
 		self.assertIsNone(account)
 
+	# endregion
+
+	# region accounts
+
 	def _assert_can_retrieve_accounts(self, pagination, sorting, expected_accounts, is_harvesting=False):
 		# Act:
 		accounts = self.nem_rest_facade.get_accounts(pagination, sorting, is_harvesting)
@@ -104,35 +111,35 @@ class TestNemRestFacade(DatabaseTestBase):
 
 	def test_can_retrieve_accounts_filtered_by_limit(self):
 		self._assert_can_retrieve_accounts(
-			pagination=Pagination(limit=1, offset=0),
+			pagination=Pagination(1, 0),
 			sorting=Sorting(field='BALANCE', order='DESC'),
 			expected_accounts=[EXPECTED_ACCOUNT_2]
 		)
 
 	def test_can_retrieve_accounts_filtered_by_offset(self):
 		self._assert_can_retrieve_accounts(
-			pagination=Pagination(limit=1, offset=1),
+			pagination=Pagination(1, 1),
 			sorting=Sorting(field='BALANCE', order='DESC'),
 			expected_accounts=[EXPECTED_ACCOUNT_1]
 		)
 
 	def test_can_retrieve_accounts_sorted_by_balance_asc(self):
 		self._assert_can_retrieve_accounts(
-			pagination=Pagination(limit=10, offset=0),
+			pagination=Pagination(10, 0),
 			sorting=Sorting(field='BALANCE', order='ASC'),
 			expected_accounts=[EXPECTED_ACCOUNT_1, EXPECTED_ACCOUNT_2]
 		)
 
 	def test_can_retrieve_accounts_sorted_by_balance_desc(self):
 		self._assert_can_retrieve_accounts(
-			pagination=Pagination(limit=10, offset=0),
+			pagination=Pagination(10, 0),
 			sorting=Sorting(field='BALANCE', order='DESC'),
 			expected_accounts=[EXPECTED_ACCOUNT_2, EXPECTED_ACCOUNT_1]
 		)
 
 	def test_can_retrieve_harvesting_accounts(self):
 		self._assert_can_retrieve_accounts(
-			pagination=Pagination(limit=10, offset=0),
+			pagination=Pagination(10, 0),
 			sorting=Sorting(field='BALANCE', order='DESC'),
 			expected_accounts=[EXPECTED_ACCOUNT_2],
 			is_harvesting=True

--- a/explorer/rest/tests/test/DatabaseTestUtils.py
+++ b/explorer/rest/tests/test/DatabaseTestUtils.py
@@ -83,6 +83,20 @@ ACCOUNTS = [
 		'INACTIVE',
 		None,
 		None,
+		None),
+	Account(
+		Address('NBFWZ4IVRHEIBRCGHLYDS62FSFTBM3VDFA7E6LSQ'),
+		PublicKey('a5f06d59b97aa40c82afb941a61fb6483bdb7491805cdb9dc47d92136983b9a5'),
+		None,
+		0.123456,
+		3000000,
+		99999,
+		[{'quantity': 3000000, 'namespace': 'nem.xem'}],
+		15,
+		'LOCKED',
+		'ACTIVE',
+		None,
+		None,
 		None)
 ]
 
@@ -111,6 +125,26 @@ ACCOUNT_VIEWS = [
 		min_cosignatories=ACCOUNTS[0].min_cosignatories,
 		cosignatory_of=ACCOUNTS[0].cosignatory_of,
 		cosignatories=ACCOUNTS[0].cosignatories
+	),
+	AccountView(
+		address=str(ACCOUNTS[1].address),
+		public_key=str(ACCOUNTS[1].public_key) if ACCOUNTS[1].public_key else None,
+		remote_address=None,
+		importance=0.123456,
+		balance=3.0,
+		vested_balance=0.099999,
+		mosaics=[{
+			'namespace_name': 'nem.xem',
+			'quantity': 3000000
+		}],
+		harvested_fees=0.0,
+		harvested_blocks=ACCOUNTS[1].harvested_blocks,
+		status=ACCOUNTS[1].status,
+		remote_status=ACCOUNTS[1].remote_status,
+		last_harvested_height=0,
+		min_cosignatories=ACCOUNTS[1].min_cosignatories,
+		cosignatory_of=ACCOUNTS[1].cosignatory_of,
+		cosignatories=ACCOUNTS[1].cosignatories
 	)
 ]
 

--- a/explorer/rest/tests/test_rest.py
+++ b/explorer/rest/tests/test_rest.py
@@ -256,6 +256,10 @@ def test_api_nem_account_not_found(client):  # pylint: disable=redefined-outer-n
 	} == response.json
 
 
+# endregion
+
+# region /accounts
+
 def _assert_get_api_nem_accounts(client, expected_status_code, expected_result, **query_params):  # pylint: disable=redefined-outer-name
 	# Arrange:
 	query_string = '&'.join(f'{key}={val}' for key, val in query_params.items())

--- a/explorer/rest/tests/test_rest.py
+++ b/explorer/rest/tests/test_rest.py
@@ -96,8 +96,8 @@ def test_api_nem_block_non_exist(client):  # pylint: disable=redefined-outer-nam
 
 
 def test_api_nem_block_by_invalid_height(client):  # pylint: disable=redefined-outer-name
-	_assert_get_api_nem_block_by_height(client, 'invalid', 400, {
-		'message': 'Bad request',
+	_assert_get_api_nem_block_by_height(client, 0, 400, {
+		'message': 'Height must be greater than or equal to 1',
 		'status': 400
 	})
 
@@ -120,15 +120,15 @@ def _assert_get_api_nem_blocks(client, expected_status_code, expected_result, **
 	assert expected_result == response.json
 
 
-def _assert_get_api_nem_blocks_fail(client, expected_status_code, **query_params):  # pylint: disable=redefined-outer-name
+def _assert_get_api_nem_blocks_fail(client, expected_message, **query_params):  # pylint: disable=redefined-outer-name
 	# Act:
 	response = _get_api_nem_blocks(client, **query_params)
 
 	# Assert:
-	_assert_status_code_and_headers(response, expected_status_code)
+	_assert_status_code_and_headers(response, 400)
 	assert {
-		'message': 'Bad request',
-		'status': expected_status_code
+		'message': expected_message,
+		'status': 400
 	} == response.json
 
 
@@ -166,23 +166,19 @@ def test_api_nem_blocks_with_all_params(client):  # pylint: disable=redefined-ou
 
 
 def test_api_nem_blocks_invalid_min_height(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_blocks_fail(client, 400, min_height=0)
-	_assert_get_api_nem_blocks_fail(client, 400, min_height='invalid')
+	_assert_get_api_nem_blocks_fail(client, 'Minimum height must be greater than or equal to 1', min_height=0)
 
 
 def test_api_nem_blocks_invalid_limit(client):  # pylint: disable=redefined-outer-name
-	_assert_get_api_nem_blocks_fail(client, 400, limit=-1)
-	_assert_get_api_nem_blocks_fail(client, 400, limit='invalid')
+	_assert_get_api_nem_blocks_fail(client, 'Limit and offset must be greater than or equal to 0', limit=-1)
 
 
 def test_api_nem_blocks_invalid_offset(client):  # pylint: disable=redefined-outer-name
-	_assert_get_api_nem_blocks_fail(client, 400, offset=-1)
-	_assert_get_api_nem_blocks_fail(client, 400, offset='invalid')
+	_assert_get_api_nem_blocks_fail(client, 'Limit and offset must be greater than or equal to 0', offset=-1)
 
 
 def test_api_nem_blocks_invalid_sort(client):  # pylint: disable=redefined-outer-name
-	_assert_get_api_nem_blocks_fail(client, 400, sort=-1)
-	_assert_get_api_nem_blocks_fail(client, 400, sort='invalid')
+	_assert_get_api_nem_blocks_fail(client, 'Sort must be either ASC or DESC', sort='invalid')
 
 
 # endregion
@@ -199,14 +195,14 @@ def _assert_get_nem_account_success(client, expected_result, **query_params):  #
 	assert expected_result == response.json
 
 
-def _assert_get_nem_account_bad_request(client, **query_params):  # pylint: disable=redefined-outer-name
+def _assert_get_nem_account_bad_request(client, expected_message, **query_params):  # pylint: disable=redefined-outer-name
 	# Act:
 	response = client.get('/api/nem/account', query_string=query_params)
 
 	# Assert:
 	_assert_status_code_and_headers(response, 400)
 	assert {
-		'message': 'Bad request',
+		'message': expected_message,
 		'status': 400
 	} == response.json
 
@@ -226,22 +222,23 @@ def test_api_nem_account_by_public_key(client):  # pylint: disable=redefined-out
 
 
 def test_api_nem_account_missing_params(client):  # pylint: disable=redefined-outer-name
-	_assert_get_nem_account_bad_request(client)
+	_assert_get_nem_account_bad_request(client, 'Exactly one of address or publicKey must be provided')
 
 
 def test_api_nem_account_both_params(client):  # pylint: disable=redefined-outer-name
 	_assert_get_nem_account_bad_request(
 		client,
+		'Exactly one of address or publicKey must be provided',
 		address='NCXIQA4FF5JB6AMQ53NQ3ZMRD3X3PJEWDJJJIGHT',
 		publicKey='107051C28A2C009A83AE0861CDBFF7C1CBAB387C964CC433F7D191D9C3115ED7')
 
 
 def test_api_nem_account_invalid_address(client):  # pylint: disable=redefined-outer-name
-	_assert_get_nem_account_bad_request(client, address='INVALIDADDRESS')
+	_assert_get_nem_account_bad_request(client, 'Invalid address format', address='INVALIDADDRESS')
 
 
 def test_api_nem_account_invalid_public_key(client):  # pylint: disable=redefined-outer-name,invalid-name
-	_assert_get_nem_account_bad_request(client, publicKey='INVALIDPUBLICKEY')
+	_assert_get_nem_account_bad_request(client, 'Invalid public key format', publicKey='INVALIDPUBLICKEY')
 
 
 def test_api_nem_account_not_found(client):  # pylint: disable=redefined-outer-name
@@ -260,14 +257,14 @@ def test_api_nem_account_not_found(client):  # pylint: disable=redefined-outer-n
 
 # region /accounts
 
-def _assert_get_nem_accounts_bad_request(client, **query_params):  # pylint: disable=redefined-outer-name
+def _assert_get_nem_accounts_bad_request(client, expected_message, **query_params):  # pylint: disable=redefined-outer-name
 	# Act:
 	response = client.get('/api/nem/accounts', query_string=query_params)
 
 	# Assert:
 	_assert_status_code_and_headers(response, 400)
 	assert {
-		'message': 'Bad request',
+		'message': expected_message,
 		'status': 400
 	} == response.json
 
@@ -312,18 +309,19 @@ def test_api_nem_accounts_applies_sorted_by_balance_asc(client):  # pylint: disa
 
 
 def test_api_nem_accounts_invalid_limit(client):  # pylint: disable=redefined-outer-name
-	_assert_get_nem_accounts_bad_request(client, limit=-1)
+	_assert_get_nem_accounts_bad_request(client, 'Limit and offset must be greater than or equal to 0', limit=-1)
 
 
 def test_api_nem_accounts_invalid_offset(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_nem_accounts_bad_request(client, offset=-1)
+	_assert_get_nem_accounts_bad_request(client, 'Limit and offset must be greater than or equal to 0', offset=-1)
 
 
 def test_api_nem_accounts_invalid_sort_field(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_nem_accounts_bad_request(client, sort_field='INVALID')
+	_assert_get_nem_accounts_bad_request(client, 'Sort field must be BALANCE', sort_field='INVALID')
 
 
 def test_api_nem_accounts_invalid_sort_order(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_nem_accounts_bad_request(client, sort_order='INVALID')
+	_assert_get_nem_accounts_bad_request(client, 'Sort order must be either ASC or DESC', sort_order='INVALID')
+
 
 # endregion

--- a/explorer/rest/tests/test_rest.py
+++ b/explorer/rest/tests/test_rest.py
@@ -255,4 +255,71 @@ def test_api_nem_account_not_found(client):  # pylint: disable=redefined-outer-n
 		'status': 404
 	} == response.json
 
+
+def _assert_get_api_nem_accounts(client, expected_status_code, expected_result, **query_params):  # pylint: disable=redefined-outer-name
+	# Arrange:
+	query_string = '&'.join(f'{key}={val}' for key, val in query_params.items())
+	client.get(f'/api/nem/accounts?{query_string}')
+
+	# Act:
+	response = client.get(f'/api/nem/accounts?{query_string}')
+
+	# Assert:
+	_assert_status_code_and_headers(response, expected_status_code)
+	assert expected_result == response.json
+
+
+def test_api_nem_accounts_without_params(client):  # pylint: disable=redefined-outer-name
+	_assert_get_api_nem_accounts(client, 200, [ACCOUNT_VIEWS[1].to_dict(), ACCOUNT_VIEWS[0].to_dict()])
+
+
+def test_api_nem_accounts_applies_limit(client):  # pylint: disable=redefined-outer-name
+	_assert_get_api_nem_accounts(client, 200, [ACCOUNT_VIEWS[1].to_dict()], limit=1)
+
+
+def test_api_nem_accounts_applies_offset(client):  # pylint: disable=redefined-outer-name
+	_assert_get_api_nem_accounts(client, 200, [ACCOUNT_VIEWS[0].to_dict()], offset=1)
+
+
+def test_api_nem_accounts_applies_sorted_by_balance_desc(client):  # pylint: disable=redefined-outer-name, invalid-name
+	_assert_get_api_nem_accounts(
+		client,
+		200,
+		[ACCOUNT_VIEWS[1].to_dict(), ACCOUNT_VIEWS[0].to_dict()],
+		sort_field='BALANCE',
+		sort_order='DESC'
+	)
+
+
+def test_api_nem_accounts_applies_sorted_by_balance_asc(client):  # pylint: disable=redefined-outer-name, invalid-name
+	_assert_get_api_nem_accounts(client, 200, [ACCOUNT_VIEWS[0].to_dict(), ACCOUNT_VIEWS[1].to_dict()], sort_field='BALANCE', sort_order='ASC')
+
+
+def test_api_nem_accounts_invalid_limit(client):  # pylint: disable=redefined-outer-name
+	_assert_get_api_nem_accounts(client, 400, {
+		'message': 'Bad request',
+		'status': 400
+	}, limit=-1)
+
+
+def test_api_nem_accounts_invalid_offset(client):  # pylint: disable=redefined-outer-name, invalid-name
+	_assert_get_api_nem_accounts(client, 400, {
+		'message': 'Bad request',
+		'status': 400
+	}, offset=-1)
+
+
+def test_api_nem_accounts_invalid_sort_field(client):  # pylint: disable=redefined-outer-name, invalid-name
+	_assert_get_api_nem_accounts(client, 400, {
+		'message': 'Bad request',
+		'status': 400
+	}, sort_field='INVALID')
+
+
+def test_api_nem_accounts_invalid_sort_order(client):  # pylint: disable=redefined-outer-name, invalid-name
+	_assert_get_api_nem_accounts(client, 400, {
+		'message': 'Bad request',
+		'status': 400
+	}, sort_order='INVALID')
+
 # endregion

--- a/explorer/rest/tests/test_rest.py
+++ b/explorer/rest/tests/test_rest.py
@@ -260,6 +260,18 @@ def test_api_nem_account_not_found(client):  # pylint: disable=redefined-outer-n
 
 # region /accounts
 
+def _assert_get_nem_accounts_bad_request(client, **query_params):  # pylint: disable=redefined-outer-name
+	# Act:
+	response = client.get('/api/nem/accounts', query_string=query_params)
+
+	# Assert:
+	_assert_status_code_and_headers(response, 400)
+	assert {
+		'message': 'Bad request',
+		'status': 400
+	} == response.json
+
+
 def _assert_get_api_nem_accounts(client, expected_status_code, expected_result, **query_params):  # pylint: disable=redefined-outer-name
 	# Arrange:
 	query_string = '&'.join(f'{key}={val}' for key, val in query_params.items())
@@ -300,30 +312,18 @@ def test_api_nem_accounts_applies_sorted_by_balance_asc(client):  # pylint: disa
 
 
 def test_api_nem_accounts_invalid_limit(client):  # pylint: disable=redefined-outer-name
-	_assert_get_api_nem_accounts(client, 400, {
-		'message': 'Bad request',
-		'status': 400
-	}, limit=-1)
+	_assert_get_nem_accounts_bad_request(client, limit=-1)
 
 
 def test_api_nem_accounts_invalid_offset(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_accounts(client, 400, {
-		'message': 'Bad request',
-		'status': 400
-	}, offset=-1)
+	_assert_get_nem_accounts_bad_request(client, offset=-1)
 
 
 def test_api_nem_accounts_invalid_sort_field(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_accounts(client, 400, {
-		'message': 'Bad request',
-		'status': 400
-	}, sort_field='INVALID')
+	_assert_get_nem_accounts_bad_request(client, sort_field='INVALID')
 
 
 def test_api_nem_accounts_invalid_sort_order(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_accounts(client, 400, {
-		'message': 'Bad request',
-		'status': 400
-	}, sort_order='INVALID')
+	_assert_get_nem_accounts_bad_request(client, sort_order='INVALID')
 
 # endregion


### PR DESCRIPTION
Problem: Missing account listing endpoint in the rest service.
Solution: Added a new `/accounts` endpoint that can query account listing, refactoring unit test code