### PR TITLE
[tools/shoestring] fix: renew-certificates fails with relative path

### DIFF
--- a/tools/shoestring/README.md
+++ b/tools/shoestring/README.md
@@ -237,6 +237,7 @@ renew-certificates --config CONFIG [--directory DIRECTORY] --ca-key-path CA_KEY_
   --ca-key-path CA_KEY_PATH path to main private key PEM file
   --renew-ca                renews CA certificate too
   --retain-node-key         retain node key
+  --force                   force overwrite of certificates
 ```
 
 When `--renew-ca` is set, both CA and node certificates will be regenerated. Otherwise, only node certificate will be.

--- a/tools/shoestring/shoestring/commands/renew_certificates.py
+++ b/tools/shoestring/shoestring/commands/renew_certificates.py
@@ -10,7 +10,7 @@ from shoestring.internal.ShoestringConfiguration import parse_shoestring_configu
 
 async def run_main(args):
 	config = parse_shoestring_configuration(args.config)
-	directories = Preparer.DirectoryLocator(None, Path(args.directory))
+	directories = Preparer.DirectoryLocator(None, Path(args.directory).absolute())
 
 	ca_key_path = Path(args.ca_key_path).absolute()
 	if not ca_key_path.exists():

--- a/tools/shoestring/shoestring/commands/renew_certificates.py
+++ b/tools/shoestring/shoestring/commands/renew_certificates.py
@@ -27,7 +27,11 @@ async def run_main(args):
 		factory.generate_node_certificate(config.node.node_common_name)
 		factory.create_node_certificate_chain()
 
-		factory.package(directories.certificates, '' if args.renew_ca else 'node')
+		package_filter = '' if args.renew_ca else 'node'
+		if args.force:
+			factory.remove_package_files(directories.certificates, package_filter)
+
+		factory.package(directories.certificates, package_filter)
 
 
 def add_arguments(parser):
@@ -36,4 +40,5 @@ def add_arguments(parser):
 	parser.add_argument('--ca-key-path', help=_('argument-help-ca-key-path'), required=True)
 	parser.add_argument('--renew-ca', help=_('argument-help-renew-certificates-renew-ca'), action='store_true')
 	parser.add_argument('--retain-node-key', help=_('argument-help-renew-certificates-retain-node-key'), action='store_true')
+	parser.add_argument('--force', help=_('argument-help-renew-certificates-force'), action='store_true')
 	parser.set_defaults(func=run_main)

--- a/tools/shoestring/shoestring/internal/CertificateFactory.py
+++ b/tools/shoestring/shoestring/internal/CertificateFactory.py
@@ -196,13 +196,21 @@ class CertificateFactory:
 		full_crt += _read_file('ca.crt.pem')
 		_write_file('node.full.crt.pem', full_crt)
 
+	_CERTIFICATE_FILENAMES = ['node.crt.pem', 'node.key.pem', 'ca.pubkey.pem', 'ca.crt.pem', 'node.full.crt.pem']
+
 	@staticmethod
 	def package(output_directory, package_filter=''):
 		"""Creates a package of final files required for node deployment in the specifed output directory."""
 
-		CertificateFactory._package(output_directory, package_filter, [
-			'node.crt.pem', 'node.key.pem', 'ca.pubkey.pem', 'ca.crt.pem', 'node.full.crt.pem'
-		])
+		CertificateFactory._package(output_directory, package_filter, CertificateFactory._CERTIFICATE_FILENAMES)
+
+	@staticmethod
+	def remove_package_files(output_directory, package_filter=''):
+		"""Removes existing package certificate files."""
+
+		for filename in CertificateFactory._CERTIFICATE_FILENAMES:
+			if filename.startswith(package_filter):
+				(Path(output_directory) / filename).unlink(missing_ok=True)
 
 	def export_ca(self):
 		"""Exports the CA private key."""
@@ -216,8 +224,5 @@ class CertificateFactory:
 				continue
 
 			destination_path = Path(output_directory) / filename
-
-			# rm dest file if exist or move will fail to open
-			Path(destination_path).unlink(missing_ok=True)
 			shutil.move(filename, destination_path)
 			destination_path.chmod(0o400)

--- a/tools/shoestring/shoestring/internal/CertificateFactory.py
+++ b/tools/shoestring/shoestring/internal/CertificateFactory.py
@@ -16,6 +16,7 @@ class CertificateFactory:
 
 		self.temp_directory = None
 		self.original_working_directory = None
+		self._certificate_filenames = ['node.crt.pem', 'node.key.pem', 'ca.pubkey.pem', 'ca.crt.pem', 'node.full.crt.pem']
 
 	def __enter__(self):
 		self.temp_directory = tempfile.TemporaryDirectory()
@@ -196,19 +197,15 @@ class CertificateFactory:
 		full_crt += _read_file('ca.crt.pem')
 		_write_file('node.full.crt.pem', full_crt)
 
-	_CERTIFICATE_FILENAMES = ['node.crt.pem', 'node.key.pem', 'ca.pubkey.pem', 'ca.crt.pem', 'node.full.crt.pem']
-
-	@staticmethod
-	def package(output_directory, package_filter=''):
+	def package(self, output_directory, package_filter=''):
 		"""Creates a package of final files required for node deployment in the specifed output directory."""
 
-		CertificateFactory._package(output_directory, package_filter, CertificateFactory._CERTIFICATE_FILENAMES)
+		CertificateFactory._package(output_directory, package_filter, self._certificate_filenames)
 
-	@staticmethod
-	def remove_package_files(output_directory, package_filter=''):
+	def remove_package_files(self, output_directory, package_filter=''):
 		"""Removes existing package certificate files."""
 
-		for filename in CertificateFactory._CERTIFICATE_FILENAMES:
+		for filename in self._certificate_filenames:
 			if filename.startswith(package_filter):
 				(Path(output_directory) / filename).unlink(missing_ok=True)
 

--- a/tools/shoestring/shoestring/internal/CertificateFactory.py
+++ b/tools/shoestring/shoestring/internal/CertificateFactory.py
@@ -7,6 +7,8 @@ from pathlib import Path
 class CertificateFactory:
 	"""Uses openssl to generate SSL certificates and related files."""
 
+	CERTIFICATE_FILENAMES = ['node.crt.pem', 'node.key.pem', 'ca.pubkey.pem', 'ca.crt.pem', 'node.full.crt.pem']
+
 	def __init__(self, openssl_executor, ca_key_path, ca_password=None):
 		"""Creates a factory."""
 
@@ -16,7 +18,6 @@ class CertificateFactory:
 
 		self.temp_directory = None
 		self.original_working_directory = None
-		self._certificate_filenames = ['node.crt.pem', 'node.key.pem', 'ca.pubkey.pem', 'ca.crt.pem', 'node.full.crt.pem']
 
 	def __enter__(self):
 		self.temp_directory = tempfile.TemporaryDirectory()
@@ -200,12 +201,12 @@ class CertificateFactory:
 	def package(self, output_directory, package_filter=''):
 		"""Creates a package of final files required for node deployment in the specifed output directory."""
 
-		CertificateFactory._package(output_directory, package_filter, self._certificate_filenames)
+		CertificateFactory._package(output_directory, package_filter, self.CERTIFICATE_FILENAMES)
 
 	def remove_package_files(self, output_directory, package_filter=''):
 		"""Removes existing package certificate files."""
 
-		for filename in self._certificate_filenames:
+		for filename in self.CERTIFICATE_FILENAMES:
 			if filename.startswith(package_filter):
 				(Path(output_directory) / filename).unlink(missing_ok=True)
 

--- a/tools/shoestring/shoestring/internal/CertificateFactory.py
+++ b/tools/shoestring/shoestring/internal/CertificateFactory.py
@@ -216,5 +216,8 @@ class CertificateFactory:
 				continue
 
 			destination_path = Path(output_directory) / filename
+
+			# rm dest file if exist or move will fail to open
+			Path(destination_path).unlink(missing_ok=True)
 			shutil.move(filename, destination_path)
 			destination_path.chmod(0o400)

--- a/tools/shoestring/shoestring/lang/en/LC_MESSAGES/messages.po
+++ b/tools/shoestring/shoestring/lang/en/LC_MESSAGES/messages.po
@@ -20,7 +20,7 @@ msgid "argument-help-announce-transaction-transaction"
 msgstr "file containing serialized transaction to send"
 
 #: shoestring/commands/min_cosignatures_count.py:35
-#: shoestring/commands/renew_certificates.py:36
+#: shoestring/commands/renew_certificates.py:40
 #: shoestring/commands/setup.py:155 shoestring/commands/signer.py:93
 msgid "argument-help-ca-key-path"
 msgstr "path to main private key PEM file"
@@ -29,7 +29,7 @@ msgstr "path to main private key PEM file"
 #: shoestring/commands/health.py:74 shoestring/commands/import_bootstrap.py:49
 #: shoestring/commands/import_harvesters.py:97 shoestring/commands/init.py:29
 #: shoestring/commands/min_cosignatures_count.py:34
-#: shoestring/commands/renew_certificates.py:34
+#: shoestring/commands/renew_certificates.py:38
 #: shoestring/commands/renew_voting_keys.py:112
 #: shoestring/commands/reset_data.py:86 shoestring/commands/setup.py:147
 #: shoestring/commands/signer.py:92
@@ -37,7 +37,7 @@ msgid "argument-help-config"
 msgstr "path to shoestring configuration file"
 
 #: shoestring/commands/health.py:75
-#: shoestring/commands/renew_certificates.py:35
+#: shoestring/commands/renew_certificates.py:39
 #: shoestring/commands/renew_voting_keys.py:113
 #: shoestring/commands/reset_data.py:87 shoestring/commands/setup.py:149
 msgid "argument-help-directory"
@@ -103,11 +103,15 @@ msgstr "Symbol network name to use for generating address"
 msgid "argument-help-pemview-show-private"
 msgstr "output private key to console too"
 
-#: shoestring/commands/renew_certificates.py:37
+#: shoestring/commands/renew_certificates.py:43
+msgid "argument-help-renew-certificates-force"
+msgstr "force overwrite of certificates"
+
+#: shoestring/commands/renew_certificates.py:41
 msgid "argument-help-renew-certificates-renew-ca"
 msgstr "renews CA certificate too"
 
-#: shoestring/commands/renew_certificates.py:38
+#: shoestring/commands/renew_certificates.py:42
 msgid "argument-help-renew-certificates-retain-node-key"
 msgstr "retain node key"
 

--- a/tools/shoestring/shoestring/lang/ja/LC_MESSAGES/messages.po
+++ b/tools/shoestring/shoestring/lang/ja/LC_MESSAGES/messages.po
@@ -18,7 +18,7 @@ msgid "argument-help-announce-transaction-transaction"
 msgstr "送信するシリアライズ済みトランザクションファイル"
 
 #: shoestring/commands/min_cosignatures_count.py:35
-#: shoestring/commands/renew_certificates.py:36
+#: shoestring/commands/renew_certificates.py:40
 #: shoestring/commands/setup.py:155 shoestring/commands/signer.py:93
 msgid "argument-help-ca-key-path"
 msgstr "メイン秘密鍵PEMファイルへのパス"
@@ -27,7 +27,7 @@ msgstr "メイン秘密鍵PEMファイルへのパス"
 #: shoestring/commands/health.py:74 shoestring/commands/import_bootstrap.py:49
 #: shoestring/commands/import_harvesters.py:97 shoestring/commands/init.py:29
 #: shoestring/commands/min_cosignatures_count.py:34
-#: shoestring/commands/renew_certificates.py:34
+#: shoestring/commands/renew_certificates.py:38
 #: shoestring/commands/renew_voting_keys.py:112
 #: shoestring/commands/reset_data.py:86 shoestring/commands/setup.py:147
 #: shoestring/commands/signer.py:92
@@ -35,7 +35,7 @@ msgid "argument-help-config"
 msgstr "shoestring設定ファイルへのパス"
 
 #: shoestring/commands/health.py:75
-#: shoestring/commands/renew_certificates.py:35
+#: shoestring/commands/renew_certificates.py:39
 #: shoestring/commands/renew_voting_keys.py:113
 #: shoestring/commands/reset_data.py:87 shoestring/commands/setup.py:149
 msgid "argument-help-directory"
@@ -101,11 +101,15 @@ msgstr ""
 msgid "argument-help-pemview-show-private"
 msgstr ""
 
-#: shoestring/commands/renew_certificates.py:37
+#: shoestring/commands/renew_certificates.py:43
+msgid "argument-help-renew-certificates-force"
+msgstr ""
+
+#: shoestring/commands/renew_certificates.py:41
 msgid "argument-help-renew-certificates-renew-ca"
 msgstr "CA証明書も更新"
 
-#: shoestring/commands/renew_certificates.py:38
+#: shoestring/commands/renew_certificates.py:42
 msgid "argument-help-renew-certificates-retain-node-key"
 msgstr "ノードキーを保持"
 

--- a/tools/shoestring/shoestring/lang/messages.pot
+++ b/tools/shoestring/shoestring/lang/messages.pot
@@ -11,7 +11,7 @@ msgid "argument-help-announce-transaction-transaction"
 msgstr ""
 
 #: shoestring/commands/min_cosignatures_count.py:35
-#: shoestring/commands/renew_certificates.py:36
+#: shoestring/commands/renew_certificates.py:40
 #: shoestring/commands/setup.py:155 shoestring/commands/signer.py:93
 msgid "argument-help-ca-key-path"
 msgstr ""
@@ -20,7 +20,7 @@ msgstr ""
 #: shoestring/commands/health.py:74 shoestring/commands/import_bootstrap.py:49
 #: shoestring/commands/import_harvesters.py:97 shoestring/commands/init.py:29
 #: shoestring/commands/min_cosignatures_count.py:34
-#: shoestring/commands/renew_certificates.py:34
+#: shoestring/commands/renew_certificates.py:38
 #: shoestring/commands/renew_voting_keys.py:112
 #: shoestring/commands/reset_data.py:86 shoestring/commands/setup.py:147
 #: shoestring/commands/signer.py:92
@@ -28,7 +28,7 @@ msgid "argument-help-config"
 msgstr ""
 
 #: shoestring/commands/health.py:75
-#: shoestring/commands/renew_certificates.py:35
+#: shoestring/commands/renew_certificates.py:39
 #: shoestring/commands/renew_voting_keys.py:113
 #: shoestring/commands/reset_data.py:87 shoestring/commands/setup.py:149
 msgid "argument-help-directory"
@@ -94,11 +94,15 @@ msgstr ""
 msgid "argument-help-pemview-show-private"
 msgstr ""
 
-#: shoestring/commands/renew_certificates.py:37
+#: shoestring/commands/renew_certificates.py:43
+msgid "argument-help-renew-certificates-force"
+msgstr ""
+
+#: shoestring/commands/renew_certificates.py:41
 msgid "argument-help-renew-certificates-renew-ca"
 msgstr ""
 
-#: shoestring/commands/renew_certificates.py:38
+#: shoestring/commands/renew_certificates.py:42
 msgid "argument-help-renew-certificates-retain-node-key"
 msgstr ""
 

--- a/tools/shoestring/tests/commands/test_renew_certificates.py
+++ b/tools/shoestring/tests/commands/test_renew_certificates.py
@@ -41,11 +41,11 @@ def _assert_node_full_certificate(ca_certificate_filepath, node_certificate_file
 	assert node_full_crt_data == node_crt_data + ca_crt_data
 
 
-async def _assert_can_renew_node_certificate(ca_password=None, retain_key=False):
+async def _assert_can_renew_node_certificate(ca_password=None, retain_key=False, use_relative_path=False):
 	# pylint: disable=too-many-locals
 
 	# Arrange:
-	with tempfile.TemporaryDirectory() as output_directory:
+	with tempfile.TemporaryDirectory(dir=os.getcwd() if use_relative_path else None) as output_directory:
 		config_filepath_1 = _create_configuration(output_directory, ca_password, 'ORIGINAL CA CN', 'ORIGINAL NODE CN', '1.shoestring.ini')
 		config_filepath_2 = _create_configuration(output_directory, ca_password, 'ORIGINAL CA CN', 'NEW NODE CN', '2.shoestring.ini')
 		preparer = Preparer(output_directory, parse_shoestring_configuration(config_filepath_1))
@@ -71,6 +71,8 @@ async def _assert_can_renew_node_certificate(ca_password=None, retain_key=False)
 		node_key_path = preparer.directories.certificates / 'node.key.pem'
 		node_key_data = _load_binary_file_data(node_key_path)
 
+		node_path = output_directory if not use_relative_path else str(Path(output_directory).relative_to(os.getcwd()))
+
 		# Sanity:
 		assert_certificate_properties(node_certificate_path, 'ORIGINAL CA CN', 'ORIGINAL NODE CN', 375)
 		assert_certificate_properties(ca_certificate_path, 'ORIGINAL CA CN', 'ORIGINAL CA CN', 20 * 365)
@@ -79,7 +81,7 @@ async def _assert_can_renew_node_certificate(ca_password=None, retain_key=False)
 		await main([
 			'renew-certificates',
 			'--config', str(config_filepath_2),
-			'--directory', output_directory,
+			'--directory', node_path,
 			'--ca-key-path', str(ca_key_path),
 			*(['--retain-node-key'] if retain_key else [])
 		])
@@ -114,6 +116,8 @@ async def test_can_renew_node_certificate_with_ca_password():
 async def test_can_renew_node_certificate_with_retain_key():
 	await _assert_can_renew_node_certificate(retain_key=True)
 
+async def test_can_renew_node_certificate_with_relative_path():
+	await _assert_can_renew_node_certificate(use_relative_path=True)
 # endregion
 
 

--- a/tools/shoestring/tests/commands/test_renew_certificates.py
+++ b/tools/shoestring/tests/commands/test_renew_certificates.py
@@ -45,7 +45,12 @@ async def _assert_can_renew_node_certificate(ca_password=None, retain_key=False,
 	# pylint: disable=too-many-locals
 
 	# Arrange:
-	with tempfile.TemporaryDirectory(dir=os.getcwd() if use_relative_path else None) as output_directory:
+	if use_relative_path and not force:
+		# Set the temp directory to cwd so that temp and relative paths are resolved to the same filesystem.
+		# If install path and temp are on different filesystem device then --force has to be used.
+		tempfile.tempdir = os.getcwd()
+
+	with tempfile.TemporaryDirectory() as output_directory:
 		config_filepath_1 = _create_configuration(output_directory, ca_password, 'ORIGINAL CA CN', 'ORIGINAL NODE CN', '1.shoestring.ini')
 		config_filepath_2 = _create_configuration(output_directory, ca_password, 'ORIGINAL CA CN', 'NEW NODE CN', '2.shoestring.ini')
 		preparer = Preparer(output_directory, parse_shoestring_configuration(config_filepath_1))
@@ -119,6 +124,14 @@ async def test_can_renew_node_certificate_with_retain_key():
 
 
 async def test_can_renew_node_certificate_with_relative_path():
+	await _assert_can_renew_node_certificate(use_relative_path=True)
+
+
+async def test_can_renew_node_certificate_with_force():
+	await _assert_can_renew_node_certificate(force=True)
+
+
+async def test_can_renew_node_certificate_with_relative_path_and_force():
 	await _assert_can_renew_node_certificate(use_relative_path=True, force=True)
 
 # endregion

--- a/tools/shoestring/tests/commands/test_renew_certificates.py
+++ b/tools/shoestring/tests/commands/test_renew_certificates.py
@@ -116,6 +116,7 @@ async def test_can_renew_node_certificate_with_ca_password():
 async def test_can_renew_node_certificate_with_retain_key():
 	await _assert_can_renew_node_certificate(retain_key=True)
 
+
 async def test_can_renew_node_certificate_with_relative_path():
 	await _assert_can_renew_node_certificate(use_relative_path=True)
 # endregion

--- a/tools/shoestring/tests/commands/test_renew_certificates.py
+++ b/tools/shoestring/tests/commands/test_renew_certificates.py
@@ -71,7 +71,7 @@ async def _assert_can_renew_node_certificate(ca_password=None, retain_key=False,
 		node_key_path = preparer.directories.certificates / 'node.key.pem'
 		node_key_data = _load_binary_file_data(node_key_path)
 
-		node_path = output_directory if not use_relative_path else str(Path(output_directory).relative_to(os.getcwd()))
+		node_path = Path(output_directory) if not use_relative_path else Path(output_directory).relative_to(os.getcwd())
 
 		# Sanity:
 		assert_certificate_properties(node_certificate_path, 'ORIGINAL CA CN', 'ORIGINAL NODE CN', 375)
@@ -81,7 +81,7 @@ async def _assert_can_renew_node_certificate(ca_password=None, retain_key=False,
 		await main([
 			'renew-certificates',
 			'--config', str(config_filepath_2),
-			'--directory', node_path,
+			'--directory', str(node_path),
 			'--ca-key-path', str(ca_key_path),
 			*(['--retain-node-key'] if retain_key else [])
 		])

--- a/tools/shoestring/tests/commands/test_renew_certificates.py
+++ b/tools/shoestring/tests/commands/test_renew_certificates.py
@@ -119,6 +119,7 @@ async def test_can_renew_node_certificate_with_retain_key():
 
 async def test_can_renew_node_certificate_with_relative_path():
 	await _assert_can_renew_node_certificate(use_relative_path=True)
+
 # endregion
 
 

--- a/tools/shoestring/tests/commands/test_renew_certificates.py
+++ b/tools/shoestring/tests/commands/test_renew_certificates.py
@@ -41,7 +41,7 @@ def _assert_node_full_certificate(ca_certificate_filepath, node_certificate_file
 	assert node_full_crt_data == node_crt_data + ca_crt_data
 
 
-async def _assert_can_renew_node_certificate(ca_password=None, retain_key=False, use_relative_path=False):
+async def _assert_can_renew_node_certificate(ca_password=None, retain_key=False, use_relative_path=False, force=False):
 	# pylint: disable=too-many-locals
 
 	# Arrange:
@@ -83,7 +83,8 @@ async def _assert_can_renew_node_certificate(ca_password=None, retain_key=False,
 			'--config', str(config_filepath_2),
 			'--directory', str(node_path),
 			'--ca-key-path', str(ca_key_path),
-			*(['--retain-node-key'] if retain_key else [])
+			*(['--retain-node-key'] if retain_key else []),
+			*(['--force'] if force else [])
 		])
 
 		# Assert: node certificate is regenerated (subject changed)
@@ -118,7 +119,7 @@ async def test_can_renew_node_certificate_with_retain_key():
 
 
 async def test_can_renew_node_certificate_with_relative_path():
-	await _assert_can_renew_node_certificate(use_relative_path=True)
+	await _assert_can_renew_node_certificate(use_relative_path=True, force=True)
 
 # endregion
 

--- a/tools/shoestring/tests/internal/test_CertificateFactory.py
+++ b/tools/shoestring/tests/internal/test_CertificateFactory.py
@@ -11,6 +11,8 @@ from shoestring.internal.OpensslExecutor import OpensslExecutor
 
 
 class CertificateFactoryTest(unittest.TestCase):
+	# pylint: disable=too-many-public-methods
+
 	# region common utils
 
 	@staticmethod
@@ -378,7 +380,6 @@ class CertificateFactoryTest(unittest.TestCase):
 			with tempfile.TemporaryDirectory() as ca_directory:
 				ca_key_path = self._create_ca_private_key(ca_directory)
 				with CertificateFactory(self._create_executor(), ca_key_path) as factory:
-
 					# Act + Assert: should not raise even when files are absent
 					factory.remove_package_files(cert_directory)
 					factory.remove_package_files(cert_directory, 'node')
@@ -392,10 +393,14 @@ class CertificateFactoryTest(unittest.TestCase):
 			extra_file = Path(cert_directory) / 'other.txt'
 			extra_file.write_text('keep me', encoding='utf8')
 
+			# Sanity:
+			self.assertEqual(6, len(os.listdir(cert_directory)))
+
 			# Act:
 			self._remove_cert_package(cert_directory)
 
 			# Assert: unrelated file is untouched
+			self.assertEqual(1, len(os.listdir(cert_directory)))
 			self.assertTrue(extra_file.exists())
 			self.assertEqual('keep me', extra_file.read_text(encoding='utf8'))
 

--- a/tools/shoestring/tests/internal/test_CertificateFactory.py
+++ b/tools/shoestring/tests/internal/test_CertificateFactory.py
@@ -314,6 +314,93 @@ class CertificateFactoryTest(unittest.TestCase):
 
 	# endregion
 
+	# region remove_package_files
+
+	def _create_cert_package(self, package_directory):
+		with tempfile.TemporaryDirectory() as ca_directory:
+			ca_key_path = self._create_ca_private_key(ca_directory)
+			with CertificateFactory(self._create_executor(), ca_key_path) as factory:
+				factory.extract_ca_public_key()
+				factory.generate_random_node_private_key()
+				factory.generate_ca_certificate('my CA common name')
+				factory.generate_node_certificate('my NODE common name')
+				factory.create_node_certificate_chain()
+				factory.package(package_directory)
+
+	def _remove_cert_package(self, package_directory, package_filter=''):
+		with CertificateFactory(self._create_executor(), package_directory) as factory:
+			factory.remove_package_files(package_directory, package_filter)
+
+	def test_remove_package_files_removes_all_files_when_no_filter(self):
+		# Arrange:
+		with tempfile.TemporaryDirectory() as cert_directory:
+			self._create_cert_package(cert_directory)
+			all_cert_files = ['node.crt.pem', 'node.key.pem', 'ca.pubkey.pem', 'ca.crt.pem', 'node.full.crt.pem']
+
+			# Act:
+			self._remove_cert_package(cert_directory)
+
+			# Assert: all certificate files are removed
+			for filename in all_cert_files:
+				self.assertFalse((Path(cert_directory) / filename).exists(), f'{filename} should have been removed')
+
+	def test_remove_package_files_removes_only_node_files_when_node_filter(self):
+		# Arrange:
+		with tempfile.TemporaryDirectory() as cert_directory:
+			self._create_cert_package(cert_directory)
+
+			# Act:
+			self._remove_cert_package(cert_directory, 'node')
+
+			# Assert: only node files are removed, ca files are untouched
+			for filename in ['node.crt.pem', 'node.key.pem', 'node.full.crt.pem']:
+				self.assertFalse((Path(cert_directory) / filename).exists(), f'{filename} should have been removed')
+			for filename in ['ca.pubkey.pem', 'ca.crt.pem']:
+				self.assertTrue((Path(cert_directory) / filename).exists(), f'{filename} should still exist')
+
+	def test_remove_package_files_removes_only_ca_files_when_ca_filter(self):
+		# Arrange:
+		with tempfile.TemporaryDirectory() as cert_directory:
+			self._create_cert_package(cert_directory)
+
+			# Act:
+			self._remove_cert_package(cert_directory, 'ca')
+
+			# Assert:
+			for filename in ['ca.pubkey.pem', 'ca.crt.pem']:
+				self.assertFalse((Path(cert_directory) / filename).exists(), f'{filename} should have been removed')
+			for filename in ['node.crt.pem', 'node.key.pem', 'node.full.crt.pem']:
+				self.assertTrue((Path(cert_directory) / filename).exists(), f'{filename} should still exist')
+
+	def test_remove_package_files_succeeds_when_files_do_not_exist(self):
+		# Arrange:
+		with tempfile.TemporaryDirectory() as cert_directory:
+			with tempfile.TemporaryDirectory() as ca_directory:
+				ca_key_path = self._create_ca_private_key(ca_directory)
+				with CertificateFactory(self._create_executor(), ca_key_path) as factory:
+
+					# Act + Assert: should not raise even when files are absent
+					factory.remove_package_files(cert_directory)
+					factory.remove_package_files(cert_directory, 'node')
+					factory.remove_package_files(cert_directory, 'ca')
+
+	def test_remove_package_files_does_not_remove_non_certificate_files(self):
+		# Arrange:
+		with tempfile.TemporaryDirectory() as cert_directory:
+			self._create_cert_package(cert_directory)
+
+			extra_file = Path(cert_directory) / 'other.txt'
+			extra_file.write_text('keep me', encoding='utf8')
+
+			# Act:
+			self._remove_cert_package(cert_directory)
+
+			# Assert: unrelated file is untouched
+			self.assertTrue(extra_file.exists())
+			self.assertEqual('keep me', extra_file.read_text(encoding='utf8'))
+
+	# endregion
+
 	# region packaging
 
 	def _assert_all_files_read_only(self, directory, expected_files):


### PR DESCRIPTION
problem: renew-certificates fails to find the CA certificate file when a relative path is used
solution: convert the relative path to an absolute one, which allows finding the certs folder

[tools/shoestring] fix: file move fails
problem: shutil.move() uses copy2() function for cross-device files.
         copy fails to open the file as 'rw' since they are readonly
solution: remove the destination file if it exist before the move()