### PR TITLE
[explorer/rest] feat: Added mosaic rich list endpoint

### DIFF
--- a/explorer/rest/rest/__init__.py
+++ b/explorer/rest/rest/__init__.py
@@ -216,6 +216,26 @@ def setup_nem_routes(app, nem_api_facade):  # pylint: disable=too-many-statement
 
 		return jsonify(results)
 
+	@app.route('/api/nem/mosaic/rich/list')
+	def api_get_nem_mosaic_rich_list_by_name():
+		try:
+			limit = int(request.args.get('limit', 10))
+			offset = int(request.args.get('offset', 0))
+			namespace_name = request.args.get('namespace_name', 'nem.xem')
+
+			if limit < 0 or offset < 0:
+				raise ValueError('Limit and offset must be greater than or equal to 0')
+
+		except ValueError as error:
+			abort(400, error)
+
+		results = nem_api_facade.get_mosaic_rich_list(
+			pagination=Pagination(limit, offset),
+			namespace_name=namespace_name
+		)
+
+		return jsonify(results)
+
 
 def setup_error_handlers(app):
 	@app.errorhandler(404)

--- a/explorer/rest/rest/db/NemDatabase.py
+++ b/explorer/rest/rest/db/NemDatabase.py
@@ -5,7 +5,7 @@ from symbolchain.nem.Network import Address
 
 from rest.model.Account import AccountView
 from rest.model.Block import BlockView
-from rest.model.Mosaic import MosaicView
+from rest.model.Mosaic import MosaicRichListView, MosaicView
 from rest.model.Namespace import NamespaceView
 
 from .DatabaseConnection import DatabaseConnectionPool
@@ -163,6 +163,21 @@ class NemDatabase(DatabaseConnectionPool):
 			root_namespace_registered_height=root_namespace_registered_height,
 			root_namespace_registered_timestamp=str(root_namespace_registered_timestamp),
 			root_namespace_expiration_height=root_namespace_expiration_height,
+		)
+
+	@staticmethod
+	def _create_mosaic_rich_list_view(result):
+		(
+			address,
+			remark,
+			balance,
+			divisibility
+		) = result
+
+		return MosaicRichListView(
+			address=str(Address(address)),
+			remark=remark,
+			balance=_format_relative(balance, divisibility)
 		)
 
 	@staticmethod
@@ -419,3 +434,41 @@ class NemDatabase(DatabaseConnectionPool):
 			results = cursor.fetchall()
 
 			return [self._create_mosaic_view(result) for result in results]
+
+	def get_mosaic_rich_list(self, pagination, namespace_name):
+		"""Gets mosaic rich list by namespace name pagination in database."""
+
+		sql = '''
+			WITH mosaic_list AS (
+					SELECT
+						a.address,
+						ar.remarks,
+						(mosaic->>'quantity')::bigint as balance
+					FROM
+						accounts a
+						LEFT JOIN account_remarks ar
+							ON ar.address = a.address
+						CROSS JOIN LATERAL jsonb_array_elements(a.mosaics) AS mosaic
+						WHERE (mosaic->>'namespace') = %s AND (mosaic->>'quantity')::bigint > 0
+				)
+				SELECT
+					ml.address,
+					ml.remarks,
+					ml.balance,
+					m.divisibility
+				FROM
+					mosaic_list ml
+					LEFT JOIN mosaics m
+						ON m.namespace_name = %s
+				ORDER BY ml.balance DESC
+				LIMIT %s OFFSET %s
+		'''
+
+		params = [namespace_name, namespace_name, pagination.limit, pagination.offset]
+
+		with self.connection() as connection:
+			cursor = connection.cursor()
+			cursor.execute(sql, params)
+			results = cursor.fetchall()
+
+			return [self._create_mosaic_rich_list_view(result) for result in results]

--- a/explorer/rest/rest/facade/NemRestFacade.py
+++ b/explorer/rest/rest/facade/NemRestFacade.py
@@ -131,3 +131,10 @@ class NemRestFacade:
 		mosaics = self.nem_db.get_mosaics(pagination, sort)
 
 		return [mosaic.to_dict() for mosaic in mosaics]
+
+	def get_mosaic_rich_list(self, pagination, namespace_name):
+		"""Gets mosaic rich list pagination."""
+
+		mosaic_rich_list = self.nem_db.get_mosaic_rich_list(pagination, namespace_name)
+
+		return [item.to_dict() for item in mosaic_rich_list]

--- a/explorer/rest/rest/model/Mosaic.py
+++ b/explorer/rest/rest/model/Mosaic.py
@@ -84,3 +84,28 @@ class MosaicView:  # pylint: disable=too-many-instance-attributes,too-few-public
 			'rootNamespaceRegisteredTimestamp': self.root_namespace_registered_timestamp,
 			'rootNamespaceExpirationHeight': self.root_namespace_expiration_height
 		}
+
+
+class MosaicRichListView:
+	def __init__(self, address, remark, balance):
+		"""Create mosaic rich list view."""
+
+		self.address = address
+		self.remark = remark
+		self.balance = balance
+
+	def __eq__(self, other):
+		return isinstance(other, MosaicRichListView) and all([
+			self.address == other.address,
+			self.remark == other.remark,
+			self.balance == other.balance
+		])
+
+	def to_dict(self):
+		"""Formats the mosaic rich list info as a dictionary."""
+
+		return {
+			'address': self.address,
+			'remark': self.remark,
+			'balance': self.balance
+		}

