### PR TITLE
[explorer/rest] feat: Added transaction statistics date range endpoint

### DIFF
--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -47,6 +47,13 @@ class NemDatabase(DatabaseConnection):
 			'''
 		)
 
+		cursor.execute(
+			'''
+			CREATE INDEX IF NOT EXISTS idx_blocks_timestamp
+				ON blocks(timestamp)
+			'''
+		)
+
 		# Create indexes for namespaces table
 		cursor.execute(
 			'''

--- a/explorer/rest/rest/__init__.py
+++ b/explorer/rest/rest/__init__.py
@@ -1,4 +1,5 @@
 import configparser
+from datetime import date
 from pathlib import Path
 
 from flask import Flask, abort, jsonify, request
@@ -50,7 +51,7 @@ def setup_nem_facade(app):
 	return NemRestFacade(db_params, rest_config)
 
 
-def setup_nem_routes(app, nem_api_facade):  # pylint: disable=too-many-statements
+def setup_nem_routes(app, nem_api_facade):  # pylint: disable=too-many-statements, too-many-locals
 	@app.route('/api/nem/block/<height>')
 	def api_get_nem_block_by_height(height):
 		try:
@@ -252,6 +253,29 @@ def setup_nem_routes(app, nem_api_facade):  # pylint: disable=too-many-statement
 	@app.route('/api/nem/transaction/statistics')
 	def api_get_nem_transaction_statistics():
 		return jsonify(nem_api_facade.get_transaction_statistics())
+
+	@app.route('/api/nem/transaction/statistics/range')
+	def api_get_nem_transaction_statistics_by_date_range():  # pylint: disable=invalid-name
+		start_date = request.args.get('startDate', '').strip()
+		end_date = request.args.get('endDate', '').strip()
+		period_type = request.args.get('periodType', '').strip().upper()
+
+		if not start_date or not end_date or not period_type:
+			abort(400, 'startDate, endDate and period type are required')
+
+		try:
+			start_date = date.fromisoformat(start_date)
+			end_date = date.fromisoformat(end_date)
+
+			if start_date > end_date:
+				raise ValueError('start date must be less than or equal to end date')
+			if period_type not in ['DAY', 'MONTH']:
+				raise ValueError('Period type must be either DAY or MONTH')
+
+		except ValueError as error:
+			abort(400, error)
+
+		return jsonify(nem_api_facade.get_transaction_statistics_by_date_range(start_date, end_date, period_type))
 
 
 def setup_error_handlers(app):

--- a/explorer/rest/rest/db/NemDatabase.py
+++ b/explorer/rest/rest/db/NemDatabase.py
@@ -743,7 +743,7 @@ class NemDatabase(DatabaseConnectionPool):
 
 			return self._create_transaction_statistic_view(result) if result else None
 
-	def get_transaction_statistics_by_date_range(self, start_date, end_date, period_type):
+	def get_transaction_statistics_by_date_range(self, start_date, end_date, period_type):  # pylint: disable=invalid-name
 		"""Gets transaction statistics grouped by period from database."""
 
 		period_format = 'YYYY-MM-DD' if 'DAY' == period_type else 'YYYY-MM'
@@ -753,7 +753,7 @@ class NemDatabase(DatabaseConnectionPool):
 				TO_CHAR(DATE_TRUNC('{period_type}', timestamp), '{period_format}') AS period,
 				COALESCE(SUM(total_transactions), 0) AS total_transactions
 			FROM blocks
