### PR TITLE
[explorer/rest] feat: added nem health endpoint

### DIFF
--- a/explorer/rest/requirements.txt
+++ b/explorer/rest/requirements.txt
@@ -1,5 +1,6 @@
 aiohttp==3.13.3
-Flask==3.1.3
+Flask[async]==3.1.2
+asgiref>=3.2
 psycopg2-binary==2.9.11
 symbol-sdk-python==3.3.0
 zenlog==1.1

--- a/explorer/rest/requirements.txt
+++ b/explorer/rest/requirements.txt
@@ -6,3 +6,5 @@ symbol-sdk-python==3.3.0
 zenlog==1.1
 Path==17.1.1
 flask_cors==6.0.2
+symbol-lightapi~=0.0.9
+aiolimiter~=1.2.1

--- a/explorer/rest/rest/__init__.py
+++ b/explorer/rest/rest/__init__.py
@@ -7,7 +7,7 @@ from symbolchain.CryptoTypes import PublicKey
 from zenlog import log
 
 from rest.facade.NemRestFacade import NemRestFacade
-from rest.model.common import DatabaseConfig, Pagination, Sorting
+from rest.model.common import DatabaseConfig, Pagination, RestConfig, Sorting
 
 
 def create_app():
@@ -27,8 +27,6 @@ def setup_nem_facade(app):
 	app.config.from_envvar('EXPLORER_REST_SETTINGS')
 	config = configparser.ConfigParser()
 	db_path = Path(app.config.get('DATABASE_CONFIG_FILEPATH'))
-	network_name = app.config.get('NETWORK_NAME', 'mainnet')
-	node_url = app.config.get('NODE_URL', 'http://localhost:7890')
 
 	log.info(f'loading database config from {db_path}')
 
@@ -43,7 +41,13 @@ def setup_nem_facade(app):
 		nem_db_config['port']
 	)
 
-	return NemRestFacade(node_url, db_params, network_name)
+	rest_config = RestConfig(
+		app.config.get('NETWORK_NAME', 'mainnet'),
+		app.config.get('NODE_URL', 'http://localhost:7890'),
+		int(app.config.get('MAX_LAG_BLOCKS', 2))
+	)
+
+	return NemRestFacade(db_params, rest_config)
 
 
 def setup_nem_routes(app, nem_api_facade):  # pylint: disable=too-many-statements

--- a/explorer/rest/rest/__init__.py
+++ b/explorer/rest/rest/__init__.py
@@ -115,6 +115,8 @@ def setup_nem_routes(app, nem_api_facade):  # pylint: disable=too-many-statement
 		if not result:
 			abort(404)
 
+		return jsonify(result)
+
 	@app.route('/api/nem/health')
 	async def api_get_nem_health():
 		result = await nem_api_facade.get_health()

--- a/explorer/rest/rest/__init__.py
+++ b/explorer/rest/rest/__init__.py
@@ -118,6 +118,10 @@ def setup_nem_routes(app, nem_api_facade):  # pylint: disable=too-many-statement
 		if not result:
 			abort(404)
 
+	@app.route('/api/nem/health')
+	async def api_get_nem_health():
+		result = await nem_api_facade.get_health()
+
 		return jsonify(result)
 
 	@app.route('/api/nem/accounts')

--- a/explorer/rest/rest/__init__.py
+++ b/explorer/rest/rest/__init__.py
@@ -28,6 +28,7 @@ def setup_nem_facade(app):
 	config = configparser.ConfigParser()
 	db_path = Path(app.config.get('DATABASE_CONFIG_FILEPATH'))
 	network_name = app.config.get('NETWORK_NAME', 'mainnet')
+	node_url = app.config.get('NODE_URL', 'http://localhost:7890')
 
 	log.info(f'loading database config from {db_path}')
 
@@ -42,7 +43,7 @@ def setup_nem_facade(app):
 		nem_db_config['port']
 	)
 
-	return NemRestFacade(db_params, network_name)
+	return NemRestFacade(node_url, db_params, network_name)
 
 
 def setup_nem_routes(app, nem_api_facade):  # pylint: disable=too-many-statements

