### PR TITLE
[explorer/puller] feat: process transactions from blocks

### DIFF
--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -107,13 +107,6 @@ class NemDatabase(DatabaseConnection):
 			'''
 		)
 
-		cursor.execute(
-			'''
-			CREATE INDEX IF NOT EXISTS idx_tx_inner_transaction_id
-				ON transactions(inner_transaction_id)
-			'''
-		)
-
 		# Create indexes for transactions_mosaic table
 		cursor.execute(
 			'''
@@ -232,9 +225,7 @@ class NemDatabase(DatabaseConnection):
 				signature bytea,
 				amount bigint,
 				is_inner boolean DEFAULT false,
-				inner_transaction_id int,
-				payload jsonb,
-				FOREIGN KEY (inner_transaction_id) REFERENCES transactions(id)
+				payload jsonb
 			)
 			'''
 		)
@@ -497,10 +488,9 @@ class NemDatabase(DatabaseConnection):
 				signature,
 				amount,
 				is_inner,
-				inner_transaction_id,
 				payload
 			)
-			VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+			VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 			RETURNING id
 			''',
 			(
@@ -516,7 +506,6 @@ class NemDatabase(DatabaseConnection):
 				unhexlify(transaction.signature) if transaction.signature else None,
 				transaction.amount,
 				transaction.is_inner,
-				transaction.inner_transaction_id,
 				json.dumps(transaction.payload) if transaction.payload else None
 			)
 		)

--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -102,13 +102,6 @@ class NemDatabase(DatabaseConnection):
 
 		cursor.execute(
 			'''
-			CREATE INDEX IF NOT EXISTS idx_tx_sender_public_key
-				ON transactions(sender_public_key)
-			'''
-		)
-
-		cursor.execute(
-			'''
 			CREATE INDEX IF NOT EXISTS idx_tx_is_inner
 				ON transactions(is_inner)
 			'''

--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -63,6 +63,79 @@ class NemDatabase(DatabaseConnection):
 			'''
 		)
 
+		# Create indexes for transactions table
+		cursor.execute(
+			'''
+			CREATE INDEX IF NOT EXISTS idx_transactions_hash
+				ON transactions (transaction_hash)
+			'''
+		)
+
+		cursor.execute(
+			'''
+			CREATE INDEX IF NOT EXISTS idx_transaction_type
+				ON transactions (transaction_type)
+			'''
+		)
+
+		cursor.execute(
+			'''
+			CREATE INDEX IF NOT EXISTS idx_transaction_height
+				ON transactions(height DESC)
+				WHERE is_inner = false
+			'''
+		)
+
+		cursor.execute(
+			'''
+			CREATE INDEX IF NOT EXISTS idx_tx_recipient
+				ON transactions(recipient_address)
+			'''
+		)
+
+		cursor.execute(
+			'''
+			CREATE INDEX IF NOT EXISTS idx_tx_sender_address
+				ON transactions(sender_address)
+			'''
+		)
+
+		cursor.execute(
+			'''
+			CREATE INDEX IF NOT EXISTS idx_tx_sender_public_key
+				ON transactions(sender_public_key)
+			'''
+		)
+
+		cursor.execute(
+			'''
+			CREATE INDEX IF NOT EXISTS idx_tx_is_inner
+				ON transactions(is_inner)
+			'''
+		)
+
+		cursor.execute(
+			'''
+			CREATE INDEX IF NOT EXISTS idx_tx_inner_transaction_id
+				ON transactions(inner_transaction_id)
+			'''
+		)
+
+		# Create indexes for transactions_mosaic table
+		cursor.execute(
+			'''
+			CREATE INDEX IF NOT EXISTS idx_mosaic_tx_i
+				ON transactions_mosaic(transaction_id)
+			'''
+		)
+
+		cursor.execute(
+			'''
+			CREATE INDEX IF NOT EXISTS idx_mosaic_lookup
+				ON transactions_mosaic(namespace_name)
+			'''
+		)
+
 	def create_tables(self):
 		"""Creates database tables."""
 
@@ -145,6 +218,44 @@ class NemDatabase(DatabaseConnection):
 				levy_namespace_name varchar(146),
 				levy_fee bigint,
 				levy_recipient bytea
+			)
+			'''
+		)
+
+		# Create Transactions table
+		cursor.execute(
+			'''
+			CREATE TABLE IF NOT EXISTS transactions (
+				id serial PRIMARY KEY,
+				transaction_hash bytea UNIQUE NOT NULL,
+				transaction_type int NOT NULL,
+				height bigint NOT NULL,
+				sender_public_key bytea NOT NULL,
+				sender_address bytea NOT NULL,
+				recipient_address bytea,
+				fee bigint DEFAULT 0,
+				timestamp timestamp NOT NULL,
+				deadline timestamp NOT NULL,
+				signature bytea,
+				amount bigint,
+				is_inner boolean DEFAULT false,
+				inner_transaction_id int,
+				payload jsonb,
+				FOREIGN KEY (inner_transaction_id) REFERENCES transactions(id)
+			)
+			'''
+		)
+
+		# Create Transactions mosaic table
+		cursor.execute(
+			'''
+			CREATE TABLE IF NOT EXISTS transactions_mosaic (
+				id serial PRIMARY KEY,
+				transaction_id int NOT NULL,
+				namespace_name varchar(146),
+				quantity bigint,
+				FOREIGN KEY (transaction_id) REFERENCES transactions(id)
+				ON DELETE CASCADE
 			)
 			'''
 		)
@@ -371,5 +482,70 @@ class NemDatabase(DatabaseConnection):
 			(
 				adjustment,
 				namespace_name
+			)
+		)
+
+	@staticmethod
+	def insert_transaction(cursor, transaction):
+		"""Inserts transaction information."""
+
+		cursor.execute(
+			'''
+			INSERT INTO transactions (
+				transaction_hash,
+				transaction_type,
+				height,
+				sender_public_key,
+				sender_address,
+				recipient_address,
+				fee,
+				timestamp,
+				deadline,
+				signature,
+				amount,
+				is_inner,
+				inner_transaction_id,
+				payload
+			)
+			VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+			RETURNING id
+			''',
+			(
+				unhexlify(transaction.transaction_hash),
+				transaction.transaction_type,
+				transaction.height,
+				transaction.sender_public_key.bytes,
+				transaction.sender_address.bytes,
+				transaction.recipient_address.bytes if transaction.recipient_address else None,
+				transaction.fee,
+				transaction.timestamp,
+				transaction.deadline,
+				unhexlify(transaction.signature) if transaction.signature else None,
+				transaction.amount,
+				transaction.is_inner,
+				transaction.inner_transaction_id,
+				json.dumps(transaction.payload) if transaction.payload else None
+			)
+		)
+
+		return cursor.fetchone()[0]
+
+	@staticmethod
+	def insert_transaction_mosaic(cursor, transaction_id, mosaic):
+		"""Inserts transaction mosaic information."""
+
+		cursor.execute(
+			'''
+			INSERT INTO transactions_mosaic (
+				transaction_id,
+				namespace_name,
+				quantity
+			)
+			VALUES (%s, %s, %s)
+			''',
+			(
+				transaction_id,
+				mosaic.namespace_name,
+				mosaic.quantity
 			)
 		)

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -368,11 +368,17 @@ class NemPuller:
 		"""Create TransactionRecord from transaction data."""
 
 		payload = None
