### PR TITLE
[bridge] fix: use the release version of lightapi

### DIFF
--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -25,13 +25,7 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 # Create application directory
 WORKDIR /app
-COPY bridge/ /app/bridge
-
-# need the latest lightapi(remove when lightapi is published to pypi)
-COPY lightapi/python /app/lightapi
-
-USER root
-RUN pip install -e /app/lightapi
+COPY . /app/bridge
 
 USER ubuntu
 RUN pip install -r /app/bridge/requirements.txt \

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -154,7 +154,7 @@ As an alternative to manually installing dependencies and running scripts, you c
 ### Build the Docker image
 
 ```sh
-docker build -t symbolplatform/bridge:1.1 -f Dockerfile --network host ..
+docker build -t symbolplatform/bridge:1.1 -f Dockerfile --network host .
 ```
 
 ### Running the Bridge

--- a/bridge/requirements.txt
+++ b/bridge/requirements.txt
@@ -2,6 +2,6 @@ aiolimiter~=1.2.1 # remove when updating lightapi
 asgiref~=3.11.0
 filelock==3.25.0
 Flask==3.1.3
-symbol-lightapi~=0.0.7
+symbol-lightapi~=0.0.8
 symbol-sdk-python==3.3.0
 web3==7.14.1

--- a/bridge/scripts/ci/test.sh
+++ b/bridge/scripts/ci/test.sh
@@ -3,5 +3,4 @@
 set -ex
 
 TEST_RUNNER=$([ "$1" = "code-coverage" ] && echo "coverage run --append" || echo "python3")
-PYTHONPATH=.:./../lightapi/python ${TEST_RUNNER} -m pytest --asyncio-mode=auto -v
-
+PYTHONPATH=. ${TEST_RUNNER} -m pytest --asyncio-mode=auto -v


### PR DESCRIPTION
problem: Bridge is using the symbol-lightapi from dev branch
solution: update the Bridge to use release version of symbol-lightapi