### PR TITLE
[explorer/puller] fix: refactor and bug fix

### DIFF
--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -107,13 +107,6 @@ class NemDatabase(DatabaseConnection):
 			'''
 		)
 
-		cursor.execute(
-			'''
-			CREATE INDEX IF NOT EXISTS idx_tx_inner_transaction_id
-				ON transactions(inner_transaction_id)
-			'''
-		)
-
 		# Create indexes for transactions_mosaic table
 		cursor.execute(
 			'''
@@ -232,9 +225,7 @@ class NemDatabase(DatabaseConnection):
 				signature bytea,
 				amount bigint,
 				is_inner boolean DEFAULT false,
-				inner_transaction_id int,
-				payload jsonb,
-				FOREIGN KEY (inner_transaction_id) REFERENCES transactions(id)
+				payload jsonb
 			)
 			'''
 		)
@@ -497,10 +488,9 @@ class NemDatabase(DatabaseConnection):
 				signature,
 				amount,
 				is_inner,
-				inner_transaction_id,
 				payload
 			)
-			VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+			VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 			RETURNING id
 			''',
 			(
@@ -516,7 +506,6 @@ class NemDatabase(DatabaseConnection):
 				unhexlify(transaction.signature) if transaction.signature else None,
 				transaction.amount,
 				transaction.is_inner,
-				transaction.inner_transaction_id,
 				json.dumps(transaction.payload) if transaction.payload else None
 			)
 		)

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -74,7 +74,6 @@ TransactionRecord = namedtuple('TransactionRecord', [
 	'amount',
 	'transaction_type',
 	'is_inner',
-	'inner_transaction_id',
 	'sender_address',
 	'recipient_address',
 	'payload'
@@ -364,7 +363,7 @@ class NemPuller:
 		adjustment = transaction.delta if transaction.supply_type == 1 else -transaction.delta
 		self.nem_db.update_mosaic_total_supply(cursor, transaction.namespace_name, adjustment)
 
-	def _build_transaction_record(self, transaction, is_inner, inner_transaction_id=None):
+	def _build_transaction_record(self, transaction, is_inner):
 		"""Create TransactionRecord from transaction data."""
 
 		payload = None
@@ -456,17 +455,16 @@ class NemPuller:
 			signature=transaction.signature,
 			transaction_type=transaction.transaction_type,
 			is_inner=is_inner,
-			inner_transaction_id=inner_transaction_id,  # to be updated after insertion if it's an inner transaction
 			sender_address=self._convert_public_key_to_address(transaction.sender),
 			recipient_address=recipient_address,
 			payload=payload
 		)
 
-	def _process_transaction(self, cursor, transaction, block_height, is_inner, inner_transaction_id=None):
+	def _process_transaction(self, cursor, transaction, block_height, is_inner):
 		# pylint: disable=too-many-arguments,too-many-positional-arguments
 		"""Process a single transaction."""
 
-		transaction_record = self._build_transaction_record(transaction, is_inner, inner_transaction_id)
+		transaction_record = self._build_transaction_record(transaction, is_inner)
 		transaction_id = self.nem_db.insert_transaction(cursor, transaction_record)
 
 		if transaction.transaction_type == TransactionType.TRANSFER.value and transaction.mosaics:
@@ -485,21 +483,19 @@ class NemPuller:
 		"""Process transactions in a block."""
 
 		for transaction in block_transactions:
-			inner_transaction_id = None
 
 			# Handle inner transaction first to get its ID for linking
 			if hasattr(transaction, 'other_transaction'):
 				# For inner transactions, we set the transaction hash to the inner hash
 				transaction.other_transaction.transaction_hash = transaction.inner_hash
 				transaction.other_transaction.height = transaction.height
-				inner_transaction_id = self._process_transaction(cursor, transaction=transaction.other_transaction, block_height=height, is_inner=True)
+				self._process_transaction(cursor, transaction=transaction.other_transaction, block_height=height, is_inner=True)
 
 			self._process_transaction(
 				cursor,
 				transaction=transaction,
 				block_height=height,
-				is_inner=False,
-				inner_transaction_id=inner_transaction_id
+				is_inner=False
 			)
 
 	async def sync_nemesis_block(self):

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -457,7 +457,7 @@ class NemPuller:
 			transaction_type=transaction.transaction_type,
 			is_inner=is_inner,
 			inner_transaction_id=inner_transaction_id,  # to be updated after insertion if it's an inner transaction
-			sender_address=transaction.sender,
+			sender_address=self._convert_public_key_to_address(transaction.sender),
 			recipient_address=recipient_address,
 			payload=payload
 		)

--- a/explorer/puller/tests/db/test_NemDatabase.py
+++ b/explorer/puller/tests/db/test_NemDatabase.py
@@ -91,7 +91,6 @@ TRANSACTIONS = [
 		),
 		transaction_type=257,
 		is_inner=False,
-		inner_transaction_id=None,
 		sender_address=Address('TCJLCZSOQ6RGWHTPSV2DW467WZSHK4NBSITND4OF'),
 		recipient_address=Address('TBZWVEKB2XMTO4F3RAOEIBWRBMPQ5N23G56ZJM4I'),
 		payload='{}'
@@ -691,7 +690,6 @@ class NemDatabaseTest(unittest.TestCase):
 					encode(signature, 'hex'),
 					amount,
 					is_inner,
-					inner_transaction_id,
 					payload
 				FROM transactions
 				WHERE id = %s
@@ -715,7 +713,6 @@ class NemDatabaseTest(unittest.TestCase):
 			TRANSACTIONS[0].signature,
 			2000000,
 			False,
-			None,
 			'{}'
 		))
 

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -934,7 +934,6 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			signature=transaction.signature,
 			transaction_type=transaction.transaction_type,
 			is_inner=False,
-			inner_transaction_id=None,
 			sender_address=self.puller.nem_facade.network.public_key_to_address(transaction.sender),
 			recipient_address=recipient_address,
 			payload=payload
@@ -1240,7 +1239,6 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 	@patch('puller.facade.NemPuller.NemPuller._process_transaction')
 	def test_can_process_transactions_inner_outer(self, mock_process_transaction):
 		# Arrange:
-		mock_process_transaction.return_value = 1  # Simulate inserted transaction ID for linking inner transactions
 		block_data = NEM_CONNECTOR_RESPONSE_BLOCKS[2]
 
 		block = Block(
@@ -1284,6 +1282,5 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		self.assertEqual(process_transaction_calls[1][1], {
 			'transaction': block.transactions[0],
 			'block_height': 3,
-			'is_inner': False,
-			'inner_transaction_id': 1
+			'is_inner': False
 		})

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -935,7 +935,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			transaction_type=transaction.transaction_type,
 			is_inner=False,
 			inner_transaction_id=None,
-			sender_address=transaction.sender,
+			sender_address=self.puller.nem_facade.network.public_key_to_address(transaction.sender),
 			recipient_address=recipient_address,
 			payload=payload
 		))


### PR DESCRIPTION
Problem: 
- Found that `sender_address` didn't convert to an address.
- `inner_transaction_id` is not required

Solution:
- convert sender public key to address.
- Removed inner_transaction_id, as it already has an index for transaction hash, when looking up for the multisig inner transaction, It can just query by transaction hash