### PR TITLE
[explorer/rest] feat: Added transaction statistics endpoint

### DIFF
--- a/explorer/rest/rest/__init__.py
+++ b/explorer/rest/rest/__init__.py
@@ -249,6 +249,10 @@ def setup_nem_routes(app, nem_api_facade):  # pylint: disable=too-many-statement
 
 		return jsonify(result)
 
+	@app.route('/api/nem/transaction/statistics')
+	def api_get_nem_transaction_statistics():
+		return jsonify(nem_api_facade.get_transaction_statistics())
+
 
 def setup_error_handlers(app):
 	@app.errorhandler(404)

--- a/explorer/rest/rest/db/NemDatabase.py
+++ b/explorer/rest/rest/db/NemDatabase.py
@@ -8,7 +8,7 @@ from rest.model.Account import AccountView
 from rest.model.Block import BlockView
 from rest.model.Mosaic import MosaicRichListView, MosaicView
 from rest.model.Namespace import NamespaceView
-from rest.model.Statistic import StatisticAccountView
+from rest.model.Statistic import StatisticAccountView, StatisticTransactionView
 from rest.model.Transaction import TransactionRecord, TransactionView
 
 from .DatabaseConnection import DatabaseConnectionPool
@@ -246,6 +246,21 @@ class NemDatabase(DatabaseConnectionPool):
 			timestamp=str(transaction.timestamp),
 			deadline=str(transaction.deadline),
 			signature=_format_bytes(transaction.signature)
+		)
+
+	@staticmethod
+	def _create_transaction_statistic_view(result):
+
+		(
+			total_transactions,
+			transaction_last_24_hours,
+			transaction_last_30_days
+		) = result
+
+		return StatisticTransactionView(
+			total_transactions=total_transactions,
+			transaction_last_24_hours=transaction_last_24_hours,
+			transaction_last_30_days=transaction_last_30_days
 		)
 
 	@staticmethod
@@ -676,3 +691,36 @@ class NemDatabase(DatabaseConnectionPool):
 			inner_transaction = self._get_transaction_query(inner_hash, is_inner=True)
 
 		return self._create_transaction_view(transaction, inner_transaction) if transaction else None
+
+	def get_transaction_statistics(self):
+		"""Gets transaction statistics from database."""
+
+		with self.connection() as connection:
+			cursor = connection.cursor()
+			cursor.execute('''
+				WITH latest_block AS (
+					SELECT MAX(timestamp) AS max_timestamp
+					FROM blocks
+				)
+				SELECT
+					COALESCE(SUM(b.total_transactions), 0) AS total_transactions,
+					COALESCE(SUM(
+						CASE
+							WHEN b.timestamp > lb.max_timestamp - INTERVAL '24 hours'
+							THEN b.total_transactions
+							ELSE 0
+						END
+					), 0) AS transaction_last_24_hours,
+					COALESCE(SUM(
+						CASE
+							WHEN b.timestamp > lb.max_timestamp - INTERVAL '30 days'
+							THEN b.total_transactions
+							ELSE 0
+						END
+					), 0) AS transaction_last_30_days
+				FROM blocks b
+				CROSS JOIN latest_block lb;
+			''')
+			result = cursor.fetchone()
+
+			return self._create_transaction_statistic_view(result) if result else None

--- a/explorer/rest/rest/facade/NemRestFacade.py
+++ b/explorer/rest/rest/facade/NemRestFacade.py
@@ -152,3 +152,10 @@ class NemRestFacade:
 		transaction = self.nem_db.get_transaction_by_hash(transaction_hash)
 
 		return transaction.to_dict() if transaction else None
+
+	def get_transaction_statistics(self):
+		"""Gets transaction statistics."""
+
+		transaction_statistics = self.nem_db.get_transaction_statistics()
+
+		return transaction_statistics.to_dict() if transaction_statistics else None

--- a/explorer/rest/rest/model/Statistic.py
+++ b/explorer/rest/rest/model/Statistic.py
@@ -27,3 +27,26 @@ class StatisticAccountView:  # pylint: disable=too-many-positional-arguments, to
 			'totalImportance': self.total_importance,
 			'eligibleHarvestAccounts': self.eligible_harvest_accounts
 		}
+
+
+class StatisticTransactionView:
+	def __init__(self, total_transactions, transaction_last_24_hours, transaction_last_30_days):
+		""""Create statistic view."""
+
+		self.total_transactions = total_transactions
+		self.transaction_last_24_hours = transaction_last_24_hours
+		self.transaction_last_30_days = transaction_last_30_days
+
+	def __eq__(self, other):
+		return isinstance(other, StatisticTransactionView) and all([
+			self.total_transactions == other.total_transactions,
+			self.transaction_last_24_hours == other.transaction_last_24_hours,
+			self.transaction_last_30_days == other.transaction_last_30_days
+		])
+
+	def to_dict(self):
+		return {
+			'total': self.total_transactions,
+			'last24Hours': self.transaction_last_24_hours,
+			'last30Days': self.transaction_last_30_days
+		}

