### PR TITLE
[explorer/puller] feat: process namespace from blocks

### DIFF
--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -47,6 +47,14 @@ class NemDatabase(DatabaseConnection):
 			'''
 		)
 
+		# Create indexes for namespaces table
+		cursor.execute(
+			'''
+			CREATE INDEX IF NOT EXISTS idx_namespaces_root_namespace
+				ON namespaces (root_namespace)
+			'''
+		)
+
 	def create_tables(self):
 		"""Creates database tables."""
 
@@ -92,6 +100,20 @@ class NemDatabase(DatabaseConnection):
 				signer bytea NOT NULL,
 				signature bytea NOT NULL,
 				size bigint DEFAULT 0
+			)
+			'''
+		)
+
+		# Create Namespaces table
+		cursor.execute(
+			'''
+			CREATE TABLE IF NOT EXISTS namespaces (
+				id serial PRIMARY KEY,
+				root_namespace varchar(16) NOT NULL UNIQUE,
+				owner bytea NOT NULL,
+				registered_height bigint NOT NULL,
+				expiration_height bigint NOT NULL,
+				sub_namespaces VARCHAR(146)[] DEFAULT '{}'
 			)
 			'''
 		)
@@ -199,5 +221,46 @@ class NemDatabase(DatabaseConnection):
 				total_fees,
 				last_height,
 				harvester.bytes
+			)
+		)
+
+	def upsert_namespace(self, cursor, namespace):  # pylint: disable=no-self-use
+		"""Insert or update namespace information."""
+
+		cursor.execute(
+			'''
+			INSERT INTO namespaces (
+				root_namespace,
+				owner,
+				registered_height,
+				expiration_height
+			)
+			VALUES (%s, %s, %s, %s)
+			ON CONFLICT (root_namespace)
+			DO UPDATE SET
+				owner = EXCLUDED.owner,
+				registered_height = EXCLUDED.registered_height,
+				expiration_height = EXCLUDED.expiration_height
+			''',
+			(
+				namespace.root_namespace,
+				namespace.owner.bytes,
+				namespace.registered_height,
+				namespace.expiration_height
+			)
+		)
+
+	def update_sub_namespaces(self, cursor, sub_namespace, root_namespace):  # pylint: disable=no-self-use
+		"""Appends sub-namespace to a root namespace's sub_namespaces array."""
+
+		cursor.execute(
+			'''
+			UPDATE namespaces
+			SET sub_namespaces = array_append(sub_namespaces, %s)
+			WHERE root_namespace = %s
+			''',
+			(
+				sub_namespace,
+				root_namespace
 			)
 		)

--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -122,7 +122,8 @@ class NemDatabase(DatabaseConnection):
 
 		self.connection.commit()
 
-	def insert_block(self, cursor, block):  # pylint: disable=no-self-use
+	@staticmethod
+	def insert_block(cursor, block):
 		"""Adds block height into table."""
 
 		cursor.execute(
@@ -156,7 +157,8 @@ class NemDatabase(DatabaseConnection):
 		results = cursor.fetchone()
 		return 0 if results[0] is None else results[0]
 
-	def upsert_account(self, cursor, account_info):  # pylint: disable=no-self-use
+	@staticmethod
+	def upsert_account(cursor, account_info):
 		"""Insert or update account information."""
 
 		cursor.execute(
@@ -208,7 +210,8 @@ class NemDatabase(DatabaseConnection):
 			)
 		)
 
-	def update_account_harvested_fees(self, cursor, harvester, total_fees, last_height):  # pylint: disable=no-self-use
+	@staticmethod
+	def update_account_harvested_fees(cursor, harvester, total_fees, last_height):
 		"""Updates harvested fees for an account."""
 
 		cursor.execute(

--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -224,7 +224,8 @@ class NemDatabase(DatabaseConnection):
 			)
 		)
 
-	def upsert_namespace(self, cursor, namespace):  # pylint: disable=no-self-use
+	@staticmethod
+	def upsert_namespace(cursor, namespace):
 		"""Insert or update namespace information."""
 
 		cursor.execute(
@@ -250,7 +251,8 @@ class NemDatabase(DatabaseConnection):
 			)
 		)
 