--- a/explorer/rest/tests/db/test_NemDatabase.py
+++ b/explorer/rest/tests/db/test_NemDatabase.py
@@ -1,7 +1,15 @@
 from rest import Pagination, Sorting
 from rest.db.NemDatabase import NemDatabase
 
-from ..test.DatabaseTestUtils import ACCOUNT_VIEWS, ACCOUNTS, BLOCK_VIEWS, MOSAIC_VIEWS, NAMESPACE_VIEWS, DatabaseTestBase
+from ..test.DatabaseTestUtils import (
+	ACCOUNT_VIEWS,
+	ACCOUNTS,
+	BLOCK_VIEWS,
+	MOSAIC_RICH_LIST_VIEWS,
+	MOSAIC_VIEWS,
+	NAMESPACE_VIEWS,
+	DatabaseTestBase
+)
 
 # region test data
 
@@ -17,9 +25,13 @@ EXPECTED_NAMESPACE_VIEW_1 = NAMESPACE_VIEWS[0]
 
 EXPECTED_NAMESPACE_VIEW_2 = NAMESPACE_VIEWS[1]
 
+EXPECTED_NAMESPACE_VIEW_3 = NAMESPACE_VIEWS[2]
+
 EXPECTED_MOSAIC_VIEW_1 = MOSAIC_VIEWS[0]
 
 EXPECTED_MOSAIC_VIEW_2 = MOSAIC_VIEWS[1]
+
+EXPECTED_MOSAIC_VIEW_3 = MOSAIC_VIEWS[2]
 
 # endregion
 
@@ -128,10 +140,10 @@ class NemDatabaseTest(DatabaseTestBase):  # pylint: disable=too-many-public-meth
 		self.assertEqual(expected_namespace, namespace_view)
 
 	def test_can_query_namespace_by_root_namespace(self):
-		self._assert_can_query_namespace_by_name('root', EXPECTED_NAMESPACE_VIEW_1)
+		self._assert_can_query_namespace_by_name('root', EXPECTED_NAMESPACE_VIEW_2)
 
 	def test_can_query_namespace_by_sub_namespace(self):
-		self._assert_can_query_namespace_by_name('root_sub.sub_1', EXPECTED_NAMESPACE_VIEW_2)
+		self._assert_can_query_namespace_by_name('root_sub.sub_1', EXPECTED_NAMESPACE_VIEW_3)
 
 	def test_cannot_query_nonexistent_namespace(self):
 		self._assert_can_query_namespace_by_name('nonexistent', None)
@@ -151,13 +163,21 @@ class NemDatabaseTest(DatabaseTestBase):  # pylint: disable=too-many-public-meth
 		self._assert_can_query_namespaces_with_filter(Pagination(1, 0), 'desc', [EXPECTED_NAMESPACE_VIEW_2])
 
 	def test_can_query_namespaces_filtered_offset_1(self):
-		self._assert_can_query_namespaces_with_filter(Pagination(1, 1), 'desc', [EXPECTED_NAMESPACE_VIEW_1])
+		self._assert_can_query_namespaces_with_filter(Pagination(1, 1), 'desc', [EXPECTED_NAMESPACE_VIEW_3])
 
 	def test_can_query_namespaces_sorted_by_registered_height_asc(self):
-		self._assert_can_query_namespaces_with_filter(Pagination(10, 0), 'asc', [EXPECTED_NAMESPACE_VIEW_1, EXPECTED_NAMESPACE_VIEW_2])
+		self._assert_can_query_namespaces_with_filter(
+			Pagination(10, 0),
+			'asc',
+			[EXPECTED_NAMESPACE_VIEW_1, EXPECTED_NAMESPACE_VIEW_2, EXPECTED_NAMESPACE_VIEW_3]
+		)
 
 	def test_can_query_namespaces_sorted_by_registered_height_desc(self):
-		self._assert_can_query_namespaces_with_filter(Pagination(10, 0), 'desc', [EXPECTED_NAMESPACE_VIEW_2, EXPECTED_NAMESPACE_VIEW_1])
+		self._assert_can_query_namespaces_with_filter(
+			Pagination(10, 0),
+			'desc',
+			[EXPECTED_NAMESPACE_VIEW_2, EXPECTED_NAMESPACE_VIEW_3, EXPECTED_NAMESPACE_VIEW_1]
+		)
 
 	# endregion
 
@@ -171,7 +191,7 @@ class NemDatabaseTest(DatabaseTestBase):  # pylint: disable=too-many-public-meth
 		self.assertEqual(expected_mosaic, mosaic_view)
 
 	def test_can_query_mosaic_by_namespace_name(self):
-		self._assert_can_query_mosaic_by_name('root.mosaic', EXPECTED_MOSAIC_VIEW_1)
+		self._assert_can_query_mosaic_by_name('root.mosaic', EXPECTED_MOSAIC_VIEW_2)
 
 	def test_cannot_query_nonexistent_mosaic(self):
 		self._assert_can_query_mosaic_by_name('nonexistent', None)
@@ -191,12 +211,42 @@ class NemDatabaseTest(DatabaseTestBase):  # pylint: disable=too-many-public-meth
 		self._assert_can_query_mosaics_with_filter(Pagination(1, 0), 'desc', [EXPECTED_MOSAIC_VIEW_2])
 
 	def test_can_query_mosaics_filtered_offset_1(self):
-		self._assert_can_query_mosaics_with_filter(Pagination(1, 1), 'desc', [EXPECTED_MOSAIC_VIEW_1])
+		self._assert_can_query_mosaics_with_filter(Pagination(1, 1), 'desc', [EXPECTED_MOSAIC_VIEW_3])
 
 	def test_can_query_mosaics_sorted_by_registered_height_asc(self):