--- a/explorer/rest/rest/__init__.py
+++ b/explorer/rest/rest/__init__.py
@@ -1,5 +1,4 @@
 import configparser
-from collections import namedtuple
 from pathlib import Path
 
 from flask import Flask, abort, jsonify, request
@@ -8,10 +7,7 @@ from symbolchain.CryptoTypes import PublicKey
 from zenlog import log
 
 from rest.facade.NemRestFacade import NemRestFacade
-
-DatabaseConfig = namedtuple('DatabaseConfig', ['database', 'user', 'password', 'host', 'port'])
-Pagination = namedtuple('Pagination', ['limit', 'offset'])
-Sorting = namedtuple('Sorting', ['field', 'order'])
+from rest.model.common import DatabaseConfig, Pagination, Sorting
 
 
 def create_app():

--- a/explorer/rest/rest/facade/NemRestFacade.py
+++ b/explorer/rest/rest/facade/NemRestFacade.py
@@ -11,12 +11,13 @@ from rest.model.common import Pagination
 class NemRestFacade:
 	"""Nem Rest Facade."""
 
-	def __init__(self, node_url, db_config, network_name):
+	def __init__(self, db_config, rest_config):
 		"""Creates a facade object."""
 
-		self.network = NetworkLocator.find_by_name(Network.NETWORKS, network_name)
+		self.network = NetworkLocator.find_by_name(Network.NETWORKS, rest_config.network_name)
 		self.nem_db = NemDatabase(db_config, self.network)
-		self.nem_connector = NemConnector(node_url, self.network)
+		self.nem_connector = NemConnector(rest_config.node_url, self.network)
+		self.max_lag_blocks = rest_config.max_lag_blocks
 
 	def get_block(self, height):
 		"""Gets block by height."""
@@ -64,7 +65,6 @@ class NemRestFacade:
 
 		last_db_synced_at = latest_block.timestamp
 		last_db_height = latest_block.height
-		max_lag_blocks = 2  # Allow up to 2 blocks of lag between node height and database height
 
 		# Check node connectivity and height
 		try:
@@ -85,7 +85,7 @@ class NemRestFacade:
 
 		# Check synchronization lag
 		sync_lag_blocks = max(0, node_height - last_db_height)
-		backend_synced = sync_lag_blocks <= max_lag_blocks
+		backend_synced = sync_lag_blocks <= self.max_lag_blocks  # Allow up to configured blocks of lag between node height and database height
 		errors = []
 
 		if not backend_synced:

--- a/explorer/rest/rest/facade/NemRestFacade.py
+++ b/explorer/rest/rest/facade/NemRestFacade.py
@@ -48,3 +48,29 @@ class NemRestFacade:
 		accounts = self.nem_db.get_accounts(pagination, sorting, is_harvesting)
 
 		return [account.to_dict() for account in accounts]
+
+	async def get_health(self):
+		"""Gets health of the node."""
+
+		latest_block = self.nem_db.get_blocks(limit=1, offset=0, min_height=1, sort='DESC')[0]
+
+		last_synced_at = latest_block.timestamp
+		last_block_height = latest_block.height
+		is_healthy = True
+		errors = []
+
+		try:
+			await self.nem_connector.node_info()
+		except Exception:
+			is_healthy = False
+			errors.append({
+				"type": "synchronization",
+				"message": "Node is not responding"
+			})
+
+		return {
+				"isHealthy": is_healthy,
+				"lastSyncedAt": last_synced_at,
+				"lastBlockHeight": last_block_height,
+				"errors": errors
+			}

--- a/explorer/rest/rest/facade/NemRestFacade.py
+++ b/explorer/rest/rest/facade/NemRestFacade.py
@@ -62,23 +62,44 @@ class NemRestFacade:
 			sort='DESC'
 		)[0]
 