-	def update_sub_namespaces(self, cursor, sub_namespace, root_namespace):  # pylint: disable=no-self-use
+	@staticmethod
+	def update_sub_namespaces(cursor, sub_namespace, root_namespace):
 		"""Appends sub-namespace to a root namespace's sub_namespaces array."""
 
 		cursor.execute(

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -6,6 +6,7 @@ from queue import Queue
 
 from symbolchain.CryptoTypes import PublicKey
 from symbolchain.facade.NemFacade import NemFacade
+from symbolchain.nc import TransactionType
 from symbolchain.nem.Network import Address, Network
 from symbollightapi.connector.NemConnector import NemConnector
 from symbollightapi.model.Exceptions import NodeException
@@ -39,6 +40,12 @@ AccountRecord = namedtuple('AccountRecord', [
 	'min_cosignatories',
 	'cosignatory_of',
 	'cosignatories'
+])
+NamespaceRecord = namedtuple('NamespaceRecord', [
+	'root_namespace',
+	'owner',
+	'registered_height',
+	'expiration_height'
 ])
 DatabaseConfig = namedtuple('DatabaseConfig', ['database', 'user', 'password', 'host', 'port'])
 
@@ -260,6 +267,44 @@ class NemPuller:
 				last_height
 			)
 
+	def _process_root_namespace(self, cursor, transaction, block_height):
+		"""Process root namespace data."""
+
+		# add 1 year to expired height
+		expired_height = block_height + (365 * 1440)
+
+		namespace = NamespaceRecord(
+			root_namespace=transaction.namespace,
+			owner=transaction.sender,
+			registered_height=block_height,
+			expiration_height=expired_height
+		)
+
+		self.nem_db.upsert_namespace(cursor, namespace)
+
+	def _process_sub_namespace(self, cursor, transaction):
+		"""Process sub namespace data."""
+
+		root_namespace = transaction.parent.split('.')[0]
+
+		new_sub_namespace = f'{transaction.parent}.{transaction.namespace}'
+		self.nem_db.update_sub_namespaces(cursor, new_sub_namespace, root_namespace)
+
+	def _process_namespace(self, cursor, transaction, block_height):  # pylint: disable=no-self-use
+		"""Process namespace in a block."""
+
+		if transaction.parent:
+			self._process_sub_namespace(cursor, transaction)
+		else:
+			self._process_root_namespace(cursor, transaction, block_height)
+
+	def _process_transactions(self, cursor, block_transactions, height):  # pylint: disable=no-self-use
+		"""Process transactions in a block."""
+
+		for transaction in block_transactions:
+			if transaction.transaction_type == TransactionType.NAMESPACE_REGISTRATION.value:
+				self._process_namespace(cursor, transaction, height)
+
 	async def sync_nemesis_block(self):
 		"""Sync and write Nemesis block to database."""
 
@@ -271,6 +316,8 @@ class NemPuller:
 
 		addresses = self._extract_addresses_from_block(nemesis_block)
 		await self._process_account_batch(cursor, addresses)
+
+		self._process_transactions(cursor, nemesis_block.transactions, nemesis_block.height)
 
 		self._commit_blocks('Committed Nemesis block')
 
@@ -315,6 +362,8 @@ class NemPuller:
 				current_fees + block.total_fee,
 				block.height
 			)
+
+			self._process_transactions(cursor, block.transactions, block.height)
 
 			# Batch commits
 			if processed % batch_size == 0:

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -67,7 +67,8 @@ class NemPuller:
 		self.nem_connector = NemConnector(node_url, network)
 		self.nem_facade = NemFacade(str(network))
 
-	async def _retry_operation(self, operation, description, retries=3, delay=2):  # pylint: disable=no-self-use
+	@staticmethod
+	async def _retry_operation(operation, description, retries=3, delay=2):
 		"""Retries an async operation with exponential backoff."""
 
 		for attempt in range(1, retries + 1):
@@ -198,7 +199,8 @@ class NemPuller:
 
 		self.nem_db.insert_block(cursor, block)
 