-		self._assert_can_query_mosaics_with_filter(Pagination(10, 0), 'asc', [EXPECTED_MOSAIC_VIEW_1, EXPECTED_MOSAIC_VIEW_2])
+		self._assert_can_query_mosaics_with_filter(
+			Pagination(10, 0),
+			'asc',
+			[EXPECTED_MOSAIC_VIEW_1, EXPECTED_MOSAIC_VIEW_2, EXPECTED_MOSAIC_VIEW_3]
+		)
 
 	def test_can_query_mosaics_sorted_by_registered_height_desc(self):
-		self._assert_can_query_mosaics_with_filter(Pagination(10, 0), 'desc', [EXPECTED_MOSAIC_VIEW_2, EXPECTED_MOSAIC_VIEW_1])
+		self._assert_can_query_mosaics_with_filter(
+			Pagination(10, 0),
+			'desc',
+			[EXPECTED_MOSAIC_VIEW_2, EXPECTED_MOSAIC_VIEW_3, EXPECTED_MOSAIC_VIEW_1]
+		)
+
+	# endregion
+
+	# region mosaic rich list
+
+	def _assert_can_query_mosaic_rich_list_with_filter(self, pagination, namespace_name, expected_mosaic_rich_list):
+		# Act:
+		mosaic_rich_list_view = self.nem_db.get_mosaic_rich_list(pagination, namespace_name)
+		print(mosaic_rich_list_view)
+		print(expected_mosaic_rich_list)
+
+		# Assert:
+		self.assertEqual(expected_mosaic_rich_list, mosaic_rich_list_view)
+
+	def test_can_query_mosaic_rich_list_by_name(self):
+		self._assert_can_query_mosaic_rich_list_with_filter(Pagination(10, 0), 'nem.xem', [MOSAIC_RICH_LIST_VIEWS[1], MOSAIC_RICH_LIST_VIEWS[0]])
+
+	def test_can_query_mosaic_rich_list_with_limit_offset(self):
+		self._assert_can_query_mosaic_rich_list_with_filter(Pagination(1, 0), 'nem.xem', [MOSAIC_RICH_LIST_VIEWS[1]])
+
+	def test_can_query_mosaic_rich_list_filtered_offset_1(self):
+		self._assert_can_query_mosaic_rich_list_with_filter(Pagination(1, 1), 'nem.xem', [MOSAIC_RICH_LIST_VIEWS[0]])
 
 	# endregion

--- a/explorer/rest/tests/facade/test_NemRestFacade.py
+++ b/explorer/rest/tests/facade/test_NemRestFacade.py
@@ -6,7 +6,7 @@ from symbollightapi.model.Exceptions import NodeException
 from rest.facade.NemRestFacade import NemRestFacade
 from rest.model.common import Pagination, RestConfig, Sorting
 
-from ..test.DatabaseTestUtils import ACCOUNT_VIEWS, BLOCK_VIEWS, MOSAIC_VIEWS, NAMESPACE_VIEWS, DatabaseTestBase
+from ..test.DatabaseTestUtils import ACCOUNT_VIEWS, BLOCK_VIEWS, MOSAIC_RICH_LIST_VIEWS, MOSAIC_VIEWS, NAMESPACE_VIEWS, DatabaseTestBase
 
 # region test data
 
@@ -22,9 +22,17 @@ EXPECTED_NAMESPACE_1 = NAMESPACE_VIEWS[0].to_dict()
 
 EXPECTED_NAMESPACE_2 = NAMESPACE_VIEWS[1].to_dict()
 
+EXPECTED_NAMESPACE_3 = NAMESPACE_VIEWS[2].to_dict()
+
 EXPECTED_MOSAIC_1 = MOSAIC_VIEWS[0].to_dict()
 
 EXPECTED_MOSAIC_2 = MOSAIC_VIEWS[1].to_dict()
+
+EXPECTED_MOSAIC_3 = MOSAIC_VIEWS[2].to_dict()
+
+EXPECTED_MOSAIC_RICH_LIST_1 = MOSAIC_RICH_LIST_VIEWS[0].to_dict()
+
+EXPECTED_MOSAIC_RICH_LIST_2 = MOSAIC_RICH_LIST_VIEWS[1].to_dict()
 
 # endregion
 
@@ -228,10 +236,10 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 		self.assertEqual(expected_namespace, namespace)
 
 	def test_can_retrieve_namespace_by_root_namespace_name(self):
-		self._assert_can_retrieve_namespace_by_name(name='root', expected_namespace=EXPECTED_NAMESPACE_1)
+		self._assert_can_retrieve_namespace_by_name(name='root', expected_namespace=EXPECTED_NAMESPACE_2)
 
 	def test_can_retrieve_namespace_by_sub_namespace_name(self):
-		self._assert_can_retrieve_namespace_by_name(name='root_sub.sub_1', expected_namespace=EXPECTED_NAMESPACE_2)
+		self._assert_can_retrieve_namespace_by_name(name='root_sub.sub_1', expected_namespace=EXPECTED_NAMESPACE_3)
 
 	def test_returns_none_for_nonexistent_namespace_name(self):
 		self._assert_can_retrieve_namespace_by_name(name='nonexistent', expected_namespace=None)
