### PR TITLE
[tools/shoestring]: add --output-transaction-only flag to setup command

### DIFF
--- a/tools/shoestring/shoestring/commands/renew_voting_keys.py
+++ b/tools/shoestring/shoestring/commands/renew_voting_keys.py
@@ -99,7 +99,7 @@ async def run_main(args):
 	# add new root voting key
 	voter_configurator = VoterConfigurator(config_manager)
 	new_voting_key_file_epoch_range = voter_configurator.generate_voting_key_file(directories.voting_keys, current_finalization_epoch)
-	transaction_builder.link_voting_public_key(voter_configurator.voting_key_pair.public_key, *new_voting_key_file_epoch_range)
+	transaction_builder.link_voting_public_key(voter_configurator.voting_public_key, *new_voting_key_file_epoch_range)
 
 	# generate transaction
 	await _save_transaction(config.transaction, directories, transaction_builder)

--- a/tools/shoestring/shoestring/commands/setup.py
+++ b/tools/shoestring/shoestring/commands/setup.py
@@ -10,7 +10,7 @@ from shoestring.internal.ConfigurationManager import ConfigurationManager, load_
 from shoestring.internal.NodeFeatures import NodeFeatures
 from shoestring.internal.NodewatchClient import get_current_finalization_epoch
 from shoestring.internal.PackageResolver import download_and_extract_package
-from shoestring.internal.PeerDownloader import download_peers
+from shoestring.internal.PeerDownloader import download_peers, find_api_node
 from shoestring.internal.PemUtils import read_public_key_from_public_key_pem_file
 from shoestring.internal.Preparer import Preparer
 from shoestring.internal.ShoestringConfiguration import parse_shoestring_configuration
@@ -76,10 +76,19 @@ async def _prepare_linking_transaction(preparer, api_endpoint):
 
 async def run_main(args):
 	config = parse_shoestring_configuration(args.config)
+	is_initial_setup = hasattr(args, 'security')
+
+	if is_initial_setup and args.output_transaction_only:
+		log.info(_('setup-status-output-transaction-only'))
+
+		api_endpoint = await find_api_node(config.services.nodewatch)
+		preparer = Preparer(Path(args.directory), config, log)
+		preparer.load_keys()
+
+		await _prepare_linking_transaction(preparer, api_endpoint)
+		return
 
 	with Preparer(Path(args.directory), config, log) as preparer:
-		is_initial_setup = hasattr(args, 'security')
-
 		if is_initial_setup and preparer.directories.resources.exists():
 			log.error(_('setup-resources-directory-exists').format(directory=preparer.directories.resources))
 			sys.exit(1)
@@ -144,4 +153,5 @@ def add_arguments(parser, is_initial_setup=True):
 	if is_initial_setup:
 		parser.add_argument('--security', help=_('argument-help-setup-security'), choices=SECURITY_MODES, default='default')
 		parser.add_argument('--ca-key-path', help=_('argument-help-ca-key-path'), required=True)
+		parser.add_argument('--output-transaction-only', help=_('argument-help-setup-output-transaction-only'), action='store_true')
 		parser.set_defaults(func=run_main)

--- a/tools/shoestring/shoestring/internal/HarvesterConfigurator.py
+++ b/tools/shoestring/shoestring/internal/HarvesterConfigurator.py
@@ -62,3 +62,13 @@ class HarvesterConfigurator:
 
 		for name in ('remote', 'vrf'):
 			(Path(directory) / f'{name}.pem').chmod(0o400)
+
+	def load_harvester_keys_from_directory(self, directory):
+		"""Loads harvester private key files from disk."""
+
+		if not self.is_enabled:
+			return
+
+		storage = PrivateKeyStorage(directory)
+		self.remote_key_pair = KeyPair(storage.load('remote'))
+		self.vrf_key_pair = KeyPair(storage.load('vrf'))

--- a/tools/shoestring/shoestring/internal/PeerDownloader.py
+++ b/tools/shoestring/shoestring/internal/PeerDownloader.py
@@ -5,8 +5,22 @@ from zenlog import log
 
 from .NodeDownloader import NodeDownloader
 
-# region download_peers
+# region find_api_node
 
+
+async def find_api_node(nodewatch_endpoint):
+	"""Finds an api node."""
+
+	downloader = NodeDownloader(nodewatch_endpoint)
+	downloader.max_output_nodes = 1
+	await downloader.download_peer_nodes()
+
+	return downloader.select_api_endpoints()[0]
+
+# endregion
+
+
+# region download_peers
 
 def _save_peers_file(nodes, directory, name):
 	nodes.sort(key=lambda node: node['publicKey'])

--- a/tools/shoestring/shoestring/internal/Preparer.py
+++ b/tools/shoestring/shoestring/internal/Preparer.py
@@ -327,6 +327,15 @@ class Preparer:
 				current_finalization_epoch,
 				grace_period_epochs)
 
