### PR TITLE
[explorer/rest] feat: Added account statistics endpoint

### DIFF
--- a/explorer/rest/rest/__init__.py
+++ b/explorer/rest/rest/__init__.py
@@ -121,6 +121,10 @@ def setup_nem_routes(app, nem_api_facade):  # pylint: disable=too-many-statement
 
 		return jsonify(result)
 
+	@app.route('/api/nem/account/statistics')
+	def api_get_nem_account_statistics():
+		return jsonify(nem_api_facade.get_account_statistics())
+
 	@app.route('/api/nem/health')
 	async def api_get_nem_health():
 		result = await nem_api_facade.get_health()

--- a/explorer/rest/rest/db/NemDatabase.py
+++ b/explorer/rest/rest/db/NemDatabase.py
@@ -8,6 +8,7 @@ from rest.model.Account import AccountView
 from rest.model.Block import BlockView
 from rest.model.Mosaic import MosaicRichListView, MosaicView
 from rest.model.Namespace import NamespaceView
+from rest.model.Statistic import StatisticAccountView
 from rest.model.Transaction import TransactionRecord, TransactionView
 
 from .DatabaseConnection import DatabaseConnectionPool
@@ -102,6 +103,25 @@ class NemDatabase(DatabaseConnectionPool):
 			min_cosignatories=min_cosignatories,
 			cosignatory_of=[_format_address_bytes_to_string(address) for address in cosignatory_of] if cosignatory_of else None,
 			cosignatories=[_format_address_bytes_to_string(address) for address in cosignatories] if cosignatories else None
+		)
+
+	@staticmethod
+	def _create_account_statistic_view(result):
+
+		(
+			total_accounts,
+			accounts_with_balance,
+			harvested_accounts,
+			total_importance,
+			eligible_harvest_accounts
+		) = result
+
+		return StatisticAccountView(
+			total_accounts=total_accounts,
+			accounts_with_balance=accounts_with_balance,
+			harvested_accounts=harvested_accounts,
+			eligible_harvest_accounts=eligible_harvest_accounts,
+			total_importance=float(total_importance)
 		)
 
 	@staticmethod
@@ -448,6 +468,23 @@ class NemDatabase(DatabaseConnectionPool):
 			results = cursor.fetchall()
 
 			return [self._create_account_view(result) for result in results]
+
+	def get_account_statistics(self):
+		"""Gets account statistics from database."""
+
+		with self.connection() as connection:
+			cursor = connection.cursor()
+			cursor.execute('''
+				SELECT
+					(SELECT COUNT(*) FROM accounts) AS total_accounts,
+					(SELECT COUNT(*) FROM accounts WHERE balance > 0) AS accounts_with_balance,
+					(SELECT COUNT(*) FROM accounts WHERE harvested_blocks > 0) AS harvested_accounts,
+					COALESCE((SELECT SUM(importance) FROM accounts), 0) AS total_importance,
+					(SELECT COUNT(*) FROM accounts WHERE vested_balance > 10000) AS eligible_harvest_accounts
+			''')
+			result = cursor.fetchone()
+
+			return self._create_account_statistic_view(result) if result else None
 
 	def get_namespace_by_name(self, name):
 		"""Gets namespace by root namespace or sub namespace name."""

--- a/explorer/rest/rest/db/NemDatabase.py
+++ b/explorer/rest/rest/db/NemDatabase.py
@@ -476,15 +476,16 @@ class NemDatabase(DatabaseConnectionPool):
 			cursor = connection.cursor()
 			cursor.execute('''
 				SELECT
-					(SELECT COUNT(*) FROM accounts) AS total_accounts,
-					(SELECT COUNT(*) FROM accounts WHERE balance > 0) AS accounts_with_balance,
-					(SELECT COUNT(*) FROM accounts WHERE harvested_blocks > 0) AS harvested_accounts,
-					COALESCE((SELECT SUM(importance) FROM accounts), 0) AS total_importance,
-					(SELECT COUNT(*) FROM accounts WHERE vested_balance > 10000) AS eligible_harvest_accounts
+					COUNT(*) AS total_accounts,
+					COUNT(*) FILTER (WHERE balance > 0) AS accounts_with_balance,
+					COUNT(*) FILTER (WHERE harvested_blocks > 0) AS harvested_accounts,
+					COALESCE(SUM(importance), 0) AS total_importance,
+					COUNT(*) FILTER (WHERE vested_balance > 10000) AS eligible_harvest_accounts
+				FROM accounts
 			''')
 			result = cursor.fetchone()
 