@@ -258,21 +266,21 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 		self._assert_can_retrieve_namespaces(
 			pagination=Pagination(1, 1),
 			sort='DESC',
-			expected_namespaces=[EXPECTED_NAMESPACE_1]
+			expected_namespaces=[EXPECTED_NAMESPACE_3]
 		)
 
 	def test_can_retrieve_namespaces_sorted_by_registered_height_asc(self):
 		self._assert_can_retrieve_namespaces(
 			pagination=Pagination(10, 0),
 			sort='ASC',
-			expected_namespaces=[EXPECTED_NAMESPACE_1, EXPECTED_NAMESPACE_2]
+			expected_namespaces=[EXPECTED_NAMESPACE_1, EXPECTED_NAMESPACE_2, EXPECTED_NAMESPACE_3]
 		)
 
 	def test_can_retrieve_namespaces_sorted_by_registered_height_desc(self):
 		self._assert_can_retrieve_namespaces(
 			pagination=Pagination(10, 0),
 			sort='DESC',
-			expected_namespaces=[EXPECTED_NAMESPACE_2, EXPECTED_NAMESPACE_1]
+			expected_namespaces=[EXPECTED_NAMESPACE_2, EXPECTED_NAMESPACE_3, EXPECTED_NAMESPACE_1]
 		)
 
 	# endregion
@@ -287,7 +295,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 		self.assertEqual(expected_mosaic, mosaic)
 
 	def test_can_retrieve_mosaic_by_namespace_name(self):
-		self._assert_can_retrieve_mosaic_by_namespace_name(namespace_name='root.mosaic', expected_mosaic=EXPECTED_MOSAIC_1)
+		self._assert_can_retrieve_mosaic_by_namespace_name(namespace_name='root.mosaic', expected_mosaic=EXPECTED_MOSAIC_2)
 
 	def test_returns_none_for_nonexistent_mosaic_namespace_name(self):
 		self._assert_can_retrieve_mosaic_by_namespace_name(namespace_name='nonexistent', expected_mosaic=None)
@@ -314,21 +322,49 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 		self._assert_can_retrieve_mosaics(
 			pagination=Pagination(1, 1),
 			sort='DESC',
-			expected_mosaics=[EXPECTED_MOSAIC_1]
+			expected_mosaics=[EXPECTED_MOSAIC_3]
 		)
 
 	def test_can_retrieve_mosaics_sorted_by_registered_height_asc(self):
 		self._assert_can_retrieve_mosaics(
 			pagination=Pagination(10, 0),
 			sort='ASC',
-			expected_mosaics=[EXPECTED_MOSAIC_1, EXPECTED_MOSAIC_2]
+			expected_mosaics=[EXPECTED_MOSAIC_1, EXPECTED_MOSAIC_2, EXPECTED_MOSAIC_3]
 		)
 
 	def test_can_retrieve_mosaics_sorted_by_registered_height_desc(self):
 		self._assert_can_retrieve_mosaics(
 			pagination=Pagination(10, 0),
 			sort='DESC',
-			expected_mosaics=[EXPECTED_MOSAIC_2, EXPECTED_MOSAIC_1]
+			expected_mosaics=[EXPECTED_MOSAIC_2, EXPECTED_MOSAIC_3, EXPECTED_MOSAIC_1]
+		)
+
+	# endregion
+
+	# region mosaic rich list
+	def _assert_can_retrieve_mosaic_rich_list(self, pagination, expected_mosaic_rich_list):
+		# Act:
+		mosaic_rich_list = self.nem_rest_facade.get_mosaic_rich_list(pagination, 'nem.xem')
+
+		# Assert:
+		self.assertEqual(expected_mosaic_rich_list, mosaic_rich_list)
+
+	def test_can_retrieve_mosaic_rich_list_by_namespace_name(self):
+		self._assert_can_retrieve_mosaic_rich_list(
+			pagination=Pagination(10, 0),
+			expected_mosaic_rich_list=[EXPECTED_MOSAIC_RICH_LIST_2, EXPECTED_MOSAIC_RICH_LIST_1]
+		)
+
+	def test_can_retrieve_mosaic_rich_list_filtered_by_limit(self):
+		self._assert_can_retrieve_mosaic_rich_list(
+			pagination=Pagination(1, 0),
+			expected_mosaic_rich_list=[EXPECTED_MOSAIC_RICH_LIST_2]
+		)
+
+	def test_can_retrieve_mosaic_rich_list_filtered_by_offset(self):
+		self._assert_can_retrieve_mosaic_rich_list(
+			pagination=Pagination(1, 1),
+			expected_mosaic_rich_list=[EXPECTED_MOSAIC_RICH_LIST_1]
 		)
 
 	# endregion

--- a/explorer/rest/tests/model/test_Mosaic.py
+++ b/explorer/rest/tests/model/test_Mosaic.py
@@ -1,6 +1,6 @@
 import unittest
 
-from rest.model.Mosaic import MosaicView
+from rest.model.Mosaic import MosaicRichListView, MosaicView
 
 
 class MosaicTest(unittest.TestCase):
@@ -107,3 +107,53 @@ class MosaicTest(unittest.TestCase):
 		self.assertNotEqual(mosaic_view, self._create_default_mosaic_view(('root_namespace_registered_height', 2)))
 		self.assertNotEqual(mosaic_view, self._create_default_mosaic_view(('root_namespace_registered_timestamp', '2015-03-29 20:34:19')))
 		self.assertNotEqual(mosaic_view, self._create_default_mosaic_view(('root_namespace_expiration_height', 525701)))