-		last_synced_at = latest_block.timestamp
-		last_block_height = latest_block.height
-		is_healthy = True
+		last_db_synced_at = latest_block.timestamp
+		last_db_height = latest_block.height
+		max_lag_blocks = 2  # Allow up to 2 blocks of lag between node height and database height
+
+		# Check node connectivity and height
+		try:
+			node_height = await self.nem_connector.chain_height()
+		except NodeException as error:
+			return {
+				'isHealthy': False,
+				'nodeUp': False,
+				'nodeHeight': None,
+				'backendSynced': False,
+				'lastDBSyncedAt': last_db_synced_at,
+				'lastDBHeight': last_db_height,
+				'errors': [{
+					'type': 'synchronization',
+					'message': str(error)
+				}]
+			}
+
+		# Check synchronization lag
+		sync_lag_blocks = max(0, node_height - last_db_height)
+		backend_synced = sync_lag_blocks <= max_lag_blocks
 		errors = []
 
-		try:
-			await self.nem_connector.node_info()
-		except NodeException as error:
-			is_healthy = False
+		if not backend_synced:
 			errors.append({
 				'type': 'synchronization',
-				'message': str(error)
+				'message': f'Database is {sync_lag_blocks} blocks behind node height'
 			})
 
 		return {
-			'isHealthy': is_healthy,
-			'lastSyncedAt': last_synced_at,
-			'lastBlockHeight': last_block_height,
+			'isHealthy': backend_synced,
+			'nodeUp': True,
+			'nodeHeight': node_height,
+			'backendSynced': backend_synced,
+			'lastDBSyncedAt': last_db_synced_at,
+			'lastDBHeight': last_db_height,
 			'errors': errors
 		}

--- a/explorer/rest/rest/facade/NemRestFacade.py
+++ b/explorer/rest/rest/facade/NemRestFacade.py
@@ -1,6 +1,8 @@
 from symbolchain.CryptoTypes import PublicKey
 from symbolchain.nem.Network import Address, Network
 from symbolchain.Network import NetworkLocator
+from symbollightapi.connector.NemConnector import NemConnector
+from symbollightapi.model.Exceptions import NodeException
 
 from rest.db.NemDatabase import NemDatabase
 
@@ -8,11 +10,12 @@ from rest.db.NemDatabase import NemDatabase
 class NemRestFacade:
 	"""Nem Rest Facade."""
 
-	def __init__(self, db_config, network_name):
+	def __init__(self, node_url, db_config, network_name):
 		"""Creates a facade object."""
 
 		self.network = NetworkLocator.find_by_name(Network.NETWORKS, network_name)
 		self.nem_db = NemDatabase(db_config, self.network)
+		self.nem_connector = NemConnector(node_url, self.network)
 
 	def get_block(self, height):
 		"""Gets block by height."""

--- a/explorer/rest/rest/facade/NemRestFacade.py
+++ b/explorer/rest/rest/facade/NemRestFacade.py
@@ -5,6 +5,7 @@ from symbollightapi.connector.NemConnector import NemConnector
 from symbollightapi.model.Exceptions import NodeException
 
 from rest.db.NemDatabase import NemDatabase
+from rest.model.common import Pagination
 
 
 class NemRestFacade:
@@ -55,7 +56,11 @@ class NemRestFacade:
 	async def get_health(self):
 		"""Gets health of the node."""
 
-		latest_block = self.nem_db.get_blocks(limit=1, offset=0, min_height=1, sort='DESC')[0]
+		latest_block = self.nem_db.get_blocks(
+			pagination=Pagination(1, 0),
+			min_height=1,
+			sort='DESC'
+		)[0]
 
 		last_synced_at = latest_block.timestamp
 		last_block_height = latest_block.height
@@ -64,16 +69,16 @@ class NemRestFacade:
 
 		try:
 			await self.nem_connector.node_info()
-		except Exception:
+		except NodeException as error:
 			is_healthy = False
 			errors.append({
-				"type": "synchronization",
-				"message": "Node is not responding"
+				'type': 'synchronization',
+				'message': str(error)
 			})
 
 		return {
-				"isHealthy": is_healthy,
-				"lastSyncedAt": last_synced_at,
-				"lastBlockHeight": last_block_height,
-				"errors": errors
-			}
+			'isHealthy': is_healthy,
+			'lastSyncedAt': last_synced_at,
+			'lastBlockHeight': last_block_height,
+			'errors': errors
+		}

