### PR TITLE
Pr/shoestring multisig

### DIFF
--- a/tools/shoestring/README.md
+++ b/tools/shoestring/README.md
@@ -181,6 +181,13 @@ signer --config CONFIG --ca-key-path CA_KEY_PATH [--save] filename
   --save                    save signed payload into same file as input
 ```
 
+For aggregate transactions, `signer` can be run multiple times against the same payload file.
+The first run signs the aggregate transaction itself.
+Subsequent runs with different cosignatory keys append aggregate cosignatures instead of replacing the existing aggregate signature.
+
+For aggregate bonded transactions, the first signing run will additionally create a hash lock transaction in `filename` with `.hash_lock.dat` suffix.
+Subsequent cosigning runs do not recreate or replace that hash lock file.
+
 ### announce-transaction
 
 Announces a transaction to the network.
@@ -317,10 +324,10 @@ General properties:
 ```
 feeMultiplier             Min fee multiplier of generated transactions
 timeoutHours              Timeout of generated transactions (in hours)
-minCosignaturesCount      Minimum number of cosignatures generated transactions will require
+minCosignaturesCount      Minimum number of cosignatures generated aggregate transactions will require
 ```
 
-When `signer` command is signing an aggregate bonded transaction, it will additionally generate a hash lock transaction
+When `signer` command is signing an aggregate bonded transaction for the first time, it will additionally generate a hash lock transaction
 using the following properties:
 ```
 hashLockDuration          Hash lock duration in blocks

--- a/tools/shoestring/shoestring/commands/announce_transaction.py
+++ b/tools/shoestring/shoestring/commands/announce_transaction.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from symbolchain import sc
 from symbolchain.facade.SymbolFacade import SymbolFacade
 from symbollightapi.connector.SymbolConnector import SymbolConnector
@@ -25,6 +27,10 @@ async def run_main(args):
 
 	announce_transaction = connector.announce_transaction
 	if sc.TransactionType.AGGREGATE_BONDED == transaction_type:
+		hash_lock_filepath = Path(args.transaction).with_suffix('.hash_lock.dat')
+		if not hash_lock_filepath.exists():
+			log.warning(_('announce-transaction-missing-hash-lock').format(hash_lock_filepath=hash_lock_filepath))
+
 		announce_transaction = connector.announce_partial_transaction
 
 	await announce_transaction(transaction)

--- a/tools/shoestring/shoestring/commands/min_cosignatures_count.py
+++ b/tools/shoestring/shoestring/commands/min_cosignatures_count.py
@@ -18,7 +18,9 @@ async def run_main(args):
 	log.info(_('general-connecting-to-node').format(endpoint=api_endpoint))
 	connector = SymbolConnector(api_endpoint)
 
-	public_key = read_public_key_from_private_key_pem_file(args.ca_key_path)
+	public_key = config.transaction.signer_public_key
+	if not public_key:
+		public_key = read_public_key_from_private_key_pem_file(args.ca_key_path)
 	address = config.network.public_key_to_address(public_key)
 	min_cosignatures_count = await calculate_min_cosignatures_count(connector, address)
 	log.info(_('min-cosignatures-count-cosignatures-detected').format(min_cosignatures_count=min_cosignatures_count, address=address))

--- a/tools/shoestring/shoestring/commands/renew_voting_keys.py
+++ b/tools/shoestring/shoestring/commands/renew_voting_keys.py
@@ -89,7 +89,9 @@ async def run_main(args):
 		log.error(_('renew-voting-keys-maximum-already-registered'))
 		return
 
-	account_public_key = read_public_key_from_public_key_pem_file(directories.certificates / 'ca.pubkey.pem')
+	account_public_key = config.transaction.signer_public_key
+	if not account_public_key:
+		account_public_key = read_public_key_from_public_key_pem_file(directories.certificates / 'ca.pubkey.pem')
 	transaction_builder = LinkTransactionBuilder(account_public_key, config.network)
 
 	# remove expired root voting keys

--- a/tools/shoestring/shoestring/commands/setup.py
+++ b/tools/shoestring/shoestring/commands/setup.py
@@ -62,7 +62,9 @@ async def _prepare_linking_transaction(preparer, api_endpoint):
 	log.info(_('general-connecting-to-node').format(endpoint=api_endpoint))
 	connector = SymbolConnector(api_endpoint)
 
-	account_public_key = read_public_key_from_public_key_pem_file(preparer.directories.certificates / 'ca.pubkey.pem')
+	account_public_key = preparer.config.transaction.signer_public_key
+	if not account_public_key:
+		account_public_key = read_public_key_from_public_key_pem_file(preparer.directories.certificates / 'ca.pubkey.pem')
 	existing_links = await connector.account_links(account_public_key)
 
 	network_time = await connector.network_time()

--- a/tools/shoestring/shoestring/commands/signer.py
+++ b/tools/shoestring/shoestring/commands/signer.py
@@ -15,6 +15,7 @@ def _is_aggregate(transaction):
 
 
 def _is_signed(transaction):
+	# Symbol serializes unsigned transactions with an all-zero signature field
 	return any(transaction.signature.bytes)
 
 
@@ -80,7 +81,7 @@ def run_main(args):
 		is_cosigning = key_pair.public_key.bytes != transaction.signer_public_key.bytes
 
 		if is_cosigning and _has_cosignature(transaction, key_pair.public_key):
