### PR TITLE
[lightapi/python] feat: added unconfirmed transaction endpoint

### DIFF
--- a/lightapi/python/symbollightapi/connector/NemConnector.py
+++ b/lightapi/python/symbollightapi/connector/NemConnector.py
@@ -1,4 +1,5 @@
 import asyncio
+import random
 from binascii import hexlify
 from collections import namedtuple
 
@@ -393,5 +394,36 @@ class NemConnector(BasicConnector):
 			specific_args = TransactionHandler().map[tx_type](tx_json)
 
 		return TransactionFactory.create_transaction(tx_type, common_args, specific_args)
+
+	# endregion
+
+	# region POST (get_unconfirmed_transactions)
+
+	async def get_unconfirmed_transactions(self):
+		"""Gets unconfirmed transactions."""
+
+		characters = '0123456789abcdef'
+		random_challenge = ''.join(random.choices(characters, k=64))
+
+		unconfirmed_transactions = await self.post(
+			'transactions/unconfirmed',
+			{
+				'entity': {
+					'hashShortIds': []
+				},
+				'challenge': {
+					'data': random_challenge
+				}
+			},
+			property_name='entity'
+		)
+
+		return [
+			self._map_to_transaction({
+				'tx': tx,
+				'hash': None,
+				'innerHash': None
+			}, 0) for tx in unconfirmed_transactions['data']
+		]
 
 	# endregion

--- a/lightapi/python/tests/connector/test_NemConnector.py
+++ b/lightapi/python/tests/connector/test_NemConnector.py
@@ -1423,7 +1423,6 @@ async def test_unconfirmed_transactions(server):  # pylint: disable=redefined-ou
 
 	# Act:
 	unconfirmed_transactions = await connector.get_unconfirmed_transactions()
-	print(vars(unconfirmed_transactions[0]))
 
 	# Assert:
 	assert [f'{server.make_url("")}/transactions/unconfirmed'] == server.mock.urls

--- a/lightapi/python/tests/connector/test_NemConnector.py
+++ b/lightapi/python/tests/connector/test_NemConnector.py
@@ -626,7 +626,19 @@ async def server(aiohttp_client):  # pylint: disable=too-many-statements
 			return await self._process(request, {
 				'signature': '0' * 128,
 				'entity': {
-					'data': [CHAIN_BLOCK_1['txes'][1]['tx']]
+					'data': [
+						{
+							'timeStamp': 73397,
+							'amount': 1000000,
+							'signature': '0' * 128,
+							'fee': 150000,
+							'recipient': 'NCOPERAWEWCD4A34NP5UQCCKEX44MW4SL3QYJYS5',
+							'type': 257,
+							'deadline': 83397,
+							'message': {},
+							'version': 1744830465,
+							'signer': '8d07f90fb4bbe7715fa327c926770166a11be2e494a970605f2e12557f66c9b9'
+						},]
 				}
 			})
 
@@ -1411,14 +1423,24 @@ async def test_unconfirmed_transactions(server):  # pylint: disable=redefined-ou
 
 	# Act:
 	unconfirmed_transactions = await connector.get_unconfirmed_transactions()
+	print(vars(unconfirmed_transactions[0]))
 
 	# Assert:
-	setattr(EXPECTED_BLOCK_2.transactions[1], 'transaction_hash', None)
-	setattr(EXPECTED_BLOCK_2.transactions[1], 'height', 0)
-
 	assert [f'{server.make_url("")}/transactions/unconfirmed'] == server.mock.urls
 	assert [
-		EXPECTED_BLOCK_2.transactions[1]
+		TransferTransaction(
+			transaction_hash=None,
+			height=0,
+			sender=PublicKey('8d07f90fb4bbe7715fa327c926770166a11be2e494a970605f2e12557f66c9b9'),
+			fee=150000,
+			timestamp=73397,
+			deadline=83397,
+			signature='0' * 128,
+			amount=1000000,
+			recipient=Address('NCOPERAWEWCD4A34NP5UQCCKEX44MW4SL3QYJYS5'),
+			mosaics=None,
+			message=None
+		),
 	] == unconfirmed_transactions
 
 # endregion

--- a/lightapi/python/tests/connector/test_NemConnector.py
+++ b/lightapi/python/tests/connector/test_NemConnector.py
@@ -622,6 +622,14 @@ async def server(aiohttp_client):  # pylint: disable=too-many-statements
 		async def local_block_at(self, request):
 			return await self._process(request, CHAIN_BLOCK_1)
 
+		async def transactions_unconfirmed(self, request):
+			return await self._process(request, {
+				'signature': '0' * 128,
+				'entity': {
+					'data': [CHAIN_BLOCK_1['txes'][1]['tx']]
+				}
+			})
+
 	# create a mock server
 	mock_server = MockNemServer()
 
@@ -642,6 +650,7 @@ async def server(aiohttp_client):  # pylint: disable=too-many-statements
 	app.router.add_post('/transaction/announce', mock_server.announce_transaction)
 	app.router.add_post('/local/chain/blocks-after', mock_server.local_chain_blocks_after)
 	app.router.add_post('/local/block/at', mock_server.local_block_at)
+	app.router.add_post('/transactions/unconfirmed', mock_server.transactions_unconfirmed)
 	server = await aiohttp_client(app)  # pylint: disable=redefined-outer-name
 
 	server.mock = mock_server
@@ -1390,5 +1399,26 @@ async def test_can_query_block_at(server):  # pylint: disable=redefined-outer-na
 	# Assert:
 	assert [f'{server.make_url("")}/local/block/at'] == server.mock.urls
 	assert EXPECTED_BLOCK_2 == block
+
+# endregion
+
+
+# region POST (get_unconfirmed_transactions)
+
+async def test_unconfirmed_transactions(server):  # pylint: disable=redefined-outer-name
+	# Arrange:
+	connector = NemConnector(server.make_url(''))
+
+	# Act:
+	unconfirmed_transactions = await connector.get_unconfirmed_transactions()
+
+	# Assert:
+	setattr(EXPECTED_BLOCK_2.transactions[1], 'transaction_hash', None)
+	setattr(EXPECTED_BLOCK_2.transactions[1], 'height', 0)
+
+	assert [f'{server.make_url("")}/transactions/unconfirmed'] == server.mock.urls
+	assert [
+		EXPECTED_BLOCK_2.transactions[1]
+	] == unconfirmed_transactions
 
 # endregion


### PR DESCRIPTION
Problem: nem explorer required an unconfirmed transaction endpoint.
Solution: Added a method for the unconfirmed transaction POST request.