--- a/explorer/rest/rest/model/common.py
+++ b/explorer/rest/rest/model/common.py
@@ -3,3 +3,4 @@ from collections import namedtuple
 DatabaseConfig = namedtuple('DatabaseConfig', ['database', 'user', 'password', 'host', 'port'])
 Pagination = namedtuple('Pagination', ['limit', 'offset'])
 Sorting = namedtuple('Sorting', ['field', 'order'])
+RestConfig = namedtuple('RestConfig', ['network_name', 'node_url', 'max_lag_blocks'])

--- a/explorer/rest/rest/model/common.py
+++ b/explorer/rest/rest/model/common.py
@@ -1,0 +1,5 @@
+from collections import namedtuple
+
+DatabaseConfig = namedtuple('DatabaseConfig', ['database', 'user', 'password', 'host', 'port'])
+Pagination = namedtuple('Pagination', ['limit', 'offset'])
+Sorting = namedtuple('Sorting', ['field', 'order'])

--- a/explorer/rest/tests/facade/test_NemRestFacade.py
+++ b/explorer/rest/tests/facade/test_NemRestFacade.py
@@ -1,5 +1,10 @@
-from rest import Pagination, Sorting
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from symbollightapi.model.Exceptions import NodeException
+
 from rest.facade.NemRestFacade import NemRestFacade
+from rest.model.common import Pagination, Sorting
 
 from ..test.DatabaseTestUtils import ACCOUNT_VIEWS, BLOCK_VIEWS, DatabaseTestBase
 
@@ -20,7 +25,7 @@ class TestNemRestFacade(DatabaseTestBase):
 
 	def setUp(self):
 		super().setUp()
-		self.nem_rest_facade = NemRestFacade(self.db_config, 'mainnet')
+		self.nem_rest_facade = NemRestFacade('http://localhost:7890', self.db_config, 'mainnet')
 
 	# region block
 
@@ -144,4 +149,37 @@ class TestNemRestFacade(DatabaseTestBase):
 			expected_accounts=[EXPECTED_ACCOUNT_2],
 			is_harvesting=True
 		)
+
+	# endregion
+
+	# region health
+
+	@patch('rest.facade.NemRestFacade.NemConnector.node_info')
+	def test_can_retrieve_health(self, mock_node_info):
+		# Arrange:
+		mock_node_info.return_value = AsyncMock()
+
+		# Act:
+		result = asyncio.run(self.nem_rest_facade.get_health())
+
+		# Assert:
+		self.assertTrue(result['isHealthy'])
+		self.assertEqual(EXPECTED_BLOCK_2['timestamp'], result['lastSyncedAt'])
+		self.assertEqual(EXPECTED_BLOCK_2['height'], result['lastBlockHeight'])
+		self.assertEqual([], result['errors'])
+
+	@patch('rest.facade.NemRestFacade.NemConnector.node_info')
+	def test_can_retrieve_health_with_node_exception(self, mock_node_info):
+		# Arrange:
+		mock_node_info.side_effect = NodeException('Connection refused')
+
+		# Act:
+		result = asyncio.run(self.nem_rest_facade.get_health())
+
+		# Assert:
+		self.assertFalse(result['isHealthy'])
+		self.assertEqual(EXPECTED_BLOCK_2['timestamp'], result['lastSyncedAt'])
+		self.assertEqual(EXPECTED_BLOCK_2['height'], result['lastBlockHeight'])
+		self.assertEqual([{'type': 'synchronization', 'message': 'Connection refused'}], result['errors'])
+
 	# endregion

--- a/explorer/rest/tests/facade/test_NemRestFacade.py
+++ b/explorer/rest/tests/facade/test_NemRestFacade.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 from symbollightapi.model.Exceptions import NodeException
 
@@ -21,7 +21,7 @@ EXPECTED_ACCOUNT_2 = ACCOUNT_VIEWS[1].to_dict()
 # endregion
 
 
