### PR TITLE
[tools/shoestring] fix: MongoDB fails with too many open files

### DIFF
--- a/tools/shoestring/shoestring/templates/docker-compose-dual.yaml
+++ b/tools/shoestring/shoestring/templates/docker-compose-dual.yaml
@@ -8,6 +8,10 @@ services:
     stop_signal: SIGINT
     ports:
       - 127.0.0.1:27017:27017
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
     volumes:
       - ./dbdata:/dbdata:rw
       - ./dbdata:/data:rw
@@ -16,6 +20,10 @@ services:
     image: '{{ mongo_image }}'
     user: '{{ user }}'
     command: /bin/bash /startup/mongors.sh /real_data/startup/mongo-initialized
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
     volumes:
       - ./startup:/startup:ro
       - ./mongo:/mongo:ro


### PR DESCRIPTION
problem: Docker 29 reduces the open file limit to 1024, which causes errors in MongoDB
solution: increase the open file limit for MongoDB

We need to increase the open limits on the MongoDB container, also.
```
{"t":{"$date":"2026-03-10T04:35:46.285+00:00"},"s":"I",  "c":"NETWORK",  "id":23018,   "ctx":"listener","msg":"Error accepting new connection on local endpoint","attr":{"localEndpoint":"0.0.0.0:27017","error":"Too many open files"}}
{"t":{"$date":"2026-03-10T04:35:46.285+00:00"},"s":"I",  "c":"NETWORK",  "id":23018,   "ctx":"listener","msg":"Error accepting new connection on local endpoint","attr":{"localEndpoint":"0.0.0.0:27017","error":"Too many open files"}}
```