-			WHERE timestamp >= %s AND timestamp < %s + INTERVAL '1 day'
+			WHERE timestamp >= %s::date AND timestamp < %s::date + INTERVAL '1 day'
 			GROUP BY DATE_TRUNC('{period_type}', timestamp)
 			ORDER BY DATE_TRUNC('{period_type}', timestamp) ASC
 		'''

--- a/explorer/rest/rest/db/NemDatabase.py
+++ b/explorer/rest/rest/db/NemDatabase.py
@@ -8,7 +8,12 @@ from rest.model.Account import AccountView
 from rest.model.Block import BlockView
 from rest.model.Mosaic import MosaicRichListView, MosaicView
 from rest.model.Namespace import NamespaceView
-from rest.model.Statistic import StatisticAccountView, StatisticTransactionView
+from rest.model.Statistic import (
+	StatisticAccountView,
+	StatisticTransactionDateRangeDataView,
+	StatisticTransactionDateRangeView,
+	StatisticTransactionView
+)
 from rest.model.Transaction import TransactionRecord, TransactionView
 
 from .DatabaseConnection import DatabaseConnectionPool
@@ -261,6 +266,19 @@ class NemDatabase(DatabaseConnectionPool):
 			total_transactions=total_transactions,
 			transaction_last_24_hours=transaction_last_24_hours,
 			transaction_last_30_days=transaction_last_30_days
+		)
+
+	@staticmethod
+	def _create_transaction_date_range_statistic_view(results, period_type):
+
+		return StatisticTransactionDateRangeView(
+			period_type=period_type,
+			data=[
+				StatisticTransactionDateRangeDataView(
+					period=period,
+					total_transactions=total_transactions
+				) for period, total_transactions in results
+			]
 		)
 
 	@staticmethod
@@ -724,3 +742,25 @@ class NemDatabase(DatabaseConnectionPool):
 			result = cursor.fetchone()
 
 			return self._create_transaction_statistic_view(result) if result else None
+
+	def get_transaction_statistics_by_date_range(self, start_date, end_date, period_type):
+		"""Gets transaction statistics grouped by period from database."""
+
+		period_format = 'YYYY-MM-DD' if 'DAY' == period_type else 'YYYY-MM'
+
+		sql = f'''
+			SELECT
+				TO_CHAR(DATE_TRUNC('{period_type}', timestamp), '{period_format}') AS period,
+				COALESCE(SUM(total_transactions), 0) AS total_transactions
+			FROM blocks
+			WHERE timestamp >= %s AND timestamp < %s + INTERVAL '1 day'
+			GROUP BY DATE_TRUNC('{period_type}', timestamp)
+			ORDER BY DATE_TRUNC('{period_type}', timestamp) ASC
+		'''
+
+		with self.connection() as connection:
+			cursor = connection.cursor()
+			cursor.execute(sql, (start_date, end_date))
+			results = cursor.fetchall()
+
+			return self._create_transaction_date_range_statistic_view(results, period_type)

--- a/explorer/rest/rest/facade/NemRestFacade.py
+++ b/explorer/rest/rest/facade/NemRestFacade.py
@@ -159,3 +159,10 @@ class NemRestFacade:
 		transaction_statistics = self.nem_db.get_transaction_statistics()
 
 		return transaction_statistics.to_dict() if transaction_statistics else None
+
+	def get_transaction_statistics_by_date_range(self, start_date, end_date, period_type):  # pylint: disable=invalid-name
+		"""Gets transaction statistics grouped by period type."""
+
+		transaction_statistics = self.nem_db.get_transaction_statistics_by_date_range(start_date, end_date, period_type)
+
+		return transaction_statistics.to_dict() if transaction_statistics else None

--- a/explorer/rest/rest/model/Statistic.py
+++ b/explorer/rest/rest/model/Statistic.py
@@ -52,3 +52,43 @@ class StatisticTransactionView:
 			'last24Hours': self.transaction_last_24_hours,
 			'last30Days': self.transaction_last_30_days
 		}
+
+
+class StatisticTransactionDateRangeDataView:
+	def __init__(self, period, total_transactions):
+		""""Create transaction statistic date range data view."""
+
+		self.period = period
+		self.total_transactions = total_transactions
+
+	def __eq__(self, other):
+		return isinstance(other, StatisticTransactionDateRangeDataView) and all([
+			self.period == other.period,
+			self.total_transactions == other.total_transactions
+		])
+
+	def to_dict(self):
+		return {
+			'period': self.period,
+			'totalTransactions': self.total_transactions
+		}
+
+
+class StatisticTransactionDateRangeView:
+	def __init__(self, period_type, data):
+		""""Create transaction statistic date range view."""
+
+		self.period_type = period_type
+		self.data = data
+
+	def __eq__(self, other):
+		return isinstance(other, StatisticTransactionDateRangeView) and all([
+			self.period_type == other.period_type,
+			self.data == other.data
+		])
+
+	def to_dict(self):
+		return {
+			'periodType': self.period_type.lower(),
+			'data': [item.to_dict() for item in self.data]
+		}

--- a/explorer/rest/rest/model/Statistic.py
+++ b/explorer/rest/rest/model/Statistic.py
@@ -56,7 +56,7 @@ class StatisticTransactionView:
 
 class StatisticTransactionDateRangeDataView:
 	def __init__(self, period, total_transactions):
-		""""Create transaction statistic date range data view."""
+		"""Create transaction statistic date range data view."""
 
 		self.period = period
 		self.total_transactions = total_transactions
@@ -68,6 +68,8 @@ class StatisticTransactionDateRangeDataView:
 		])
 
 	def to_dict(self):
+		"""Formats the transaction statistic date range data as a dictionary."""
+
 		return {
 			'period': self.period,
 			'totalTransactions': self.total_transactions
@@ -76,7 +78,7 @@ class StatisticTransactionDateRangeDataView:
 
 class StatisticTransactionDateRangeView:
 	def __init__(self, period_type, data):
-		""""Create transaction statistic date range view."""
+		"""Create transaction statistic date range view."""
 
 		self.period_type = period_type
 		self.data = data
@@ -88,6 +90,8 @@ class StatisticTransactionDateRangeView:
 		])
 
 	def to_dict(self):
+		"""Formats the transaction statistic date range as a dictionary."""
+
 		return {
 			'periodType': self.period_type.lower(),
 			'data': [item.to_dict() for item in self.data]

--- a/explorer/rest/tests/db/test_NemDatabase.py
+++ b/explorer/rest/tests/db/test_NemDatabase.py
@@ -9,6 +9,8 @@ from ..test.DatabaseTestUtils import (
 	MOSAIC_RICH_LIST_VIEWS,
 	MOSAIC_VIEWS,
 	NAMESPACE_VIEWS,
+	TRANSACTION_DAILY_STATISTIC_VIEW,
+	TRANSACTION_MONTH_STATISTIC_VIEW,
 	TRANSACTION_STATISTIC_VIEW,
 	TRANSACTIONS_VIEWS,
 	DatabaseTestBase
@@ -333,5 +335,19 @@ class NemDatabaseTest(DatabaseTestBase):  # pylint: disable=too-many-public-meth
 
 		# Assert:
 		self.assertEqual(TRANSACTION_STATISTIC_VIEW, transaction_statistics)
+
+	def test_can_query_transaction_statistics_grouped_daily(self):
+		# Act:
+		transaction_statistics = self.nem_db.get_transaction_statistics_by_date_range('2015-03-29', '2015-03-29', 'DAY')
+
+		# Assert:
+		self.assertEqual(TRANSACTION_DAILY_STATISTIC_VIEW, transaction_statistics)
+
+	def test_can_query_transaction_statistics_grouped_month(self):
+		# Act:
+		transaction_statistics = self.nem_db.get_transaction_statistics_by_date_range('2015-03-01', '2015-03-31', 'MONTH')
+
+		# Assert:
+		self.assertEqual(TRANSACTION_MONTH_STATISTIC_VIEW, transaction_statistics)
 
 	# endregion

--- a/explorer/rest/tests/facade/test_NemRestFacade.py
+++ b/explorer/rest/tests/facade/test_NemRestFacade.py
@@ -13,6 +13,8 @@ from ..test.DatabaseTestUtils import (
 	MOSAIC_RICH_LIST_VIEWS,
 	MOSAIC_VIEWS,
 	NAMESPACE_VIEWS,
+	TRANSACTION_DAILY_STATISTIC_VIEW,
+	TRANSACTION_MONTH_STATISTIC_VIEW,
 	TRANSACTION_STATISTIC_VIEW,
 	TRANSACTIONS_VIEWS,
 	DatabaseTestBase
@@ -31,6 +33,10 @@ EXPECTED_ACCOUNT_2 = ACCOUNT_VIEWS[1].to_dict()
 EXPECTED_ACCOUNT_STATISTIC = ACCOUNT_STATISTIC_VIEW.to_dict()
 
 EXPECTED_TRANSACTION_STATISTIC = TRANSACTION_STATISTIC_VIEW.to_dict()
+
+EXPECTED_TRANSACTION_DAILY_STATISTICS = TRANSACTION_DAILY_STATISTIC_VIEW.to_dict()
+
+EXPECTED_TRANSACTION_MONTH_STATISTICS = TRANSACTION_MONTH_STATISTIC_VIEW.to_dict()
 
 EXPECTED_NAMESPACE_1 = NAMESPACE_VIEWS[0].to_dict()
 
@@ -427,5 +433,19 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 
 		# Assert:
 		self.assertEqual(EXPECTED_TRANSACTION_STATISTIC, transaction_statistics)
+
+	def test_can_retrieve_transaction_statistics_by_day(self):
+		# Act:
+		transaction_statistics = self.nem_rest_facade.get_transaction_statistics_by_date_range('2015-03-29', '2015-03-29', 'DAY')
+
+		# Assert:
+		self.assertEqual(EXPECTED_TRANSACTION_DAILY_STATISTICS, transaction_statistics)
+
+	def test_can_retrieve_transaction_statistics_by_month(self):
+		# Act:
+		transaction_statistics = self.nem_rest_facade.get_transaction_statistics_by_date_range('2015-03-01', '2015-03-31', 'MONTH')
+
+		# Assert:
+		self.assertEqual(EXPECTED_TRANSACTION_MONTH_STATISTICS, transaction_statistics)
 
 	# endregion

--- a/explorer/rest/tests/model/test_Statistic.py
+++ b/explorer/rest/tests/model/test_Statistic.py
@@ -1,6 +1,11 @@
 import unittest
 
-from rest.model.Statistic import StatisticAccountView, StatisticTransactionView
+from rest.model.Statistic import (
+	StatisticAccountView,
+	StatisticTransactionDateRangeDataView,
+	StatisticTransactionDateRangeView,
+	StatisticTransactionView
+)
 
 
 class StatisticAccountViewTest(unittest.TestCase):
@@ -109,3 +114,113 @@ class StatisticTransactionViewTest(unittest.TestCase):
 		self.assertNotEqual(statistic_transaction_view, self._create_default_statistic_transaction_view(('total_transactions', 101)))
 		self.assertNotEqual(statistic_transaction_view, self._create_default_statistic_transaction_view(('transaction_last_24_hours', 21)))
 		self.assertNotEqual(statistic_transaction_view, self._create_default_statistic_transaction_view(('transaction_last_30_days', 51)))
+
+
+class StatisticTransactionDateRangeDataViewTest(unittest.TestCase):
+	@staticmethod
+	def _create_default_statistic_transaction_date_range_data_view(override=None):
+		transaction_range_data_view = StatisticTransactionDateRangeDataView(
+			period='2015-03-29',
+			total_transactions=20
+		)
+
+		if override:
+			setattr(transaction_range_data_view, override[0], override[1])
+
+		return transaction_range_data_view
+
+	def test_can_create_statistic_transaction_date_range_data_view(self):
+		# Act:
+		transaction_range_data_view = self._create_default_statistic_transaction_date_range_data_view()
+
+		# Assert:
+		self.assertEqual('2015-03-29', transaction_range_data_view.period)
+		self.assertEqual(20, transaction_range_data_view.total_transactions)
+
+	def test_can_convert_statistic_transaction_date_range_data_to_simple_dict(self):
+		# Arrange:
+		transaction_range_data_view = self._create_default_statistic_transaction_date_range_data_view()
+
+		# Act:
+		transaction_range_data_view_dict = transaction_range_data_view.to_dict()
+
+		# Assert:
+		self.assertEqual({
+			'period': '2015-03-29',
+			'totalTransactions': 20
+		}, transaction_range_data_view_dict)
+
+	def test_eq_is_supported(self):
+		# Arrange:
+		transaction_range_data_view = self._create_default_statistic_transaction_date_range_data_view()
+
+		# Assert:
+		self.assertEqual(transaction_range_data_view, self._create_default_statistic_transaction_date_range_data_view())
+		self.assertNotEqual(transaction_range_data_view, None)
+		self.assertNotEqual(transaction_range_data_view, 'transaction_range_data_view')
+		self.assertNotEqual(
+			transaction_range_data_view,
+			self._create_default_statistic_transaction_date_range_data_view(('period', '2015-03-30'))
+		)
+		self.assertNotEqual(
+			transaction_range_data_view,
+			self._create_default_statistic_transaction_date_range_data_view(('total_transactions', 21))
+		)
+
+
+class StatisticTransactionDateRangeViewTest(unittest.TestCase):
+	@staticmethod
+	def _create_default_statistic_transaction_date_range_view(override=None):
+		statistic_transaction_range_view = StatisticTransactionDateRangeView(
+			period_type='DAY',
+			data=[StatisticTransactionDateRangeDataView(
+				period='2015-03-29',
+				total_transactions=20
+			)]
+		)
+
+		if override:
+			setattr(statistic_transaction_range_view, override[0], override[1])
+
+		return statistic_transaction_range_view
+
+	def test_can_create_statistic_transaction_date_range_view(self):
+		# Act:
+		statistic_transaction_range_view = self._create_default_statistic_transaction_date_range_view()
+
+		# Assert:
+		self.assertEqual('DAY', statistic_transaction_range_view.period_type)
+		self.assertEqual([StatisticTransactionDateRangeDataView(
+			period='2015-03-29',
+			total_transactions=20
+		)], statistic_transaction_range_view.data)
+
+	def test_can_convert_statistic_transaction_date_range_view_to_simple_dict(self):
+		# Arrange:
+		statistic_transaction_range_view = self._create_default_statistic_transaction_date_range_view()
+
+		# Act:
+		transaction_range_view_dict = statistic_transaction_range_view.to_dict()
+
+		# Assert:
+		self.assertEqual({
+			'periodType': 'day',
+			'data': [{
+				'period': '2015-03-29',
+				'totalTransactions': 20
+			}]
+		}, transaction_range_view_dict)
+
+	def test_eq_is_supported(self):
+		# Arrange:
+		statistic_transaction_range_view = self._create_default_statistic_transaction_date_range_view()
+
+		# Assert:
+		self.assertEqual(statistic_transaction_range_view, self._create_default_statistic_transaction_date_range_view())
+		self.assertNotEqual(statistic_transaction_range_view, None)
+		self.assertNotEqual(statistic_transaction_range_view, 'statistic_transaction_range_view')
+		self.assertNotEqual(
+			statistic_transaction_range_view,
+			self._create_default_statistic_transaction_date_range_view(('period_type', 'MONTH'))
+		)
+		self.assertNotEqual(statistic_transaction_range_view, self._create_default_statistic_transaction_date_range_view(('data', [])))

--- a/explorer/rest/tests/test/DatabaseTestUtils.py
+++ b/explorer/rest/tests/test/DatabaseTestUtils.py
@@ -13,7 +13,12 @@ from rest.model.Account import AccountView
 from rest.model.Block import BlockView
 from rest.model.Mosaic import MosaicRichListView, MosaicView
 from rest.model.Namespace import NamespaceView
-from rest.model.Statistic import StatisticAccountView, StatisticTransactionView
+from rest.model.Statistic import (
+	StatisticAccountView,
+	StatisticTransactionDateRangeDataView,
+	StatisticTransactionDateRangeView,
+	StatisticTransactionView
+)
 from rest.model.Transaction import TransactionView
 
 Block = namedtuple(
@@ -522,6 +527,26 @@ TRANSACTION_STATISTIC_VIEW = StatisticTransactionView(
 	total_transactions=8,
 	transaction_last_24_hours=8,
 	transaction_last_30_days=8
+)
+
+TRANSACTION_DAILY_STATISTIC_VIEW = StatisticTransactionDateRangeView(
+	period_type='DAY',
+	data=[
+		StatisticTransactionDateRangeDataView(
+			period='2015-03-29',
+			total_transactions=8
+		)
+	]
+)
+
+TRANSACTION_MONTH_STATISTIC_VIEW = StatisticTransactionDateRangeView(
+	period_type='MONTH',
+	data=[
+		StatisticTransactionDateRangeDataView(
+			period='2015-03',
+			total_transactions=8
+		)
+	]
 )
 
 NAMESPACE_VIEWS = [

--- a/explorer/rest/tests/test_rest.py
+++ b/explorer/rest/tests/test_rest.py
@@ -16,6 +16,8 @@ from .test.DatabaseTestUtils import (
 	MOSAIC_RICH_LIST_VIEWS,
 	MOSAIC_VIEWS,
 	NAMESPACE_VIEWS,
+	TRANSACTION_DAILY_STATISTIC_VIEW,
+	TRANSACTION_MONTH_STATISTIC_VIEW,
 	TRANSACTION_STATISTIC_VIEW,
 	TRANSACTIONS_VIEWS,
 	DatabaseConfig,
@@ -631,6 +633,72 @@ def test_api_nem_transaction_statistics(client):  # pylint: disable=redefined-ou
 	# Assert:
 	_assert_status_code_and_headers(response, 200)
 	assert TRANSACTION_STATISTIC_VIEW.to_dict() == response.json
+
+
+def test_api_nem_transaction_statistics_date_range_by_day(client):  # pylint: disable=redefined-outer-name, invalid-name
+	# Act:
+	response = client.get('/api/nem/transaction/statistics/range', query_string={
+		'startDate': '2015-03-29',
+		'endDate': '2015-03-29',
+		'periodType': 'DAY'
+	})
+
+	# Assert:
+	_assert_status_code_and_headers(response, 200)
+	assert TRANSACTION_DAILY_STATISTIC_VIEW.to_dict() == response.json
+
+
+def test_api_nem_transaction_statistics_date_range_by_month(client):  # pylint: disable=redefined-outer-name, invalid-name
+	# Act:
+	response = client.get('/api/nem/transaction/statistics/range', query_string={
+		'startDate': '2015-03-01',
+		'endDate': '2015-03-31',
+		'periodType': 'MONTH'
+	})
+
+	# Assert:
+	_assert_status_code_and_headers(response, 200)
+	assert TRANSACTION_MONTH_STATISTIC_VIEW.to_dict() == response.json
+
+
+def _assert_invalid_transaction_statistics_param(client, expected_message, query_params):  # pylint: disable=redefined-outer-name
+	# Act:
+	response = client.get('/api/nem/transaction/statistics/range', query_string=query_params)
+
+	# Assert:
+	_assert_status_code_400(response, expected_message)
+
+
+def test_api_nem_transaction_statistics_with_missing_params(client):  # pylint: disable=redefined-outer-name, invalid-name
+	_assert_invalid_transaction_statistics_param(
+		client,
+		'startDate, endDate and period type are required',
+		{}
+	)
+
+
+def test_api_nem_transaction_statistics_with_invalid_period_type(client):  # pylint: disable=redefined-outer-name, invalid-name
+	_assert_invalid_transaction_statistics_param(
+		client,
+		'Period type must be either DAY or MONTH',
+		{
+			'startDate': '2015-03-01',
+			'endDate': '2015-03-31',
+			'periodType': 'YEAR'
+		}
+	)
+
+
+def test_api_nem_transaction_statistics_with_invalid_date_range(client):  # pylint: disable=redefined-outer-name, invalid-name
+	_assert_invalid_transaction_statistics_param(
+		client,
+		'start date must be less than or equal to end date',
+		{
+			'startDate': '2015-03-31',
+			'endDate': '2015-03-01',
+			'periodType': 'MONTH'
+		}
+	)
 
 
 # endregion


### PR DESCRIPTION
Problem: Currently, transaction statistics can't be queried by date range.
Solution: Added a new endpoint, `/api/nem/transaction/statistics/range` with support for `day|month` grouping and a date range filter.