+
+
+class MosaicRichListTest(unittest.TestCase):
+	@staticmethod
+	def _create_default_mosaic_rich_list_view(override=None):
+		mosaic_rich_list_view = MosaicRichListView(
+			address='TBZWVEKB2XMTO4F3RAOEIBWRBMPQ5N23G56ZJM4I',
+			remark='Test remark',
+			balance=1000
+		)
+
+		if override:
+			setattr(mosaic_rich_list_view, override[0], override[1])
+
+		return mosaic_rich_list_view
+
+	def test_can_create_mosaic_rich_list_view(self):
+		# Act:
+		mosaic_rich_list_view = self._create_default_mosaic_rich_list_view()
+
+		# Assert:
+		self.assertEqual('TBZWVEKB2XMTO4F3RAOEIBWRBMPQ5N23G56ZJM4I', mosaic_rich_list_view.address)
+		self.assertEqual('Test remark', mosaic_rich_list_view.remark)
+		self.assertEqual(1000, mosaic_rich_list_view.balance)
+
+	def test_can_convert_to_simple_dict(self):
+		# Arrange:
+		mosaic_rich_list_view = self._create_default_mosaic_rich_list_view()
+
+		# Act:
+		mosaic_rich_list_view_dict = mosaic_rich_list_view.to_dict()
+
+		# Assert:
+		self.assertEqual({
+			'address': 'TBZWVEKB2XMTO4F3RAOEIBWRBMPQ5N23G56ZJM4I',
+			'remark': 'Test remark',
+			'balance': 1000
+		}, mosaic_rich_list_view_dict)
+
+	def test_eq_is_supported(self):
+		# Arrange:
+		mosaic_rich_list_view = self._create_default_mosaic_rich_list_view()
+
+		# Assert:
+		self.assertEqual(mosaic_rich_list_view, self._create_default_mosaic_rich_list_view())
+		self.assertNotEqual(mosaic_rich_list_view, None)
+		self.assertNotEqual(mosaic_rich_list_view, 'mosaic_rich_list_view')
+		self.assertNotEqual(mosaic_rich_list_view, self._create_default_mosaic_rich_list_view(('address', 'ABC')))
+		self.assertNotEqual(mosaic_rich_list_view, self._create_default_mosaic_rich_list_view(('remark', 'Updated remark')))
+		self.assertNotEqual(mosaic_rich_list_view, self._create_default_mosaic_rich_list_view(('balance', 2000)))

--- a/explorer/rest/tests/test/DatabaseTestUtils.py
+++ b/explorer/rest/tests/test/DatabaseTestUtils.py
@@ -10,7 +10,7 @@ from symbolchain.nem.Network import Address, Network
 from rest.db.NemDatabase import NemDatabase
 from rest.model.Account import AccountView
 from rest.model.Block import BlockView