-class TestNemRestFacade(DatabaseTestBase):
+class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-methods
 
 	def setUp(self):
 		super().setUp()
@@ -154,32 +154,55 @@ class TestNemRestFacade(DatabaseTestBase):
 
 	# region health
 
-	@patch('rest.facade.NemRestFacade.NemConnector.node_info')
-	def test_can_retrieve_health(self, mock_node_info):
+	@patch('rest.facade.NemRestFacade.NemConnector.chain_height')
+	def test_can_retrieve_health(self, mock_chain_height):
 		# Arrange:
-		mock_node_info.return_value = AsyncMock()
+		mock_chain_height.return_value = 2
 
 		# Act:
 		result = asyncio.run(self.nem_rest_facade.get_health())
 
 		# Assert:
 		self.assertTrue(result['isHealthy'])
-		self.assertEqual(EXPECTED_BLOCK_2['timestamp'], result['lastSyncedAt'])
-		self.assertEqual(EXPECTED_BLOCK_2['height'], result['lastBlockHeight'])
+		self.assertTrue(result['nodeUp'])
+		self.assertEqual(2, result['nodeHeight'])
+		self.assertTrue(result['backendSynced'])
+		self.assertEqual(EXPECTED_BLOCK_2['timestamp'], result['lastDBSyncedAt'])
+		self.assertEqual(EXPECTED_BLOCK_2['height'], result['lastDBHeight'])
 		self.assertEqual([], result['errors'])
 
-	@patch('rest.facade.NemRestFacade.NemConnector.node_info')
-	def test_can_retrieve_health_with_node_exception(self, mock_node_info):
+	@patch('rest.facade.NemRestFacade.NemConnector.chain_height')
+	def test_can_retrieve_health_with_node_sync_lag(self, mock_chain_height):
 		# Arrange:
-		mock_node_info.side_effect = NodeException('Connection refused')
+		mock_chain_height.return_value = 5
 
 		# Act:
 		result = asyncio.run(self.nem_rest_facade.get_health())
 
 		# Assert:
 		self.assertFalse(result['isHealthy'])
-		self.assertEqual(EXPECTED_BLOCK_2['timestamp'], result['lastSyncedAt'])
-		self.assertEqual(EXPECTED_BLOCK_2['height'], result['lastBlockHeight'])
+		self.assertTrue(result['nodeUp'])
+		self.assertEqual(5, result['nodeHeight'])
+		self.assertFalse(result['backendSynced'])
+		self.assertEqual(EXPECTED_BLOCK_2['timestamp'], result['lastDBSyncedAt'])
+		self.assertEqual(EXPECTED_BLOCK_2['height'], result['lastDBHeight'])
+		self.assertEqual([{'type': 'synchronization', 'message': 'Database is 3 blocks behind node height'}], result['errors'])
+
+	@patch('rest.facade.NemRestFacade.NemConnector.chain_height')
+	def test_can_retrieve_health_with_node_exception(self, mock_chain_height):
+		# Arrange:
+		mock_chain_height.side_effect = NodeException('Connection refused')
+
+		# Act:
+		result = asyncio.run(self.nem_rest_facade.get_health())
+
+		# Assert:
+		self.assertFalse(result['isHealthy'])
+		self.assertFalse(result['nodeUp'])
+		self.assertIsNone(result['nodeHeight'])
+		self.assertFalse(result['backendSynced'])
+		self.assertEqual(EXPECTED_BLOCK_2['timestamp'], result['lastDBSyncedAt'])
+		self.assertEqual(EXPECTED_BLOCK_2['height'], result['lastDBHeight'])
 		self.assertEqual([{'type': 'synchronization', 'message': 'Connection refused'}], result['errors'])
 
 	# endregion

--- a/explorer/rest/tests/facade/test_NemRestFacade.py
+++ b/explorer/rest/tests/facade/test_NemRestFacade.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from symbollightapi.model.Exceptions import NodeException
 
 from rest.facade.NemRestFacade import NemRestFacade
-from rest.model.common import Pagination, Sorting
+from rest.model.common import Pagination, RestConfig, Sorting
 
 from ..test.DatabaseTestUtils import ACCOUNT_VIEWS, BLOCK_VIEWS, DatabaseTestBase
 
