### PR TITLE
[explorer/rest] feat: Added transaction endpoint

### DIFF
--- a/explorer/rest/rest/__init__.py
+++ b/explorer/rest/rest/__init__.py
@@ -236,6 +236,15 @@ def setup_nem_routes(app, nem_api_facade):  # pylint: disable=too-many-statement
 
 		return jsonify(results)
 
+	@app.route('/api/nem/transaction/<transaction_hash>')
+	def api_get_nem_transaction_by_hash(transaction_hash):
+		result = nem_api_facade.get_transaction_by_hash(transaction_hash)
+
+		if not result:
+			abort(404)
+
+		return jsonify(result)
+
 
 def setup_error_handlers(app):
 	@app.errorhandler(404)

--- a/explorer/rest/rest/db/NemDatabase.py
+++ b/explorer/rest/rest/db/NemDatabase.py
@@ -567,13 +567,13 @@ class NemDatabase(DatabaseConnectionPool):
 				})
 
 			if mosaics:
+				multiplier = 0 if amount == 0 else _format_xem_relative(amount)
 				for mosaic in mosaics:
-					multiplies = amount if amount == 0 else _format_xem_relative(amount)
-					amount = mosaic['quantity'] * multiplies
+					mosaic_amount = mosaic['quantity'] * multiplier
 
 					value.append({
 						'namespace': mosaic['namespace_name'],
-						'amount': _format_relative(amount, mosaic['divisibility'])
+						'amount': _format_relative(mosaic_amount, mosaic['divisibility'])
 					})
 			else:
 				value.append({

--- a/explorer/rest/rest/db/NemDatabase.py
+++ b/explorer/rest/rest/db/NemDatabase.py
@@ -1,12 +1,14 @@
 from binascii import hexlify
 
 from symbolchain.CryptoTypes import PublicKey
+from symbolchain.nc import TransactionType
 from symbolchain.nem.Network import Address
 
 from rest.model.Account import AccountView
 from rest.model.Block import BlockView
 from rest.model.Mosaic import MosaicRichListView, MosaicView
 from rest.model.Namespace import NamespaceView
+from rest.model.Transaction import TransactionRecord, TransactionView
 
 from .DatabaseConnection import DatabaseConnectionPool
 
@@ -180,6 +182,58 @@ class NemDatabase(DatabaseConnectionPool):
 			balance=_format_relative(balance, divisibility)
 		)
 
+	def _create_transaction_view(self, transaction, inner_transaction=None):
+		transaction_type_mapping = {
+			257: TransactionType.TRANSFER.name,
+			2049: TransactionType.ACCOUNT_KEY_LINK.name,
+			4100: TransactionType.MULTISIG.name,
+			4097: TransactionType.MULTISIG_ACCOUNT_MODIFICATION.name,
+			16385: TransactionType.MOSAIC_DEFINITION.name,
+			16386: TransactionType.MOSAIC_SUPPLY_CHANGE.name,
+			8193: TransactionType.NAMESPACE_REGISTRATION.name
+		}
+
+		value = self._build_transaction_payload(transaction.transaction_type, transaction.payload, transaction.amount, transaction.mosaics)
+		embedded_transaction = []
+		from_address = str(Address(transaction.from_address))
+		to_address = str(Address(transaction.to_address)) if transaction.to_address else None
+
+		if inner_transaction:
+			value = None
+			embedded_transaction.append({
+				'initiator': str(Address(transaction.from_address)),
+				'transactionHash': _format_bytes(inner_transaction.transaction_hash),
+				'transactionType': transaction_type_mapping.get(inner_transaction.transaction_type),
+				'signatures': [{
+					'fee': _format_xem_relative(signature['fee']),
+					'signature': signature['signature'],
+					'signer': str(self.network.public_key_to_address(PublicKey(signature['sender'])))
+				} for signature in transaction.payload['signatures']],
+				'fee': _format_xem_relative(inner_transaction.fee),
+				'value': self._build_transaction_payload(
+					inner_transaction.transaction_type,
+					inner_transaction.payload,
+					inner_transaction.amount,
+					inner_transaction.mosaics
+				),
+			})
+			from_address = str(Address(inner_transaction.from_address))
+			to_address = str(Address(inner_transaction.to_address)) if inner_transaction.to_address else None
+
+		return TransactionView(
+			transaction_hash=_format_bytes(transaction.transaction_hash),
+			transaction_type=transaction_type_mapping.get(transaction.transaction_type),
+			from_address=from_address,
+			to_address=to_address,
+			value=value,
+			embedded_transactions=embedded_transaction if embedded_transaction else None,
+			fee=_format_xem_relative(transaction.fee),
+			height=transaction.height,
+			timestamp=str(transaction.timestamp),
+			deadline=str(transaction.deadline),
+			signature=_format_bytes(transaction.signature)
+		)
+
 	@staticmethod
 	def _generate_account_query(where_condition, order_condition='', limit_condition=''):
 		"""Base account query."""
@@ -288,6 +342,37 @@ class NemDatabase(DatabaseConnectionPool):
 			{where_condition}
 			{order_condition}
 			{limit_condition}
+		'''
+
+	@staticmethod
+	def _generate_transaction_sql_query():
+		"""Base transaction query."""
+
+		return '''
+			SELECT
+				t.transaction_hash,
+				t.transaction_type,
+				t.sender_address as from_address,
+				t.fee,
+				t.height,
+				t.timestamp,
+				t.deadline,
+				t.signature,
+				t.recipient_address as to_address,
+				t.payload,
+				t.amount,
+				COALESCE(m.mosaics, '[]'::json) AS mosaics
+			FROM transactions t
+			LEFT JOIN LATERAL (
+				SELECT json_agg(json_build_object(
+				'namespace_name', tm.namespace_name,
+				'quantity', tm.quantity,
+				'divisibility', mo.divisibility)) AS mosaics
+			FROM transactions_mosaic tm
+			LEFT JOIN mosaics mo
+				ON mo.namespace_name = tm.namespace_name
+			WHERE tm.transaction_id = t.id
+			) m ON true
 		'''
 
 	def _get_account(self, where_condition, query_bytes):
@@ -472,3 +557,90 @@ class NemDatabase(DatabaseConnectionPool):
 			results = cursor.fetchall()
 
 			return [self._create_mosaic_rich_list_view(result) for result in results]
+
+	def _build_transaction_payload(self, transaction_type, payload, amount, mosaics):
+		"""Builds transaction payload based on transaction type."""
+
+		value = []
+
+		if transaction_type == TransactionType.TRANSFER.value:
+			if payload['message']:
+				value.append({
+					'message': {
+						'isPlain': payload['message']['is_plain'],
+						'payload': payload['message']['payload']
+					},
+				})
+
+			if mosaics:
+				for mosaic in mosaics:
+					multiplies = amount if amount == 0 else _format_xem_relative(amount)
+					amount = mosaic['quantity'] * multiplies
+
+					value.append({
+						'namespace': mosaic['namespace_name'],
+						'amount': _format_relative(amount, mosaic['divisibility'])
+					})
+			else:
+				value.append({
+					'namespace': 'nem.xem',
+					'amount': _format_xem_relative(amount)
+				})
+		elif transaction_type == TransactionType.ACCOUNT_KEY_LINK.value:
+			value.append({
+				'mode': payload['mode'],
+				'remoteAccount': payload['remote_account'],
+			})
+		elif transaction_type == TransactionType.MULTISIG_ACCOUNT_MODIFICATION.value:
+			value.append({
+				'minCosignatories': payload['min_cosignatories'],
+				'modifications': [{
+					'cosignatoryAccount': str(self.network.public_key_to_address(PublicKey(modification['cosignatory_account']))),
+					'modificationType': modification['modification_type']
+				} for modification in payload['modifications']]
+			})
+		elif transaction_type == TransactionType.NAMESPACE_REGISTRATION.value:
+			value.append({
+				'sinkFee': _format_xem_relative(payload['rental_fee']),
+				'parent': payload['parent'],
+				'namespaceName': payload['namespace']
+			})
+		elif transaction_type == TransactionType.MOSAIC_DEFINITION.value:
+			value.append({
+				'sinkFee': _format_xem_relative(payload['creation_fee']),
+				'mosaicNamespaceName': payload['namespace_name'],
+			})
+		elif transaction_type == TransactionType.MOSAIC_SUPPLY_CHANGE.value:
+			value.append({
+				'supplyType': payload['supply_type'],
+				'delta': payload['delta'],
+				'namespaceName': payload['namespace_name']
+			})
+
+		return value
+
+	def _get_transaction_query(self, transaction_hash, is_inner=False):
+		"""Gets transaction by where clause."""
+
+		sql = self._generate_transaction_sql_query()
+		sql += ' WHERE t.transaction_hash = %s AND t.is_inner = %s'
+		params = ('\\x' + transaction_hash, is_inner)
+
+		with self.connection() as connection:
+			cursor = connection.cursor()
+			cursor.execute(sql, params)
+			result = cursor.fetchone()
+
+			return TransactionRecord(*result) if result else None
+
+	def get_transaction_by_hash(self, transaction_hash, is_inner=False):
+		"""Gets transaction by hash in database."""
+
+		transaction = self._get_transaction_query(transaction_hash, is_inner)
+		inner_transaction = None
+
+		if transaction[1] == TransactionType.MULTISIG.value:
+			inner_hash = transaction[9]['inner_hash']
+			inner_transaction = self._get_transaction_query(inner_hash, is_inner=True)
+
+		return self._create_transaction_view(transaction, inner_transaction)

--- a/explorer/rest/rest/db/NemDatabase.py
+++ b/explorer/rest/rest/db/NemDatabase.py
@@ -639,8 +639,8 @@ class NemDatabase(DatabaseConnectionPool):
 		transaction = self._get_transaction_query(transaction_hash, is_inner)
 		inner_transaction = None
 
-		if transaction[1] == TransactionType.MULTISIG.value:
+		if transaction and transaction[1] == TransactionType.MULTISIG.value:
 			inner_hash = transaction[9]['inner_hash']
 			inner_transaction = self._get_transaction_query(inner_hash, is_inner=True)
 
-		return self._create_transaction_view(transaction, inner_transaction)
+		return self._create_transaction_view(transaction, inner_transaction) if transaction else None

--- a/explorer/rest/rest/db/NemDatabase.py
+++ b/explorer/rest/rest/db/NemDatabase.py
@@ -17,6 +17,10 @@ def _format_bytes(buffer):
 	return hexlify(buffer).decode('utf8').upper()
 
 
+def _format_address_bytes_to_string(buffer):
+	return str(Address(buffer))
+
+
 def _format_xem_relative(amount):
 	return amount / (10 ** 6)
 
@@ -53,7 +57,7 @@ class NemDatabase(DatabaseConnectionPool):
 			total_transactions=total_transactions,
 			difficulty=difficulty,
 			block_hash=_format_bytes(block_hash),
-			beneficiary=str(Address(beneficiary)),
+			beneficiary=_format_address_bytes_to_string(beneficiary),
 			signer=str(self.network.public_key_to_address(PublicKey(signer))),
 			signature=_format_bytes(signature),
 			size=size
@@ -80,9 +84,9 @@ class NemDatabase(DatabaseConnectionPool):
 		) = result
 
 		return AccountView(
-			address=str(Address(address)),
+			address=_format_address_bytes_to_string(address),
 			public_key=str(PublicKey(public_key)) if public_key else None,
-			remote_address=str(Address(remote_address)) if remote_address else None,
+			remote_address=_format_address_bytes_to_string(remote_address) if remote_address else None,
 			importance=importance,
 			balance=_format_xem_relative(balance),
 			vested_balance=_format_xem_relative(vested_balance),
@@ -96,8 +100,8 @@ class NemDatabase(DatabaseConnectionPool):
 			remote_status=remote_status,
 			last_harvested_height=last_harvested_height,
 			min_cosignatories=min_cosignatories,
-			cosignatory_of=[str(Address(address)) for address in cosignatory_of] if cosignatory_of else None,
-			cosignatories=[str(Address(address)) for address in cosignatories] if cosignatories else None
+			cosignatory_of=[_format_address_bytes_to_string(address) for address in cosignatory_of] if cosignatory_of else None,
+			cosignatories=[_format_address_bytes_to_string(address) for address in cosignatories] if cosignatories else None
 		)
 
 	@staticmethod
@@ -161,7 +165,7 @@ class NemDatabase(DatabaseConnectionPool):
 			levy_type=levy_types.get(levy_type, None),
 			levy_namespace_name=levy_namespace_name,
 			levy_fee=_format_relative(levy_fee, levy_divisibility) if levy_type else None,
-			levy_recipient=str(Address(levy_recipient)) if levy_recipient else None,
+			levy_recipient=_format_address_bytes_to_string(levy_recipient) if levy_recipient else None,
 			root_namespace_registered_height=root_namespace_registered_height,
 			root_namespace_registered_timestamp=str(root_namespace_registered_timestamp),
 			root_namespace_expiration_height=root_namespace_expiration_height,
@@ -177,33 +181,23 @@ class NemDatabase(DatabaseConnectionPool):
 		) = result
 
 		return MosaicRichListView(
-			address=str(Address(address)),
+			address=_format_address_bytes_to_string(address),
 			remark=remark,
 			balance=_format_relative(balance, divisibility)
 		)
 
 	def _create_transaction_view(self, transaction, inner_transaction=None):
-		transaction_type_mapping = {
-			257: TransactionType.TRANSFER.name,
-			2049: TransactionType.ACCOUNT_KEY_LINK.name,
-			4100: TransactionType.MULTISIG.name,
-			4097: TransactionType.MULTISIG_ACCOUNT_MODIFICATION.name,
-			16385: TransactionType.MOSAIC_DEFINITION.name,
-			16386: TransactionType.MOSAIC_SUPPLY_CHANGE.name,
-			8193: TransactionType.NAMESPACE_REGISTRATION.name
-		}
-
 		value = self._build_transaction_payload(transaction.transaction_type, transaction.payload, transaction.amount, transaction.mosaics)
 		embedded_transaction = []
-		from_address = str(Address(transaction.from_address))
-		to_address = str(Address(transaction.to_address)) if transaction.to_address else None
+		from_address = _format_address_bytes_to_string(transaction.from_address)
+		to_address = _format_address_bytes_to_string(transaction.to_address) if transaction.to_address else None
 
 		if inner_transaction:
 			value = None
 			embedded_transaction.append({
-				'initiator': str(Address(transaction.from_address)),
+				'initiator': _format_address_bytes_to_string(transaction.from_address),
 				'transactionHash': _format_bytes(inner_transaction.transaction_hash),
-				'transactionType': transaction_type_mapping.get(inner_transaction.transaction_type),
+				'transactionType': TransactionType(inner_transaction.transaction_type).name,
 				'signatures': [{
 					'fee': _format_xem_relative(signature['fee']),
 					'signature': signature['signature'],
@@ -217,12 +211,12 @@ class NemDatabase(DatabaseConnectionPool):
 					inner_transaction.mosaics
 				),
 			})
-			from_address = str(Address(inner_transaction.from_address))
-			to_address = str(Address(inner_transaction.to_address)) if inner_transaction.to_address else None
+			from_address = _format_address_bytes_to_string(inner_transaction.from_address)
+			to_address = _format_address_bytes_to_string(inner_transaction.to_address) if inner_transaction.to_address else None
 
 		return TransactionView(
 			transaction_hash=_format_bytes(transaction.transaction_hash),
-			transaction_type=transaction_type_mapping.get(transaction.transaction_type),
+			transaction_type=TransactionType(transaction.transaction_type).name,
 			from_address=from_address,
 			to_address=to_address,
 			value=value,
@@ -639,8 +633,8 @@ class NemDatabase(DatabaseConnectionPool):
 		transaction = self._get_transaction_query(transaction_hash, is_inner)
 		inner_transaction = None
 
-		if transaction and transaction[1] == TransactionType.MULTISIG.value:
-			inner_hash = transaction[9]['inner_hash']
+		if transaction and transaction.transaction_type == TransactionType.MULTISIG.value:
+			inner_hash = transaction.payload['inner_hash']
 			inner_transaction = self._get_transaction_query(inner_hash, is_inner=True)
 
 		return self._create_transaction_view(transaction, inner_transaction) if transaction else None

--- a/explorer/rest/rest/facade/NemRestFacade.py
+++ b/explorer/rest/rest/facade/NemRestFacade.py
@@ -138,3 +138,10 @@ class NemRestFacade:
 		mosaic_rich_list = self.nem_db.get_mosaic_rich_list(pagination, namespace_name)
 
 		return [item.to_dict() for item in mosaic_rich_list]
+
+	def get_transaction_by_hash(self, transaction_hash):
+		"""Gets transaction by hash."""
+
+		transaction = self.nem_db.get_transaction_by_hash(transaction_hash)
+
+		return transaction.to_dict() if transaction else None

--- a/explorer/rest/rest/model/Transaction.py
+++ b/explorer/rest/rest/model/Transaction.py
@@ -1,0 +1,80 @@
+from collections import namedtuple
+
+TransactionRecord = namedtuple('TransactionRecord', [
+	'transaction_hash',
+	'transaction_type',
+	'from_address',
+	'fee',
+	'height',
+	'timestamp',
+	'deadline',
+	'signature',
+	'to_address',
+	'payload',
+	'amount',
+	'mosaics'
+])
+
+
+class TransactionView:  # pylint: disable=too-many-instance-attributes, too-many-positional-arguments
+	def __init__(
+		self,
+		transaction_hash,
+		transaction_type,
+		from_address,
+		to_address,
+		value,
+		embedded_transactions,
+		fee,
+		height,
+		timestamp,
+		deadline,
+		signature
+	):
+		"""Create transaction list view."""
+
+		# pylint: disable=too-many-arguments
+
+		self.transaction_hash = transaction_hash
+		self.transaction_type = transaction_type
+		self.from_address = from_address
+		self.to_address = to_address
+		self.value = value
+		self.embedded_transactions = embedded_transactions
+		self.fee = fee
+		self.height = height
+		self.timestamp = timestamp
+		self.deadline = deadline
+		self.signature = signature
+
+	def __eq__(self, other):
+		return isinstance(other, TransactionView) and all([
+			self.transaction_hash == other.transaction_hash,
+			self.transaction_type == other.transaction_type,
+			self.from_address == other.from_address,
+			self.to_address == other.to_address,
+			self.value == other.value,
+			self.embedded_transactions == other.embedded_transactions,
+			self.fee == other.fee,
+			self.height == other.height,
+			self.timestamp == other.timestamp,
+			self.deadline == other.deadline,
+			self.signature == other.signature
+		])
+
+	def to_dict(self):
+		"""Formats the transaction list info as a dictionary."""
+
+		return {
+			'transactionHash': self.transaction_hash,
+			'transactionType': self.transaction_type,
+			'fromAddress': self.from_address,
+			'toAddress': self.to_address,
+			'value': self.value,
+			'embeddedTransactions': self.embedded_transactions,
+			'fee': self.fee,
+			'height': self.height,
+			'timestamp': self.timestamp,
+			'deadline': self.deadline,
+			'signature': self.signature,
+		}

--- a/explorer/rest/tests/db/test_NemDatabase.py
+++ b/explorer/rest/tests/db/test_NemDatabase.py
@@ -8,6 +8,7 @@ from ..test.DatabaseTestUtils import (
 	MOSAIC_RICH_LIST_VIEWS,
 	MOSAIC_VIEWS,
 	NAMESPACE_VIEWS,
+	TRANSACTIONS_VIEWS,
 	DatabaseTestBase
 )
 
@@ -250,3 +251,61 @@ class NemDatabaseTest(DatabaseTestBase):  # pylint: disable=too-many-public-meth
 		self._assert_can_query_mosaic_rich_list_with_filter(Pagination(1, 1), 'nem.xem', [MOSAIC_RICH_LIST_VIEWS[0]])
 
 	# endregion
+
+	# region transaction
+
+	def test_can_query_transfer_by_hash(self):
+		# Act:
+		transaction_view = self.nem_db.get_transaction_by_hash('0' * 63 + '1')
+
+		# Assert:
+		self.assertEqual(TRANSACTIONS_VIEWS[0], transaction_view)
+
+	def test_can_query_transfer_v2_by_hash(self):
+		# Act:
+		transaction_view = self.nem_db.get_transaction_by_hash('0' * 63 + '2')
+
+		# Assert:
+		self.assertEqual(TRANSACTIONS_VIEWS[1], transaction_view)
+
+	def test_can_query_account_link_by_hash(self):
+		# Act:
+		transaction_view = self.nem_db.get_transaction_by_hash('0' * 63 + '3')
+
+		# Assert:
+		self.assertEqual(TRANSACTIONS_VIEWS[2], transaction_view)
+
+	def test_can_query_multisig_account_modification_by_hash(self):
+		# Act:
+		transaction_view = self.nem_db.get_transaction_by_hash('0' * 63 + '4')
+
+		# Assert:
+		self.assertEqual(TRANSACTIONS_VIEWS[3], transaction_view)
+
+	def test_can_query_multisig_by_hash(self):
+		# Act:
+		transaction_view = self.nem_db.get_transaction_by_hash('0' * 63 + '5')
+
+		# Assert:
+		self.assertEqual(TRANSACTIONS_VIEWS[4], transaction_view)
+
+	def test_can_query_namespace_registration_by_hash(self):
+		# Act:
+		transaction_view = self.nem_db.get_transaction_by_hash('0' * 63 + '7')
+
+		# Assert:
+		self.assertEqual(TRANSACTIONS_VIEWS[5], transaction_view)
+
+	def test_can_query_mosaic_definition_by_hash(self):
+		# Act:
+		transaction_view = self.nem_db.get_transaction_by_hash('0' * 63 + '8')
+
+		# Assert:
+		self.assertEqual(TRANSACTIONS_VIEWS[6], transaction_view)
+
+	def test_can_query_mosaic_supply_change_by_hash(self):
+		# Act:
+		transaction_view = self.nem_db.get_transaction_by_hash('0' * 63 + '9')
+
+		# Assert:
+		self.assertEqual(TRANSACTIONS_VIEWS[7], transaction_view)

--- a/explorer/rest/tests/facade/test_NemRestFacade.py
+++ b/explorer/rest/tests/facade/test_NemRestFacade.py
@@ -6,7 +6,15 @@ from symbollightapi.model.Exceptions import NodeException
 from rest.facade.NemRestFacade import NemRestFacade
 from rest.model.common import Pagination, RestConfig, Sorting
 
-from ..test.DatabaseTestUtils import ACCOUNT_VIEWS, BLOCK_VIEWS, MOSAIC_RICH_LIST_VIEWS, MOSAIC_VIEWS, NAMESPACE_VIEWS, DatabaseTestBase
+from ..test.DatabaseTestUtils import (
+	ACCOUNT_VIEWS,
+	BLOCK_VIEWS,
+	MOSAIC_RICH_LIST_VIEWS,
+	MOSAIC_VIEWS,
+	NAMESPACE_VIEWS,
+	TRANSACTIONS_VIEWS,
+	DatabaseTestBase
+)
 
 # region test data
 
@@ -33,6 +41,8 @@ EXPECTED_MOSAIC_3 = MOSAIC_VIEWS[2].to_dict()
 EXPECTED_MOSAIC_RICH_LIST_1 = MOSAIC_RICH_LIST_VIEWS[0].to_dict()
 
 EXPECTED_MOSAIC_RICH_LIST_2 = MOSAIC_RICH_LIST_VIEWS[1].to_dict()
+
+EXPECTED_TRANSACTION_1 = TRANSACTIONS_VIEWS[0].to_dict()
 
 # endregion
 
@@ -365,6 +375,29 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 		self._assert_can_retrieve_mosaic_rich_list(
 			pagination=Pagination(1, 1),
 			expected_mosaic_rich_list=[EXPECTED_MOSAIC_RICH_LIST_1]
+		)
+
+	# endregion
+
+	# region transaction
+
+	def _assert_can_retrieve_transaction_by_hash(self, transaction_hash, expected_transaction):
+		# Act:
+		transaction = self.nem_rest_facade.get_transaction_by_hash(transaction_hash)
+
+		# Assert:
+		self.assertEqual(expected_transaction, transaction)
+
+	def test_can_retrieve_transaction_by_hash(self):
+		self._assert_can_retrieve_transaction_by_hash(
+			transaction_hash='0' * 63 + '1',
+			expected_transaction=EXPECTED_TRANSACTION_1
+		)
+
+	def test_returns_none_for_nonexistent_transaction_hash(self):
+		self._assert_can_retrieve_transaction_by_hash(
+			transaction_hash='1' * 64,
+			expected_transaction=None
 		)
 
 	# endregion

--- a/explorer/rest/tests/model/test_Transaction.py
+++ b/explorer/rest/tests/model/test_Transaction.py
@@ -1,0 +1,90 @@
+import unittest
+
+from rest.model.Transaction import TransactionView
+
+
+class TransactionViewTest(unittest.TestCase):
+	@staticmethod
+	def _create_default_transaction_view(override=None):
+		transaction_view = TransactionView(
+			transaction_hash='0000000000000000000000000000000000000000000000000000000000000001',
+			transaction_type='TRANSFER',
+			from_address='TBZWVEKB2XMTO4F3RAOEIBWRBMPQ5N23G56ZJM4I',
+			to_address='TCJLCZSOQ6RGWHTPSV2DW467WZSHK4NBSITND4OF',
+			value=[
+				{
+					'namespace': 'nem.xem',
+					'amount': 10.5
+				}
+			],
+			embedded_transactions=None,
+			fee=3.0,
+			height=1000,
+			timestamp='2015-03-29 00:06:25',
+			deadline='2015-03-29 00:21:25',
+			signature='0' * 128
+		)
+
+		if override:
+			setattr(transaction_view, override[0], override[1])
+
+		return transaction_view
+
+	def test_can_create_transaction_view(self):
+		# Act:
+		transaction_view = self._create_default_transaction_view()
+
+		# Assert:
+		self.assertEqual('0' * 63 + '1', transaction_view.transaction_hash)
+		self.assertEqual('TRANSFER', transaction_view.transaction_type)
+		self.assertEqual('TBZWVEKB2XMTO4F3RAOEIBWRBMPQ5N23G56ZJM4I', transaction_view.from_address)
+		self.assertEqual('TCJLCZSOQ6RGWHTPSV2DW467WZSHK4NBSITND4OF', transaction_view.to_address)
+		self.assertEqual([{'namespace': 'nem.xem', 'amount': 10.5}], transaction_view.value)
+		self.assertEqual(None, transaction_view.embedded_transactions)
+		self.assertEqual(3.0, transaction_view.fee)
+		self.assertEqual(1000, transaction_view.height)
+		self.assertEqual('2015-03-29 00:06:25', transaction_view.timestamp)
+		self.assertEqual('2015-03-29 00:21:25', transaction_view.deadline)
+		self.assertEqual('0' * 128, transaction_view.signature)
+
+	def test_can_convert_to_simple_dict(self):
+		# Arrange:
+		transaction_view = self._create_default_transaction_view()
+
+		# Act:
+		transaction_view_dict = transaction_view.to_dict()
+
+		# Assert:
+		self.assertEqual({
+			'transactionHash': '0000000000000000000000000000000000000000000000000000000000000001',
+			'transactionType': 'TRANSFER',
+			'fromAddress': 'TBZWVEKB2XMTO4F3RAOEIBWRBMPQ5N23G56ZJM4I',
+			'toAddress': 'TCJLCZSOQ6RGWHTPSV2DW467WZSHK4NBSITND4OF',
+			'value': [{'namespace': 'nem.xem', 'amount': 10.5}],
+			'embeddedTransactions': None,
+			'fee': 3.0,
+			'height': 1000,
+			'timestamp': '2015-03-29 00:06:25',
+			'deadline': '2015-03-29 00:21:25',
+			'signature': '0' * 128,
+		}, transaction_view_dict)
+
+	def test_eq_is_supported(self):
+		# Arrange:
+		transaction_view = self._create_default_transaction_view()
+
+		# Assert:
+		self.assertEqual(transaction_view, self._create_default_transaction_view())
+		self.assertNotEqual(transaction_view, None)
+		self.assertNotEqual(transaction_view, 'transaction_view')
+		self.assertNotEqual(transaction_view, self._create_default_transaction_view(('transaction_hash', '0' * 64)))
+		self.assertNotEqual(transaction_view, self._create_default_transaction_view(('transaction_type', 'ACCOUNT_KEY_LINK')))
+		self.assertNotEqual(transaction_view, self._create_default_transaction_view(('from_address', 'TCJLCZSOQ6RGWHTPSV2DW467WZSHK4NBSITND4OF')))
+		self.assertNotEqual(transaction_view, self._create_default_transaction_view(('to_address', 'TBZWVEKB2XMTO4F3RAOEIBWRBMPQ5N23G56ZJM4I')))
+		self.assertNotEqual(transaction_view, self._create_default_transaction_view(('value', [{'namespace': 'nem.other', 'amount': 5.0}])))
+		self.assertNotEqual(transaction_view, self._create_default_transaction_view(('embedded_transactions', [None])))
+		self.assertNotEqual(transaction_view, self._create_default_transaction_view(('fee', 5000000)))
+		self.assertNotEqual(transaction_view, self._create_default_transaction_view(('height', 2000)))
+		self.assertNotEqual(transaction_view, self._create_default_transaction_view(('timestamp', '2015-03-29 01:06:25')))
+		self.assertNotEqual(transaction_view, self._create_default_transaction_view(('deadline', '2015-03-29 01:21:25')))
+		self.assertNotEqual(transaction_view, self._create_default_transaction_view(('signature', 'ABCDEF0123456789ABCDEF0123456789')))

--- a/explorer/rest/tests/test/DatabaseTestUtils.py
+++ b/explorer/rest/tests/test/DatabaseTestUtils.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 import json
 import unittest
 from binascii import unhexlify
@@ -12,6 +13,7 @@ from rest.model.Account import AccountView
 from rest.model.Block import BlockView
 from rest.model.Mosaic import MosaicRichListView, MosaicView
 from rest.model.Namespace import NamespaceView
+from rest.model.Transaction import TransactionView
 
 Block = namedtuple(
 	'Block',
@@ -67,6 +69,26 @@ Mosaic = namedtuple('Mosaic', [
 	'levy_recipient'
 ])
 AddressRemarks = namedtuple('Address_Remarks', ['address', 'remarks'])
+Transaction = namedtuple('Transaction', [
+	'transaction_hash',
+	'height',
+	'sender_public_key',
+	'fee',
+	'timestamp',
+	'deadline',
+	'signature',
+	'amount',
+	'transaction_type',
+	'is_inner',
+	'sender_address',
+	'recipient_address',
+	'payload'
+])
+TransactionMosaic = namedtuple('Transaction_Mosaic', [
+	'transaction_id',
+	'namespace_name',
+	'quantity'
+])
 DatabaseConfig = namedtuple('DatabaseConfig', ['database', 'user', 'password', 'host', 'port'])
 
 # region test data
@@ -215,6 +237,210 @@ ADDRESS_REMARKS = [
 	)
 ]
 
+TRANSACTIONS = [
+	Transaction(  # Transfer transaction v1
+		transaction_hash='0' * 63 + '1',
+		height=2,
+		sender_public_key=PublicKey('f9bd190dd0c364261f5c8a74870cc7f7374e631352293c62ecc437657e5de2cd'),
+		fee=150000,
+		timestamp='2015-03-29 00:06:25',
+		deadline='2015-03-29 20:34:19',
+		amount=5000000,
+		signature='0' * 128,
+		transaction_type=257,
+		is_inner=False,
+		sender_address=Address('NAGHXD63C4V6REWGXCVKJ2SBS3GUAXGTRQZQXPRO'),
+		recipient_address=Address('NBFWZ4IVRHEIBRCGHLYDS62FSFTBM3VDFA7E6LSQ'),
+		payload={
+			'message': None
+		}
+	),
+	Transaction(  # Transfer transaction v2
+		transaction_hash='0' * 63 + '2',
+		height=2,
+		sender_public_key=PublicKey('f9bd190dd0c364261f5c8a74870cc7f7374e631352293c62ecc437657e5de2cd'),
+		fee=150000,
+		timestamp='2015-03-29 00:06:25',
+		deadline='2015-03-29 20:34:19',
+		amount=2000000,
+		signature='0' * 128,
+		transaction_type=257,
+		is_inner=False,
+		sender_address=Address('NAGHXD63C4V6REWGXCVKJ2SBS3GUAXGTRQZQXPRO'),
+		recipient_address=Address('NBFWZ4IVRHEIBRCGHLYDS62FSFTBM3VDFA7E6LSQ'),
+		payload={
+			'message': {
+				'payload': 'Test message',
+				'is_plain': 1
+			}
+		}
+	),
+	Transaction(  # Account Link
+		transaction_hash='0' * 63 + '3',
+		height=2,
+		sender_public_key=PublicKey('f9bd190dd0c364261f5c8a74870cc7f7374e631352293c62ecc437657e5de2cd'),
+		fee=150000,
+		timestamp='2015-03-29 00:06:25',
+		deadline='2015-03-29 20:34:19',
+		amount=None,
+		signature='0' * 128,
+		transaction_type=2049,
+		is_inner=False,
+		sender_address=Address('NAGHXD63C4V6REWGXCVKJ2SBS3GUAXGTRQZQXPRO'),
+		recipient_address=None,
+		payload={
+			'mode': 1,
+			'remote_account': 'a5f06d59b97aa40c82afb941a61fb6483bdb7491805cdb9dc47d92136983b9a5'
+		}
+	),
+	Transaction(  # Multisig account modification
+		transaction_hash='0' * 63 + '4',
+		height=2,
+		sender_public_key=PublicKey('f9bd190dd0c364261f5c8a74870cc7f7374e631352293c62ecc437657e5de2cd'),
+		fee=150000,
+		timestamp='2015-03-29 00:06:25',
+		deadline='2015-03-29 20:34:19',
+		amount=None,
+		signature='0' * 128,
+		transaction_type=4097,
+		is_inner=False,
+		sender_address=Address('NAGHXD63C4V6REWGXCVKJ2SBS3GUAXGTRQZQXPRO'),
+		recipient_address=None,
+		payload={
+			'min_cosignatories': 1,
+			'modifications': [
+				{
+					'modification_type': 0,
+					'cosignatory_account': 'a5f06d59b97aa40c82afb941a61fb6483bdb7491805cdb9dc47d92136983b9a5'
+				}
+			]
+		}
+	),
+	Transaction(  # Multisig transaction
+		transaction_hash='0' * 63 + '5',
+		height=2,
+		sender_public_key=PublicKey('f9bd190dd0c364261f5c8a74870cc7f7374e631352293c62ecc437657e5de2cd'),
+		fee=150000,
+		timestamp='2015-03-29 00:06:25',
+		deadline='2015-03-29 20:34:19',
+		amount=None,
+		signature='0' * 128,
+		transaction_type=4100,
+		is_inner=False,
+		sender_address=Address('NAGHXD63C4V6REWGXCVKJ2SBS3GUAXGTRQZQXPRO'),
+		recipient_address=None,
+		payload={
+			'inner_hash': '0' * 63 + '6',
+			'signatures': [
+				{
+					'transaction_type': 4098,
+					'timestamp': '2015-03-29 00:06:25',
+					'deadline': '2015-03-29 20:34:19',
+					'fee': 150000,
+					'other_hash': '0' * 63 + '6',
+					'other_account': 'a5f06d59b97aa40c82afb941a61fb6483bdb7491805cdb9dc47d92136983b9a5',
+					'sender': '8D07F90FB4BBE7715FA327C926770166A11BE2E494A970605F2E12557F66C9B9',
+					'signature': '0' * 128
+				}
+			]
+		}
+	),
+	Transaction(  # inner Transfer transaction
+		transaction_hash='0' * 63 + '6',
+		height=2,
+		sender_public_key=PublicKey('f9bd190dd0c364261f5c8a74870cc7f7374e631352293c62ecc437657e5de2cd'),
+		fee=150000,
+		timestamp='2015-03-29 00:06:25',
+		deadline='2015-03-29 20:34:19',
+		amount=5000000,
+		signature='0' * 128,
+		transaction_type=257,
+		is_inner=True,
+		sender_address=Address('NAGHXD63C4V6REWGXCVKJ2SBS3GUAXGTRQZQXPRO'),
+		recipient_address=Address('NBFWZ4IVRHEIBRCGHLYDS62FSFTBM3VDFA7E6LSQ'),
+		payload={
+			'message': None
+		}
+	),
+	Transaction(  # Namespace registration
+		transaction_hash='0' * 63 + '7',
+		height=2,
+		sender_public_key=PublicKey('f9bd190dd0c364261f5c8a74870cc7f7374e631352293c62ecc437657e5de2cd'),
+		fee=150000,
+		timestamp='2015-03-29 00:06:25',
+		deadline='2015-03-29 20:34:19',
+		amount=None,
+		signature='0' * 128,
+		transaction_type=8193,
+		is_inner=False,
+		sender_address=Address('NAGHXD63C4V6REWGXCVKJ2SBS3GUAXGTRQZQXPRO'),
+		recipient_address=Address('NBFWZ4IVRHEIBRCGHLYDS62FSFTBM3VDFA7E6LSQ'),
+		payload={
+			'rental_fee': 100000000,
+			'parent': 'test',
+			'namespace': 'namespace'
+		}
+	),
+	Transaction(  # Mosaic definition
+		transaction_hash='0' * 63 + '8',
+		height=2,
+		sender_public_key=PublicKey('f9bd190dd0c364261f5c8a74870cc7f7374e631352293c62ecc437657e5de2cd'),
+		fee=150000,
+		timestamp='2015-03-29 00:06:25',
+		deadline='2015-03-29 20:34:19',
+		amount=None,
+		signature='0' * 128,
+		transaction_type=16385,
+		is_inner=False,
+		sender_address=Address('NAGHXD63C4V6REWGXCVKJ2SBS3GUAXGTRQZQXPRO'),
+		recipient_address=Address('NBFWZ4IVRHEIBRCGHLYDS62FSFTBM3VDFA7E6LSQ'),
+		payload={
+			'creation_fee': 200000000,
+			'creator': 'f9bd190dd0c364261f5c8a74870cc7f7374e631352293c62ecc437657e5de2cd',
+			'description': 'Test mosaic',
+			'namespace_name': 'root.mosaic',
+			'mosaic_properties': {
+				'divisibility': 0,
+				'initial_supply': 1000000,
+				'supply_mutable': False,
+				'transferable': True
+			},
+			'levy': {
+				'type': 1,
+				'fee': 1000000,
+				'recipient': 'NAGHXD63C4V6REWGXCVKJ2SBS3GUAXGTRQZQXPRO',
+				'namespace_name': 'nem.xem'
+			}
+		}
+	),
+	Transaction(  # Mosaic supply change
+		transaction_hash='0' * 63 + '9',
+		height=2,
+		sender_public_key=PublicKey('f9bd190dd0c364261f5c8a74870cc7f7374e631352293c62ecc437657e5de2cd'),
+		fee=150000,
+		timestamp='2015-03-29 00:06:25',
+		deadline='2015-03-29 20:34:19',
+		amount=None,
+		signature='0' * 128,
+		transaction_type=16386,
+		is_inner=False,
+		sender_address=Address('NAGHXD63C4V6REWGXCVKJ2SBS3GUAXGTRQZQXPRO'),
+		recipient_address=None,
+		payload={
+			'namespace_name': 'root.mosaic',
+			'supply_type': 1,
+			'delta': 1000000
+		}
+	)
+]
+
+TRANSACTIONS_MOSAIC = [
+	TransactionMosaic(  # use for transaction v2
+		transaction_id=2,
+		namespace_name='root.mosaic',
+		quantity=2000000
+	)
+]
 
 BLOCK_VIEWS = [
 	BlockView(*BLOCKS[0]._replace(
@@ -378,6 +604,163 @@ MOSAIC_RICH_LIST_VIEWS = [
 	)
 ]
 
+TRANSACTIONS_VIEWS = [
+	TransactionView(
+		transaction_hash='0' * 63 + '1',
+		transaction_type='TRANSFER',
+		from_address=str(TRANSACTIONS[0].sender_address),
+		to_address=str(TRANSACTIONS[0].recipient_address),
+		value=[
+			{
+				'namespace': 'nem.xem',
+				'amount': 5.0
+			}
+		],
+		embedded_transactions=None,
+		fee=0.15,
+		height=TRANSACTIONS[0].height,
+		timestamp=TRANSACTIONS[0].timestamp,
+		deadline=TRANSACTIONS[0].deadline,
+		signature=TRANSACTIONS[0].signature.upper()
+	),
+	TransactionView(
+		transaction_hash='0' * 63 + '2',
+		transaction_type='TRANSFER',
+		from_address=str(TRANSACTIONS[1].sender_address),
+		to_address=str(TRANSACTIONS[1].recipient_address),
+		value=[
+			{
+				'message': {
+					'isPlain': 1,
+					'payload': 'Test message'
+				}
+			},
+			{
+				'namespace': 'root.mosaic',
+				'amount': 4000000.0
+			}
+		],
+		embedded_transactions=None,
+		fee=0.15,
+		height=TRANSACTIONS[1].height,
+		timestamp=TRANSACTIONS[1].timestamp,
+		deadline=TRANSACTIONS[1].deadline,
+		signature=TRANSACTIONS[1].signature.upper()
+	),
+	TransactionView(
+		transaction_hash='0' * 63 + '3',
+		transaction_type='ACCOUNT_KEY_LINK',
+		from_address=str(TRANSACTIONS[2].sender_address),
+		to_address=None,
+		value=[{
+			'mode': 1,
+			'remoteAccount': 'a5f06d59b97aa40c82afb941a61fb6483bdb7491805cdb9dc47d92136983b9a5'
+		}],
+		embedded_transactions=None,
+		fee=0.15,
+		height=TRANSACTIONS[2].height,
+		timestamp=TRANSACTIONS[2].timestamp,
+		deadline=TRANSACTIONS[2].deadline,
+		signature=TRANSACTIONS[2].signature.upper()
+	),
+	TransactionView(
+		transaction_hash='0' * 63 + '4',
+		transaction_type='MULTISIG_ACCOUNT_MODIFICATION',
+		from_address=str(TRANSACTIONS[3].sender_address),
+		to_address=None,
+		value=[{
+			'minCosignatories': 1,
+			'modifications': [{
+				'cosignatoryAccount': 'NBFWZ4IVRHEIBRCGHLYDS62FSFTBM3VDFA7E6LSQ',
+				'modificationType': 0,
+			}]
+		}],
+		embedded_transactions=None,
+		fee=0.15,
+		height=TRANSACTIONS[3].height,
+		timestamp=TRANSACTIONS[3].timestamp,
+		deadline=TRANSACTIONS[3].deadline,
+		signature=TRANSACTIONS[3].signature.upper()
+	),
+	TransactionView(
+		transaction_hash='0' * 63 + '5',
+		transaction_type='MULTISIG',
+		from_address=str(TRANSACTIONS[5].sender_address),
+		to_address=str(TRANSACTIONS[5].recipient_address),
+		value=None,
+		embedded_transactions=[{
+			'initiator': 'NAGHXD63C4V6REWGXCVKJ2SBS3GUAXGTRQZQXPRO',
+			'transactionHash': '0' * 63 + '6',
+			'transactionType': 'TRANSFER',
+			'signatures': [{
+				'fee': 0.15,
+				'signature': '0' * 128,
+				'signer': 'NANEMOABLAGR72AZ2RV3V4ZHDCXW25XQ73O7OBT5'
+			}],
+			'fee': 0.15,
+			'value': [{
+				'namespace': 'nem.xem',
+				'amount': 5.0
+			}]
+		}],
+		fee=0.15,
+		height=TRANSACTIONS[4].height,
+		timestamp=TRANSACTIONS[4].timestamp,
+		deadline=TRANSACTIONS[4].deadline,
+		signature=TRANSACTIONS[4].signature.upper()
+	),
+	TransactionView(
+		transaction_hash='0' * 63 + '7',
+		transaction_type='NAMESPACE_REGISTRATION',
+		from_address=str(TRANSACTIONS[6].sender_address),
+		to_address=str(TRANSACTIONS[6].recipient_address),
+		value=[{
+			'sinkFee': 100.0,
+			'parent': 'test',
+			'namespaceName': 'namespace'
+		}],
+		embedded_transactions=None,
+		fee=0.15,
+		height=TRANSACTIONS[6].height,
+		timestamp=TRANSACTIONS[6].timestamp,
+		deadline=TRANSACTIONS[6].deadline,
+		signature=TRANSACTIONS[6].signature.upper()
+	),
+	TransactionView(
+		transaction_hash='0' * 63 + '8',
+		transaction_type='MOSAIC_DEFINITION',
+		from_address=str(TRANSACTIONS[7].sender_address),
+		to_address=str(TRANSACTIONS[7].recipient_address),
+		value=[{
+			'sinkFee': 200.0,
+			'mosaicNamespaceName': 'root.mosaic'
+		}],
+		embedded_transactions=None,
+		fee=0.15,
+		height=TRANSACTIONS[7].height,
+		timestamp=TRANSACTIONS[7].timestamp,
+		deadline=TRANSACTIONS[7].deadline,
+		signature=TRANSACTIONS[7].signature.upper()
+	),
+	TransactionView(
+		transaction_hash='0' * 63 + '9',
+		transaction_type='MOSAIC_SUPPLY_CHANGE',
+		from_address=str(TRANSACTIONS[8].sender_address),
+		to_address=None,
+		value=[{
+			'supplyType': 1,
+			'delta': 1000000,
+			'namespaceName': 'root.mosaic'
+		}],
+		embedded_transactions=None,
+		fee=0.15,
+		height=TRANSACTIONS[8].height,
+		timestamp=TRANSACTIONS[8].timestamp,
+		deadline=TRANSACTIONS[8].deadline,
+		signature=TRANSACTIONS[8].signature.upper()
+	),
+]
+
 # endregion
 
 
@@ -469,6 +852,38 @@ def initialize_database(db_config, network_name):
 				id serial PRIMARY KEY,
 				address bytea UNIQUE,
 				remarks varchar NOT NULL
+			)
+			'''
+		)
+
+		cursor.execute(
+			'''
+			CREATE TABLE IF NOT EXISTS transactions (
+				id serial PRIMARY KEY,
+				transaction_hash bytea UNIQUE NOT NULL,
+				transaction_type int NOT NULL,
+				height bigint NOT NULL,
+				sender_public_key bytea NOT NULL,
+				sender_address bytea NOT NULL,
+				recipient_address bytea,
+				fee bigint DEFAULT 0,
+				timestamp timestamp NOT NULL,
+				deadline timestamp NOT NULL,
+				signature bytea,
+				amount bigint,
+				is_inner boolean DEFAULT false,
+				payload jsonb
+			)
+			'''
+		)
+
+		cursor.execute(
+			'''
+			CREATE TABLE IF NOT EXISTS transactions_mosaic (
+				id serial PRIMARY KEY,
+				transaction_id int NOT NULL,
+				namespace_name varchar(146),
+				quantity bigint
 			)
 			'''
 		)