+	def load_keys(self):
+		"""Loads keys from disk based on enabled features."""
+
+		if NodeFeatures.HARVESTER in self.config.node.features:
+			self.harvester_configurator.load_harvester_keys_from_directory(self.directories.keys)
+
+		if NodeFeatures.VOTER in self.config.node.features:
+			self.new_voting_key_file_epoch_range = self.voter_configurator.load_voting_key_from_directory(self.directories.voting_keys)
+
 	def generate_certificates(self, ca_key_path, require_ca=True):
 		"""Generates and packages all certificates."""
 
@@ -392,9 +401,7 @@ class Preparer:
 					existing_links.voting_public_keys[0].end_epoch)
 
 			if NodeFeatures.VOTER in self.config.node.features and self.new_voting_key_file_epoch_range:
-				transaction_builder.link_voting_public_key(
-					self.voter_configurator.voting_key_pair.public_key,
-					*self.new_voting_key_file_epoch_range)
+				transaction_builder.link_voting_public_key(self.voter_configurator.voting_public_key, *self.new_voting_key_file_epoch_range)
 
 		aggregate_transaction, transaction_hash = transaction_builder.build(
 			NetworkTimestamp(timestamp).add_hours(self.config.transaction.timeout_hours),

--- a/tools/shoestring/shoestring/internal/VoterConfigurator.py
+++ b/tools/shoestring/shoestring/internal/VoterConfigurator.py
@@ -25,10 +25,12 @@ class VoterConfigurator:
 
 		if not self.is_imported:
 			self.voting_key_pair = KeyPair(PrivateKey.random())
+			self.voting_public_key = self.voting_key_pair.public_key
 		else:
 			# when importing, each file should have its own key pair
 			# since the voting keys don't need to be reregistered later, the keys don't need to be extracted
 			self.voting_key_pair = None
+			self.voting_public_key = None
 
 	def patch_configuration(self):
 		"""Patches voting settings."""
@@ -81,6 +83,16 @@ class VoterConfigurator:
 		output_filepath.chmod(0o600)
 
 		return EpochRange(start_epoch, end_epoch)
+
+	def load_voting_key_from_directory(self, directory):
+		"""Loads (latest) voting key file from disk."""
+
+		descriptors = inspect_voting_key_files(directory)
+		latest_descriptor = descriptors[-1]
+
+		self.voting_key_pair = None
+		self.voting_public_key = latest_descriptor.public_key
+		return EpochRange(latest_descriptor.start_epoch, latest_descriptor.end_epoch)
 
 
 def inspect_voting_key_files(directory):

--- a/tools/shoestring/shoestring/lang/en/LC_MESSAGES/messages.po
+++ b/tools/shoestring/shoestring/lang/en/LC_MESSAGES/messages.po
@@ -21,7 +21,7 @@ msgstr "file containing serialized transaction to send"
 
 #: shoestring/commands/min_cosignatures_count.py:35
 #: shoestring/commands/renew_certificates.py:36
-#: shoestring/commands/setup.py:146 shoestring/commands/signer.py:93
+#: shoestring/commands/setup.py:155 shoestring/commands/signer.py:93
 msgid "argument-help-ca-key-path"
 msgstr "path to main private key PEM file"
 
@@ -31,7 +31,7 @@ msgstr "path to main private key PEM file"
 #: shoestring/commands/min_cosignatures_count.py:34
 #: shoestring/commands/renew_certificates.py:34
 #: shoestring/commands/renew_voting_keys.py:112
-#: shoestring/commands/reset_data.py:86 shoestring/commands/setup.py:138
+#: shoestring/commands/reset_data.py:86 shoestring/commands/setup.py:147
 #: shoestring/commands/signer.py:92
 msgid "argument-help-config"
 msgstr "path to shoestring configuration file"
@@ -39,7 +39,7 @@ msgstr "path to shoestring configuration file"
 #: shoestring/commands/health.py:75
 #: shoestring/commands/renew_certificates.py:35
 #: shoestring/commands/renew_voting_keys.py:113
-#: shoestring/commands/reset_data.py:87 shoestring/commands/setup.py:140
+#: shoestring/commands/reset_data.py:87 shoestring/commands/setup.py:149
 msgid "argument-help-directory"
 msgstr "installation directory (default: {default_path})"
 
@@ -115,21 +115,25 @@ msgstr "retain node key"
 msgid "argument-help-reset-data-purge-harvesters"
 msgstr "purge harvesters.dat file"
 
-#: shoestring/commands/setup.py:141
+#: shoestring/commands/setup.py:156
+msgid "argument-help-setup-output-transaction-only"
+msgstr "only output linking transaction from a previous setup"
+
+#: shoestring/commands/setup.py:150
 msgid "argument-help-setup-overrides"
 msgstr "path to custom user settings"
 
-#: shoestring/commands/init.py:28 shoestring/commands/setup.py:139
+#: shoestring/commands/init.py:28 shoestring/commands/setup.py:148
 msgid "argument-help-setup-package"
 msgstr ""
 "Network configuration package. Possible values: (name | file:///filename "
 "| http(s)://uri) (default: mainnet)"
 
-#: shoestring/commands/setup.py:142
+#: shoestring/commands/setup.py:151
 msgid "argument-help-setup-rest-overrides"
 msgstr "path to custom user REST settings (this is only valid for API roles)"
 
-#: shoestring/commands/setup.py:145
+#: shoestring/commands/setup.py:154
 msgid "argument-help-setup-security"
 msgstr "security mode (default: default)"
 
@@ -161,7 +165,7 @@ msgstr "connecting to {endpoint}"
 
 #: shoestring/commands/init.py:17 shoestring/commands/reset_data.py:56
 #: shoestring/internal/Preparer.py:193
-#: shoestring/internal/VoterConfigurator.py:53
+#: shoestring/internal/VoterConfigurator.py:55
 msgid "general-copying-file"
 msgstr "copying FILE {source_path} into {destination_path}"
 
@@ -170,7 +174,7 @@ msgid "general-copying-tree"
 msgstr "copying TREE {source_path} to {destination_path}"
 
 #: shoestring/commands/renew_voting_keys.py:46
-#: shoestring/internal/Preparer.py:408
+#: shoestring/internal/Preparer.py:415
 msgid "general-created-aggregate-transaction"
 msgstr "created aggregate transaction with hash {transaction_hash}"
 
@@ -378,11 +382,11 @@ msgstr "detected current finalization epoch as {epoch}"
 msgid "nodewatch-client-detected-height"
 msgstr "detected last finalized height as {height}"
 
-#: shoestring/internal/PeerDownloader.py:65
+#: shoestring/internal/PeerDownloader.py:79
 msgid "peer-downloader-loading-api-endpoints"
 msgstr "loading api endpoints from {filepath}'"
 
-#: shoestring/internal/PeerDownloader.py:20
+#: shoestring/internal/PeerDownloader.py:34
 msgid "peer-downloader-saved-file"
 msgstr "saved peers file {filepath}"
 
@@ -456,11 +460,15 @@ msgstr ""
 "no transaction has been generated because account is already properly "
 "configured"
 
-#: shoestring/commands/setup.py:84
+#: shoestring/commands/setup.py:93
 msgid "setup-resources-directory-exists"
 msgstr ""
 "setup failed because resources directory {directory} already exists, did "
 "you intend to run upgrade?"
+
+#: shoestring/commands/setup.py:82
+msgid "setup-status-output-transaction-only"
+msgstr "generating linking transaction from previous setup..."
 
 #: shoestring/commands/signer.py:32
 msgid "signer-aggregate-transaction"

--- a/tools/shoestring/shoestring/lang/ja/LC_MESSAGES/messages.po
+++ b/tools/shoestring/shoestring/lang/ja/LC_MESSAGES/messages.po
@@ -19,7 +19,7 @@ msgstr "送信するシリアライズ済みトランザクションファイル
 
 #: shoestring/commands/min_cosignatures_count.py:35
 #: shoestring/commands/renew_certificates.py:36
-#: shoestring/commands/setup.py:146 shoestring/commands/signer.py:93
+#: shoestring/commands/setup.py:155 shoestring/commands/signer.py:93
 msgid "argument-help-ca-key-path"
 msgstr "メイン秘密鍵PEMファイルへのパス"
 
@@ -29,7 +29,7 @@ msgstr "メイン秘密鍵PEMファイルへのパス"
 #: shoestring/commands/min_cosignatures_count.py:34
 #: shoestring/commands/renew_certificates.py:34
 #: shoestring/commands/renew_voting_keys.py:112
-#: shoestring/commands/reset_data.py:86 shoestring/commands/setup.py:138
+#: shoestring/commands/reset_data.py:86 shoestring/commands/setup.py:147
 #: shoestring/commands/signer.py:92
 msgid "argument-help-config"
 msgstr "shoestring設定ファイルへのパス"
@@ -37,7 +37,7 @@ msgstr "shoestring設定ファイルへのパス"
 #: shoestring/commands/health.py:75
 #: shoestring/commands/renew_certificates.py:35
 #: shoestring/commands/renew_voting_keys.py:113
-#: shoestring/commands/reset_data.py:87 shoestring/commands/setup.py:140
+#: shoestring/commands/reset_data.py:87 shoestring/commands/setup.py:149
 msgid "argument-help-directory"
 msgstr "インストールディレクトリ（デフォルト: {default_path}）"
 
@@ -113,21 +113,25 @@ msgstr "ノードキーを保持"
 msgid "argument-help-reset-data-purge-harvesters"
 msgstr "harvesters.datファイルを削除"
 
-#: shoestring/commands/setup.py:141
+#: shoestring/commands/setup.py:156
+msgid "argument-help-setup-output-transaction-only"
+msgstr ""
+
+#: shoestring/commands/setup.py:150
 msgid "argument-help-setup-overrides"
 msgstr "カスタムユーザー設定ファイルへのパス"
 
-#: shoestring/commands/init.py:28 shoestring/commands/setup.py:139
+#: shoestring/commands/init.py:28 shoestring/commands/setup.py:148
 msgid "argument-help-setup-package"
 msgstr ""
 "ネットワーク構成パッケージ。可能な値：（name | file:///filename | "
 "http(s)://uri）（デフォルト：mainnet）"
 
-#: shoestring/commands/setup.py:142
+#: shoestring/commands/setup.py:151
 msgid "argument-help-setup-rest-overrides"
 msgstr "カスタムユーザーREST設定へのパス（これはAPIロールにのみ有効）"
 
-#: shoestring/commands/setup.py:145
+#: shoestring/commands/setup.py:154
 msgid "argument-help-setup-security"
 msgstr "セキュリティモード（デフォルト：default）"
 
@@ -159,7 +163,7 @@ msgstr "ノード {endpoint} へ接続中"
 
 #: shoestring/commands/init.py:17 shoestring/commands/reset_data.py:56
 #: shoestring/internal/Preparer.py:193
-#: shoestring/internal/VoterConfigurator.py:53
+#: shoestring/internal/VoterConfigurator.py:55
 msgid "general-copying-file"
 msgstr "ファイル {source_path} を {destination_path} へコピー中"
 
@@ -168,7 +172,7 @@ msgid "general-copying-tree"
 msgstr "ツリー {source_path} を {destination_path} へコピー中"
 
 #: shoestring/commands/renew_voting_keys.py:46
-#: shoestring/internal/Preparer.py:408
+#: shoestring/internal/Preparer.py:415
 msgid "general-created-aggregate-transaction"
 msgstr "ハッシュ {transaction_hash} の集約トランザクションを作成しました"
 
@@ -370,11 +374,11 @@ msgstr "現在の最終エポックが {epoch} として検出されました"
 msgid "nodewatch-client-detected-height"
 msgstr "最後に確定したブロック高が {height} として検出されました"
 
-#: shoestring/internal/PeerDownloader.py:65
+#: shoestring/internal/PeerDownloader.py:79
 msgid "peer-downloader-loading-api-endpoints"
 msgstr "ファイル {filepath} からAPIエンドポイントを読み込み中"
 
-#: shoestring/internal/PeerDownloader.py:20
+#: shoestring/internal/PeerDownloader.py:34
 msgid "peer-downloader-saved-file"
 msgstr "保存されたピアファイル {filepath}"
 
@@ -446,9 +450,13 @@ msgstr "ディレクトリ {directory} を削除しています"
 msgid "setup-no-state-changes-required"
 msgstr "アカウントは既に適切に設定されているため、トランザクションを生成しません"
 
-#: shoestring/commands/setup.py:84
+#: shoestring/commands/setup.py:93
 msgid "setup-resources-directory-exists"
 msgstr "リソースディレクトリ {directory} はすでに存在するため、セットアップに失敗しました。アップグレードを実行するつもりでしたか？"
+
+#: shoestring/commands/setup.py:82
+msgid "setup-status-output-transaction-only"
+msgstr ""
 
 #: shoestring/commands/signer.py:32
 msgid "signer-aggregate-transaction"

--- a/tools/shoestring/shoestring/lang/messages.pot
+++ b/tools/shoestring/shoestring/lang/messages.pot
@@ -12,7 +12,7 @@ msgstr ""
 
 #: shoestring/commands/min_cosignatures_count.py:35
 #: shoestring/commands/renew_certificates.py:36
-#: shoestring/commands/setup.py:146 shoestring/commands/signer.py:93
+#: shoestring/commands/setup.py:155 shoestring/commands/signer.py:93
 msgid "argument-help-ca-key-path"
 msgstr ""
 
@@ -22,7 +22,7 @@ msgstr ""
 #: shoestring/commands/min_cosignatures_count.py:34
 #: shoestring/commands/renew_certificates.py:34
 #: shoestring/commands/renew_voting_keys.py:112
-#: shoestring/commands/reset_data.py:86 shoestring/commands/setup.py:138
+#: shoestring/commands/reset_data.py:86 shoestring/commands/setup.py:147
 #: shoestring/commands/signer.py:92
 msgid "argument-help-config"
 msgstr ""
@@ -30,7 +30,7 @@ msgstr ""
 #: shoestring/commands/health.py:75
 #: shoestring/commands/renew_certificates.py:35
 #: shoestring/commands/renew_voting_keys.py:113
-#: shoestring/commands/reset_data.py:87 shoestring/commands/setup.py:140
+#: shoestring/commands/reset_data.py:87 shoestring/commands/setup.py:149
 msgid "argument-help-directory"
 msgstr ""
 
@@ -106,19 +106,23 @@ msgstr ""
 msgid "argument-help-reset-data-purge-harvesters"
 msgstr ""
 
-#: shoestring/commands/setup.py:141
+#: shoestring/commands/setup.py:156
+msgid "argument-help-setup-output-transaction-only"
+msgstr ""
+
+#: shoestring/commands/setup.py:150
 msgid "argument-help-setup-overrides"
 msgstr ""
 
-#: shoestring/commands/init.py:28 shoestring/commands/setup.py:139
+#: shoestring/commands/init.py:28 shoestring/commands/setup.py:148
 msgid "argument-help-setup-package"
 msgstr ""
 
-#: shoestring/commands/setup.py:142
+#: shoestring/commands/setup.py:151
 msgid "argument-help-setup-rest-overrides"
 msgstr ""
 
-#: shoestring/commands/setup.py:145
+#: shoestring/commands/setup.py:154
 msgid "argument-help-setup-security"
 msgstr ""
 
@@ -150,7 +154,7 @@ msgstr ""
 
 #: shoestring/commands/init.py:17 shoestring/commands/reset_data.py:56
 #: shoestring/internal/Preparer.py:193
-#: shoestring/internal/VoterConfigurator.py:53
+#: shoestring/internal/VoterConfigurator.py:55
 msgid "general-copying-file"
 msgstr ""
 
@@ -159,7 +163,7 @@ msgid "general-copying-tree"
 msgstr ""
 
 #: shoestring/commands/renew_voting_keys.py:46
-#: shoestring/internal/Preparer.py:408
+#: shoestring/internal/Preparer.py:415
 msgid "general-created-aggregate-transaction"
 msgstr ""
 
@@ -359,11 +363,11 @@ msgstr ""
 msgid "nodewatch-client-detected-height"
 msgstr ""
 
-#: shoestring/internal/PeerDownloader.py:65
+#: shoestring/internal/PeerDownloader.py:79
 msgid "peer-downloader-loading-api-endpoints"
 msgstr ""
 
-#: shoestring/internal/PeerDownloader.py:20
+#: shoestring/internal/PeerDownloader.py:34
 msgid "peer-downloader-saved-file"
 msgstr ""
 
@@ -435,8 +439,12 @@ msgstr ""
 msgid "setup-no-state-changes-required"
 msgstr ""
 
-#: shoestring/commands/setup.py:84
+#: shoestring/commands/setup.py:93
 msgid "setup-resources-directory-exists"
+msgstr ""
+
+#: shoestring/commands/setup.py:82
+msgid "setup-status-output-transaction-only"
 msgstr ""
 
 #: shoestring/commands/signer.py:32

--- a/tools/shoestring/tests/commands/test_setup.py
+++ b/tools/shoestring/tests/commands/test_setup.py
@@ -491,3 +491,63 @@ async def test_cannot_rerun_setup_when_directory_exists(server):  # pylint: disa
 				assert 1 == ex_info.value.code
 
 # endregion
+
+
+# region output-transaction-only
+
+def _read_file_contents(filepath):
+	with open(filepath, 'rb') as infile:
+		return infile.read()
+
+
+async def _assert_can_regenerate_links(server, node_features):  # pylint: disable=redefined-outer-name
+	# Arrange:
+	with tempfile.TemporaryDirectory() as output_directory:
+		with tempfile.TemporaryDirectory() as package_directory:
+			prepare_shoestring_configuration(package_directory, node_features, server.make_url(''), api_https=False)
+			_prepare_overrides(package_directory)
+			prepare_testnet_package(package_directory, 'resources.zip')
+
+			with tempfile.TemporaryDirectory() as ca_directory:
+				# - run initial setup
+				setup_command_args = [
+					'setup',
+					'--config', str(Path(package_directory) / 'sai.shoestring.ini'),
+					'--security', 'insecure',
+					'--package', f'file://{Path(package_directory) / "resources.zip"}',
+					'--directory', output_directory,
+					'--ca-key-path', str(Path(ca_directory) / 'xyz.key.pem'),
+					'--overrides', str(Path(package_directory) / 'user_overrides.ini')
+				]
+				await main(setup_command_args)
+
+				# - read (and delete) generated transaction
+				transaction_filepath = Path(output_directory) / 'linking_transaction.dat'
+				original_transaction = _read_file_contents(transaction_filepath)
+				transaction_filepath.unlink()
+
+				# Sanity:
+				assert not transaction_filepath.exists()
+
+				# Act: rerun with --output-transaction-only
+				await main(setup_command_args + ['--output-transaction-only'])
+
+				# Assert: same transaction was generated
+				assert transaction_filepath.exists()
+
+				regenerated_transaction = _read_file_contents(transaction_filepath)
+				assert original_transaction == regenerated_transaction
+
+
+async def test_can_regenerate_links_harvester_node(server):  # pylint: disable=redefined-outer-name
+	await _assert_can_regenerate_links(server, NodeFeatures.HARVESTER)
+
+
+async def test_can_regenerate_links_voter_node(server):  # pylint: disable=redefined-outer-name
+	await _assert_can_regenerate_links(server, NodeFeatures.VOTER)
+
+
+async def test_can_regenerate_links_full_node(server):  # pylint: disable=redefined-outer-name
+	await _assert_can_regenerate_links(server, NodeFeatures.API | NodeFeatures.HARVESTER | NodeFeatures.VOTER)
+
+# endregion

--- a/tools/shoestring/tests/internal/test_HarvesterConfigurator.py
+++ b/tools/shoestring/tests/internal/test_HarvesterConfigurator.py
@@ -145,3 +145,31 @@ class HarvesterConfiguratorTest(unittest.TestCase):
 			# Assert:
 			generated_files = sorted([path.name for path in Path(keys_directory).iterdir()])
 			self.assertEqual([], generated_files)
+
+	def test_can_load_harvester_keys_from_directory_enabled(self):
+		# Arrange:
+		with tempfile.TemporaryDirectory() as keys_directory:
+			configurator = HarvesterConfigurator(None)
+			configurator.generate_harvester_key_files(keys_directory)
+
+			# Act:
+			configurator2 = HarvesterConfigurator(None)
+			configurator2.load_harvester_keys_from_directory(keys_directory)
+
+			# Assert:
+			self.assertEqual(configurator.remote_key_pair.public_key, configurator2.remote_key_pair.public_key)
+			self.assertEqual(configurator.vrf_key_pair.public_key, configurator2.vrf_key_pair.public_key)
+
+	def test_cannot_load_harvester_keys_from_directory_disabled(self):
+		# Arrange:
+		with tempfile.TemporaryDirectory() as keys_directory:
+			configurator = HarvesterConfigurator(None)
+			configurator.generate_harvester_key_files(keys_directory)
+
+			# Act:
+			configurator2 = HarvesterConfigurator(None, 'none')
+			configurator2.load_harvester_keys_from_directory(keys_directory)
+
+			# Assert: nothing was loaded
+			self.assertFalse(hasattr(configurator2, 'remote_key_pair'))
+			self.assertFalse(hasattr(configurator2, 'vrf_key_pair'))

--- a/tools/shoestring/tests/internal/test_PeerDownloader.py
+++ b/tools/shoestring/tests/internal/test_PeerDownloader.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from shoestring.internal.PeerDownloader import download_peers, load_api_endpoints
+from shoestring.internal.PeerDownloader import download_peers, find_api_node, load_api_endpoints
 
 from ..test.MockNodewatchServer import setup_mock_nodewatch_server
 
@@ -19,6 +19,23 @@ async def nodewatch_server(aiohttp_client):
 
 
 # pylint: disable=invalid-name
+
+
+# region find_api_node
+
+async def test_can_find_api_node(nodewatch_server):  # pylint: disable=redefined-outer-name
+	# Act:
+	endpoint = await find_api_node(nodewatch_server.make_url(''))
+
+	# Assert:
+	assert endpoint in [
+		'http://ik1-432-48199.vs.sakura.ne.jp:3333',
+		'http://0-0-5symbol.open-nodes.com:3000',
+		'http://wolf.importance.jp:3000',
+		'https://whydah.symbolmain.net:3001'
+	]
+
+# endregion
 
 
 # region download_peers

--- a/tools/shoestring/tests/internal/test_Preparer.py
+++ b/tools/shoestring/tests/internal/test_Preparer.py
@@ -586,6 +586,93 @@ class PreparerTest(unittest.TestCase):
 
 	# endregion
 
+	# region load_keys
+
+	def _can_load_keys(self, node_features, asserter):
+		# Arrange: use a full node to generate all files
+		with tempfile.TemporaryDirectory() as output_directory:
+			full_node_features = NodeFeatures.API | NodeFeatures.HARVESTER | NodeFeatures.VOTER
+			with Preparer(output_directory, self._create_configuration(full_node_features)) as preparer:
+				self._initialize_temp_directory_with_package_files(preparer)
+				preparer.prepare_resources()
+				preparer.configure_keys(5, 4)
+
+				# Act: only load keys for the specified features
+				preparer2 = Preparer(output_directory, self._create_configuration(node_features))
+				preparer2.load_keys()
+
+				# Assert:
+				asserter(preparer, preparer2)
+
+	def _assert_harvester_keys_not_loaded(self, preparer, preparer2):
+		harvester_configurator = preparer.harvester_configurator
+		harvester_configurator2 = preparer2.harvester_configurator
+		self.assertNotEqual(harvester_configurator.remote_key_pair.public_key, harvester_configurator2.remote_key_pair.public_key)
+		self.assertNotEqual(harvester_configurator.vrf_key_pair.public_key, harvester_configurator2.vrf_key_pair.public_key)
+
+	def _assert_harvester_keys_loaded(self, preparer, preparer2):
+		harvester_configurator = preparer.harvester_configurator
+		harvester_configurator2 = preparer2.harvester_configurator
+		self.assertEqual(harvester_configurator.remote_key_pair.public_key, harvester_configurator2.remote_key_pair.public_key)
+		self.assertEqual(harvester_configurator.vrf_key_pair.public_key, harvester_configurator2.vrf_key_pair.public_key)
+
+	def _assert_voter_keys_not_loaded(self, preparer, preparer2):
+		self.assertNotEqual(preparer.voter_configurator.voting_public_key, preparer2.voter_configurator.voting_public_key)
+		self.assertEqual(None, preparer2.new_voting_key_file_epoch_range)
+
+	def _assert_voter_keys_loaded(self, preparer, preparer2):
+		self.assertEqual(preparer.voter_configurator.voting_public_key, preparer2.voter_configurator.voting_public_key)
+
+		self.assertNotEqual(None, preparer2.new_voting_key_file_epoch_range)
+		self.assertEqual(preparer.new_voting_key_file_epoch_range, preparer2.new_voting_key_file_epoch_range)
+
+	def test_can_load_keys_peer_node(self):
+		def asserter(preparer, preparer2):
+			# Assert: nothing was loaded
+			self._assert_harvester_keys_not_loaded(preparer, preparer2)
+			self._assert_voter_keys_not_loaded(preparer, preparer2)
+
+		# Act:
+		self._can_load_keys(NodeFeatures.PEER, asserter)
+
+	def test_can_load_keys_api_node(self):
+		def asserter(preparer, preparer2):
+			# Assert: nothing was loaded
+			self._assert_harvester_keys_not_loaded(preparer, preparer2)
+			self._assert_voter_keys_not_loaded(preparer, preparer2)
+
+		# Act:
+		self._can_load_keys(NodeFeatures.API, asserter)
+
+	def test_can_load_keys_harvester_node(self):
+		def asserter(preparer, preparer2):
+			# Assert: only harvester keys were loaded
+			self._assert_harvester_keys_loaded(preparer, preparer2)
+			self._assert_voter_keys_not_loaded(preparer, preparer2)
+
+		# Act:
+		self._can_load_keys(NodeFeatures.HARVESTER, asserter)
+
+	def test_can_load_keys_voter_node(self):
+		def asserter(preparer, preparer2):
+			# Assert: only voter keys were loaded
+			self._assert_harvester_keys_not_loaded(preparer, preparer2)
+			self._assert_voter_keys_loaded(preparer, preparer2)
+
+		# Act:
+		self._can_load_keys(NodeFeatures.VOTER, asserter)
+
+	def test_can_load_keys_full_node(self):
+		def asserter(preparer, preparer2):
+			# Assert: harvester and voter keys were loaded
+			self._assert_harvester_keys_loaded(preparer, preparer2)
+			self._assert_voter_keys_loaded(preparer, preparer2)
+
+		# Act:
+		self._can_load_keys(NodeFeatures.API | NodeFeatures.HARVESTER | NodeFeatures.VOTER, asserter)
+
+	# endregion
+
 	# region generate_certificates
 
 	@staticmethod
@@ -919,7 +1006,7 @@ class PreparerTest(unittest.TestCase):
 				assert_aggregate_transaction(self, transaction, expected_aggregate_descriptor)
 				self.assertEqual(1, len(transaction.transactions))
 
-				new_voting_public_key = preparer.voter_configurator.voting_key_pair.public_key
+				new_voting_public_key = preparer.voter_configurator.voting_public_key
 				assert_link_transaction(
 					self,
 					transaction.transactions[0],
@@ -930,8 +1017,9 @@ class PreparerTest(unittest.TestCase):
 		imports_config,
 		expected_link_transaction_count,
 		expect_harvester_links,
-		expect_voter_links
-	):  # pylint: disable=too-many-locals
+		expect_voter_links,
+		reload_keys=False
+	):  # pylint: disable=too-many-arguments, too-many-positional-arguments, too-many-locals,
 		# Arrange:
 		account_public_key = self._random_public_key()
 