@@ -25,7 +25,11 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 
 	def setUp(self):
 		super().setUp()
-		self.nem_rest_facade = NemRestFacade('http://localhost:7890', self.db_config, 'mainnet')
+		self.nem_rest_facade = NemRestFacade(self.db_config, RestConfig(
+			network_name='mainnet',
+			node_url='http://localhost:7890',
+			max_lag_blocks=2
+		))
 
 	# region block
 

--- a/explorer/rest/tests/test_rest.py
+++ b/explorer/rest/tests/test_rest.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 import pytest
 import testing.postgresql
@@ -329,10 +329,10 @@ def test_api_nem_accounts_invalid_sort_order(client):  # pylint: disable=redefin
 # region /health
 
 
-@patch('rest.facade.NemRestFacade.NemConnector.node_info')
-def test_api_nem_health(mock_node_info, client):  # pylint: disable=redefined-outer-name
+@patch('rest.facade.NemRestFacade.NemConnector.chain_height')
+def test_api_nem_health(mock_chain_height, client):  # pylint: disable=redefined-outer-name
 	# Arrange:
-	mock_node_info.return_value = AsyncMock()
+	mock_chain_height.return_value = 2
 
 	# Act:
 	response = client.get('/api/nem/health')
@@ -341,16 +341,19 @@ def test_api_nem_health(mock_node_info, client):  # pylint: disable=redefined-ou
 	_assert_status_code_and_headers(response, 200)
 	assert {
 		'isHealthy': True,
-		'lastSyncedAt': EXPECTED_BLOCK_VIEW_2.timestamp,
-		'lastBlockHeight': EXPECTED_BLOCK_VIEW_2.height,
+		'nodeUp': True,
+		'nodeHeight': 2,
+		'backendSynced': True,
+		'lastDBSyncedAt': EXPECTED_BLOCK_VIEW_2.timestamp,
+		'lastDBHeight': EXPECTED_BLOCK_VIEW_2.height,
 		'errors': []
 	} == response.json
 
 
-@patch('rest.facade.NemRestFacade.NemConnector.node_info')
-def test_api_nem_health_node_fails(mock_node_info, client):  # pylint: disable=redefined-outer-name
+@patch('rest.facade.NemRestFacade.NemConnector.chain_height')
+def test_api_nem_health_node_behind(mock_chain_height, client):  # pylint: disable=redefined-outer-name
 	# Arrange:
-	mock_node_info.side_effect = NodeException('Connection refused')
+	mock_chain_height.return_value = 10
 
 	# Act:
 	response = client.get('/api/nem/health')
@@ -359,8 +362,35 @@ def test_api_nem_health_node_fails(mock_node_info, client):  # pylint: disable=r
 	_assert_status_code_and_headers(response, 200)
 	assert {
 		'isHealthy': False,
-		'lastSyncedAt': EXPECTED_BLOCK_VIEW_2.timestamp,
-		'lastBlockHeight': EXPECTED_BLOCK_VIEW_2.height,
+		'nodeUp': True,
+		'nodeHeight': 10,
+		'backendSynced': False,
+		'lastDBSyncedAt': EXPECTED_BLOCK_VIEW_2.timestamp,
+		'lastDBHeight': EXPECTED_BLOCK_VIEW_2.height,
+		'errors': [{
+			'type': 'synchronization',
+			'message': 'Database is 8 blocks behind node height'
+		}]
+	} == response.json
+
+
+@patch('rest.facade.NemRestFacade.NemConnector.chain_height')
+def test_api_nem_health_node_fails(mock_chain_height, client):  # pylint: disable=redefined-outer-name
+	# Arrange:
+	mock_chain_height.side_effect = NodeException('Connection refused')
+
+	# Act:
+	response = client.get('/api/nem/health')
+
+	# Assert:
+	_assert_status_code_and_headers(response, 200)
+	assert {
+		'isHealthy': False,
+		'nodeUp': False,
+		'nodeHeight': None,
+		'backendSynced': False,
+		'lastDBSyncedAt': EXPECTED_BLOCK_VIEW_2.timestamp,
+		'lastDBHeight': EXPECTED_BLOCK_VIEW_2.height,
 		'errors': [{'type': 'synchronization', 'message': 'Connection refused'}]
 	} == response.json
 