+		recipient_address = None
+		amount = None
 		if transaction.transaction_type == TransactionType.TRANSFER.value:
 			payload = {
-				'payload': transaction.message.payload,
-				'is_plain': transaction.message.is_plain,
-			} if transaction.message else {}
+				'message': {
+					'payload': transaction.message.payload,
+					'is_plain': transaction.message.is_plain,
+				} if transaction.message else None
+			}
+			recipient_address = transaction.recipient
+			amount = transaction.amount
 		elif transaction.transaction_type == TransactionType.ACCOUNT_KEY_LINK.value:
 			payload = {
 				'mode': transaction.mode,
@@ -407,14 +413,13 @@ class NemPuller:
 			}
 		elif transaction.transaction_type == TransactionType.NAMESPACE_REGISTRATION.value:
 			payload = {
-				'rental_fee_sink': str(transaction.rental_fee_sink),
 				'rental_fee': transaction.rental_fee,
 				'parent': transaction.parent,
 				'namespace': transaction.namespace
 			}
+			recipient_address = transaction.rental_fee_sink
 		elif transaction.transaction_type == TransactionType.MOSAIC_DEFINITION.value:
 			payload = {
-				'creation_fee_sink': str(transaction.creation_fee_sink),
 				'creation_fee': transaction.creation_fee,
 				'creator': str(transaction.sender),
 				'description': transaction.description,
@@ -432,6 +437,7 @@ class NemPuller:
 					'recipient': str(transaction.levy.recipient)
 				} if transaction.levy else None
 			}
+			recipient_address = transaction.creation_fee_sink
 		elif transaction.transaction_type == TransactionType.MOSAIC_SUPPLY_CHANGE.value:
 			payload = {
 				'namespace_name': transaction.namespace_name,
@@ -446,13 +452,13 @@ class NemPuller:
 			fee=transaction.fee,
 			timestamp=self._convert_timestamp_to_datetime(transaction.timestamp),
 			deadline=self._convert_timestamp_to_datetime(transaction.deadline),
-			amount=transaction.amount if hasattr(transaction, 'amount') else None,
+			amount=amount,
 			signature=transaction.signature,
 			transaction_type=transaction.transaction_type,
 			is_inner=is_inner,
 			inner_transaction_id=inner_transaction_id,  # to be updated after insertion if it's an inner transaction
 			sender_address=transaction.sender,
-			recipient_address=transaction.recipient if hasattr(transaction, 'recipient') else None,
+			recipient_address=recipient_address,
 			payload=payload
 		)
 

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -74,7 +74,6 @@ TransactionRecord = namedtuple('TransactionRecord', [
 	'amount',
 	'transaction_type',
 	'is_inner',
-	'inner_transaction_id',
 	'sender_address',
 	'recipient_address',
 	'payload'
@@ -364,7 +363,7 @@ class NemPuller:
 		adjustment = transaction.delta if transaction.supply_type == 1 else -transaction.delta
 		self.nem_db.update_mosaic_total_supply(cursor, transaction.namespace_name, adjustment)
 
-	def _build_transaction_record(self, transaction, is_inner, inner_transaction_id=None):
+	def _build_transaction_record(self, transaction, is_inner):
 		"""Create TransactionRecord from transaction data."""
 
 		payload = None
@@ -456,17 +455,16 @@ class NemPuller:
 			signature=transaction.signature,
 			transaction_type=transaction.transaction_type,
 			is_inner=is_inner,
-			inner_transaction_id=inner_transaction_id,  # to be updated after insertion if it's an inner transaction
-			sender_address=transaction.sender,
+			sender_address=self._convert_public_key_to_address(transaction.sender),
 			recipient_address=recipient_address,
 			payload=payload
 		)
 
-	def _process_transaction(self, cursor, transaction, block_height, is_inner, inner_transaction_id=None):
+	def _process_transaction(self, cursor, transaction, block_height, is_inner):
 		# pylint: disable=too-many-arguments,too-many-positional-arguments
 		"""Process a single transaction."""
 
-		transaction_record = self._build_transaction_record(transaction, is_inner, inner_transaction_id)
+		transaction_record = self._build_transaction_record(transaction, is_inner)
 		transaction_id = self.nem_db.insert_transaction(cursor, transaction_record)
 
 		if transaction.transaction_type == TransactionType.TRANSFER.value and transaction.mosaics:
@@ -485,21 +483,19 @@ class NemPuller:
 		"""Process transactions in a block."""
 
 		for transaction in block_transactions:
-			inner_transaction_id = None
 
 			# Handle inner transaction first to get its ID for linking
 			if hasattr(transaction, 'other_transaction'):
 				# For inner transactions, we set the transaction hash to the inner hash
 				transaction.other_transaction.transaction_hash = transaction.inner_hash
 				transaction.other_transaction.height = transaction.height
-				inner_transaction_id = self._process_transaction(cursor, transaction=transaction.other_transaction, block_height=height, is_inner=True)
+				self._process_transaction(cursor, transaction=transaction.other_transaction, block_height=height, is_inner=True)
 
 			self._process_transaction(
 				cursor,
 				transaction=transaction,
 				block_height=height,
-				is_inner=False,
-				inner_transaction_id=inner_transaction_id
+				is_inner=False
 			)
 
 	async def sync_nemesis_block(self):

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -455,16 +455,46 @@ class NemPuller:
 			recipient_address=transaction.recipient if hasattr(transaction, 'recipient') else None,
 			payload=payload
 		)
+
+	def _process_transaction(self, cursor, transaction, block_height, is_inner, inner_transaction_id=None):
+		# pylint: disable=too-many-arguments,too-many-positional-arguments
+		"""Process a single transaction."""
+
+		transaction_record = self._build_transaction_record(transaction, is_inner, inner_transaction_id)
+		transaction_id = self.nem_db.insert_transaction(cursor, transaction_record)
+
+		if transaction.transaction_type == TransactionType.TRANSFER.value and transaction.mosaics:
+			for mosaic in transaction.mosaics:
+				self.nem_db.insert_transaction_mosaic(cursor, transaction_id, mosaic)
+		elif transaction.transaction_type == TransactionType.NAMESPACE_REGISTRATION.value:
+			self._process_namespace(cursor, transaction, block_height)
+		elif transaction.transaction_type == TransactionType.MOSAIC_DEFINITION.value:
+			self._process_mosaic_definition(cursor, transaction, block_height)
+		elif transaction.transaction_type == TransactionType.MOSAIC_SUPPLY_CHANGE.value:
+			self._process_mosaic_supply_change(cursor, transaction)
+
+		return transaction_id
+
 	def _process_transactions(self, cursor, block_transactions, height):
 		"""Process transactions in a block."""
 
 		for transaction in block_transactions:
-			if transaction.transaction_type == TransactionType.NAMESPACE_REGISTRATION.value:
-				self._process_namespace(cursor, transaction, height)
-			elif transaction.transaction_type == TransactionType.MOSAIC_DEFINITION.value:
-				self._process_mosaic_definition(cursor, transaction, height)
-			elif transaction.transaction_type == TransactionType.MOSAIC_SUPPLY_CHANGE.value:
-				self._process_mosaic_supply_change(cursor, transaction)
+			inner_transaction_id = None
+
+			# Handle inner transaction first to get its ID for linking
+			if hasattr(transaction, 'other_transaction'):
+				# For inner transactions, we set the transaction hash to the inner hash
+				transaction.other_transaction.transaction_hash = transaction.inner_hash
+				transaction.other_transaction.height = transaction.height
+				inner_transaction_id = self._process_transaction(cursor, transaction=transaction.other_transaction, block_height=height, is_inner=True)
+
+			self._process_transaction(
+				cursor,
+				transaction=transaction,
+				block_height=height,
+				is_inner=False,
+				inner_transaction_id=inner_transaction_id
+			)
 
 	async def sync_nemesis_block(self):
 		"""Sync and write Nemesis block to database."""

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -63,6 +63,22 @@ MosaicRecord = namedtuple('MosaicRecord', [
 	'levy_fee',
 	'levy_recipient'
 ])
+TransactionRecord = namedtuple('TransactionRecord', [
+	'transaction_hash',
+	'height',
+	'sender_public_key',
+	'fee',
+	'timestamp',
+	'deadline',
+	'signature',
+	'amount',
+	'transaction_type',
+	'is_inner',
+	'inner_transaction_id',
+	'sender_address',
+	'recipient_address',
+	'payload'
+])
 DatabaseConfig = namedtuple('DatabaseConfig', ['database', 'user', 'password', 'host', 'port'])
 
 
@@ -348,6 +364,97 @@ class NemPuller:
 		adjustment = transaction.delta if transaction.supply_type == 1 else -transaction.delta
 		self.nem_db.update_mosaic_total_supply(cursor, transaction.namespace_name, adjustment)
 
+	def _build_transaction_record(self, transaction, is_inner, inner_transaction_id=None):
+		"""Create TransactionRecord from transaction data."""
+
+		payload = None
+		if transaction.transaction_type == TransactionType.TRANSFER.value:
+			payload = {
+				'payload': transaction.message.payload,
+				'is_plain': transaction.message.is_plain,
+			} if transaction.message else {}
+		elif transaction.transaction_type == TransactionType.ACCOUNT_KEY_LINK.value:
+			payload = {
+				'mode': transaction.mode,
+				'remote_account': str(transaction.remote_account)
+			}
+		elif transaction.transaction_type == TransactionType.MULTISIG_ACCOUNT_MODIFICATION.value:
+			payload = {
+				'min_cosignatories': transaction.min_cosignatories,
+				'modifications': [
+					{
+						'modification_type': modification.modification_type,
+						'cosignatory_account': str(modification.cosignatory_account)
+					}
+					for modification in transaction.modifications
+				]
+			}
+		elif transaction.transaction_type == TransactionType.MULTISIG.value:
+			payload = {
+				'inner_hash': transaction.inner_hash,
+				'signatures': [
+					{
+						'transaction_type': signature.transaction_type,
+						'timestamp': self._convert_timestamp_to_datetime(signature.timestamp),
+						'deadline': self._convert_timestamp_to_datetime(signature.deadline),
+						'fee': signature.fee,
+						'other_hash': signature.other_hash,
+						'other_account': str(signature.other_account),
+						'sender': str(signature.sender),
+						'signature': signature.signature
+					} for signature in transaction.signatures
+				]
+			}
+		elif transaction.transaction_type == TransactionType.NAMESPACE_REGISTRATION.value:
+			payload = {
+				'rental_fee_sink': str(transaction.rental_fee_sink),
+				'rental_fee': transaction.rental_fee,
+				'parent': transaction.parent,
+				'namespace': transaction.namespace
+			}
+		elif transaction.transaction_type == TransactionType.MOSAIC_DEFINITION.value:
+			payload = {
+				'creation_fee_sink': str(transaction.creation_fee_sink),
+				'creation_fee': transaction.creation_fee,
+				'creator': str(transaction.sender),
+				'description': transaction.description,
+				'namespace_name': transaction.namespace_name,
+				'mosaic_properties': {
+					'divisibility': transaction.properties.divisibility,
+					'initial_supply': transaction.properties.initial_supply,
+					'supply_mutable': transaction.properties.supply_mutable,
+					'transferable': transaction.properties.transferable
+				},
+				'levy': {
+					'type': transaction.levy.type,
+					'namespace_name': transaction.levy.namespace_name,
+					'fee': transaction.levy.fee,
+					'recipient': str(transaction.levy.recipient)
+				} if transaction.levy else None
+			}
+		elif transaction.transaction_type == TransactionType.MOSAIC_SUPPLY_CHANGE.value:
+			payload = {
+				'namespace_name': transaction.namespace_name,
+				'supply_type': transaction.supply_type,
+				'delta': transaction.delta
+			}
+
+		return TransactionRecord(
+			transaction_hash=transaction.transaction_hash,
+			height=transaction.height,
+			sender_public_key=transaction.sender,
+			fee=transaction.fee,
+			timestamp=self._convert_timestamp_to_datetime(transaction.timestamp),
+			deadline=self._convert_timestamp_to_datetime(transaction.deadline),
+			amount=transaction.amount if hasattr(transaction, 'amount') else None,
+			signature=transaction.signature,
+			transaction_type=transaction.transaction_type,
+			is_inner=is_inner,
+			inner_transaction_id=inner_transaction_id,  # to be updated after insertion if it's an inner transaction
+			sender_address=transaction.sender,
+			recipient_address=transaction.recipient if hasattr(transaction, 'recipient') else None,
+			payload=payload
+		)
 	def _process_transactions(self, cursor, block_transactions, height):
 		"""Process transactions in a block."""
 

--- a/explorer/puller/tests/db/test_NemDatabase.py
+++ b/explorer/puller/tests/db/test_NemDatabase.py
@@ -91,7 +91,6 @@ TRANSACTIONS = [
 		),
 		transaction_type=257,
 		is_inner=False,
-		inner_transaction_id=None,
 		sender_address=Address('TCJLCZSOQ6RGWHTPSV2DW467WZSHK4NBSITND4OF'),
 		recipient_address=Address('TBZWVEKB2XMTO4F3RAOEIBWRBMPQ5N23G56ZJM4I'),
 		payload='{}'
@@ -691,7 +690,6 @@ class NemDatabaseTest(unittest.TestCase):
 					encode(signature, 'hex'),
 					amount,
 					is_inner,
-					inner_transaction_id,
 					payload
 				FROM transactions
 				WHERE id = %s
@@ -715,7 +713,6 @@ class NemDatabaseTest(unittest.TestCase):
 			TRANSACTIONS[0].signature,
 			2000000,
 			False,
-			None,
 			'{}'
 		))
 

--- a/explorer/puller/tests/db/test_NemDatabase.py
+++ b/explorer/puller/tests/db/test_NemDatabase.py
@@ -1,11 +1,11 @@
 import datetime
 import unittest