@@ -951,7 +1039,11 @@ class PreparerTest(unittest.TestCase):
 				preparer.configure_keys(5, 4)
 
 				# Act:
-				transaction = preparer.prepare_linking_transaction(account_public_key, existing_links, 2222)
+				if not reload_keys:
+					transaction = preparer.prepare_linking_transaction(account_public_key, existing_links, 2222)
+				else:
+					preparer2 = Preparer(output_directory, config)
+					transaction = preparer2.prepare_linking_transaction(account_public_key, existing_links, 2222)
 
 				# Assert:
 				if 0 == expected_link_transaction_count:
@@ -1003,7 +1095,7 @@ class PreparerTest(unittest.TestCase):
 						LinkDescriptor(TransactionType.VOTING_KEY_LINK, first_existing_voting_public_key, LinkAction.UNLINK, (1111, 2222)))
 
 					# - check voting unlinks
-					new_voting_public_key = preparer.voter_configurator.voting_key_pair.public_key
+					new_voting_public_key = preparer.voter_configurator.voting_public_key
 					assert_link_transaction(
 						self,
 						transaction.transactions[voter_links_start_index + 1],
@@ -1050,5 +1142,16 @@ class PreparerTest(unittest.TestCase):
 
 			# Act + Assert: neither harvester nor voter (un)links are present
 			self._assert_prepare_linking_transaction_can_create_aggregate_with_all_links_and_unlinks(imports_config, 0, False, False)
+
+	def test_prepare_linking_transaction_can_create_aggregate_with_all_links_and_unlinks_import_harvester_and_voter_after_load_keys(self):
+		# Arrange: copy of previous test, except loads keys into a fresh preparer
+		with tempfile.TemporaryDirectory() as source_directory:
+			imports_harvester_filepath = Path(source_directory) / 'import.properties'
+			self._write_harvester_imports_file(imports_harvester_filepath)
+
+			imports_config = ImportsConfiguration(imports_harvester_filepath, source_directory, None)
+
+			# Act + Assert: neither harvester nor voter (un)links are present (using a fresh preparer with loaded keys)
+			self._assert_prepare_linking_transaction_can_create_aggregate_with_all_links_and_unlinks(imports_config, 0, False, False, True)
 
 	# endregion

--- a/tools/shoestring/tests/internal/test_VoterConfigurator.py
+++ b/tools/shoestring/tests/internal/test_VoterConfigurator.py
@@ -40,9 +40,12 @@ class VoterConfiguratorTest(unittest.TestCase):
 
 		# Assert:
 		self.assertEqual(False, configurator1.is_imported)
-		self.assertEqual(False, configurator2.is_imported)
+		self.assertEqual(configurator1.voting_public_key, configurator1.voting_key_pair.public_key)
 
-		self.assertEqual(2, len(set([configurator1.voting_key_pair.public_key, configurator2.voting_key_pair.public_key])))
+		self.assertEqual(False, configurator2.is_imported)
+		self.assertEqual(configurator2.voting_public_key, configurator2.voting_key_pair.public_key)
+
+		self.assertEqual(2, len(set([configurator1.voting_public_key, configurator2.voting_public_key])))
 
 	def test_configurator_can_import_key_pairs(self):
 		# Act:
@@ -52,6 +55,7 @@ class VoterConfiguratorTest(unittest.TestCase):
 		self.assertEqual(True, configurator.is_imported)
 
 		self.assertEqual(None, configurator.voting_key_pair)
+		self.assertEqual(None, configurator.voting_public_key)
 
 	def test_can_patch_configuration(self):
 		# Arrange:
@@ -132,7 +136,7 @@ class VoterConfiguratorTest(unittest.TestCase):
 			(start_epoch, end_epoch, root_public_key) = self._read_voting_key_file_header(new_voting_key_tree_file)
 			self.assertEqual(5 + 1 + 1, start_epoch)
 			self.assertEqual(5 + 1 + 1 + 221, end_epoch)
-			self.assertEqual(configurator.voting_key_pair.public_key, root_public_key)
+			self.assertEqual(configurator.voting_public_key, root_public_key)
 			self.assertEqual(0o600, new_voting_key_tree_file.stat().st_mode & 0o777)
 
 			# - check return values:
@@ -158,7 +162,7 @@ class VoterConfiguratorTest(unittest.TestCase):
 			(start_epoch, end_epoch, root_public_key) = self._read_voting_key_file_header(new_voting_key_tree_file)
 			self.assertEqual(5 + 1 + 7, start_epoch)
 			self.assertEqual(5 + 1 + 7 + 221, end_epoch)
-			self.assertEqual(configurator.voting_key_pair.public_key, root_public_key)
+			self.assertEqual(configurator.voting_public_key, root_public_key)
 			self.assertEqual(0o600, new_voting_key_tree_file.stat().st_mode & 0o777)
 
 			# - check return values:
@@ -188,10 +192,10 @@ class VoterConfiguratorTest(unittest.TestCase):
 			(start_epoch, end_epoch, root_public_key) = self._read_voting_key_file_header(new_voting_key_tree_file)
 			self.assertEqual(400, start_epoch)
 			self.assertEqual(400 + 221, end_epoch)
-			self.assertEqual(configurator.voting_key_pair.public_key, root_public_key)
+			self.assertEqual(configurator.voting_public_key, root_public_key)
 			self.assertEqual(0o600, new_voting_key_tree_file.stat().st_mode & 0o777)
 
-			# - check return values:
+			# - check return values
 			self.assertEqual(400, epoch_range.start_epoch)
 			self.assertEqual(400 + 221, epoch_range.end_epoch)
 
@@ -227,6 +231,32 @@ class VoterConfiguratorTest(unittest.TestCase):
 
 				# - returned range is unset
 				self.assertEqual(None, epoch_range)
+	# endregion
+
+	# region load_voting_key_from_directory
+
+	def test_can_load_voting_key_from_directory(self):
+		# Arrange:
+		with tempfile.TemporaryDirectory() as temp_directory:
+			voting_key_file_directory = self._prepare_generate_voting_key_file_test(temp_directory)
+
+			self._write_voting_key_file_header(voting_key_file_directory, 'private_key_tree3.dat', 100, 199)
+			self._write_voting_key_file_header(voting_key_file_directory, 'private_key_tree5.dat', 200, 299)
+			public_key_3 = self._write_voting_key_file_header(voting_key_file_directory, 'private_key_tree7.dat', 300, 399)
+
+			# Act:
+			config_manager = ConfigurationManager(temp_directory)
+			configurator = VoterConfigurator(config_manager)
+			epoch_range = configurator.load_voting_key_from_directory(voting_key_file_directory)
+
+			# Assert: only public key should be set
+			self.assertEqual(None, configurator.voting_key_pair)
+			self.assertEqual(public_key_3, configurator.voting_public_key)
+
+			# - check return values
+			self.assertEqual(300, epoch_range.start_epoch)
+			self.assertEqual(399, epoch_range.end_epoch)
+
 	# endregion
 
 	# region inspect_voting_key_files


### PR DESCRIPTION
 problem: linking-transactions.dat may expire before user is able to send it
solution: allow rerunning setup with --output-transaction-only to regenerate transaction

   issue: #2047