@@ -598,6 +1013,60 @@ def initialize_database(db_config, network_name):
 				''', (
 					address_remark.address.bytes,
 					address_remark.remarks
+				)
+			)
+
+		for transaction in TRANSACTIONS:
+			cursor.execute(
+				'''
+				INSERT INTO transactions (
+					transaction_hash,
+					transaction_type,
+					height,
+					sender_public_key,
+					sender_address,
+					recipient_address,
+					fee,
+					timestamp,
+					deadline,
+					signature,
+					amount,
+					is_inner,
+					payload
+				)
+				VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+				''',
+				(
+					unhexlify(transaction.transaction_hash),
+					transaction.transaction_type,
+					transaction.height,
+					transaction.sender_public_key.bytes,
+					transaction.sender_address.bytes,
+					transaction.recipient_address.bytes if transaction.recipient_address else None,
+					transaction.fee,
+					transaction.timestamp,
+					transaction.deadline,
+					unhexlify(transaction.signature) if transaction.signature else None,
+					transaction.amount,
+					transaction.is_inner,
+					json.dumps(transaction.payload) if transaction.payload else None
+				)
+			)
+
+		for transaction_mosaic in TRANSACTIONS_MOSAIC:
+			cursor.execute(
+				'''
+				INSERT INTO transactions_mosaic (
+					transaction_id,
+					namespace_name,
+					quantity
+				)
+				VALUES (%s, %s, %s)
+				''',
+				(
+					transaction_mosaic.transaction_id,
+					transaction_mosaic.namespace_name,
+					transaction_mosaic.quantity
 				)
 			)
 

--- a/explorer/rest/tests/test/DatabaseTestUtils.py
+++ b/explorer/rest/tests/test/DatabaseTestUtils.py
@@ -437,6 +437,11 @@ TRANSACTIONS = [
 TRANSACTIONS_MOSAIC = [
 	TransactionMosaic(  # use for transaction v2
 		transaction_id=2,
+		namespace_name='nem.xem',
+		quantity=2000000
+	),
+	TransactionMosaic(
+		transaction_id=2,
 		namespace_name='root.mosaic',
 		quantity=2000000
 	)
@@ -634,6 +639,10 @@ TRANSACTIONS_VIEWS = [
 					'isPlain': 1,
 					'payload': 'Test message'
 				}
+			},
+			{
+				'namespace': 'nem.xem',
+				'amount': 4.0
 			},
 			{
 				'namespace': 'root.mosaic',

--- a/explorer/rest/tests/test_rest.py
+++ b/explorer/rest/tests/test_rest.py
@@ -15,6 +15,7 @@ from .test.DatabaseTestUtils import (
 	MOSAIC_RICH_LIST_VIEWS,
 	MOSAIC_VIEWS,
 	NAMESPACE_VIEWS,
+	TRANSACTIONS_VIEWS,
 	DatabaseConfig,
 	initialize_database
 )
@@ -127,7 +128,8 @@ def test_data_not_found(client):  # pylint: disable=redefined-outer-name
 		('block', '/3'),
 		('account', '?address=NANEMOABLAGR72AZ2RV3V4ZHDCXW25XQ73O7OBT5'),
 		('namespace', '/nonexistent'),
-		('mosaic', '/nonexistent')]:
+		('mosaic', '/nonexistent'),
+		('transaction', '0' * 64)]:
 		# Act:
 		response = client.get(f'/api/nem/{module}{params}')
 
@@ -540,7 +542,7 @@ def test_api_mosaics_with_all_params(client):  # pylint: disable=redefined-outer
 
 # endregion
 
-# region /mosaic/rich/list Todo: fix line to long
+# region /mosaic/rich/list
 
 def _assert_get_api_nem_mosaic_rich_list(client, expected_status_code, expected_result, **query_params):
 	# pylint: disable=redefined-outer-name
@@ -591,3 +593,13 @@ def test_api_mosaic_rich_list_applies_offset(client):  # pylint: disable=redefin
 
 
 # endregion
+
+# region /transaction/<transaction_hash>
+
+def test_api_nem_transaction_by_hash(client):  # pylint: disable=redefined-outer-name
+	# Act:
+	response = client.get('/api/nem/transaction/' + TRANSACTIONS_VIEWS[0].transaction_hash)
+
+	# Assert:
+	_assert_status_code_and_headers(response, 200)
+	assert TRANSACTIONS_VIEWS[0].to_dict() == response.json


### PR DESCRIPTION
Problem: Missing transaction query by hash endpoint.
Solution: 
- Added  `/transaction/<transaction_hash>` endpoint for query by transaction hash