-			log.info(_('signer-signed-transaction').format(
+			log.info(_('signer-already-cosigned-transaction').format(
 				transaction_type=transaction.type_,
 				transaction_hash=facade.hash_transaction(transaction)))
 			if args.save:

--- a/tools/shoestring/shoestring/commands/signer.py
+++ b/tools/shoestring/shoestring/commands/signer.py
@@ -72,7 +72,9 @@ def run_main(args):
 	key_pair = KeyPair(read_private_key_from_private_key_pem_file(args.ca_key_path, config.node.ca_password))
 	is_cosigning = False
 
-	if _is_aggregate(transaction) and not _is_signed(transaction):  # first signer becomes aggregate initiator
+	# For multisig payloads, the prebuilt aggregate can carry the multisig account public key as a placeholder.
+	# The first real signer becomes the aggregate initiator / announcer and therefore replaces the outer signer.
+	if _is_aggregate(transaction) and not _is_signed(transaction):
 		transaction.signer_public_key = sc.PublicKey(key_pair.public_key.bytes)
 	elif _is_aggregate(transaction):
 		is_cosigning = key_pair.public_key.bytes != transaction.signer_public_key.bytes

--- a/tools/shoestring/shoestring/commands/signer.py
+++ b/tools/shoestring/shoestring/commands/signer.py
@@ -14,6 +14,14 @@ def _is_aggregate(transaction):
 	return transaction.type_ in (sc.TransactionType.AGGREGATE_BONDED, sc.TransactionType.AGGREGATE_COMPLETE)
 
 
+def _is_signed(transaction):
+	return any(transaction.signature.bytes)
+
+
+def _has_cosignature(transaction, public_key):
+	return any(public_key.bytes == cosignature.signer_public_key.bytes for cosignature in transaction.cosignatures)
+
+
 def _load_transaction(filename):
 	with open(filename, 'rb') as infile:
 		payload = infile.read()
@@ -47,24 +55,44 @@ def _sign_transaction(facade, key_pair, transaction):
 	return transaction_hash
 
 
+def _cosign_transaction(facade, key_pair, transaction):
+	cosignature = facade.cosign_transaction(key_pair, transaction)
+	transaction.cosignatures.append(cosignature)
+
+	transaction_hash = facade.hash_transaction(transaction)
+	log.info(_('signer-signed-transaction').format(transaction_type=transaction.type_, transaction_hash=transaction_hash))
+	return transaction_hash
+
+
 def run_main(args):
 	config = parse_shoestring_configuration(args.config)
 	facade = SymbolFacade(config.network)
 
 	transaction = _load_transaction(args.filename)
 	key_pair = KeyPair(read_private_key_from_private_key_pem_file(args.ca_key_path, config.node.ca_password))
+	is_cosigning = False
 
-	if _is_aggregate(transaction):  # change the aggregate signer to be a valid cosigner
+	if _is_aggregate(transaction) and not _is_signed(transaction):  # first signer becomes aggregate initiator
 		transaction.signer_public_key = sc.PublicKey(key_pair.public_key.bytes)
+	elif _is_aggregate(transaction):
+		is_cosigning = key_pair.public_key.bytes != transaction.signer_public_key.bytes
+
+		if is_cosigning and _has_cosignature(transaction, key_pair.public_key):
+			log.info(_('signer-signed-transaction').format(
+				transaction_type=transaction.type_,
+				transaction_hash=facade.hash_transaction(transaction)))
+			if args.save:
+				write_transaction_to_file(transaction, Path(args.filename))
+			return
 
 	_print_transaction(transaction)
 
-	transaction_hash = _sign_transaction(facade, key_pair, transaction)
+	transaction_hash = _cosign_transaction(facade, key_pair, transaction) if is_cosigning else _sign_transaction(facade, key_pair, transaction)
 
 	if args.save:
 		write_transaction_to_file(transaction, Path(args.filename))
 
-	if sc.TransactionType.AGGREGATE_BONDED != transaction.type_:
+	if is_cosigning or sc.TransactionType.AGGREGATE_BONDED != transaction.type_:
 		return
 
 	hash_lock_transaction = facade.transaction_factory.create({

--- a/tools/shoestring/shoestring/internal/ShoestringConfiguration.py
+++ b/tools/shoestring/shoestring/internal/ShoestringConfiguration.py
@@ -2,7 +2,7 @@ import configparser
 import datetime
 from collections import namedtuple
 
-from symbolchain.CryptoTypes import Hash256
+from symbolchain.CryptoTypes import Hash256, PublicKey
 from symbolchain.symbol.Network import Network
 
 from .NodeFeatures import NodeFeatures
@@ -10,7 +10,8 @@ from .NodeFeatures import NodeFeatures
 ImagesConfiguration = namedtuple('ImagesConfiguration', ['client', 'rest', 'mongo'])
 ServicesConfiguration = namedtuple('ServicesConfiguration', ['nodewatch'])
 TransactionConfiguration = namedtuple('TransactionConfiguration', [
-	'fee_multiplier', 'timeout_hours', 'min_cosignatures_count', 'hash_lock_duration', 'currency_mosaic_id', 'locked_funds_per_aggregate'
+	'fee_multiplier', 'timeout_hours', 'min_cosignatures_count', 'hash_lock_duration', 'currency_mosaic_id', 'locked_funds_per_aggregate',
+	'signer_public_key'
 ])
 ImportsConfiguration = namedtuple('ImportsConfiguration', ['harvester', 'voter', 'node_key'])
 NodeConfiguration = namedtuple('NodeConfiguration', [
@@ -50,6 +51,7 @@ def parse_transaction_configuration(config):
 	hash_lock_duration = int(config['hashLockDuration'])
 	currency_mosaic_id = int(config['currencyMosaicId'], 16)
 	locked_funds_per_aggregate = int(config['lockedFundsPerAggregate'])
+	signer_public_key = PublicKey(config['signerPublicKey']) if 'signerPublicKey' in config and config['signerPublicKey'] else None
 
 	return TransactionConfiguration(
 		fee_multiplier,
@@ -57,7 +59,8 @@ def parse_transaction_configuration(config):
 		min_cosignatures_count,
 		hash_lock_duration,
 		currency_mosaic_id,
-		locked_funds_per_aggregate)
+		locked_funds_per_aggregate,
+		signer_public_key)
 
 
 def parse_imports_configuration(config):

--- a/tools/shoestring/shoestring/lang/en/LC_MESSAGES/messages.po
+++ b/tools/shoestring/shoestring/lang/en/LC_MESSAGES/messages.po
@@ -486,6 +486,10 @@ msgstr "Inner transactions:"
 msgid "signer-signed-transaction"
 msgstr "Signed transaction {transaction_type} with hash: {transaction_hash}"
 
+#: shoestring/commands/signer.py:84
+msgid "signer-already-cosigned-transaction"
+msgstr "transaction {transaction_type} with hash {transaction_hash} was already cosigned by this key, skipping"
+
 #: shoestring/commands/signer.py:26
 msgid "signer-transaction"
 msgstr "Transaction: {transaction}"

--- a/tools/shoestring/shoestring/lang/en/LC_MESSAGES/messages.po
+++ b/tools/shoestring/shoestring/lang/en/LC_MESSAGES/messages.po
@@ -5,17 +5,21 @@ msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
-#: shoestring/commands/announce_transaction.py:31
+#: shoestring/commands/announce_transaction.py:38
 msgid "announce-transaction-announce-successful"
 msgstr "transaction was successfully sent to the network"
 
-#: shoestring/commands/announce_transaction.py:24
+#: shoestring/commands/announce_transaction.py:26
+msgid "announce-transaction-missing-hash-lock"
+msgstr "aggregate bonded transaction was selected but no adjacent hash lock file was found at {hash_lock_filepath}"
+
+#: shoestring/commands/announce_transaction.py:22
 msgid "announce-transaction-preparing-to-announce"
 msgstr ""
 "preparing to announce transaction {transaction_hash} of type "
 "{transaction_type}"
 
-#: shoestring/commands/announce_transaction.py:36
+#: shoestring/commands/announce_transaction.py:43
 msgid "argument-help-announce-transaction-transaction"
 msgstr "file containing serialized transaction to send"
 
@@ -930,4 +934,3 @@ msgstr "Welcome"
 #: shoestring/wizard/screens/welcome.py:39
 msgid "wizard-welcome-upgrade"
 msgstr "upgrade"
-

--- a/tools/shoestring/shoestring/lang/ja/LC_MESSAGES/messages.po
+++ b/tools/shoestring/shoestring/lang/ja/LC_MESSAGES/messages.po
@@ -474,6 +474,10 @@ msgstr "内部トランザクション:"
 msgid "signer-signed-transaction"
 msgstr "ハッシュ: {transaction_hash} のトランザクション {transaction_type} に署名しました"
 
+#: shoestring/commands/signer.py:84
+msgid "signer-already-cosigned-transaction"
+msgstr "トランザクション {transaction_type} (ハッシュ: {transaction_hash}) はすでにこの鍵で連署済みのためスキップします"
+
 #: shoestring/commands/signer.py:26
 msgid "signer-transaction"
 msgstr "トランザクション: {transaction}"

--- a/tools/shoestring/shoestring/lang/ja/LC_MESSAGES/messages.po
+++ b/tools/shoestring/shoestring/lang/ja/LC_MESSAGES/messages.po
@@ -5,15 +5,19 @@ msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
-#: shoestring/commands/announce_transaction.py:31
+#: shoestring/commands/announce_transaction.py:38
 msgid "announce-transaction-announce-successful"
 msgstr "トランザクションはネットワークに正常に送信されました"
 
-#: shoestring/commands/announce_transaction.py:24
+#: shoestring/commands/announce_transaction.py:26
+msgid "announce-transaction-missing-hash-lock"
+msgstr "aggregate bonded トランザクションが選択されましたが、隣接する hash lock ファイル {hash_lock_filepath} が見つかりません"
+
+#: shoestring/commands/announce_transaction.py:22
 msgid "announce-transaction-preparing-to-announce"
 msgstr "{transaction_type}タイプのトランザクション{transaction_hash}をアナウンスする準備中"
 
-#: shoestring/commands/announce_transaction.py:36
+#: shoestring/commands/announce_transaction.py:43
 msgid "argument-help-announce-transaction-transaction"
 msgstr "送信するシリアライズ済みトランザクションファイル"
 
@@ -913,4 +917,3 @@ msgstr "ようこそ"
 #: shoestring/wizard/screens/welcome.py:39
 msgid "wizard-welcome-upgrade"
 msgstr "アップグレード"
-

--- a/tools/shoestring/shoestring/lang/messages.pot
+++ b/tools/shoestring/shoestring/lang/messages.pot
@@ -1,12 +1,16 @@
-#: shoestring/commands/announce_transaction.py:31
+#: shoestring/commands/announce_transaction.py:38
 msgid "announce-transaction-announce-successful"
 msgstr ""
 
-#: shoestring/commands/announce_transaction.py:24
+#: shoestring/commands/announce_transaction.py:26
+msgid "announce-transaction-missing-hash-lock"
+msgstr ""
+
+#: shoestring/commands/announce_transaction.py:22
 msgid "announce-transaction-preparing-to-announce"
 msgstr ""
 
-#: shoestring/commands/announce_transaction.py:36
+#: shoestring/commands/announce_transaction.py:43
 msgid "argument-help-announce-transaction-transaction"
 msgstr ""
 
@@ -900,4 +904,3 @@ msgstr ""
 #: shoestring/wizard/screens/welcome.py:39
 msgid "wizard-welcome-upgrade"
 msgstr ""
-

--- a/tools/shoestring/shoestring/lang/messages.pot
+++ b/tools/shoestring/shoestring/lang/messages.pot
@@ -463,6 +463,10 @@ msgstr ""
 msgid "signer-signed-transaction"
 msgstr ""
 
+#: shoestring/commands/signer.py:84
+msgid "signer-already-cosigned-transaction"
+msgstr ""
+
 #: shoestring/commands/signer.py:26
 msgid "signer-transaction"
 msgstr ""

--- a/tools/shoestring/tests/commands/test_announce_transaction.py
+++ b/tools/shoestring/tests/commands/test_announce_transaction.py
@@ -11,6 +11,7 @@ from shoestring.__main__ import main
 from shoestring.internal.NodeFeatures import NodeFeatures
 
 from ..test.ConfigurationTestUtils import prepare_shoestring_configuration
+from ..test.LogTestUtils import assert_message_is_logged
 from ..test.MockNodewatchServer import setup_mock_nodewatch_server
 
 # region server fixture
@@ -98,5 +99,64 @@ async def test_can_announce_aggregate_bonded_transaction(server):  # pylint: dis
 
 	# Act + Assert:
 	await _run_test(server, 'transactions/partial', create_transaction_descriptor)
+
+
+async def test_warns_when_announcing_aggregate_bonded_transaction_without_adjacent_hash_lock_file(server, caplog):  # pylint: disable=redefined-outer-name
+	# Arrange:
+	with tempfile.TemporaryDirectory() as output_directory:
+		config_filepath = prepare_shoestring_configuration(output_directory, NodeFeatures.PEER, server.make_url(''))
+
+		facade = SymbolFacade('testnet')
+		transaction_filepath = Path(output_directory) / 'transaction.dat'
+		with open(transaction_filepath, 'wb') as outfile:
+			transaction = facade.transaction_factory.create({
+				**_create_aggregate_transaction_descriptor('aggregate_bonded_transaction_v3'),
+				'signer_public_key': KeyPair(PrivateKey.random()).public_key,
+				'deadline': 1234000
+			})
+			outfile.write(transaction.serialize())
+
+		# Act:
+		await main([
+			'announce-transaction',
+			'--config', str(config_filepath),
+			'--transaction', str(transaction_filepath)
+		])
+
+		# Assert:
+		assert_message_is_logged(
+			f'aggregate bonded transaction was selected but no adjacent hash lock file was found at {transaction_filepath.with_suffix(".hash_lock.dat")}',
+			caplog)
+
+
+async def test_does_not_warn_when_announcing_aggregate_bonded_transaction_with_adjacent_hash_lock_file(server, caplog):  # pylint: disable=redefined-outer-name
+	# Arrange:
+	with tempfile.TemporaryDirectory() as output_directory:
+		config_filepath = prepare_shoestring_configuration(output_directory, NodeFeatures.PEER, server.make_url(''))
+
+		facade = SymbolFacade('testnet')
+		transaction_filepath = Path(output_directory) / 'transaction.dat'
+		with open(transaction_filepath, 'wb') as outfile:
+			transaction = facade.transaction_factory.create({
+				**_create_aggregate_transaction_descriptor('aggregate_bonded_transaction_v3'),
+				'signer_public_key': KeyPair(PrivateKey.random()).public_key,
+				'deadline': 1234000
+			})
+			outfile.write(transaction.serialize())
+
+		transaction_filepath.with_suffix('.hash_lock.dat').write_bytes(b'placeholder')
+
+		# Act:
+		await main([
+			'announce-transaction',
+			'--config', str(config_filepath),
+			'--transaction', str(transaction_filepath)
+		])
+
+		# Assert:
+		assert [
+			record.message for record in caplog.records
+			if 'aggregate bonded transaction was selected but no adjacent hash lock file was found at' in record.message
+		] == []
 
 # endregion

--- a/tools/shoestring/tests/commands/test_min_cosignatures_count.py
+++ b/tools/shoestring/tests/commands/test_min_cosignatures_count.py
@@ -5,6 +5,7 @@ import pytest
 from symbolchain.CryptoTypes import PrivateKey
 from symbolchain.PrivateKeyStorage import PrivateKeyStorage
 from symbolchain.symbol.Network import Network
+from symbolchain.symbol.KeyPair import KeyPair
 
 from shoestring.__main__ import main
 from shoestring.internal.ConfigurationManager import ConfigurationManager
@@ -38,16 +39,19 @@ def _load_ca_address(ca_pem_filepath):
 	return Network.TESTNET.public_key_to_address(ca_public_key)
 
 
-async def _run_test(server, caplog, additional_flags, expected_config_value):    # pylint: disable=redefined-outer-name
+async def _run_test(server, caplog, additional_flags, expected_config_value, transaction_signer_public_key=None):    # pylint: disable=redefined-outer-name
 	# Arrange:
 	with tempfile.TemporaryDirectory() as output_directory:
 		PrivateKeyStorage(output_directory).save('ca.key', PrivateKey.random())
 
 		ca_pem_filepath = Path(output_directory) / 'ca.key.pem'
-		ca_address = _load_ca_address(ca_pem_filepath)
+		public_key = transaction_signer_public_key if transaction_signer_public_key else read_public_key_from_private_key_pem_file(ca_pem_filepath)
+		ca_address = Network.TESTNET.public_key_to_address(public_key)
 		server.mock.multisig_account_addresses.append(ca_address)
 
-		config_filepath = prepare_shoestring_configuration(output_directory, NodeFeatures.PEER, server.make_url(''))
+		config_filepath = prepare_shoestring_configuration(
+			output_directory, NodeFeatures.PEER, server.make_url(''),
+			transaction_signer_public_key=transaction_signer_public_key)
 
 		# Act:
 		await main([
@@ -74,6 +78,10 @@ async def test_can_detect_min_cosignatures_count_without_update_flag(server, cap
 
 async def test_can_detect_and_update_min_cosignatures_count_with_update_flag(server, caplog):  # pylint: disable=redefined-outer-name
 	await _run_test(server, caplog, ['--update'], 2)
+
+
+async def test_can_detect_min_cosignatures_count_for_configured_signer_public_key(server, caplog):  # pylint: disable=redefined-outer-name
+	await _run_test(server, caplog, [], 0, KeyPair(PrivateKey.random()).public_key)
 
 
 # endregion

--- a/tools/shoestring/tests/commands/test_renew_voting_keys.py
+++ b/tools/shoestring/tests/commands/test_renew_voting_keys.py
@@ -2,9 +2,10 @@ import os
 import shutil
 import tempfile
 from pathlib import Path
+import configparser
 
 import pytest
-from symbolchain.CryptoTypes import PrivateKey
+from symbolchain.CryptoTypes import PrivateKey, PublicKey
 from symbolchain.sc import LinkAction, TransactionFactory, TransactionType
 from symbolchain.symbol.KeyPair import KeyPair
 from symbolchain.symbol.VotingKeysGenerator import VotingKeysGenerator
@@ -302,3 +303,35 @@ async def test_cannot_renew_voting_keys_when_max_keys_are_active(server, caplog)
 
 			# no transaction is created
 			assert not (Path(output_directory) / 'renew_voting_keys_transaction.dat').exists()
+
+
+async def test_can_renew_voting_keys_for_configured_multisig_signer(server):  # pylint: disable=redefined-outer-name
+	# Arrange:
+	transaction_signer_public_key = PublicKey('F357F779799EAE88B400D45E7C3C232391CFD79EFEAA05BC38868356CBE0A4D3')
+
+	with tempfile.TemporaryDirectory() as output_directory:
+		with tempfile.TemporaryDirectory() as package_directory:
+			await _prepare_output_directory(Path(package_directory), Path(output_directory), NodeFeatures.VOTER, server.make_url(''))
+			config_filepath = prepare_shoestring_configuration(
+				package_directory,
+				NodeFeatures.VOTER,
+				server.make_url(''),
+				transaction_signer_public_key=transaction_signer_public_key)
+
+			parser = configparser.ConfigParser()
+			parser.read(config_filepath)
+			parser['transaction']['minCosignaturesCount'] = '2'
+			with open(config_filepath, 'wt', encoding='utf8') as outfile:
+				parser.write(outfile)
+
+			# Act:
+			await main([
+				'renew-voting-keys',
+				'--config', str(config_filepath),
+				'--directory', output_directory
+			])
+
+			# Assert:
+			transaction = _read_transaction(output_directory)
+			assert transaction_signer_public_key == PublicKey(transaction.signer_public_key.bytes)
+			assert transaction_signer_public_key == PublicKey(transaction.transactions[0].signer_public_key.bytes)

--- a/tools/shoestring/tests/commands/test_setup.py
+++ b/tools/shoestring/tests/commands/test_setup.py
@@ -6,8 +6,9 @@ from enum import Enum
 from pathlib import Path
 
 import pytest
-from symbolchain.CryptoTypes import PrivateKey
+from symbolchain.CryptoTypes import PrivateKey, PublicKey
 from symbolchain.PrivateKeyStorage import PrivateKeyStorage
+from symbolchain.sc import TransactionFactory
 
 from shoestring.__main__ import main
 from shoestring.internal.NodeFeatures import NodeFeatures
@@ -549,5 +550,37 @@ async def test_can_regenerate_links_voter_node(server):  # pylint: disable=redef
 
 async def test_can_regenerate_links_full_node(server):  # pylint: disable=redefined-outer-name
 	await _assert_can_regenerate_links(server, NodeFeatures.API | NodeFeatures.HARVESTER | NodeFeatures.VOTER)
+
+
+async def test_can_generate_linking_transaction_for_configured_multisig_signer(server):  # pylint: disable=redefined-outer-name
+	# Arrange:
+	transaction_signer_public_key = PublicKey('F357F779799EAE88B400D45E7C3C232391CFD79EFEAA05BC38868356CBE0A4D3')
+
+	with tempfile.TemporaryDirectory() as output_directory:
+		with tempfile.TemporaryDirectory() as package_directory:
+			prepare_shoestring_configuration(
+				package_directory,
+				NodeFeatures.HARVESTER,
+				server.make_url(''),
+				api_https=False,
+				transaction_signer_public_key=transaction_signer_public_key)
+			_prepare_overrides(package_directory)
+			prepare_testnet_package(package_directory, 'resources.zip')
+
+			with tempfile.TemporaryDirectory() as ca_directory:
+				# Act:
+				await main([
+					'setup',
+					'--config', str(Path(package_directory) / 'sai.shoestring.ini'),
+					'--security', 'insecure',
+					'--package', f'file://{Path(package_directory) / "resources.zip"}',
+					'--directory', output_directory,
+					'--ca-key-path', str(Path(ca_directory) / 'xyz.key.pem'),
+					'--overrides', str(Path(package_directory) / 'user_overrides.ini')
+				])
+
+				# Assert:
+				transaction = TransactionFactory.deserialize(_read_file_contents(Path(output_directory) / 'linking_transaction.dat'))
+				assert transaction_signer_public_key == PublicKey(transaction.transactions[0].signer_public_key.bytes)
 
 # endregion

--- a/tools/shoestring/tests/commands/test_signer.py
+++ b/tools/shoestring/tests/commands/test_signer.py
@@ -352,4 +352,39 @@ async def test_can_add_cosignature_to_aggregate_bonded_transaction_without_repla
 			transaction.cosignatures[0].signature)
 		assert initial_hash_lock_transaction.serialize() == hash_lock_transaction.serialize()
 
+
+async def test_initiator_re_sign_is_idempotent():
+	with tempfile.TemporaryDirectory() as output_directory:
+		facade = SymbolFacade('testnet')
+		initiator_key_pair = KeyPair(PrivateKey.random())
+
+		private_key_storage = PrivateKeyStorage(output_directory, None)
+		private_key_storage.save('initiator', initiator_key_pair.private_key)
+
+		transaction_filepath = Path(output_directory) / 'transaction.dat'
+		with open(transaction_filepath, 'wb') as outfile:
+			transaction = facade.transaction_factory.create({
+				**_create_aggregate_transaction_descriptor('aggregate_complete_transaction_v3', KeyPair(PrivateKey.random()).public_key),
+				'deadline': 1234000
+			})
+			outfile.write(transaction.serialize())
+
+		config_filepath = prepare_shoestring_configuration(output_directory, NodeFeatures.PEER)
+
+		for _ in range(2):
+			await main([
+				'signer',
+				'--config', str(config_filepath),
+				'--ca-key-path', str(Path(output_directory) / 'initiator.pem'),
+				'--save',
+				str(transaction_filepath)
+			])
+
+		with open(transaction_filepath, 'rb') as infile:
+			transaction = TransactionFactory.deserialize(infile.read())
+
+		assert initiator_key_pair.public_key == PublicKey(transaction.signer_public_key.bytes)
+		assert facade.verify_transaction(transaction, transaction.signature)
+		assert 0 == len(transaction.cosignatures)
+
 # endregion

--- a/tools/shoestring/tests/commands/test_signer.py
+++ b/tools/shoestring/tests/commands/test_signer.py
@@ -173,4 +173,107 @@ async def test_can_sign_aggregate_bonded_transaction_with_wrong_outer_public_key
 	# Act + Assert:
 	await _assert_can_sign_transaction(create_transaction_descriptor, check_hash_lock=True)
 
+
+async def test_can_add_cosignature_to_aggregate_complete_transaction():
+	with tempfile.TemporaryDirectory() as output_directory:
+		facade = SymbolFacade('testnet')
+		initiator_key_pair = KeyPair(PrivateKey.random())
+		cosigner_key_pair = KeyPair(PrivateKey.random())
+
+		private_key_storage = PrivateKeyStorage(output_directory, None)
+		private_key_storage.save('initiator', initiator_key_pair.private_key)
+		private_key_storage.save('cosigner', cosigner_key_pair.private_key)
+
+		transaction_filepath = Path(output_directory) / 'transaction.dat'
+		with open(transaction_filepath, 'wb') as outfile:
+			transaction = facade.transaction_factory.create({
+				**_create_aggregate_transaction_descriptor('aggregate_complete_transaction_v3', KeyPair(PrivateKey.random()).public_key),
+				'deadline': 1234000
+			})
+			outfile.write(transaction.serialize())
+
+		config_filepath = prepare_shoestring_configuration(output_directory, NodeFeatures.PEER)
+
+		await main([
+			'signer',
+			'--config', str(config_filepath),
+			'--ca-key-path', str(Path(output_directory) / 'initiator.pem'),
+			'--save',
+			str(transaction_filepath)
+		])
+
+		await main([
+			'signer',
+			'--config', str(config_filepath),
+			'--ca-key-path', str(Path(output_directory) / 'cosigner.pem'),
+			'--save',
+			str(transaction_filepath)
+		])
+
+		with open(transaction_filepath, 'rb') as infile:
+			transaction = TransactionFactory.deserialize(infile.read())
+
+		assert initiator_key_pair.public_key == PublicKey(transaction.signer_public_key.bytes)
+		assert facade.verify_transaction(transaction, transaction.signature)
+		assert 1 == len(transaction.cosignatures)
+		assert cosigner_key_pair.public_key == PublicKey(transaction.cosignatures[0].signer_public_key.bytes)
+		assert SymbolFacade.Verifier(cosigner_key_pair.public_key).verify(
+			facade.hash_transaction(transaction).bytes,
+			transaction.cosignatures[0].signature)
+
+
+async def test_can_add_cosignature_to_aggregate_bonded_transaction_without_replacing_hash_lock():
+	with tempfile.TemporaryDirectory() as output_directory:
+		facade = SymbolFacade('testnet')
+		initiator_key_pair = KeyPair(PrivateKey.random())
+		cosigner_key_pair = KeyPair(PrivateKey.random())
+
+		private_key_storage = PrivateKeyStorage(output_directory, None)
+		private_key_storage.save('initiator', initiator_key_pair.private_key)
+		private_key_storage.save('cosigner', cosigner_key_pair.private_key)
+
+		transaction_filepath = Path(output_directory) / 'transaction.dat'
+		with open(transaction_filepath, 'wb') as outfile:
+			transaction = facade.transaction_factory.create({
+				**_create_aggregate_transaction_descriptor('aggregate_bonded_transaction_v3', KeyPair(PrivateKey.random()).public_key),
+				'deadline': 1234000
+			})
+			outfile.write(transaction.serialize())
+
+		config_filepath = prepare_shoestring_configuration(output_directory, NodeFeatures.PEER)
+
+		await main([
+			'signer',
+			'--config', str(config_filepath),
+			'--ca-key-path', str(Path(output_directory) / 'initiator.pem'),
+			'--save',
+			str(transaction_filepath)
+		])
+
+		hash_lock_transaction_filepath = Path(output_directory) / 'transaction.hash_lock.dat'
+		with open(hash_lock_transaction_filepath, 'rb') as infile:
+			initial_hash_lock_transaction = TransactionFactory.deserialize(infile.read())
+
+		await main([
+			'signer',
+			'--config', str(config_filepath),
+			'--ca-key-path', str(Path(output_directory) / 'cosigner.pem'),
+			'--save',
+			str(transaction_filepath)
+		])
+
+		with open(transaction_filepath, 'rb') as infile:
+			transaction = TransactionFactory.deserialize(infile.read())
+		with open(hash_lock_transaction_filepath, 'rb') as infile:
+			hash_lock_transaction = TransactionFactory.deserialize(infile.read())
+
+		assert initiator_key_pair.public_key == PublicKey(transaction.signer_public_key.bytes)
+		assert facade.verify_transaction(transaction, transaction.signature)
+		assert 1 == len(transaction.cosignatures)
+		assert cosigner_key_pair.public_key == PublicKey(transaction.cosignatures[0].signer_public_key.bytes)
+		assert SymbolFacade.Verifier(cosigner_key_pair.public_key).verify(
+			facade.hash_transaction(transaction).bytes,
+			transaction.cosignatures[0].signature)
+		assert initial_hash_lock_transaction.serialize() == hash_lock_transaction.serialize()
+
 # endregion

--- a/tools/shoestring/tests/commands/test_signer.py
+++ b/tools/shoestring/tests/commands/test_signer.py
@@ -174,6 +174,82 @@ async def test_can_sign_aggregate_bonded_transaction_with_wrong_outer_public_key
 	await _assert_can_sign_transaction(create_transaction_descriptor, check_hash_lock=True)
 
 
+async def test_can_sign_multisig_aggregate_complete_transaction_without_replacing_inner_signer():
+	with tempfile.TemporaryDirectory() as output_directory:
+		facade = SymbolFacade('testnet')
+		multisig_public_key = KeyPair(PrivateKey.random()).public_key
+		cosigner_key_pair = KeyPair(PrivateKey.random())
+
+		private_key_storage = PrivateKeyStorage(output_directory, None)
+		private_key_storage.save('cosigner', cosigner_key_pair.private_key)
+
+		transaction_filepath = Path(output_directory) / 'transaction.dat'
+		with open(transaction_filepath, 'wb') as outfile:
+			transaction = facade.transaction_factory.create({
+				**_create_aggregate_transaction_descriptor('aggregate_complete_transaction_v3', multisig_public_key),
+				'deadline': 1234000
+			})
+			outfile.write(transaction.serialize())
+
+		config_filepath = prepare_shoestring_configuration(output_directory, NodeFeatures.PEER)
+
+		await main([
+			'signer',
+			'--config', str(config_filepath),
+			'--ca-key-path', str(Path(output_directory) / 'cosigner.pem'),
+			'--save',
+			str(transaction_filepath)
+		])
+
+		with open(transaction_filepath, 'rb') as infile:
+			transaction = TransactionFactory.deserialize(infile.read())
+
+		assert cosigner_key_pair.public_key == PublicKey(transaction.signer_public_key.bytes)
+		assert multisig_public_key == PublicKey(transaction.transactions[0].signer_public_key.bytes)
+		assert facade.verify_transaction(transaction, transaction.signature)
+
+
+async def test_can_sign_multisig_aggregate_bonded_transaction_without_replacing_inner_signer():
+	with tempfile.TemporaryDirectory() as output_directory:
+		facade = SymbolFacade('testnet')
+		multisig_public_key = KeyPair(PrivateKey.random()).public_key
+		cosigner_key_pair = KeyPair(PrivateKey.random())
+
+		private_key_storage = PrivateKeyStorage(output_directory, None)
+		private_key_storage.save('cosigner', cosigner_key_pair.private_key)
+
+		transaction_filepath = Path(output_directory) / 'transaction.dat'
+		with open(transaction_filepath, 'wb') as outfile:
+			transaction = facade.transaction_factory.create({
+				**_create_aggregate_transaction_descriptor('aggregate_bonded_transaction_v3', multisig_public_key),
+				'deadline': 1234000
+			})
+			outfile.write(transaction.serialize())
+
+		config_filepath = prepare_shoestring_configuration(output_directory, NodeFeatures.PEER)
+
+		await main([
+			'signer',
+			'--config', str(config_filepath),
+			'--ca-key-path', str(Path(output_directory) / 'cosigner.pem'),
+			'--save',
+			str(transaction_filepath)
+		])
+
+		with open(transaction_filepath, 'rb') as infile:
+			transaction = TransactionFactory.deserialize(infile.read())
+
+		assert cosigner_key_pair.public_key == PublicKey(transaction.signer_public_key.bytes)
+		assert multisig_public_key == PublicKey(transaction.transactions[0].signer_public_key.bytes)
+		assert facade.verify_transaction(transaction, transaction.signature)
+
+		hash_lock_transaction_filepath = Path(output_directory) / 'transaction.hash_lock.dat'
+		with open(hash_lock_transaction_filepath, 'rb') as infile:
+			hash_lock_transaction = TransactionFactory.deserialize(infile.read())
+
+		_assert_hash_lock_transaction(hash_lock_transaction, cosigner_key_pair.public_key, facade.hash_transaction(transaction))
+
+
 async def test_can_add_cosignature_to_aggregate_complete_transaction():
 	with tempfile.TemporaryDirectory() as output_directory:
 		facade = SymbolFacade('testnet')

--- a/tools/shoestring/tests/internal/test_Preparer.py
+++ b/tools/shoestring/tests/internal/test_Preparer.py
@@ -8,7 +8,7 @@ from zipfile import ZipFile
 
 import yaml
 from symbolchain.BufferReader import BufferReader
-from symbolchain.CryptoTypes import PrivateKey
+from symbolchain.CryptoTypes import PrivateKey, PublicKey
 from symbolchain.sc import LinkAction, TransactionType
 from symbolchain.symbol.KeyPair import KeyPair
 from symbollightapi.connector.SymbolConnector import LinkedPublicKeys, VotingPublicKey
@@ -33,12 +33,12 @@ class PreparerTest(unittest.TestCase):
 	# region utils
 
 	@staticmethod
-	def _create_configuration(node_features, api_https=True, light_api=False, imports_config=None):
+	def _create_configuration(node_features, api_https=True, light_api=False, imports_config=None, transaction_signer_public_key=None):
 		return ShoestringConfiguration(
 			'testnet',
 			None,
 			None,
-			TransactionConfiguration(234, 3, 0, 0, 0, 0),
+			TransactionConfiguration(234, 3, 0, 0, 0, 0, transaction_signer_public_key),
 			imports_config if imports_config else ImportsConfiguration(None, None, None),
 			NodeConfiguration(node_features, *([None] * 3), api_https, (NodeFeatures.API in node_features and not light_api), 'CA CN', 'NODE CN'))
 
@@ -933,6 +933,31 @@ class PreparerTest(unittest.TestCase):
 		self._assert_can_prepare_linking_transaction(
 			existing_links,
 			LinkDescriptor(TransactionType.ACCOUNT_KEY_LINK, existing_links.linked_public_key, LinkAction.UNLINK, None))
+
+	def test_prepare_linking_transaction_can_create_aggregate_for_configured_multisig_signer(self):
+		# Arrange:
+		transaction_signer_public_key = PublicKey('F357F779799EAE88B400D45E7C3C232391CFD79EFEAA05BC38868356CBE0A4D3')
+		existing_links = LinkedPublicKeys()
+		existing_links.linked_public_key = self._random_public_key()
+
+		with tempfile.TemporaryDirectory() as output_directory:
+			with Preparer(
+				output_directory,
+				self._create_configuration(NodeFeatures.PEER, transaction_signer_public_key=transaction_signer_public_key)) as preparer:
+				# Act:
+				transaction = preparer.prepare_linking_transaction(transaction_signer_public_key, existing_links, 2222)
+
+				# Assert:
+				expected_size = 168 + 88
+				expected_aggregate_descriptor = AggregateDescriptor(
+					expected_size, 234, 2222 + 3 * 60 * 60 * 1000, transaction_signer_public_key)
+				assert_aggregate_transaction(self, transaction, expected_aggregate_descriptor)
+				self.assertEqual(1, len(transaction.transactions))
+				self.assertEqual(transaction_signer_public_key, PublicKey(transaction.transactions[0].signer_public_key.bytes))
+				assert_link_transaction(
+					self,
+					transaction.transactions[0],
+					LinkDescriptor(TransactionType.ACCOUNT_KEY_LINK, existing_links.linked_public_key, LinkAction.UNLINK, None))
 
 	def test_prepare_linking_transaction_can_create_aggregate_with_vrf_key_unlink(self):
 		# Arrange:

--- a/tools/shoestring/tests/internal/test_ShoestringConfiguration.py
+++ b/tools/shoestring/tests/internal/test_ShoestringConfiguration.py
@@ -3,7 +3,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from symbolchain.CryptoTypes import Hash256
+from symbolchain.CryptoTypes import Hash256, PublicKey
 
 from shoestring.internal.NodeFeatures import NodeFeatures
 from shoestring.internal.ShoestringConfiguration import (
@@ -41,13 +41,14 @@ class ShoestringConfigurationTest(unittest.TestCase):
 	}
 
 	VALID_TRANSACTION_CONFIGURATION = {
-		'feeMultiplier': '234',
-		'timeoutHours': '3',
-		'minCosignaturesCount': '2',
-		'hashLockDuration': '1440',
-		'currencyMosaicId': '0x72C0212E67A08BCE',
-		'lockedFundsPerAggregate': '10000000'
-	}
+			'feeMultiplier': '234',
+			'timeoutHours': '3',
+			'minCosignaturesCount': '2',
+			'hashLockDuration': '1440',
+			'currencyMosaicId': '0x72C0212E67A08BCE',
+			'lockedFundsPerAggregate': '10000000',
+			'signerPublicKey': 'F357F779799EAE88B400D45E7C3C232391CFD79EFEAA05BC38868356CBE0A4D3'
+		}
 
 	VALID_IMPORTS_CONFIGURATION = {
 		'harvester': 'path/to/config-harvesting.properties',
@@ -167,12 +168,29 @@ class ShoestringConfigurationTest(unittest.TestCase):
 		self.assertEqual(1440, transaction_config.hash_lock_duration)
 		self.assertEqual(0x72C0212E67A08BCE, transaction_config.currency_mosaic_id)
 		self.assertEqual(10000000, transaction_config.locked_funds_per_aggregate)
+		self.assertEqual(PublicKey('F357F779799EAE88B400D45E7C3C232391CFD79EFEAA05BC38868356CBE0A4D3'), transaction_config.signer_public_key)
+
+	def test_can_parse_valid_transaction_configuration_without_signer_public_key(self):
+		# Arrange:
+		config = {**self.VALID_TRANSACTION_CONFIGURATION}
+		del config['signerPublicKey']
+
+		# Act:
+		transaction_config = parse_transaction_configuration(config)
+
+		# Assert:
+		self.assertEqual(None, transaction_config.signer_public_key)
 
 	def test_cannot_parse_transaction_configuration_incomplete(self):
 		# Arrange:
 		for key in self.VALID_TRANSACTION_CONFIGURATION:
 			incomplete_config = {**self.VALID_TRANSACTION_CONFIGURATION}
 			del incomplete_config[key]
+
+			if 'signerPublicKey' == key:
+				transaction_config = parse_transaction_configuration(incomplete_config)
+				self.assertEqual(None, transaction_config.signer_public_key)
+				continue
 
 			# Act + Assert:
 			with self.assertRaises(KeyError):
@@ -186,7 +204,8 @@ class ShoestringConfigurationTest(unittest.TestCase):
 			'minCosignaturesCount': 'not an int',
 			'hashLockDuration': 'not an int',
 			'currencyMosaicId': 'not an int',
-			'lockedFundsPerAggregate': 'not an int'
+			'lockedFundsPerAggregate': 'not an int',
+			'signerPublicKey': 'not a public key'
 		}
 
 		for key, value in corrupt_overrides.items():

--- a/tools/shoestring/tests/internal/test_ShoestringConfiguration.py
+++ b/tools/shoestring/tests/internal/test_ShoestringConfiguration.py
@@ -41,14 +41,14 @@ class ShoestringConfigurationTest(unittest.TestCase):
 	}
 
 	VALID_TRANSACTION_CONFIGURATION = {
-			'feeMultiplier': '234',
-			'timeoutHours': '3',
-			'minCosignaturesCount': '2',
-			'hashLockDuration': '1440',
-			'currencyMosaicId': '0x72C0212E67A08BCE',
-			'lockedFundsPerAggregate': '10000000',
-			'signerPublicKey': 'F357F779799EAE88B400D45E7C3C232391CFD79EFEAA05BC38868356CBE0A4D3'
-		}
+		'feeMultiplier': '234',
+		'timeoutHours': '3',
+		'minCosignaturesCount': '2',
+		'hashLockDuration': '1440',
+		'currencyMosaicId': '0x72C0212E67A08BCE',
+		'lockedFundsPerAggregate': '10000000',
+		'signerPublicKey': 'F357F779799EAE88B400D45E7C3C232391CFD79EFEAA05BC38868356CBE0A4D3'
+	}
 
 	VALID_IMPORTS_CONFIGURATION = {
 		'harvester': 'path/to/config-harvesting.properties',

--- a/tools/shoestring/tests/test/ConfigurationTestUtils.py
+++ b/tools/shoestring/tests/test/ConfigurationTestUtils.py
@@ -12,6 +12,9 @@ def prepare_shoestring_configuration(directory, node_features, services_nodewatc
 	parser['services']['nodewatch'] = str(services_nodewatch)
 	parser['node']['features'] = node_features.to_formatted_string()
 
+	if 'transaction_signer_public_key' in node_kwargs and node_kwargs['transaction_signer_public_key'] is not None:
+		parser['transaction']['signerPublicKey'] = str(node_kwargs['transaction_signer_public_key'])
+
 	ca_password = node_kwargs.get('ca_password', None)
 	if ca_password:
 		parser['node']['caPassword'] = f'pass:{ca_password}'

--- a/tools/shoestring/tests/test/ConfigurationTestUtils.py
+++ b/tools/shoestring/tests/test/ConfigurationTestUtils.py
@@ -12,7 +12,7 @@ def prepare_shoestring_configuration(directory, node_features, services_nodewatc
 	parser['services']['nodewatch'] = str(services_nodewatch)
 	parser['node']['features'] = node_features.to_formatted_string()
 
-	if 'transaction_signer_public_key' in node_kwargs and node_kwargs['transaction_signer_public_key'] is not None:
+	if node_kwargs.get('transaction_signer_public_key') is not None:
 		parser['transaction']['signerPublicKey'] = str(node_kwargs['transaction_signer_public_key'])
 
 	ca_password = node_kwargs.get('ca_password', None)


### PR DESCRIPTION
## Summary
- support multisig signer public key handling in `setup` and `renew-voting-keys`
- add aggregate bonded hash lock guidance in `announce-transaction`
- add signer regression coverage and clearer signer behavior logs for multisig flows
- update related shoestring multisig tests and docs

## Testing
- `python3 -m py_compile tools/shoestring/shoestring/commands/renew_voting_keys.py tools/shoestring/tests/commands/test_renew_voting_keys.py`
- `python3 -m py_compile tools/shoestring/shoestring/commands/announce_transaction.py tools/shoestring/tests/commands/test_announce_transaction.py`
- `python3 -m py_compile tools/shoestring/shoestring/commands/signer.py tools/shoestring/tests/commands/test_signer.py`
- `python3 -m py_compile tools/shoestring/tests/internal/test_ShoestringConfiguration.py tools/shoestring/tests/test/ConfigurationTestUtils.py`

`pytest` is not available in the current environment.