-from unittest.mock import MagicMock
 
 import psycopg2
 import testing.postgresql
 from symbolchain.CryptoTypes import PublicKey
 from symbolchain.nem.Network import Address
+from symbollightapi.model.Transaction import Mosaic
 from test_DatabaseConnection import DatabaseConfig
 
 from puller.db.NemDatabase import NemDatabase
@@ -721,10 +721,6 @@ class NemDatabaseTest(unittest.TestCase):
 
 	def test_insert_transaction_mosaic(self):
 		# Arrange:
-		mosaic = MagicMock()
-		mosaic.namespace_name = 'nem.xem'
-		mosaic.quantity = 2000000
-
 		with NemDatabase(self.db_config) as nem_database:
 			nem_database.create_tables()
 
@@ -739,7 +735,10 @@ class NemDatabaseTest(unittest.TestCase):
 			nem_database.insert_transaction_mosaic(
 				cursor,
 				transaction_id=1,
-				mosaic=mosaic
+				mosaic=Mosaic(
+					namespace_name='nem.xem',
+					quantity=2000000
+				)
 			)
 
 			nem_database.connection.commit()

--- a/explorer/puller/tests/db/test_NemDatabase.py
+++ b/explorer/puller/tests/db/test_NemDatabase.py
@@ -1,5 +1,6 @@
 import datetime
 import unittest
+from unittest.mock import MagicMock
 
 import psycopg2
 import testing.postgresql
@@ -8,7 +9,7 @@ from symbolchain.nem.Network import Address
 from test_DatabaseConnection import DatabaseConfig
 
 from puller.db.NemDatabase import NemDatabase
-from puller.facade.NemPuller import AccountRecord, BlockRecord, MosaicRecord, NamespaceRecord
+from puller.facade.NemPuller import AccountRecord, BlockRecord, MosaicRecord, NamespaceRecord, TransactionRecord
 
 # region test data
 
@@ -74,6 +75,29 @@ MOSAICS = [
 		levy_recipient=None
 	)
 ]
+
+TRANSACTIONS = [
+	TransactionRecord(
+		transaction_hash='438cf6375dab5a0d32f9b7bf151d4539e00a590f7c022d5572c7d41815a24be4',
+		height=2,
+		sender_public_key=PublicKey('f9bd190dd0c364261f5c8a74870cc7f7374e631352293c62ecc437657e5de2cd'),
+		fee=150000,
+		timestamp='2015-03-29 00:06:25+00:00',
+		deadline='2015-03-29 20:34:19+00:00',
+		amount=2000000,
+		signature=(
+			'1b81379847241e45da86b27911e5c9a9192ec04f644d98019657d32838b49c14'
+			'3eaa4815a3028b80f9affdbf0b94cd620f7a925e02783dda67b8627b69ddf70e'
+		),
+		transaction_type=257,
+		is_inner=False,
+		inner_transaction_id=None,
+		sender_address=Address('TCJLCZSOQ6RGWHTPSV2DW467WZSHK4NBSITND4OF'),
+		recipient_address=Address('TBZWVEKB2XMTO4F3RAOEIBWRBMPQ5N23G56ZJM4I'),
+		payload='{}'
+	)
+]
+
 # endregion
 
 
@@ -183,11 +207,13 @@ class NemDatabaseTest(unittest.TestCase):
 			results = cursor.fetchall()
 
 		# Assert:
-		self.assertEqual(len(results), 4)
+		self.assertEqual(len(results), 6)
 		self.assertEqual(results[0][0], 'accounts')
 		self.assertEqual(results[1][0], 'blocks')
 		self.assertEqual(results[2][0], 'mosaics')
 		self.assertEqual(results[3][0], 'namespaces')
+		self.assertEqual(results[4][0], 'transactions')
+		self.assertEqual(results[5][0], 'transactions_mosaic')
 
 	def test_can_insert_block(self):
 		# Arrange:
@@ -634,3 +660,105 @@ class NemDatabaseTest(unittest.TestCase):
 			adjustment=3000,
 			expected_total_supply=1000
 		)