-			return self._create_account_statistic_view(result) if result else None
+			return self._create_account_statistic_view(result)
 
 	def get_namespace_by_name(self, name):
 		"""Gets namespace by root namespace or sub namespace name."""

--- a/explorer/rest/rest/facade/NemRestFacade.py
+++ b/explorer/rest/rest/facade/NemRestFacade.py
@@ -54,6 +54,13 @@ class NemRestFacade:
 
 		return [account.to_dict() for account in accounts]
 
+	def get_account_statistics(self):
+		"""Gets account statistics."""
+
+		account_statistics = self.nem_db.get_account_statistics()
+
+		return account_statistics.to_dict() if account_statistics else None
+
 	async def get_health(self):
 		"""Gets health of the node."""
 

--- a/explorer/rest/rest/facade/NemRestFacade.py
+++ b/explorer/rest/rest/facade/NemRestFacade.py
@@ -59,7 +59,7 @@ class NemRestFacade:
 
 		account_statistics = self.nem_db.get_account_statistics()
 
-		return account_statistics.to_dict() if account_statistics else None
+		return account_statistics.to_dict()
 
 	async def get_health(self):
 		"""Gets health of the node."""

--- a/explorer/rest/rest/model/Statistic.py
+++ b/explorer/rest/rest/model/Statistic.py
@@ -1,0 +1,27 @@
+class StatisticAccountView:  # pylint: disable=too-many-positional-arguments, too-many-arguments
+	def __init__(self, total_accounts, accounts_with_balance, harvested_accounts, total_importance, eligible_harvest_accounts):
+		""""Create account statistic view."""
+
+		self.total_accounts = total_accounts
+		self.accounts_with_balance = accounts_with_balance
+		self.harvested_accounts = harvested_accounts
+		self.total_importance = total_importance
+		self.eligible_harvest_accounts = eligible_harvest_accounts
+
+	def __eq__(self, other):
+		return isinstance(other, StatisticAccountView) and all([
+			self.total_accounts == other.total_accounts,
+			self.accounts_with_balance == other.accounts_with_balance,
+			self.harvested_accounts == other.harvested_accounts,
+			self.total_importance == other.total_importance,
+			self.eligible_harvest_accounts == other.eligible_harvest_accounts
+		])
+
+	def to_dict(self):
+		return {
+			'total': self.total_accounts,
+			'withBalance': self.accounts_with_balance,
+			'harvestedAccounts': self.harvested_accounts,
+			'totalImportance': self.total_importance,
+			'eligibleHarvestAccounts': self.eligible_harvest_accounts
+		}

--- a/explorer/rest/rest/model/Statistic.py
+++ b/explorer/rest/rest/model/Statistic.py
@@ -1,6 +1,6 @@
 class StatisticAccountView:  # pylint: disable=too-many-positional-arguments, too-many-arguments
 	def __init__(self, total_accounts, accounts_with_balance, harvested_accounts, total_importance, eligible_harvest_accounts):
-		""""Create account statistic view."""
+		"""Create account statistic view."""
 
 		self.total_accounts = total_accounts
 		self.accounts_with_balance = accounts_with_balance
@@ -18,6 +18,8 @@ class StatisticAccountView:  # pylint: disable=too-many-positional-arguments, to
 		])
 
 	def to_dict(self):