-from rest.model.Mosaic import MosaicView
+from rest.model.Mosaic import MosaicRichListView, MosaicView
 from rest.model.Namespace import NamespaceView
 
 Block = namedtuple(
@@ -66,6 +66,7 @@ Mosaic = namedtuple('Mosaic', [
 	'levy_fee',
 	'levy_recipient'
 ])
+AddressRemarks = namedtuple('Address_Remarks', ['address', 'remarks'])
 DatabaseConfig = namedtuple('DatabaseConfig', ['database', 'user', 'password', 'host', 'port'])
 
 # region test data
@@ -105,7 +106,7 @@ ACCOUNTS = [
 		0.123456,
 		1000000,
 		99999,
-		[{'quantity': 1000000, 'namespace': 'nem.xem'}],
+		[{'quantity': 1000000, 'namespace': 'nem.xem'}, {'quantity': 10, 'namespace': 'root.mosaic'}],
 		10,
 		'LOCKED',
 		'INACTIVE',
@@ -119,7 +120,7 @@ ACCOUNTS = [
 		0.123456,
 		3000000,
 		99999,
-		[{'quantity': 3000000, 'namespace': 'nem.xem'}],
+		[{'quantity': 3000000, 'namespace': 'nem.xem'}, {'quantity': 15, 'namespace': 'root.mosaic'}],
 		15,
 		'LOCKED',
 		'ACTIVE',
@@ -130,9 +131,16 @@ ACCOUNTS = [
 
 NAMESPACES = [
 	Namespace(
-		'root',
+		'nem',
 		PublicKey('a5f06d59b97aa40c82afb941a61fb6483bdb7491805cdb9dc47d92136983b9a5'),
 		1,
+		0,
+		['nem.xem']
+	),
+	Namespace(
+		'root',
+		PublicKey('a5f06d59b97aa40c82afb941a61fb6483bdb7491805cdb9dc47d92136983b9a5'),
+		2,
 		525700,
 		[]
 	),
@@ -147,11 +155,27 @@ NAMESPACES = [
 
 MOSAICS = [
 	Mosaic(
+		'nem',
+		'nem.xem',
+		'network currency',
+		PublicKey('a5f06d59b97aa40c82afb941a61fb6483bdb7491805cdb9dc47d92136983b9a5'),
+		1,
+		8999999999000000,
+		8999999999000000,
+		6,
+		False,
+		True,
+		None,
+		None,
+		None,
+		None
+	),
+	Mosaic(
 		'root',
 		'root.mosaic',
 		'Test mosaic',
 		PublicKey('a5f06d59b97aa40c82afb941a61fb6483bdb7491805cdb9dc47d92136983b9a5'),
-		1,
+		2,
 		1000000,
 		1000000,
 		0,
@@ -180,6 +204,17 @@ MOSAICS = [
 	),
 ]
 
+ADDRESS_REMARKS = [
+	AddressRemarks(
+		Address('NAGHXD63C4V6REWGXCVKJ2SBS3GUAXGTRQZQXPRO'),
+		'Test remark A'
+	),
+	AddressRemarks(
+		Address('NBFWZ4IVRHEIBRCGHLYDS62FSFTBM3VDFA7E6LSQ'),
+		'Test remark B'
+	)
+]
+
 
 BLOCK_VIEWS = [
 	BlockView(*BLOCKS[0]._replace(
@@ -205,6 +240,9 @@ ACCOUNT_VIEWS = [
 		mosaics=[{
 			'namespace_name': 'nem.xem',
 			'quantity': 1000000
+		}, {
+			'namespace_name': 'root.mosaic',
+			'quantity': 10
 		}],
 		harvested_fees=0.0,
 		harvested_blocks=ACCOUNTS[0].harvested_blocks,
@@ -225,6 +263,9 @@ ACCOUNT_VIEWS = [
 		mosaics=[{
 			'namespace_name': 'nem.xem',
 			'quantity': 3000000
+		}, {
+			'namespace_name': 'root.mosaic',
+			'quantity': 15
 		}],
 		harvested_fees=0.0,
 		harvested_blocks=ACCOUNTS[1].harvested_blocks,
@@ -253,6 +294,14 @@ NAMESPACE_VIEWS = [
 		registered_timestamp=BLOCKS[1].timestamp,
 		expiration_height=NAMESPACES[1].expiration_height,
 		sub_namespaces=NAMESPACES[1].sub_namespaces
+	),
+	NamespaceView(
+		root_namespace=NAMESPACES[2].root_namespace,
+		owner=str(NAMESPACES[2].owner),
+		registered_height=NAMESPACES[2].registered_height,
+		registered_timestamp=BLOCKS[1].timestamp,
+		expiration_height=NAMESPACES[2].expiration_height,
+		sub_namespaces=NAMESPACES[2].sub_namespaces
 	)
 ]
 
@@ -268,10 +317,10 @@ MOSAIC_VIEWS = [
 		divisibility=MOSAICS[0].divisibility,
 		supply_mutable=MOSAICS[0].supply_mutable,
 		transferable=MOSAICS[0].transferable,
-		levy_type='absolute fee',
-		levy_namespace_name=MOSAICS[0].levy_namespace_name,
-		levy_fee=1.0,
-		levy_recipient='NBFWZ4IVRHEIBRCGHLYDS62FSFTBM3VDFA7E6LSQ',
+		levy_type=None,
+		levy_namespace_name=None,
+		levy_fee=None,
+		levy_recipient=None,
 		root_namespace_registered_height=NAMESPACES[0].registered_height,
 		root_namespace_registered_timestamp=BLOCKS[0].timestamp,
 		root_namespace_expiration_height=NAMESPACES[0].expiration_height
@@ -287,13 +336,45 @@ MOSAIC_VIEWS = [
 		divisibility=MOSAICS[1].divisibility,
 		supply_mutable=MOSAICS[1].supply_mutable,
 		transferable=MOSAICS[1].transferable,
+		levy_type='absolute fee',
+		levy_namespace_name=MOSAICS[1].levy_namespace_name,
+		levy_fee=1.0,
+		levy_recipient='NBFWZ4IVRHEIBRCGHLYDS62FSFTBM3VDFA7E6LSQ',
+		root_namespace_registered_height=NAMESPACES[1].registered_height,
+		root_namespace_registered_timestamp=BLOCKS[1].timestamp,
+		root_namespace_expiration_height=NAMESPACES[1].expiration_height
+	),
+	MosaicView(
+		namespace_name=MOSAICS[2].namespace_name,
+		description=MOSAICS[2].description,
+		creator='NBFWZ4IVRHEIBRCGHLYDS62FSFTBM3VDFA7E6LSQ',
+		mosaic_registered_height=MOSAICS[2].registered_height,
+		mosaic_registered_timestamp=BLOCKS[1].timestamp,
+		initial_supply=MOSAICS[2].initial_supply,
+		total_supply=MOSAICS[2].total_supply,
+		divisibility=MOSAICS[2].divisibility,
+		supply_mutable=MOSAICS[2].supply_mutable,
+		transferable=MOSAICS[2].transferable,
 		levy_type=None,
 		levy_namespace_name=None,
 		levy_fee=None,
 		levy_recipient=None,
-		root_namespace_registered_height=NAMESPACES[0].registered_height,
-		root_namespace_registered_timestamp=BLOCKS[0].timestamp,
-		root_namespace_expiration_height=NAMESPACES[0].expiration_height
+		root_namespace_registered_height=NAMESPACES[1].registered_height,
+		root_namespace_registered_timestamp=BLOCKS[1].timestamp,
+		root_namespace_expiration_height=NAMESPACES[1].expiration_height
+	)
+]
+
+MOSAIC_RICH_LIST_VIEWS = [
+	MosaicRichListView(
+		address=str(ACCOUNTS[0].address),
+		remark='Test remark A',
+		balance=1.0
+	),
+	MosaicRichListView(
+		address=str(ACCOUNTS[1].address),
+		remark='Test remark B',
+		balance=3.0
 	)
 ]
 
@@ -378,6 +459,16 @@ def initialize_database(db_config, network_name):
 				levy_namespace_name varchar(146),
 				levy_fee bigint,
 				levy_recipient bytea
+			)
+			'''
+		)
+
+		cursor.execute(
+			'''
+			CREATE TABLE IF NOT EXISTS account_remarks (
+				id serial PRIMARY KEY,
+				address bytea UNIQUE,
+				remarks varchar NOT NULL
 			)
 			'''
 		)
@@ -493,6 +584,20 @@ def initialize_database(db_config, network_name):
 					mosaic.levy_namespace_name,
 					mosaic.levy_fee,
 					mosaic.levy_recipient.bytes if mosaic.levy_recipient else None
+				)
+			)
+
+		for address_remark in ADDRESS_REMARKS:
+			cursor.execute(
+				'''
+				INSERT INTO account_remarks (
+					address,
+					remarks
+				)
+				VALUES (%s, %s)
+				''', (
+					address_remark.address.bytes,
+					address_remark.remarks
 				)
 			)
 

--- a/explorer/rest/tests/test_rest.py
+++ b/explorer/rest/tests/test_rest.py
@@ -414,11 +414,11 @@ def _assert_get_nem_namespace_by_name(client, name, expected_status_code, expect
 
 
 def test_api_namespace_by_root_namespace(client):  # pylint: disable=redefined-outer-name
-	_assert_get_nem_namespace_by_name(client, 'root', 200, NAMESPACE_VIEWS[0].to_dict())
+	_assert_get_nem_namespace_by_name(client, 'root', 200, NAMESPACE_VIEWS[1].to_dict())
 
 
 def test_api_namespace_by_sub_namespace(client):  # pylint: disable=redefined-outer-name
-	_assert_get_nem_namespace_by_name(client, 'root_sub.sub_1', 200, NAMESPACE_VIEWS[1].to_dict())
+	_assert_get_nem_namespace_by_name(client, 'root_sub.sub_1', 200, NAMESPACE_VIEWS[2].to_dict())
 
 
 # endregion
@@ -435,7 +435,7 @@ def _assert_get_api_nem_namespaces(client, expected_status_code, expected_result
 
 
 def test_api_namespaces_without_params(client):  # pylint: disable=redefined-outer-name
-	_assert_get_api_nem_namespaces(client, 200, [NAMESPACE_VIEWS[1].to_dict(), NAMESPACE_VIEWS[0].to_dict()])
+	_assert_get_api_nem_namespaces(client, 200, [NAMESPACE_VIEWS[1].to_dict(), NAMESPACE_VIEWS[2].to_dict(), NAMESPACE_VIEWS[0].to_dict()])
 
 
 def test_api_namespaces_applies_limit(client):  # pylint: disable=redefined-outer-name
@@ -443,22 +443,30 @@ def test_api_namespaces_applies_limit(client):  # pylint: disable=redefined-oute
 
 
 def test_api_namespaces_applies_offset(client):  # pylint: disable=redefined-outer-name
-	_assert_get_api_nem_namespaces(client, 200, [NAMESPACE_VIEWS[0].to_dict()], offset=1)
+	_assert_get_api_nem_namespaces(client, 200, [NAMESPACE_VIEWS[2].to_dict(), NAMESPACE_VIEWS[0].to_dict()], offset=1)
 
 
 def test_api_namespaces_applies_sorted_by_registered_height_asc(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_namespaces(client, 200, [NAMESPACE_VIEWS[0].to_dict(), NAMESPACE_VIEWS[1].to_dict()], sort='ASC')
+	_assert_get_api_nem_namespaces(client, 200, [
+		NAMESPACE_VIEWS[0].to_dict(),
+		NAMESPACE_VIEWS[1].to_dict(),
+		NAMESPACE_VIEWS[2].to_dict()
+	], sort='ASC')
 
 
 def test_api_namespaces_applies_sorted_by_registered_height_desc(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_namespaces(client, 200, [NAMESPACE_VIEWS[1].to_dict(), NAMESPACE_VIEWS[0].to_dict()], sort='DESC')
+	_assert_get_api_nem_namespaces(client, 200, [
+		NAMESPACE_VIEWS[1].to_dict(),
+		NAMESPACE_VIEWS[2].to_dict(),
+		NAMESPACE_VIEWS[0].to_dict()
+	], sort='DESC')
 
 
 def test_api_namespaces_with_all_params(client):  # pylint: disable=redefined-outer-name
 	_assert_get_api_nem_namespaces(
 		client,
 		200,
-		[NAMESPACE_VIEWS[0].to_dict()],
+		[NAMESPACE_VIEWS[2].to_dict()],
 		limit=1,
 		offset=1,
 		sort='DESC'
@@ -475,7 +483,7 @@ def test_api_mosaic_by_name(client):  # pylint: disable=redefined-outer-name
 
 	# Assert:
 	_assert_status_code_and_headers(response, 200)
-	assert MOSAIC_VIEWS[0].to_dict() == response.json
+	assert MOSAIC_VIEWS[1].to_dict() == response.json
 
 
 # endregion
@@ -492,7 +500,7 @@ def _assert_get_api_nem_mosaics(client, expected_status_code, expected_result, *
 
 
 def test_api_mosaics_without_params(client):  # pylint: disable=redefined-outer-name
-	_assert_get_api_nem_mosaics(client, 200, [MOSAIC_VIEWS[1].to_dict(), MOSAIC_VIEWS[0].to_dict()])
+	_assert_get_api_nem_mosaics(client, 200, [MOSAIC_VIEWS[1].to_dict(), MOSAIC_VIEWS[2].to_dict(), MOSAIC_VIEWS[0].to_dict()])
 
 
 def test_api_mosaics_applies_limit(client):  # pylint: disable=redefined-outer-name
@@ -500,22 +508,22 @@ def test_api_mosaics_applies_limit(client):  # pylint: disable=redefined-outer-n
 
 
 def test_api_mosaics_applies_offset(client):  # pylint: disable=redefined-outer-name
-	_assert_get_api_nem_mosaics(client, 200, [MOSAIC_VIEWS[0].to_dict()], offset=1)
+	_assert_get_api_nem_mosaics(client, 200, [MOSAIC_VIEWS[2].to_dict(), MOSAIC_VIEWS[0].to_dict()], offset=1)
 
 
 def test_api_mosaics_applies_sorted_by_registered_height_asc(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_mosaics(client, 200, [MOSAIC_VIEWS[0].to_dict(), MOSAIC_VIEWS[1].to_dict()], sort='ASC')
+	_assert_get_api_nem_mosaics(client, 200, [MOSAIC_VIEWS[0].to_dict(), MOSAIC_VIEWS[1].to_dict(), MOSAIC_VIEWS[2].to_dict()], sort='ASC')
 
 
 def test_api_mosaics_applies_sorted_by_registered_height_desc(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_mosaics(client, 200, [MOSAIC_VIEWS[1].to_dict(), MOSAIC_VIEWS[0].to_dict()], sort='DESC')
+	_assert_get_api_nem_mosaics(client, 200, [MOSAIC_VIEWS[1].to_dict(), MOSAIC_VIEWS[2].to_dict(), MOSAIC_VIEWS[0].to_dict()], sort='DESC')
 
 
 def test_api_mosaics_with_all_params(client):  # pylint: disable=redefined-outer-name
 	_assert_get_api_nem_mosaics(
 		client,
 		200,
-		[MOSAIC_VIEWS[0].to_dict()],
+		[MOSAIC_VIEWS[2].to_dict()],
 		limit=1,
 		offset=1,
 		sort='DESC'

--- a/explorer/rest/tests/test_rest.py
+++ b/explorer/rest/tests/test_rest.py
@@ -9,7 +9,15 @@ from symbollightapi.model.Exceptions import NodeException
 
 from rest import create_app
 
-from .test.DatabaseTestUtils import ACCOUNT_VIEWS, BLOCK_VIEWS, MOSAIC_VIEWS, NAMESPACE_VIEWS, DatabaseConfig, initialize_database
+from .test.DatabaseTestUtils import (
+	ACCOUNT_VIEWS,
+	BLOCK_VIEWS,
+	MOSAIC_RICH_LIST_VIEWS,
+	MOSAIC_VIEWS,
+	NAMESPACE_VIEWS,
+	DatabaseConfig,
+	initialize_database
+)
 
 DATABASE_CONFIG_INI = 'db_config.ini'
 
@@ -91,7 +99,7 @@ def _get_api(client, endpoint, **query_params):  # pylint: disable=redefined-out
 
 def test_invalid_pagination_params(client):  # pylint: disable=redefined-outer-name
 
-	for module in ['blocks', 'accounts', 'namespaces', 'mosaics']:
+	for module in ['blocks', 'accounts', 'namespaces', 'mosaics', 'mosaic/rich/list']:
 		# Act:
 		response = client.get(f'/api/nem/{module}', query_string={'limit': -1})
 
@@ -528,6 +536,58 @@ def test_api_mosaics_with_all_params(client):  # pylint: disable=redefined-outer
 		offset=1,
 		sort='DESC'
 	)
+
+
+# endregion
+
+# region /mosaic/rich/list Todo: fix line to long
+
+def _assert_get_api_nem_mosaic_rich_list(client, expected_status_code, expected_result, **query_params):
+	# pylint: disable=redefined-outer-name
+	# Act:
+	response = _get_api(client, 'mosaic/rich/list', **query_params)
+
+	# Assert:
+	_assert_status_code_and_headers(response, expected_status_code)
+	assert expected_result == response.json
+
+
+def test_api_mosaic_rich_list_without_params(client):  # pylint: disable=redefined-outer-name, invalid-name
+	_assert_get_api_nem_mosaic_rich_list(
+		client,
+		200,
+		[
+			MOSAIC_RICH_LIST_VIEWS[1].to_dict(),
+			MOSAIC_RICH_LIST_VIEWS[0].to_dict()
+		]
+	)
+
+
+def test_api_mosaic_rich_list_applies_namespace_name(client):  # pylint: disable=redefined-outer-name, invalid-name
+	_assert_get_api_nem_mosaic_rich_list(
+		client,
+		200,
+		[
+			MOSAIC_RICH_LIST_VIEWS[1].to_dict(),
+			MOSAIC_RICH_LIST_VIEWS[0].to_dict()
+		],
+		namespace_name='nem.xem'
+	)
+
+
+def test_api_mosaic_rich_list_applies_limit(client):  # pylint: disable=redefined-outer-name, invalid-name
+	_assert_get_api_nem_mosaic_rich_list(
+		client,
+		200,
+		[
+			MOSAIC_RICH_LIST_VIEWS[1].to_dict()
+		],
+		limit=1
+	)
+
+
+def test_api_mosaic_rich_list_applies_offset(client):  # pylint: disable=redefined-outer-name, invalid-name
+	_assert_get_api_nem_mosaic_rich_list(client, 200, [MOSAIC_RICH_LIST_VIEWS[0].to_dict()], offset=1)
 
 
 # endregion


### PR DESCRIPTION
Problem: Missing mosaic rich list and filter by namespace name.
Solution: 
- Added  `/mosaic/rich/list` endpoint for query by namespace name