-	def _convert_mosaics_to_json(self, account_mosaics):  # pylint: disable=no-self-use
+	@staticmethod
+	def _convert_mosaics_to_json(account_mosaics):
 		"""Convert AccountMosaic to Json format."""
 
 		return [
@@ -209,7 +211,8 @@ class NemPuller:
 			for mosaic in account_mosaics
 		]
 
-	def _create_account_record(self, account_info, mosaics_json, remote_address=None):  # pylint: disable=no-self-use
+	@staticmethod
+	def _create_account_record(account_info, mosaics_json, remote_address=None):
 		"""Create AccountRecord from account info and mosaics."""
 
 		return AccountRecord(
@@ -290,7 +293,7 @@ class NemPuller:
 		new_sub_namespace = f'{transaction.parent}.{transaction.namespace}'
 		self.nem_db.update_sub_namespaces(cursor, new_sub_namespace, root_namespace)
 
-	def _process_namespace(self, cursor, transaction, block_height):  # pylint: disable=no-self-use
+	def _process_namespace(self, cursor, transaction, block_height):
 		"""Process namespace in a block."""
 
 		if transaction.parent:
@@ -298,7 +301,7 @@ class NemPuller:
 		else:
 			self._process_root_namespace(cursor, transaction, block_height)
 
-	def _process_transactions(self, cursor, block_transactions, height):  # pylint: disable=no-self-use
+	def _process_transactions(self, cursor, block_transactions, height):
 		"""Process transactions in a block."""
 
 		for transaction in block_transactions:

--- a/explorer/puller/tests/db/test_NemDatabase.py
+++ b/explorer/puller/tests/db/test_NemDatabase.py
@@ -68,7 +68,8 @@ class NemDatabaseTest(unittest.TestCase):
 		# Destroy the temporary PostgreSQL database
 		self.postgresql.stop()
 
-	def _fetch_account_from_db(self, cursor, address):  # pylint: disable=no-self-use
+	@staticmethod
+	def _fetch_account_from_db(cursor, address):
 		"""Helper method to fetch account data from database."""
 
 		cursor.execute(
@@ -96,7 +97,8 @@ class NemDatabaseTest(unittest.TestCase):
 		)
 		return cursor.fetchone()
 
-	def _fetch_namespace_from_db(self, cursor, root_namespace):  # pylint: disable=no-self-use
+	@staticmethod
+	def _fetch_namespace_from_db(cursor, root_namespace):
 		"""Helper method to fetch namespace data from database."""
 
 		cursor.execute(

--- a/explorer/puller/tests/db/test_NemDatabase.py
+++ b/explorer/puller/tests/db/test_NemDatabase.py
@@ -8,7 +8,7 @@ from symbolchain.nem.Network import Address
 from test_DatabaseConnection import DatabaseConfig
 
 from puller.db.NemDatabase import NemDatabase
-from puller.facade.NemPuller import AccountRecord, BlockRecord
+from puller.facade.NemPuller import AccountRecord, BlockRecord, NamespaceRecord
 
 # region test data
 
@@ -96,6 +96,25 @@ class NemDatabaseTest(unittest.TestCase):
 		)
 		return cursor.fetchone()
 
+	def _fetch_namespace_from_db(self, cursor, root_namespace):  # pylint: disable=no-self-use
+		"""Helper method to fetch namespace data from database."""
+
+		cursor.execute(
+			'''
+			SELECT
+				root_namespace,
+				encode(owner, 'hex'),
+				registered_height,
+				expiration_height,
+				sub_namespaces
+			FROM namespaces
+			WHERE root_namespace = %s
+			''',
+			(root_namespace,)
+		)
+
+		return cursor.fetchone()
+
 	def test_can_create_tables(self):
 		# Arrange:
 		with NemDatabase(self.db_config) as nem_database:
@@ -114,9 +133,10 @@ class NemDatabaseTest(unittest.TestCase):
 			results = cursor.fetchall()
 
 		# Assert:
-		self.assertEqual(len(results), 2)
+		self.assertEqual(len(results), 3)
 		self.assertEqual(results[0][0], 'accounts')
 		self.assertEqual(results[1][0], 'blocks')
+		self.assertEqual(results[2][0], 'namespaces')
 
 	def test_can_insert_block(self):
 		# Arrange:
@@ -320,3 +340,114 @@ class NemDatabaseTest(unittest.TestCase):
 		# Assert:
 		self.assertEqual(result[7], 750000)  # harvested_fees
 		self.assertEqual(result[11], 20)      # last_harvested_height
+
+	def test_can_insert_namespace(self):
+		# Arrange:
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+
+			cursor = nem_database.connection.cursor()
+
+			# Act:
+			nem_database.upsert_namespace(
+				cursor,
+				namespace=NamespaceRecord(
+					root_namespace='root',
+					owner=PublicKey('8d07f90fb4bbe7715fa327c926770166a11be2e494a970605f2e12557f66c9b9'),
+					registered_height=100,
+					expiration_height=200
+				)
+			)
+
+			nem_database.connection.commit()
+			result = self._fetch_namespace_from_db(cursor, 'root')
+
+		# Assert:
+		self.assertIsNotNone(result)
+		self.assertEqual(result, (
+			'root',
+			'8d07f90fb4bbe7715fa327c926770166a11be2e494a970605f2e12557f66c9b9',
+			100,
+			200,
+			[]
+		))
+
+	def test_can_update_namespace_by_root_namespace_conflict(self):
+		# Arrange:
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+
+			cursor = nem_database.connection.cursor()
+
+			# insert initial namespace
+			nem_database.upsert_namespace(
+				cursor,
+				namespace=NamespaceRecord(
+					root_namespace='root',
+					owner=PublicKey('8d07f90fb4bbe7715fa327c926770166a11be2e494a970605f2e12557f66c9b9'),
+					registered_height=100,
+					expiration_height=200
+				)
+			)
+
+			# Act:
+			nem_database.upsert_namespace(
+				cursor,
+				namespace=NamespaceRecord(
+					root_namespace='root',
+					owner=PublicKey('f9bd190dd0c364261f5c8a74870cc7f7374e631352293c62ecc437657e5de2cd'),
+					registered_height=150,
+					expiration_height=250
+				)
+			)
+
+			nem_database.connection.commit()
+			result = self._fetch_namespace_from_db(cursor, 'root')
+
+		# Assert:
+		self.assertIsNotNone(result)
+		self.assertEqual(result, (
+			'root',
+			'f9bd190dd0c364261f5c8a74870cc7f7374e631352293c62ecc437657e5de2cd',
+			150,
+			250,
+			[]
+		))
+
+	def test_can_update_sub_namespaces(self):
+		# Arrange:
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+
+			cursor = nem_database.connection.cursor()
+
+			# insert initial namespace
+			nem_database.upsert_namespace(
+				cursor,
+				namespace=NamespaceRecord(
+					root_namespace='root',
+					owner=PublicKey('8d07f90fb4bbe7715fa327c926770166a11be2e494a970605f2e12557f66c9b9'),
+					registered_height=100,
+					expiration_height=200
+				)
+			)
+
+			# Act:
+			nem_database.update_sub_namespaces(
+				cursor,
+				'sub1',
+				'root'
+			)
+
+			nem_database.connection.commit()
+			result = self._fetch_namespace_from_db(cursor, 'root')
+
+		# Assert:
+		self.assertIsNotNone(result)
+		self.assertEqual(result, (
+			'root',
+			'8d07f90fb4bbe7715fa327c926770166a11be2e494a970605f2e12557f66c9b9',
+			100,
+			200,
+			['sub1']
+		))

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -24,7 +24,7 @@ from symbollightapi.model.Transaction import (
 	TransferTransaction
 )
 
-from puller.facade.NemPuller import AccountRecord, DatabaseConfig, NemPuller
+from puller.facade.NemPuller import AccountRecord, DatabaseConfig, NamespaceRecord, NemPuller
 
 # region test data
 
@@ -122,7 +122,7 @@ NEM_CONNECTOR_RESPONSE_BLOCKS = [
 			NamespaceRegistrationTransaction(
 				'7e547e45cfc9c34809ce184db6ae7b028360c0f1492cc37b7b4d31c22af07dc3',
 				2,
-				'a700809530e5428066807ec0d34859c52e260fc60634aaac13e3972dcfc08736',
+				PublicKey('a700809530e5428066807ec0d34859c52e260fc60634aaac13e3972dcfc08736'),
 				150000,
 				73397,
 				83397,
@@ -299,7 +299,8 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 	@patch('puller.facade.NemPuller.NemConnector.get_block')
 	@patch('puller.facade.NemPuller.NemConnector.account_info')
 	@patch('puller.facade.NemPuller.NemConnector.account_mosaics')
-	def test_can_sync_nemesis_block(self, mock_account_mosaics, mock_account_info, mock_get_block):
+	@patch('puller.facade.NemPuller.NemPuller._process_transactions')
+	def test_can_sync_nemesis_block(self, mock_process_transactions, mock_account_mosaics, mock_account_info, mock_get_block):
 		# Arrange:
 		sender_address = Address('TALICE6XEEEOBFJVY3ZCENZ7WBG6LB4KB7P7KMQX')
 		recipient_address = Address('NCOPERAWEWCD4A34NP5UQCCKEX44MW4SL3QYJYS5')
@@ -341,10 +342,14 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 				[sender_address.bytes.hex(), recipient_address.bytes.hex(), signer_address.bytes.hex()],
 				[row[0] for row in account_results],
 			)
+			self.assertEqual(mock_process_transactions.call_count, 1)
+			self.assertEqual(mock_process_transactions.call_args[0][1], NEM_CONNECTOR_RESPONSE_BLOCKS[0].transactions)
+			self.assertEqual(mock_process_transactions.call_args[0][2], NEM_CONNECTOR_RESPONSE_BLOCKS[0].height)
 
 	@patch('puller.facade.NemPuller.NemConnector.get_blocks_after')
 	@patch('puller.facade.NemPuller.NemPuller._process_account_batch')
-	def test_can_sync_blocks(self, mock_process_account_batch, mock_get_blocks_after):
+	@patch('puller.facade.NemPuller.NemPuller._process_transactions')
+	def test_can_sync_blocks(self, mock_process_transactions, mock_process_account_batch, mock_get_blocks_after):
 		# Arrange:
 		mock_get_blocks_after.return_value = NEM_CONNECTOR_RESPONSE_BLOCKS
 		mock_process_account_batch.return_value = AsyncMock()
@@ -407,6 +412,12 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			addresses = call_args[0][1]
 			self.assertEqual(len(addresses), 19)
 
+			self.assertEqual(mock_process_transactions.call_count, 3)
+			process_transactions_calls = mock_process_transactions.call_args_list
+			for i in range(mock_process_transactions.call_count):
+				self.assertEqual(process_transactions_calls[i][0][1], NEM_CONNECTOR_RESPONSE_BLOCKS[i].transactions)
+				self.assertEqual(process_transactions_calls[i][0][2], NEM_CONNECTOR_RESPONSE_BLOCKS[i].height)
+
 	@patch('puller.facade.NemPuller.NemPuller._retry_get_blocks_after')
 	@patch('puller.facade.NemPuller.log')
 	def test_sync_blocks_raise_error_connector_fail(self, mock_log, mock_retry_get_blocks_after):
@@ -426,13 +437,16 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 	@patch('puller.facade.NemPuller.NemPuller._commit_blocks')
 	@patch('puller.facade.NemPuller.NemPuller._process_account_batch')
 	@patch('puller.facade.NemPuller.NemPuller._process_harvested_fees')
+	@patch('puller.facade.NemPuller.NemPuller._process_transactions')
 	def test_db_writer_can_commits_in_batches(
 		self,
+		mock_process_transactions,
 		mock_process_harvested_fees,
 		mock_process_account_batch,
 		mock_commit_blocks,
 		mock_get_blocks_after
 	):
+		# pylint: disable=too-many-arguments,too-many-positional-arguments
 		# Arrange:
 		# Create 5 blocks to test batch commit (batch_size=2 means 2 commits + 1 final)
 		test_blocks = []
@@ -455,6 +469,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		mock_get_blocks_after.return_value = test_blocks
 		mock_process_account_batch.return_value = AsyncMock()
 		mock_process_harvested_fees.return_value = Mock()
+		mock_process_transactions.return_value = Mock()
 
 		with self.puller.nem_db as databases:
 			databases.create_tables()
@@ -482,6 +497,11 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			self.assertEqual(len(process_harvested_fees_calls), 2)
 			self.assertEqual(process_harvested_fees_calls[0][0][1], ({Address('T' + 'A' * 39): (1000000, 5)}))
 			self.assertEqual(process_harvested_fees_calls[1][0][1], ({Address('T' + 'A' * 39): (1000000, 5)}))
+
+			process_transactions_calls = mock_process_transactions.call_args_list
+			self.assertEqual(len(process_transactions_calls), 5)
+			for i in range(5):
+				self.assertEqual(process_transactions_calls[i][0][1], test_blocks[i].transactions)
 
 	def _assert_retry_operation_successful(self, mock_connector_method, operation, expected_result):
 		# Arrange:
@@ -760,4 +780,59 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			Address('TALICEPFLZQRZGPRIJTMJOCPWDNECXTNNFEN6XWA'),
 			59200000,
 			3
+		))
+
+	@patch('puller.facade.NemPuller.NemDatabase.upsert_namespace')
+	def test_can_process_root_namespace(self, mock_upsert_namespace):
+		# Arrange:
+		namespace_transaction = NEM_CONNECTOR_RESPONSE_BLOCKS[2].transactions[3]
+
+		cursor = Mock()
+
+		# Act:
+		self.puller._process_namespace(cursor, namespace_transaction, namespace_transaction.height)  # pylint: disable=protected-access
+
+		# Assert:
+		upsert_namespace_calls = mock_upsert_namespace.call_args_list
+		self.assertEqual(len(upsert_namespace_calls), 1)
+		self.assertEqual(upsert_namespace_calls[0][0], (
+			cursor,
+			NamespaceRecord(
+				root_namespace='namespace',
+				owner=PublicKey('a700809530e5428066807ec0d34859c52e260fc60634aaac13e3972dcfc08736'),
+				registered_height=2,
+				expiration_height=2 + (365 * 1440)
+			)
+		))
+
+	@patch('puller.facade.NemPuller.NemDatabase.update_sub_namespaces')
+	def test_can_process_sub_namespace(self, mock_update_sub_namespaces):
+		# Arrange:
+		namespace_transaction = NamespaceRegistrationTransaction(
+			'7e547e45cfc9c34809ce184db6ae7b028360c0f1492cc37b7b4d31c22af07dc3',
+			2,
+			PublicKey('a700809530e5428066807ec0d34859c52e260fc60634aaac13e3972dcfc08736'),
+			150000,
+			73397,
+			83397,
+			'9fc70720d0333d7d8f9eb14ef45ce45a846d37e79cf7a4244b4db36dcb0d3dfe'
+			'0170daefbf4d30f92f343110a6f03a14aedcf7913e465a4a1cc199639169410a',
+			'NAMESPACEWH4MKFMBCVFERDPOOP4FK7MTBXDPZZA',
+			100000000,
+			'root.root_1',
+			'namespace'
+		)
+
+		cursor = Mock()
+
+		# Act:
+		self.puller._process_namespace(cursor, namespace_transaction, namespace_transaction.height)  # pylint: disable=protected-access
+
+		# Assert:
+		update_sub_namespaces_calls = mock_update_sub_namespaces.call_args_list
+		self.assertEqual(len(update_sub_namespaces_calls), 1)
+		self.assertEqual(update_sub_namespaces_calls[0][0], (
+			cursor,
+			'root.root_1.namespace',
+			'root'
 		))


### PR DESCRIPTION
Problems: Missing the process namespace from blocks.
Solution:

- Added database namespace tables 
- Implemented upsert namespaces and update sub namespace
- Extracted namespace registration from transaction.