--- a/explorer/rest/rest/model/Statistic.py
+++ b/explorer/rest/rest/model/Statistic.py
@@ -31,7 +31,7 @@ class StatisticAccountView:  # pylint: disable=too-many-positional-arguments, to
 
 class StatisticTransactionView:
 	def __init__(self, total_transactions, transaction_last_24_hours, transaction_last_30_days):
-		""""Create statistic view."""
+		"""Create statistic view."""
 
 		self.total_transactions = total_transactions
 		self.transaction_last_24_hours = transaction_last_24_hours
@@ -45,6 +45,8 @@ class StatisticTransactionView:
 		])
 
 	def to_dict(self):
+		"""Formats the transaction statistic info as a dictionary."""
+
 		return {
 			'total': self.total_transactions,
 			'last24Hours': self.transaction_last_24_hours,

--- a/explorer/rest/tests/db/test_NemDatabase.py
+++ b/explorer/rest/tests/db/test_NemDatabase.py
@@ -9,6 +9,7 @@ from ..test.DatabaseTestUtils import (
 	MOSAIC_RICH_LIST_VIEWS,
 	MOSAIC_VIEWS,
 	NAMESPACE_VIEWS,
+	TRANSACTION_STATISTIC_VIEW,
 	TRANSACTIONS_VIEWS,
 	DatabaseTestBase
 )
@@ -321,5 +322,16 @@ class NemDatabaseTest(DatabaseTestBase):  # pylint: disable=too-many-public-meth
 
 		# Assert:
 		self.assertEqual(ACCOUNT_STATISTIC_VIEW, account_statistics)
+
+	# endregion
+
+	# region transaction statistics
+
+	def test_can_query_transaction_statistics(self):
+		# Act:
+		transaction_statistics = self.nem_db.get_transaction_statistics()
+
+		# Assert:
+		self.assertEqual(TRANSACTION_STATISTIC_VIEW, transaction_statistics)
 
 	# endregion

--- a/explorer/rest/tests/facade/test_NemRestFacade.py
+++ b/explorer/rest/tests/facade/test_NemRestFacade.py
@@ -13,6 +13,7 @@ from ..test.DatabaseTestUtils import (
 	MOSAIC_RICH_LIST_VIEWS,
 	MOSAIC_VIEWS,
 	NAMESPACE_VIEWS,
+	TRANSACTION_STATISTIC_VIEW,
 	TRANSACTIONS_VIEWS,
 	DatabaseTestBase
 )
@@ -28,6 +29,8 @@ EXPECTED_ACCOUNT_1 = ACCOUNT_VIEWS[0].to_dict()
 EXPECTED_ACCOUNT_2 = ACCOUNT_VIEWS[1].to_dict()
 
 EXPECTED_ACCOUNT_STATISTIC = ACCOUNT_STATISTIC_VIEW.to_dict()
+
+EXPECTED_TRANSACTION_STATISTIC = TRANSACTION_STATISTIC_VIEW.to_dict()
 
 EXPECTED_NAMESPACE_1 = NAMESPACE_VIEWS[0].to_dict()
 
@@ -413,5 +416,16 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 
 		# Assert:
 		self.assertEqual(EXPECTED_ACCOUNT_STATISTIC, account_statistics)
+
+	# endregion
+
+	# region transaction statistics
+
+	def test_can_retrieve_transaction_statistics(self):
+		# Act:
+		transaction_statistics = self.nem_rest_facade.get_transaction_statistics()
+
+		# Assert:
+		self.assertEqual(EXPECTED_TRANSACTION_STATISTIC, transaction_statistics)
 
 	# endregion

--- a/explorer/rest/tests/model/test_Statistic.py
+++ b/explorer/rest/tests/model/test_Statistic.py
@@ -1,6 +1,6 @@
 import unittest
 
-from rest.model.Statistic import StatisticAccountView
+from rest.model.Statistic import StatisticAccountView, StatisticTransactionView
 
 
 class StatisticAccountViewTest(unittest.TestCase):
@@ -59,3 +59,53 @@ class StatisticAccountViewTest(unittest.TestCase):
 		self.assertNotEqual(statistic_account_view, self._create_default_statistic_account_view(('harvested_accounts', 26)))
 		self.assertNotEqual(statistic_account_view, self._create_default_statistic_account_view(('total_importance', 0.96)))
 		self.assertNotEqual(statistic_account_view, self._create_default_statistic_account_view(('eligible_harvest_accounts', 13)))
+
+
+class StatisticTransactionViewTest(unittest.TestCase):
+	@staticmethod
+	def _create_default_statistic_transaction_view(override=None):
+		statistic_transaction_view = StatisticTransactionView(
+			total_transactions=100,
+			transaction_last_24_hours=20,
+			transaction_last_30_days=50
+		)
+
+		if override:
+			setattr(statistic_transaction_view, override[0], override[1])
+
+		return statistic_transaction_view
+
+	def test_can_create_statistic_transaction_view(self):
+		# Act:
+		statistic_transaction_view = self._create_default_statistic_transaction_view()
+
+		# Assert:
+		self.assertEqual(100, statistic_transaction_view.total_transactions)
+		self.assertEqual(20, statistic_transaction_view.transaction_last_24_hours)
+		self.assertEqual(50, statistic_transaction_view.transaction_last_30_days)
+
+	def test_can_convert_to_simple_dict(self):
+		# Arrange:
+		statistic_transaction_view = self._create_default_statistic_transaction_view()
+
+		# Act:
+		statistic_transaction_view_dict = statistic_transaction_view.to_dict()
+
+		# Assert:
+		self.assertEqual({
+			'total': 100,
+			'last24Hours': 20,
+			'last30Days': 50
+		}, statistic_transaction_view_dict)
+
+	def test_eq_is_supported(self):
+		# Arrange:
+		statistic_transaction_view = self._create_default_statistic_transaction_view()
+
+		# Assert:
+		self.assertEqual(statistic_transaction_view, self._create_default_statistic_transaction_view())
+		self.assertNotEqual(statistic_transaction_view, None)
+		self.assertNotEqual(statistic_transaction_view, 'statistic_transaction_view')
+		self.assertNotEqual(statistic_transaction_view, self._create_default_statistic_transaction_view(('total_transactions', 101)))
+		self.assertNotEqual(statistic_transaction_view, self._create_default_statistic_transaction_view(('transaction_last_24_hours', 21)))
+		self.assertNotEqual(statistic_transaction_view, self._create_default_statistic_transaction_view(('transaction_last_30_days', 51)))

--- a/explorer/rest/tests/test/DatabaseTestUtils.py
+++ b/explorer/rest/tests/test/DatabaseTestUtils.py
@@ -13,7 +13,7 @@ from rest.model.Account import AccountView
 from rest.model.Block import BlockView
 from rest.model.Mosaic import MosaicRichListView, MosaicView
 from rest.model.Namespace import NamespaceView
-from rest.model.Statistic import StatisticAccountView
+from rest.model.Statistic import StatisticAccountView, StatisticTransactionView
 from rest.model.Transaction import TransactionView
 
 Block = namedtuple(
@@ -516,6 +516,12 @@ ACCOUNT_STATISTIC_VIEW = StatisticAccountView(
 	harvested_accounts=2,
 	total_importance=0.2469120000,
 	eligible_harvest_accounts=2
+)
+
+TRANSACTION_STATISTIC_VIEW = StatisticTransactionView(
+	total_transactions=8,
+	transaction_last_24_hours=8,
+	transaction_last_30_days=8
 )
 
 NAMESPACE_VIEWS = [

--- a/explorer/rest/tests/test_rest.py
+++ b/explorer/rest/tests/test_rest.py
@@ -16,6 +16,7 @@ from .test.DatabaseTestUtils import (
 	MOSAIC_RICH_LIST_VIEWS,
 	MOSAIC_VIEWS,
 	NAMESPACE_VIEWS,
+	TRANSACTION_STATISTIC_VIEW,
 	TRANSACTIONS_VIEWS,
 	DatabaseConfig,
 	initialize_database
@@ -617,6 +618,19 @@ def test_api_nem_account_statistics(client):  # pylint: disable=redefined-outer-
 	# Assert:
 	_assert_status_code_and_headers(response, 200)
 	assert ACCOUNT_STATISTIC_VIEW.to_dict() == response.json
+
+
+# endregion
+
+# region /transaction/statistics
+
+def test_api_nem_transaction_statistics(client):  # pylint: disable=redefined-outer-name
+	# Act:
+	response = client.get('/api/nem/transaction/statistics')
+
+	# Assert:
+	_assert_status_code_and_headers(response, 200)
+	assert TRANSACTION_STATISTIC_VIEW.to_dict() == response.json
 
 
 # endregion


### PR DESCRIPTION
Problem: Missing transaction statistic information.
Solution: Added `/transaction/statistics` endpoint, the statistical information included `total_transactions`, `transaction_last_24_hours`, and `transaction_last_30_days.`