--- a/explorer/rest/tests/test_rest.py
+++ b/explorer/rest/tests/test_rest.py
@@ -257,6 +257,7 @@ def test_api_nem_account_not_found(client):  # pylint: disable=redefined-outer-n
 
 # region /accounts
 
+
 def _assert_get_nem_accounts_bad_request(client, expected_message, **query_params):  # pylint: disable=redefined-outer-name
 	# Act:
 	response = client.get('/api/nem/accounts', query_string=query_params)
@@ -326,6 +327,7 @@ def test_api_nem_accounts_invalid_sort_order(client):  # pylint: disable=redefin
 # endregion
 
 # region /health
+
 
 @patch('rest.facade.NemRestFacade.NemConnector.node_info')
 def test_api_nem_health(mock_node_info, client):  # pylint: disable=redefined-outer-name

--- a/explorer/rest/tests/test_rest.py
+++ b/explorer/rest/tests/test_rest.py
@@ -1,9 +1,11 @@
 import os
 import tempfile
 from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
 import pytest
 import testing.postgresql
+from symbollightapi.model.Exceptions import NodeException
 
 from rest import create_app
 
@@ -180,7 +182,6 @@ def test_api_nem_blocks_invalid_offset(client):  # pylint: disable=redefined-out
 def test_api_nem_blocks_invalid_sort(client):  # pylint: disable=redefined-outer-name
 	_assert_get_api_nem_blocks_fail(client, 'Sort must be either ASC or DESC', sort='invalid')
 
-
 # endregion
 
 
@@ -252,7 +253,6 @@ def test_api_nem_account_not_found(client):  # pylint: disable=redefined-outer-n
 		'status': 404
 	} == response.json
 
-
 # endregion
 
 # region /accounts
@@ -323,5 +323,43 @@ def test_api_nem_accounts_invalid_sort_field(client):  # pylint: disable=redefin
 def test_api_nem_accounts_invalid_sort_order(client):  # pylint: disable=redefined-outer-name, invalid-name
 	_assert_get_nem_accounts_bad_request(client, 'Sort order must be either ASC or DESC', sort_order='INVALID')
 
+# endregion
+
+# region /health
+
+@patch('rest.facade.NemRestFacade.NemConnector.node_info')
+def test_api_nem_health(mock_node_info, client):  # pylint: disable=redefined-outer-name
+	# Arrange:
+	mock_node_info.return_value = AsyncMock()
+
+	# Act:
+	response = client.get('/api/nem/health')
+
+	# Assert:
+	_assert_status_code_and_headers(response, 200)
+	assert {
+		'isHealthy': True,
+		'lastSyncedAt': EXPECTED_BLOCK_VIEW_2.timestamp,
+		'lastBlockHeight': EXPECTED_BLOCK_VIEW_2.height,
+		'errors': []
+	} == response.json
+
+
+@patch('rest.facade.NemRestFacade.NemConnector.node_info')
+def test_api_nem_health_node_fails(mock_node_info, client):  # pylint: disable=redefined-outer-name
+	# Arrange:
+	mock_node_info.side_effect = NodeException('Connection refused')
+
+	# Act:
+	response = client.get('/api/nem/health')
+
+	# Assert:
+	_assert_status_code_and_headers(response, 200)
+	assert {
+		'isHealthy': False,
+		'lastSyncedAt': EXPECTED_BLOCK_VIEW_2.timestamp,
+		'lastBlockHeight': EXPECTED_BLOCK_VIEW_2.height,
+		'errors': [{'type': 'synchronization', 'message': 'Connection refused'}]
+	} == response.json
 
 # endregion


### PR DESCRIPTION
Problem: Frontend requires a health check endpoint for the backend service.
Solution: Added /api/nem/health endpoint that returns backend service health status, including last synced block information and synchronization errors.