+		"""Formats the account statistic info as a dictionary."""
+
 		return {
 			'total': self.total_accounts,
 			'withBalance': self.accounts_with_balance,

--- a/explorer/rest/tests/db/test_NemDatabase.py
+++ b/explorer/rest/tests/db/test_NemDatabase.py
@@ -1,8 +1,8 @@
 from rest import Pagination, Sorting
 from rest.db.NemDatabase import NemDatabase
-from rest.model.Statistic import StatisticAccountView
 
 from ..test.DatabaseTestUtils import (
+	ACCOUNT_STATISTIC_VIEW,
 	ACCOUNT_VIEWS,
 	ACCOUNTS,
 	BLOCK_VIEWS,
@@ -320,12 +320,6 @@ class NemDatabaseTest(DatabaseTestBase):  # pylint: disable=too-many-public-meth
 		account_statistics = self.nem_db.get_account_statistics()
 
 		# Assert:
-		self.assertEqual(StatisticAccountView(
-			total_accounts=2,
-			accounts_with_balance=2,
-			harvested_accounts=2,
-			total_importance=0.2469120000,
-			eligible_harvest_accounts=2
-		), account_statistics)
+		self.assertEqual(ACCOUNT_STATISTIC_VIEW, account_statistics)
 
 	# endregion

--- a/explorer/rest/tests/db/test_NemDatabase.py
+++ b/explorer/rest/tests/db/test_NemDatabase.py
@@ -1,5 +1,6 @@
 from rest import Pagination, Sorting
 from rest.db.NemDatabase import NemDatabase
+from rest.model.Statistic import StatisticAccountView
 
 from ..test.DatabaseTestUtils import (
 	ACCOUNT_VIEWS,
@@ -309,3 +310,22 @@ class NemDatabaseTest(DatabaseTestBase):  # pylint: disable=too-many-public-meth
 
 		# Assert:
 		self.assertEqual(TRANSACTIONS_VIEWS[7], transaction_view)
+
+	# endregion
+
+	# region account statistics
+
+	def test_can_query_account_statistics(self):
+		# Act:
+		account_statistics = self.nem_db.get_account_statistics()
+
+		# Assert:
+		self.assertEqual(StatisticAccountView(
+			total_accounts=2,
+			accounts_with_balance=2,
+			harvested_accounts=2,
+			total_importance=0.2469120000,
+			eligible_harvest_accounts=2
+		), account_statistics)
+
+	# endregion

--- a/explorer/rest/tests/facade/test_NemRestFacade.py
+++ b/explorer/rest/tests/facade/test_NemRestFacade.py
@@ -401,3 +401,20 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 		)
 
 	# endregion
+
+	# region account statistics
+
+	def test_can_retrieve_account_statistics(self):
+		# Act:
+		account_statistics = self.nem_rest_facade.get_account_statistics()
+
+		# Assert:
+		self.assertEqual({
+			'total': 2,
+			'withBalance': 2,
+			'harvestedAccounts': 2,
+			'totalImportance': 0.2469120000,
+			'eligibleHarvestAccounts': 2
+		}, account_statistics)
+
+	# endregion

--- a/explorer/rest/tests/facade/test_NemRestFacade.py
+++ b/explorer/rest/tests/facade/test_NemRestFacade.py
@@ -7,6 +7,7 @@ from rest.facade.NemRestFacade import NemRestFacade
 from rest.model.common import Pagination, RestConfig, Sorting
 
 from ..test.DatabaseTestUtils import (
+	ACCOUNT_STATISTIC_VIEW,
 	ACCOUNT_VIEWS,
 	BLOCK_VIEWS,
 	MOSAIC_RICH_LIST_VIEWS,
@@ -25,6 +26,8 @@ EXPECTED_BLOCK_2 = BLOCK_VIEWS[1].to_dict()
 EXPECTED_ACCOUNT_1 = ACCOUNT_VIEWS[0].to_dict()
 
 EXPECTED_ACCOUNT_2 = ACCOUNT_VIEWS[1].to_dict()
+
+EXPECTED_ACCOUNT_STATISTIC = ACCOUNT_STATISTIC_VIEW.to_dict()
 
 EXPECTED_NAMESPACE_1 = NAMESPACE_VIEWS[0].to_dict()
 
@@ -409,12 +412,6 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 		account_statistics = self.nem_rest_facade.get_account_statistics()
 
 		# Assert:
-		self.assertEqual({
-			'total': 2,
-			'withBalance': 2,
-			'harvestedAccounts': 2,
-			'totalImportance': 0.2469120000,
-			'eligibleHarvestAccounts': 2
-		}, account_statistics)
+		self.assertEqual(EXPECTED_ACCOUNT_STATISTIC, account_statistics)
 
 	# endregion

--- a/explorer/rest/tests/model/test_Statistic.py
+++ b/explorer/rest/tests/model/test_Statistic.py
@@ -1,0 +1,61 @@
+import unittest
+
+from rest.model.Statistic import StatisticAccountView
+
+
+class StatisticAccountViewTest(unittest.TestCase):
+	@staticmethod
+	def _create_default_statistic_account_view(override=None):
+		statistic_account_view = StatisticAccountView(
+			total_accounts=100,
+			accounts_with_balance=80,
+			harvested_accounts=25,
+			total_importance=0.95,
+			eligible_harvest_accounts=12
+		)
+
+		if override:
+			setattr(statistic_account_view, override[0], override[1])
+
+		return statistic_account_view
+
+	def test_can_create_statistic_account_view(self):
+		# Act:
+		statistic_account_view = self._create_default_statistic_account_view()
+
+		# Assert:
+		self.assertEqual(100, statistic_account_view.total_accounts)
+		self.assertEqual(80, statistic_account_view.accounts_with_balance)
+		self.assertEqual(25, statistic_account_view.harvested_accounts)
+		self.assertEqual(0.95, statistic_account_view.total_importance)
+		self.assertEqual(12, statistic_account_view.eligible_harvest_accounts)
+
+	def test_can_convert_to_simple_dict(self):
+		# Arrange:
+		statistic_account_view = self._create_default_statistic_account_view()
+
+		# Act:
+		statistic_account_view_dict = statistic_account_view.to_dict()
+
+		# Assert:
+		self.assertEqual({
+			'total': 100,
+			'withBalance': 80,
+			'harvestedAccounts': 25,
+			'totalImportance': 0.95,
+			'eligibleHarvestAccounts': 12
+		}, statistic_account_view_dict)
+
+	def test_eq_is_supported(self):
+		# Arrange:
+		statistic_account_view = self._create_default_statistic_account_view()
+
+		# Assert:
+		self.assertEqual(statistic_account_view, self._create_default_statistic_account_view())
+		self.assertNotEqual(statistic_account_view, None)
+		self.assertNotEqual(statistic_account_view, 'statistic_account_view')
+		self.assertNotEqual(statistic_account_view, self._create_default_statistic_account_view(('total_accounts', 101)))
+		self.assertNotEqual(statistic_account_view, self._create_default_statistic_account_view(('accounts_with_balance', 81)))
+		self.assertNotEqual(statistic_account_view, self._create_default_statistic_account_view(('harvested_accounts', 26)))
+		self.assertNotEqual(statistic_account_view, self._create_default_statistic_account_view(('total_importance', 0.96)))
+		self.assertNotEqual(statistic_account_view, self._create_default_statistic_account_view(('eligible_harvest_accounts', 13)))

--- a/explorer/rest/tests/test/DatabaseTestUtils.py
+++ b/explorer/rest/tests/test/DatabaseTestUtils.py
@@ -13,6 +13,7 @@ from rest.model.Account import AccountView
 from rest.model.Block import BlockView
 from rest.model.Mosaic import MosaicRichListView, MosaicView
 from rest.model.Namespace import NamespaceView
+from rest.model.Statistic import StatisticAccountView
 from rest.model.Transaction import TransactionView
 
 Block = namedtuple(
@@ -508,6 +509,14 @@ ACCOUNT_VIEWS = [
 		cosignatories=ACCOUNTS[1].cosignatories
 	)
 ]
+
+ACCOUNT_STATISTIC_VIEW = StatisticAccountView(
+	total_accounts=2,
+	accounts_with_balance=2,
+	harvested_accounts=2,
+	total_importance=0.2469120000,
+	eligible_harvest_accounts=2
+)
 
 NAMESPACE_VIEWS = [
 	NamespaceView(

--- a/explorer/rest/tests/test_rest.py
+++ b/explorer/rest/tests/test_rest.py
@@ -616,7 +616,7 @@ def test_api_nem_account_statistics(client):  # pylint: disable=redefined-outer-
 
 	# Assert:
 	_assert_status_code_and_headers(response, 200)
-	assert ACCOUNT_STATISTIC_VIEW == response.json
+	assert ACCOUNT_STATISTIC_VIEW.to_dict() == response.json
 
 
 # endregion

--- a/explorer/rest/tests/test_rest.py
+++ b/explorer/rest/tests/test_rest.py
@@ -10,6 +10,7 @@ from symbollightapi.model.Exceptions import NodeException
 from rest import create_app
 
 from .test.DatabaseTestUtils import (
+	ACCOUNT_STATISTIC_VIEW,
 	ACCOUNT_VIEWS,
 	BLOCK_VIEWS,
 	MOSAIC_RICH_LIST_VIEWS,
@@ -603,3 +604,19 @@ def test_api_nem_transaction_by_hash(client):  # pylint: disable=redefined-outer
 	# Assert:
 	_assert_status_code_and_headers(response, 200)
 	assert TRANSACTIONS_VIEWS[0].to_dict() == response.json
+
+
+# endregion
+
+# region /account/statistics
+
+def test_api_nem_account_statistics(client):  # pylint: disable=redefined-outer-name
+	# Act:
+	response = client.get('/api/nem/account/statistics')
+
+	# Assert:
+	_assert_status_code_and_headers(response, 200)
+	assert ACCOUNT_STATISTIC_VIEW == response.json
+
+
+# endregion


### PR DESCRIPTION
Problem: Missing account statistic information.
Solution: Added `/account/statistics` endpoint, the statistical information included `total account`, `account with balance`, `harvested account`, `total important`, and `eligible harvest account.`