+
+	def test_can_insert_transactions(self):
+		# Arrange:
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+
+			cursor = nem_database.connection.cursor()
+
+			# Act:
+			nem_database.insert_transaction(
+				cursor,
+				transaction=TRANSACTIONS[0]
+			)
+
+			nem_database.connection.commit()
+
+			cursor.execute(
+				'''
+				SELECT
+					encode(transaction_hash, 'hex'),
+					transaction_type,
+					height,
+					encode(sender_public_key, 'hex'),
+					encode(sender_address, 'hex'),
+					encode(recipient_address, 'hex'),
+					fee,
+					timestamp,
+					deadline,
+					encode(signature, 'hex'),
+					amount,
+					is_inner,
+					inner_transaction_id,
+					payload
+				FROM transactions
+				WHERE id = %s
+				''',
+				(1,)
+			)
+			result = cursor.fetchone()
+
+		# Assert:
+		self.assertIsNotNone(result)
+		self.assertEqual(result, (
+			TRANSACTIONS[0].transaction_hash,
+			257,
+			2,
+			TRANSACTIONS[0].sender_public_key.bytes.hex(),
+			TRANSACTIONS[0].sender_address.bytes.hex(),
+			TRANSACTIONS[0].recipient_address.bytes.hex(),
+			150000,
+			datetime.datetime(2015, 3, 29, 0, 6, 25),
+			datetime.datetime(2015, 3, 29, 20, 34, 19),
+			TRANSACTIONS[0].signature,
+			2000000,
+			False,
+			None,
+			'{}'
+		))
+
+	def test_insert_transaction_mosaic(self):
+		# Arrange:
+		mosaic = MagicMock()
+		mosaic.namespace_name = 'nem.xem'
+		mosaic.quantity = 2000000
+
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+
+			cursor = nem_database.connection.cursor()
+
+			nem_database.insert_transaction(
+				cursor,
+				transaction=TRANSACTIONS[0]
+			)
+
+			# Act:
+			nem_database.insert_transaction_mosaic(
+				cursor,
+				transaction_id=1,
+				mosaic=mosaic
+			)
+
+			nem_database.connection.commit()
+
+			cursor.execute(
+				'''
+				SELECT
+					namespace_name,
+					quantity
+				FROM transactions_mosaic
+				WHERE namespace_name = %s
+				''',
+				('nem.xem',)
+			)
+			result = cursor.fetchone()
+
+		# Assert:
+		self.assertIsNotNone(result)
+		self.assertEqual(result, (
+			'nem.xem',
+			2000000
+		))

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -219,7 +219,7 @@ NEM_CONNECTOR_RESPONSE_ACCOUNT_INFO = NemAccountInfo(Address('TALICE6XEEEOBFJVY3
 # endregion
 
 
-class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-methods
+class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-methods, too-many-lines
 
 	def setUp(self):
 		self.postgresql = testing.postgresql.Postgresql()
@@ -916,3 +916,190 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			supply_type=1,
 			expected_supply_change=500000
 		)
+
+	def _assert_transaction_record(self, transaction, payload, amount=None, recipient_address=None):
+		# Act:
+		record = self.puller._build_transaction_record(transaction, False)  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual(record, TransactionRecord(
+			transaction_hash=transaction.transaction_hash,
+			height=3,
+			sender_public_key=transaction.sender,
+			fee=transaction.fee,
+			timestamp='2015-03-29 20:29:42+00:00',
+			deadline='2015-03-29 23:16:22+00:00',
+			amount=amount,
+			signature=transaction.signature,
+			transaction_type=transaction.transaction_type,
+			is_inner=False,
+			inner_transaction_id=None,
+			sender_address=transaction.sender,
+			recipient_address=recipient_address,
+			payload=payload
+		))
+
+	def test_can_build_transaction_record_transfer(self):
+		# Arrange:
+		transaction = NEM_CONNECTOR_RESPONSE_BLOCKS[2].transactions[1]
+
+		self._assert_transaction_record(
+			transaction, {
+				'payload': '476f6f64206c75636b21',
+				'is_plain': 1
+			},
+			amount=180000040000000,
+			recipient_address=transaction.recipient
+		)
+
+	def test_can_build_transaction_record_transfer_without_message(self):
+		# Arrange:
+		transaction = NEM_CONNECTOR_RESPONSE_BLOCKS[2].transactions[1]
+
+		transaction.message = None
+
+		self._assert_transaction_record(
+			transaction,
+			{},
+			amount=180000040000000,
+			recipient_address=transaction.recipient
+		)
+
+	def test_can_build_transaction_record_account_key_link(self):
+		# Arrange:
+		transaction = NEM_CONNECTOR_RESPONSE_BLOCKS[2].transactions[0]
+
+		self._assert_transaction_record(
+			transaction, {
+				'mode': 1,
+				'remote_account': '7195F4D7A40AD7E31958AE96C4AFED002962229675A4CAE8DC8A18E290618981'
+			})
+
+	def test_can_build_transaction_record_multisig_account_modification(self):
+		# Arrange:
+		transaction = NEM_CONNECTOR_RESPONSE_BLOCKS[2].transactions[2]
+
+		self._assert_transaction_record(
+			transaction, {
+				'min_cosignatories': 2,
+				'modifications': [
+					{
+						'modification_type': 1,
+						'cosignatory_account': '1FBDBDDE28DAF828245E4533765726F0B7790E0B7146E2CE205DF3E86366980B'
+					},
+					{
+						'modification_type': 1,
+						'cosignatory_account': 'F94E8702EB1943B23570B1B83BE1B81536DF35538978820E98BFCE8F999E2D37'
+					}
+				]
+			}
+		)
+
+	def test_can_build_transaction_record_multisig(self):
+		# Arrange:
+		transaction = NEM_CONNECTOR_RESPONSE_BLOCKS[2].transactions[6]
+
+		self._assert_transaction_record(
+			transaction, {
+				'inner_hash': transaction.inner_hash,
+				'signatures': [
+					{
+						'transaction_type': signature.transaction_type,
+						'timestamp': '2023-07-12 17:06:10+00:00',
+						'deadline': '2023-07-13 17:06:10+00:00',
+						'fee': signature.fee,
+						'other_hash': signature.other_hash,
+						'other_account': str(signature.other_account),
+						'sender': str(signature.sender),
+						'signature': signature.signature
+					} for signature in transaction.signatures
+				]
+			}
+		)
+
+	def test_can_build_transaction_record_namespace_registration(self):
+		# Arrange:
+		transaction = NEM_CONNECTOR_RESPONSE_BLOCKS[2].transactions[3]
+
+		self._assert_transaction_record(
+			transaction, {
+				'rental_fee_sink': str(transaction.rental_fee_sink),
+				'rental_fee': transaction.rental_fee,
+				'parent': transaction.parent,
+				'namespace': transaction.namespace,
+			})
+
+	def test_can_build_transaction_record_mosaic_definition(self):
+		# Arrange:
+		transaction = NEM_CONNECTOR_RESPONSE_BLOCKS[2].transactions[4]
+
+		self._assert_transaction_record(
+			transaction, {
+				'creation_fee_sink': str(transaction.creation_fee_sink),
+				'creation_fee': transaction.creation_fee,
+				'creator': str(transaction.sender),
+				'description': transaction.description,
+				'namespace_name': transaction.namespace_name,
+				'mosaic_properties': {
+					'divisibility': transaction.properties.divisibility,
+					'initial_supply': transaction.properties.initial_supply,
+					'supply_mutable': transaction.properties.supply_mutable,
+					'transferable': transaction.properties.transferable
+				},
+				'levy': {
+					'type': transaction.levy.type,
+					'namespace_name': transaction.levy.namespace_name,
+					'fee': transaction.levy.fee,
+					'recipient': str(transaction.levy.recipient)
+				}
+			}
+		)
+
+	def test_can_build_transaction_record_mosaic_definition_without_levy(self):
+		# Arrange:
+		mosaic_definition = NEM_CONNECTOR_RESPONSE_BLOCKS[2].transactions[4]
+
+		transaction = MosaicDefinitionTransaction(
+			mosaic_definition.transaction_hash,
+			mosaic_definition.height,
+			mosaic_definition.sender,
+			mosaic_definition.fee,
+			mosaic_definition.timestamp,
+			mosaic_definition.deadline,
+			mosaic_definition.signature,
+			mosaic_definition.creation_fee,
+			mosaic_definition.creation_fee_sink,
+			mosaic_definition.creator,
+			mosaic_definition.description,
+			mosaic_definition.properties,
+			None,
+			mosaic_definition.namespace_name
+		)
+
+		self._assert_transaction_record(
+			transaction, {
+				'creation_fee_sink': str(transaction.creation_fee_sink),
+				'creation_fee': transaction.creation_fee,
+				'creator': str(transaction.sender),
+				'description': transaction.description,
+				'namespace_name': transaction.namespace_name,
+				'mosaic_properties': {
+					'divisibility': transaction.properties.divisibility,
+					'initial_supply': transaction.properties.initial_supply,
+					'supply_mutable': transaction.properties.supply_mutable,
+					'transferable': transaction.properties.transferable
+				},
+				'levy': None
+			}
+		)
+
+	def test_can_build_transaction_record_mosaic_supply_change(self):
+		# Arrange:
+		transaction = NEM_CONNECTOR_RESPONSE_BLOCKS[2].transactions[5]
+
+		self._assert_transaction_record(
+			transaction, {
+				'supply_type': transaction.supply_type,
+				'delta': transaction.delta,
+				'namespace_name': transaction.namespace_name
+			})

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -946,8 +946,10 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 
 		self._assert_transaction_record(
 			transaction, {
-				'payload': '476f6f64206c75636b21',
-				'is_plain': 1
+				'message': {
+					'payload': '476f6f64206c75636b21',
+					'is_plain': 1
+				}
 			},
 			amount=180000040000000,
 			recipient_address=transaction.recipient
@@ -961,7 +963,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 
 		self._assert_transaction_record(
 			transaction,
-			{},
+			{'message': None},
 			amount=180000040000000,
 			recipient_address=transaction.recipient
 		)
@@ -1024,11 +1026,12 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 
 		self._assert_transaction_record(
 			transaction, {
-				'rental_fee_sink': str(transaction.rental_fee_sink),
 				'rental_fee': transaction.rental_fee,
 				'parent': transaction.parent,
 				'namespace': transaction.namespace,
-			})
+			},
+			recipient_address=transaction.rental_fee_sink
+		)
 
 	def test_can_build_transaction_record_mosaic_definition(self):
 		# Arrange:
@@ -1036,7 +1039,6 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 
 		self._assert_transaction_record(
 			transaction, {
-				'creation_fee_sink': str(transaction.creation_fee_sink),
 				'creation_fee': transaction.creation_fee,
 				'creator': str(transaction.sender),
 				'description': transaction.description,
@@ -1053,7 +1055,8 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 					'fee': transaction.levy.fee,
 					'recipient': str(transaction.levy.recipient)
 				}
-			}
+			},
+			recipient_address=transaction.creation_fee_sink
 		)
 
 	def test_can_build_transaction_record_mosaic_definition_without_levy(self):
@@ -1079,7 +1082,6 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 
 		self._assert_transaction_record(
 			transaction, {
-				'creation_fee_sink': str(transaction.creation_fee_sink),
 				'creation_fee': transaction.creation_fee,
 				'creator': str(transaction.sender),
 				'description': transaction.description,
@@ -1091,7 +1093,8 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 					'transferable': transaction.properties.transferable
 				},
 				'levy': None
-			}
+			},
+			recipient_address=transaction.creation_fee_sink
 		)
 
 	def test_can_build_transaction_record_mosaic_supply_change(self):

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -934,8 +934,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			signature=transaction.signature,
 			transaction_type=transaction.transaction_type,
 			is_inner=False,
-			inner_transaction_id=None,
-			sender_address=transaction.sender,
+			sender_address=self.puller.nem_facade.network.public_key_to_address(transaction.sender),
 			recipient_address=recipient_address,
 			payload=payload
 		))
@@ -1240,7 +1239,6 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 	@patch('puller.facade.NemPuller.NemPuller._process_transaction')
 	def test_can_process_transactions_inner_outer(self, mock_process_transaction):
 		# Arrange:
-		mock_process_transaction.return_value = 1  # Simulate inserted transaction ID for linking inner transactions
 		block_data = NEM_CONNECTOR_RESPONSE_BLOCKS[2]
 
 		block = Block(
@@ -1284,6 +1282,5 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		self.assertEqual(process_transaction_calls[1][1], {
 			'transaction': block.transactions[0],
 			'block_height': 3,
-			'is_inner': False,
-			'inner_transaction_id': 1
+			'is_inner': False
 		})

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -15,6 +15,7 @@ from symbollightapi.model.Transaction import (
 	CosignSignatureTransaction,
 	Message,
 	Modification,
+	Mosaic,
 	MosaicDefinitionTransaction,
 	MosaicLevy,
 	MosaicProperties,
@@ -1103,3 +1104,183 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 				'delta': transaction.delta,
 				'namespace_name': transaction.namespace_name
 			})
+
+	@patch('puller.facade.NemPuller.NemPuller._build_transaction_record')
+	@patch('puller.facade.NemPuller.NemDatabase.insert_transaction')
+	@patch('puller.facade.NemPuller.NemDatabase.insert_transaction_mosaic')
+	def test_can_process_transaction_transfer(self, mock_insert_transaction_mosaic, mock_insert_transaction, mock_build_transaction_record):
+		# Arrange:
+		mock_insert_transaction.return_value = 1  # Simulate inserted transaction ID for linking mosaics
+		transfer = NEM_CONNECTOR_RESPONSE_BLOCKS[2].transactions[1]
+
+		transaction = TransferTransaction(
+			transfer.transaction_hash,
+			transfer.height,
+			transfer.sender,
+			transfer.fee,
+			transfer.timestamp,
+			transfer.deadline,
+			transfer.signature,
+			transfer.amount,
+			transfer.recipient,
+			transfer.message,
+			[
+				Mosaic('namespace.test', 1000000),
+				Mosaic('nem.xem', 8000000)
+			]
+		)
+
+		cursor = Mock()
+
+		# Act:
+		self.puller._process_transaction(cursor, transaction, 3, is_inner=False)  # pylint: disable=protected-access
+
+		# Assert:
+		mock_build_transaction_record.assert_called_once()
+		mock_insert_transaction.assert_called_once()
+		insert_transaction_mosaic_calls = mock_insert_transaction_mosaic.call_args_list
+		for index, mosaic in enumerate(transaction.mosaics):
+			self.assertEqual(insert_transaction_mosaic_calls[index][0], (
+				cursor,
+				1,  # transaction_id from insert_transaction mock
+				mosaic
+			))
+
+	@patch('puller.facade.NemPuller.NemPuller._build_transaction_record')
+	@patch('puller.facade.NemPuller.NemDatabase.insert_transaction')
+	@patch('puller.facade.NemPuller.NemDatabase.insert_transaction_mosaic')
+	def test_can_process_transaction_transfer_without_mosaic(
+		self,
+		mock_insert_transaction_mosaic,
+		mock_insert_transaction,
+		mock_build_transaction_record
+	):
+		# Arrange:
+		transaction = NEM_CONNECTOR_RESPONSE_BLOCKS[2].transactions[1]
+
+		cursor = Mock()
+
+		# Act:
+		self.puller._process_transaction(cursor, transaction, 3, is_inner=False)  # pylint: disable=protected-access
+
+		# Assert:
+		mock_build_transaction_record.assert_called_once()
+		mock_insert_transaction.assert_called_once()
+		mock_insert_transaction_mosaic.assert_not_called()
+
+	@patch('puller.facade.NemPuller.NemPuller._build_transaction_record')
+	@patch('puller.facade.NemPuller.NemDatabase.insert_transaction')
+	@patch('puller.facade.NemPuller.NemPuller._process_namespace')
+	def test_can_process_transaction_namespace_registration(
+		self,
+		mock_process_namespace,
+		mock_insert_transaction,
+		mock_build_transaction_record
+	):
+		# Arrange:
+		transaction = NEM_CONNECTOR_RESPONSE_BLOCKS[2].transactions[3]
+
+		cursor = Mock()
+
+		# Act:
+		self.puller._process_transaction(cursor, transaction, 3, is_inner=False)  # pylint: disable=protected-access
+
+		# Assert:
+		mock_build_transaction_record.assert_called_once()
+		mock_insert_transaction.assert_called_once()
+		mock_process_namespace.assert_called_once_with(cursor, transaction, 3)
+
+	@patch('puller.facade.NemPuller.NemPuller._build_transaction_record')
+	@patch('puller.facade.NemPuller.NemDatabase.insert_transaction')
+	@patch('puller.facade.NemPuller.NemPuller._process_mosaic_definition')
+	def test_can_process_transaction_mosaic_definition(
+		self,
+		mock_process_mosaic_definition,
+		mock_insert_transaction,
+		mock_build_transaction_record
+	):
+		# Arrange:
+		transaction = NEM_CONNECTOR_RESPONSE_BLOCKS[2].transactions[4]
+
+		cursor = Mock()
+
+		# Act:
+		self.puller._process_transaction(cursor, transaction, 3, is_inner=False)  # pylint: disable=protected-access
+
+		# Assert:
+		mock_build_transaction_record.assert_called_once()
+		mock_insert_transaction.assert_called_once()
+		mock_process_mosaic_definition.assert_called_once_with(cursor, transaction, 3)
+
+	@patch('puller.facade.NemPuller.NemPuller._build_transaction_record')
+	@patch('puller.facade.NemPuller.NemDatabase.insert_transaction')
+	@patch('puller.facade.NemPuller.NemPuller._process_mosaic_supply_change')
+	def test_can_process_transaction_mosaic_supply_change(
+		self,
+		mock_process_mosaic_supply_change,
+		mock_insert_transaction,
+		mock_build_transaction_record
+	):
+		# Arrange:
+		transaction = NEM_CONNECTOR_RESPONSE_BLOCKS[2].transactions[5]
+
+		cursor = Mock()
+
+		# Act:
+		self.puller._process_transaction(cursor, transaction, 3, is_inner=False)  # pylint: disable=protected-access
+
+		# Assert:
+		mock_build_transaction_record.assert_called_once()
+		mock_insert_transaction.assert_called_once()
+		mock_process_mosaic_supply_change.assert_called_once_with(cursor, transaction)
+
+	@patch('puller.facade.NemPuller.NemPuller._process_transaction')
+	def test_can_process_transactions_inner_outer(self, mock_process_transaction):
+		# Arrange:
+		mock_process_transaction.return_value = 1  # Simulate inserted transaction ID for linking inner transactions
+		block_data = NEM_CONNECTOR_RESPONSE_BLOCKS[2]
+
+		block = Block(
+			block_data.height,
+			block_data.timestamp,
+			[
+				block_data.transactions[6]
+			],
+			block_data.difficulty,
+			block_data.block_hash,
+			block_data.total_fee,
+			block_data.beneficiary,
+			block_data.signer,
+			block_data.signature,
+			block_data.size
+		)
+
+		cursor = Mock()
+
+		# Act:
+		self.puller._process_transactions(cursor, block.transactions, block.height)  # pylint: disable=protected-access
+
+		# Assert:
+		process_transaction_calls = mock_process_transaction.call_args_list
+		self.assertEqual(len(process_transaction_calls), 2)  # 1 for outer transaction, 1 for inner transaction
+
+		# Ensure the inner transaction is correctly linked to the outer transaction
+		self.assertEqual(block.transactions[0].other_transaction.height, block.transactions[0].height)
+		self.assertEqual(block.transactions[0].other_transaction.transaction_hash, block.transactions[0].inner_hash)
+
+		# first call is inner transaction
+		self.assertEqual(process_transaction_calls[0][0], (cursor,))
+		self.assertEqual(process_transaction_calls[0][1], {
+			'transaction': block.transactions[0].other_transaction,
+			'block_height': 3,
+			'is_inner': True
+		})
+
+		# second call is outer transaction
+		self.assertEqual(process_transaction_calls[1][0], (cursor,))
+		self.assertEqual(process_transaction_calls[1][1], {
+			'transaction': block.transactions[0],
+			'block_height': 3,
+			'is_inner': False,
+			'inner_transaction_id': 1
+		})

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -13,6 +13,7 @@ from symbollightapi.model.Exceptions import NodeException
 from symbollightapi.model.Transaction import (
 	AccountKeyLinkTransaction,
 	CosignSignatureTransaction,
+	Message,
 	Modification,
 	MosaicDefinitionTransaction,
 	MosaicLevy,
@@ -24,7 +25,7 @@ from symbollightapi.model.Transaction import (
 	TransferTransaction
 )
 
-from puller.facade.NemPuller import AccountRecord, DatabaseConfig, MosaicRecord, NamespaceRecord, NemPuller
+from puller.facade.NemPuller import AccountRecord, DatabaseConfig, MosaicRecord, NamespaceRecord, NemPuller, TransactionRecord
 
 # region test data
 
@@ -36,14 +37,14 @@ NEM_CONNECTOR_RESPONSE_BLOCKS = [
 			TransferTransaction(
 				'd6c9902cfa23dbbdd212d720f86391dd91d215bf77d806f03a6c2dd2e730628a',
 				2,
-				'8d07f90fb4bbe7715fa327c926770166a11be2e494a970605f2e12557f66c9b9',
+				PublicKey('8d07f90fb4bbe7715fa327c926770166a11be2e494a970605f2e12557f66c9b9'),
 				9000000,
 				73397,
 				83397,
 				'e0cc7f71e353ca0aaf2f009d74aeac5f97d4796b0f08c009058fb33d93c2e8ca'
 				'68c0b63e46ff125f43314014d324ac032d2c82996a6e47068b251f1d71fdd001',
 				180000040000000,
-				'NCOPERAWEWCD4A34NP5UQCCKEX44MW4SL3QYJYS5',
+				Address('NCOPERAWEWCD4A34NP5UQCCKEX44MW4SL3QYJYS5'),
 				('476f6f64206c75636b21', 1),
 				None
 			),
@@ -80,34 +81,34 @@ NEM_CONNECTOR_RESPONSE_BLOCKS = [
 		[
 			AccountKeyLinkTransaction(
 				'306f20260a1b7af692834809d3e7d53edd41616d5076ac0fac6cfa75982185df',
-				2,
-				'22df5f43ee3739a10c346b3ec2d3878668c5514696be425f9067d3a11c777f1d',
+				3,
+				PublicKey('22df5f43ee3739a10c346b3ec2d3878668c5514696be425f9067d3a11c777f1d'),
 				8000000,
 				73397,
 				83397,
 				'1b81379847241e45da86b27911e5c9a9192ec04f644d98019657d32838b49c14'
 				'3eaa4815a3028b80f9affdbf0b94cd620f7a925e02783dda67b8627b69ddf70e',
 				1,
-				'7195f4d7a40ad7e31958ae96c4afed002962229675a4cae8dc8a18e290618981'
+				PublicKey('7195f4d7a40ad7e31958ae96c4afed002962229675a4cae8dc8a18e290618981')
 			),
 			TransferTransaction(
 				'd6c9902cfa23dbbdd212d720f86391dd91d215bf77d806f03a6c2dd2e730628a',
-				2,
-				'8d07f90fb4bbe7715fa327c926770166a11be2e494a970605f2e12557f66c9b9',
+				3,
+				PublicKey('8d07f90fb4bbe7715fa327c926770166a11be2e494a970605f2e12557f66c9b9'),
 				9000000,
 				73397,
 				83397,
 				'e0cc7f71e353ca0aaf2f009d74aeac5f97d4796b0f08c009058fb33d93c2e8ca'
 				'68c0b63e46ff125f43314014d324ac032d2c82996a6e47068b251f1d71fdd001',
 				180000040000000,
-				'NCOPERAWEWCD4A34NP5UQCCKEX44MW4SL3QYJYS5',
-				('476f6f64206c75636b21', 1),
+				Address('NCOPERAWEWCD4A34NP5UQCCKEX44MW4SL3QYJYS5'),
+				Message('476f6f64206c75636b21', 1),
 				None
 			),
 			MultisigAccountModificationTransaction(
 				'cc64ca69bfa95db2ff7ac1e21fe6d27ece189c603200ebc9778d8bb80ca25c3c',
-				2,
-				'f41b99320549741c5cce42d9e4bb836d98c50ed5415d0c3c2912d1bb50e6a0e5',
+				3,
+				PublicKey('f41b99320549741c5cce42d9e4bb836d98c50ed5415d0c3c2912d1bb50e6a0e5'),
 				40000000,
 				73397,
 				83397,
@@ -115,27 +116,27 @@ NEM_CONNECTOR_RESPONSE_BLOCKS = [
 				'4f2b486f25451a1f90da7f0e312d9e8570e4bc03798e58d19dec86feb4152307',
 				2,
 				[
-					Modification(1, '1fbdbdde28daf828245e4533765726f0b7790e0b7146e2ce205df3e86366980b'),
-					Modification(1, 'f94e8702eb1943b23570b1b83be1b81536df35538978820e98bfce8f999e2d37')
+					Modification(1, PublicKey('1fbdbdde28daf828245e4533765726f0b7790e0b7146e2ce205df3e86366980b')),
+					Modification(1, PublicKey('f94e8702eb1943b23570b1b83be1b81536df35538978820e98bfce8f999e2d37'))
 				]
 			),
 			NamespaceRegistrationTransaction(
 				'7e547e45cfc9c34809ce184db6ae7b028360c0f1492cc37b7b4d31c22af07dc3',
-				2,
+				3,
 				PublicKey('a700809530e5428066807ec0d34859c52e260fc60634aaac13e3972dcfc08736'),
 				150000,
 				73397,
 				83397,
 				'9fc70720d0333d7d8f9eb14ef45ce45a846d37e79cf7a4244b4db36dcb0d3dfe'
 				'0170daefbf4d30f92f343110a6f03a14aedcf7913e465a4a1cc199639169410a',
-				'NAMESPACEWH4MKFMBCVFERDPOOP4FK7MTBXDPZZA',
+				Address('NAMESPACEWH4MKFMBCVFERDPOOP4FK7MTBXDPZZA'),
 				100000000,
 				None,
 				'namespace'
 			),
 			MosaicDefinitionTransaction(
 				'4725e523e5d5a562121f38953d6da3ae695060533fc0c5634b31de29c3b766e1',
-				2,
+				3,
 				PublicKey('a700809530e5428066807ec0d34859c52e260fc60634aaac13e3972dcfc08736'),
 				150000,
 				73397,
@@ -143,7 +144,7 @@ NEM_CONNECTOR_RESPONSE_BLOCKS = [
 				'a80ccd44955ded7d35ee3aa011bfafd3f30cc746f63cb59a9d02171f908a0f4a'
 				'0294fcbba0b2838acd184daf1d9ae3c0f645308b442547156364192cd3d2d605',
 				10000000,
-				'NBMOSAICOD4F54EE5CDMR23CCBGOAM2XSIUX6TRS',
+				Address('NBMOSAICOD4F54EE5CDMR23CCBGOAM2XSIUX6TRS'),
 				PublicKey('a700809530e5428066807ec0d34859c52e260fc60634aaac13e3972dcfc08736'),
 				'NEM namespace test',
 				MosaicProperties(4, 3100000, False, True),
@@ -152,7 +153,7 @@ NEM_CONNECTOR_RESPONSE_BLOCKS = [
 			),
 			MosaicSupplyChangeTransaction(
 				'cb805b4499479135934e70452d12ad9ecc26c46a111fe0cdda8e09741d257708',
-				2,
+				3,
 				PublicKey('da04b4a1d64add6c70958d383f9d247af1aaa957cb89f15b2d059b278e0594d5'),
 				150000,
 				73397,
@@ -165,8 +166,8 @@ NEM_CONNECTOR_RESPONSE_BLOCKS = [
 			),
 			MultisigTransaction(
 				'3375969dbc2aaae1cad0d89854d4f41b4fef553dbe9c7d39bdf72e3c538f98fe',
-				2,
-				'aa455d831430872feb0c6ae14265209182546c985a321c501be7fdc96ed04757',
+				3,
+				PublicKey('aa455d831430872feb0c6ae14265209182546c985a321c501be7fdc96ed04757'),
 				500000,
 				73397,
 				83397,
@@ -176,8 +177,8 @@ NEM_CONNECTOR_RESPONSE_BLOCKS = [
 					CosignSignatureTransaction(
 						261593985,
 						'edcc8d1c48165f5b771087fbe3c4b4d41f5f8f6c4ce715e050b86fb4e7fdeb64',
-						'NAGJG3QFWYZ37LMI7IQPSGQNYADGSJZGJRD2DIYA',
-						'ae6754c70b7e3ba0c51617c8f9efd462d0bf680d45e09c3444e817643d277826',
+						Address('NAGJG3QFWYZ37LMI7IQPSGQNYADGSJZGJRD2DIYA'),
+						PublicKey('ae6754c70b7e3ba0c51617c8f9efd462d0bf680d45e09c3444e817643d277826'),
 						500000,
 						261680385,
 						'249bc2dbad96e827eabc991b59dff7f12cc27f3e0da8ab3db6a3201169431786'
@@ -187,13 +188,13 @@ NEM_CONNECTOR_RESPONSE_BLOCKS = [
 				TransferTransaction(
 					None,
 					None,
-					'fbae41931de6a0cc25153781321f3de0806c7ba9a191474bb9a838118c8de4d3',
+					PublicKey('fbae41931de6a0cc25153781321f3de0806c7ba9a191474bb9a838118c8de4d3'),
 					750000,
 					73397,
 					83397,
 					None,
 					150000000000,
-					'NBUH72UCGBIB64VYTAAJ7QITJ62BLISFFQOHVP65',
+					Address('NBUH72UCGBIB64VYTAAJ7QITJ62BLISFFQOHVP65'),
 					None,
 					None
 				),
@@ -800,8 +801,8 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			NamespaceRecord(
 				root_namespace='namespace',
 				owner=PublicKey('a700809530e5428066807ec0d34859c52e260fc60634aaac13e3972dcfc08736'),
-				registered_height=2,
-				expiration_height=2 + (365 * 1440)
+				registered_height=3,
+				expiration_height=3 + (365 * 1440)
 			)
 		))
 
@@ -857,7 +858,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 				namespace_name='namespace.test',
 				description='NEM namespace test',
 				creator=PublicKey('a700809530e5428066807ec0d34859c52e260fc60634aaac13e3972dcfc08736'),
-				registered_height=2,
+				registered_height=3,
 				initial_supply=3100000,
 				total_supply=3100000,
 				divisibility=4,


### PR DESCRIPTION
Problems: Missing the process transactions from blocks.
Solution:
- Added database tables.
    - `transactions`: used to store all transactions from the blocks.
    - `transactions_mosaic`:  used to store extracted mosaic transactions, making it easier to filter in queries.
- Implemented process transaction logic.