### PR TITLE
[explorer/rest] feat: Added unconfirmed transaction endpoint

### DIFF
--- a/explorer/rest/rest/__init__.py
+++ b/explorer/rest/rest/__init__.py
@@ -353,6 +353,12 @@ def setup_nem_routes(app, nem_api_facade):  # pylint: disable=too-many-statement
 
 		return jsonify(results)
 
+	@app.route('/api/nem/transactions/unconfirmed')
+	async def api_get_nem_transactions_unconfirmed():
+		result = await nem_api_facade.get_unconfirmed_transactions()
+
+		return jsonify(result)
+
 
 def setup_error_handlers(app):
 	@app.errorhandler(404)

--- a/explorer/rest/rest/db/NemDatabase.py
+++ b/explorer/rest/rest/db/NemDatabase.py
@@ -219,7 +219,7 @@ class NemDatabase(DatabaseConnectionPool):
 			value = None
 			embedded_transaction.append({
 				'initiator': _format_address_bytes_to_string(transaction.from_address),
-				'transactionHash': _format_bytes(inner_transaction.transaction_hash),
+				'transactionHash': _format_bytes(inner_transaction.transaction_hash) if inner_transaction.transaction_hash else None,
 				'transactionType': TransactionType(inner_transaction.transaction_type).name,
 				'signatures': [{
 					'fee': _format_xem_relative(signature['fee']),
@@ -237,7 +237,7 @@ class NemDatabase(DatabaseConnectionPool):
 			to_address = _format_address_bytes_to_string(inner_transaction.to_address) if inner_transaction.to_address else None
 
 		return TransactionView(
-			transaction_hash=_format_bytes(transaction.transaction_hash),
+			transaction_hash=_format_bytes(transaction.transaction_hash) if transaction.transaction_hash else None,
 			transaction_type=TransactionType(transaction.transaction_type).name,
 			from_address=from_address,
 			to_address=to_address,
@@ -247,7 +247,7 @@ class NemDatabase(DatabaseConnectionPool):
 			height=transaction.height,
 			timestamp=str(transaction.timestamp),
 			deadline=str(transaction.deadline),
-			signature=_format_bytes(transaction.signature)
+			signature=_format_bytes(transaction.signature) if transaction.signature else None
 		)
 
 	@staticmethod
@@ -854,3 +854,167 @@ class NemDatabase(DatabaseConnectionPool):
 			]
 
 		return [self._create_transaction_view(transaction) for transaction in transactions]
+
+	def _convert_timestamp_to_datetime(self, timestamp):
+		return self.network.datetime_converter.to_datetime(timestamp).strftime('%Y-%m-%d %H:%M:%S')
+
+	def _create_unconfirmed_mosaic_records(self, mosaics):
+		if not mosaics:
+			# create default nem.xem mosaic record for v1 transfer transaction
+			return [
+				{
+					'namespace_name': 'nem.xem',
+					'quantity': 1000000,
+					'divisibility': 6
+				}
+			]
+
+		mosaic_names = [mosaic.namespace_name for mosaic in mosaics]
+		divisibility_map = self._get_mosaic_divisibility_by_names(mosaic_names)
+
+		mosaic_records = []
+		for mosaic in mosaics:
+			namespace_name = mosaic.namespace_name
+			mosaic_records.append({
+				'namespace_name': namespace_name,
+				'quantity': mosaic.quantity,
+				'divisibility': divisibility_map.get(namespace_name, 0)
+			})
+
+		return mosaic_records
+
+	def _build_transaction_record(self, transaction):
+		"""Converts a connector transaction response into a database-style transaction record."""
+
+		payload = None
+		recipient_address = None
+		amount = None
+		mosaics = None
+		if transaction.transaction_type == TransactionType.TRANSFER.value:
+			payload = {
+				'message': {
+					'payload': transaction.message.payload,
+					'is_plain': transaction.message.is_plain,
+				} if transaction.message else None
+			}
+			recipient_address = transaction.recipient.bytes if transaction.recipient else None
+			amount = transaction.amount
+			mosaics = self._create_unconfirmed_mosaic_records(transaction.mosaics)
+		elif transaction.transaction_type == TransactionType.ACCOUNT_KEY_LINK.value:
+			payload = {
+				'mode': transaction.mode,
+				'remote_account': str(transaction.remote_account)
+			}
+		elif transaction.transaction_type == TransactionType.MULTISIG_ACCOUNT_MODIFICATION.value:
+			payload = {
+				'min_cosignatories': transaction.min_cosignatories,
+				'modifications': [
+					{
+						'modification_type': modification.modification_type,
+						'cosignatory_account': str(modification.cosignatory_account)
+					}
+					for modification in transaction.modifications
+				]
+			}
+		elif transaction.transaction_type == TransactionType.MULTISIG.value:
+			payload = {
+				'inner_hash': transaction.inner_hash,
+				'signatures': [
+					{
+						'transaction_type': signature.transaction_type,
+						'timestamp': self._convert_timestamp_to_datetime(signature.timestamp),
+						'deadline': self._convert_timestamp_to_datetime(signature.deadline),
+						'fee': signature.fee,
+						'other_hash': signature.other_hash,
+						'other_account': str(signature.other_account),
+						'sender': str(signature.sender),
+						'signature': signature.signature
+					} for signature in transaction.signatures
+				]
+			}
+		elif transaction.transaction_type == TransactionType.NAMESPACE_REGISTRATION.value:
+			payload = {
+				'rental_fee': transaction.rental_fee,
+				'parent': transaction.parent,
+				'namespace': transaction.namespace
+			}
+			recipient_address = transaction.rental_fee_sink
+		elif transaction.transaction_type == TransactionType.MOSAIC_DEFINITION.value:
+			payload = {
+				'creation_fee': transaction.creation_fee,
+				'creator': str(transaction.sender),
+				'description': transaction.description,
+				'namespace_name': transaction.namespace_name,
+				'mosaic_properties': {
+					'divisibility': transaction.properties.divisibility,
+					'initial_supply': transaction.properties.initial_supply,
+					'supply_mutable': transaction.properties.supply_mutable,
+					'transferable': transaction.properties.transferable
+				},
+				'levy': {
+					'type': transaction.levy.type,
+					'namespace_name': transaction.levy.namespace_name,
+					'fee': transaction.levy.fee,
+					'recipient': str(transaction.levy.recipient)
+				} if transaction.levy else None
+			}
+			recipient_address = transaction.creation_fee_sink
+		elif transaction.transaction_type == TransactionType.MOSAIC_SUPPLY_CHANGE.value:
+			payload = {
+				'namespace_name': transaction.namespace_name,
+				'supply_type': transaction.supply_type,
+				'delta': transaction.delta
+			}
+
+		return TransactionRecord(
+			transaction_hash=bytes.fromhex(transaction.transaction_hash) if transaction.transaction_hash else None,
+			transaction_type=transaction.transaction_type,
+			from_address=self.network.public_key_to_address(transaction.sender).bytes,
+			fee=transaction.fee,
+			height=transaction.height,
+			timestamp=self._convert_timestamp_to_datetime(transaction.timestamp),
+			deadline=self._convert_timestamp_to_datetime(transaction.deadline),
+			signature=bytes.fromhex(transaction.signature) if transaction.signature else None,
+			to_address=recipient_address,
+			payload=payload,
+			amount=amount,
+			mosaics=mosaics
+		)
+
+	def _get_mosaic_divisibility_by_names(self, names):
+		"""Gets mosaic by namespace name in database."""
+
+		sql = '''
+			SELECT
+				m.namespace_name,
+				m.divisibility
+			FROM mosaics m
+			WHERE m.namespace_name IN %s
+			'''
+
+		with self.connection() as connection:
+			cursor = connection.cursor()
+			cursor.execute(sql, (tuple(names),))
+			results = cursor.fetchall()
+
+			return {result[0]: result[1] for result in results}
+
+	def get_unconfirmed_transactions(self, transactions):
+		"""Gets unconfirmed transactions."""
+
+		unconfirmed_transactions = []
+
+		for transaction in transactions:
+			if transaction.transaction_type == TransactionType.MULTISIG.value:
+				inner_transaction = self._build_transaction_record(transaction.other_transaction)
+			else:
+				inner_transaction = None
+
+			unconfirmed_transactions.append(
+				self._create_transaction_view(
+					self._build_transaction_record(transaction),
+					inner_transaction
+				)
+			)
+
+		return unconfirmed_transactions

--- a/explorer/rest/rest/db/NemDatabase.py
+++ b/explorer/rest/rest/db/NemDatabase.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 from binascii import hexlify
 
 from symbolchain.CryptoTypes import PublicKey
@@ -858,26 +859,25 @@ class NemDatabase(DatabaseConnectionPool):
 	def _convert_timestamp_to_datetime(self, timestamp):
 		return self.network.datetime_converter.to_datetime(timestamp).strftime('%Y-%m-%d %H:%M:%S')
 
-	def _create_unconfirmed_mosaic_records(self, mosaics):
+	def _create_unconfirmed_mosaic_records(self, mosaics, amount):
 		if not mosaics:
 			# create default nem.xem mosaic record for v1 transfer transaction
 			return [
 				{
 					'namespace_name': 'nem.xem',
-					'quantity': 1000000,
+					'quantity': amount,
 					'divisibility': 6
 				}
 			]
 
 		mosaic_names = [mosaic.namespace_name for mosaic in mosaics]
 		divisibility_map = self._get_mosaic_divisibility_by_names(mosaic_names)
-
 		mosaic_records = []
 		for mosaic in mosaics:
 			namespace_name = mosaic.namespace_name
 			mosaic_records.append({
 				'namespace_name': namespace_name,
-				'quantity': mosaic.quantity,
+				'quantity': mosaic.quantity * amount // (10 ** 6),
 				'divisibility': divisibility_map.get(namespace_name, 0)
 			})
 
@@ -888,7 +888,6 @@ class NemDatabase(DatabaseConnectionPool):
 
 		payload = None
 		recipient_address = None
-		amount = None
 		mosaics = None
 		if transaction.transaction_type == TransactionType.TRANSFER.value:
 			payload = {
@@ -898,8 +897,7 @@ class NemDatabase(DatabaseConnectionPool):
 				} if transaction.message else None
 			}
 			recipient_address = transaction.recipient.bytes
-			amount = transaction.amount
-			mosaics = self._create_unconfirmed_mosaic_records(transaction.mosaics)
+			mosaics = self._create_unconfirmed_mosaic_records(transaction.mosaics, transaction.amount)
 		elif transaction.transaction_type == TransactionType.ACCOUNT_KEY_LINK.value:
 			payload = {
 				'mode': transaction.mode,
@@ -977,7 +975,6 @@ class NemDatabase(DatabaseConnectionPool):
 			signature=bytes.fromhex(transaction.signature) if transaction.signature else None,
 			to_address=recipient_address,
 			payload=payload,
-			amount=amount,
 			mosaics=mosaics
 		)
 

--- a/explorer/rest/rest/db/NemDatabase.py
+++ b/explorer/rest/rest/db/NemDatabase.py
@@ -883,8 +883,8 @@ class NemDatabase(DatabaseConnectionPool):
 
 		return mosaic_records
 
-	def _build_transaction_record(self, transaction):
-		"""Converts a connector transaction response into a database-style transaction record."""
+	def _build_unconfirmed_transaction_record(self, transaction):
+		"""Converts a connector unconfirmed transaction response into a database-style transaction record."""
 
 		payload = None
 		recipient_address = None
@@ -967,11 +967,11 @@ class NemDatabase(DatabaseConnectionPool):
 			}
 
 		return TransactionRecord(
-			transaction_hash=bytes.fromhex(transaction.transaction_hash) if transaction.transaction_hash else None,
+			transaction_hash=None,
 			transaction_type=transaction.transaction_type,
 			from_address=self.network.public_key_to_address(transaction.sender).bytes,
 			fee=transaction.fee,
-			height=transaction.height,
+			height=0,
 			timestamp=self._convert_timestamp_to_datetime(transaction.timestamp),
 			deadline=self._convert_timestamp_to_datetime(transaction.deadline),
 			signature=bytes.fromhex(transaction.signature) if transaction.signature else None,
@@ -1006,13 +1006,13 @@ class NemDatabase(DatabaseConnectionPool):
 
 		for transaction in transactions:
 			if transaction.transaction_type == TransactionType.MULTISIG.value:
-				inner_transaction = self._build_transaction_record(transaction.other_transaction)
+				inner_transaction = self._build_unconfirmed_transaction_record(transaction.other_transaction)
 			else:
 				inner_transaction = None
 
 			unconfirmed_transactions.append(
 				self._create_transaction_view(
-					self._build_transaction_record(transaction),
+					self._build_unconfirmed_transaction_record(transaction),
 					inner_transaction
 				)
 			)

--- a/explorer/rest/rest/db/NemDatabase.py
+++ b/explorer/rest/rest/db/NemDatabase.py
@@ -248,7 +248,7 @@ class NemDatabase(DatabaseConnectionPool):
 			height=transaction.height,
 			timestamp=str(transaction.timestamp),
 			deadline=str(transaction.deadline),
-			signature=_format_bytes(transaction.signature) if transaction.signature else None
+			signature=_format_bytes(transaction.signature)
 		)
 
 	@staticmethod

--- a/explorer/rest/rest/db/NemDatabase.py
+++ b/explorer/rest/rest/db/NemDatabase.py
@@ -897,7 +897,7 @@ class NemDatabase(DatabaseConnectionPool):
 					'is_plain': transaction.message.is_plain,
 				} if transaction.message else None
 			}
-			recipient_address = transaction.recipient.bytes if transaction.recipient else None
+			recipient_address = transaction.recipient.bytes
 			amount = transaction.amount
 			mosaics = self._create_unconfirmed_mosaic_records(transaction.mosaics)
 		elif transaction.transaction_type == TransactionType.ACCOUNT_KEY_LINK.value:
@@ -938,7 +938,7 @@ class NemDatabase(DatabaseConnectionPool):
 				'parent': transaction.parent,
 				'namespace': transaction.namespace
 			}
-			recipient_address = transaction.rental_fee_sink
+			recipient_address = transaction.rental_fee_sink.bytes
 		elif transaction.transaction_type == TransactionType.MOSAIC_DEFINITION.value:
 			payload = {
 				'creation_fee': transaction.creation_fee,
@@ -958,7 +958,7 @@ class NemDatabase(DatabaseConnectionPool):
 					'recipient': str(transaction.levy.recipient)
 				} if transaction.levy else None
 			}
-			recipient_address = transaction.creation_fee_sink
+			recipient_address = transaction.creation_fee_sink.bytes
 		elif transaction.transaction_type == TransactionType.MOSAIC_SUPPLY_CHANGE.value:
 			payload = {
 				'namespace_name': transaction.namespace_name,

--- a/explorer/rest/rest/facade/NemRestFacade.py
+++ b/explorer/rest/rest/facade/NemRestFacade.py
@@ -185,3 +185,12 @@ class NemRestFacade:
 		transaction_statistics = self.nem_db.get_transaction_statistics_by_date_range(start_date, end_date, period_type)
 
 		return transaction_statistics.to_dict() if transaction_statistics else None
+
+	async def get_unconfirmed_transactions(self):
+		"""Gets unconfirmed transactions."""
+
+		unconfirmed_transactions = await self.nem_connector.get_unconfirmed_transactions()
+
+		results = self.nem_db.get_unconfirmed_transactions(unconfirmed_transactions)
+
+		return [transaction.to_dict() for transaction in results]

--- a/explorer/rest/tests/db/test_NemDatabase.py
+++ b/explorer/rest/tests/db/test_NemDatabase.py
@@ -78,11 +78,11 @@ NEM_CONNECTOR_UNCONFIRMED_TRANSACTIONS = [
 		timestamp=73397,
 		deadline=83397,
 		signature='0' * 128,
-		amount=1000000,
+		amount=1999999,
 		recipient=Address('NCOPERAWEWCD4A34NP5UQCCKEX44MW4SL3QYJYS5'),
 		mosaics=[
-			Mosaic(namespace_name='nem.xem', quantity=1000000),
-			Mosaic(namespace_name='root.mosaic', quantity=1000000),
+			Mosaic(namespace_name='nem.xem', quantity=8000000),
+			Mosaic(namespace_name='root.mosaic', quantity=20),
 		],
 		message=Message(
 			payload='test message',
@@ -220,11 +220,11 @@ UNCONFIRMED_TRANSACTION_VIEWS = [
 			},
 			{
 				'namespace': 'nem.xem',
-				'amount': 1.0
+				'amount': 15.999992
 			},
 			{
 				'namespace': 'root.mosaic',
-				'amount': 1000000.0
+				'amount': 39.0
 			}
 		]
 	),

--- a/explorer/rest/tests/db/test_NemDatabase.py
+++ b/explorer/rest/tests/db/test_NemDatabase.py
@@ -1,5 +1,24 @@
+from symbolchain.CryptoTypes import PublicKey
+from symbolchain.nem.Network import Address
+from symbollightapi.model.Transaction import (
+	AccountKeyLinkTransaction,
+	CosignSignatureTransaction,
+	Message,
+	Modification,
+	Mosaic,
+	MosaicDefinitionTransaction,
+	MosaicLevy,
+	MosaicProperties,
+	MosaicSupplyChangeTransaction,
+	MultisigAccountModificationTransaction,
+	MultisigTransaction,
+	NamespaceRegistrationTransaction,
+	TransferTransaction
+)
+
 from rest import Pagination, Sorting
 from rest.db.NemDatabase import NemDatabase
+from rest.model.Transaction import TransactionView
 
 from ..test.DatabaseTestUtils import (
 	ACCOUNT_STATISTIC_VIEW,
@@ -38,6 +57,248 @@ EXPECTED_MOSAIC_VIEW_1 = MOSAIC_VIEWS[0]
 EXPECTED_MOSAIC_VIEW_2 = MOSAIC_VIEWS[1]
 
 EXPECTED_MOSAIC_VIEW_3 = MOSAIC_VIEWS[2]
+
+NEM_CONNECTOR_UNCONFIRMED_TRANSACTIONS = [
+	AccountKeyLinkTransaction(
+		transaction_hash=None,
+		height=0,
+		sender=PublicKey('22df5f43ee3739a10c346b3ec2d3878668c5514696be425f9067d3a11c777f1d'),
+		fee=150000,
+		timestamp=73397,
+		deadline=83397,
+		signature='0' * 128,
+		mode=1,
+		remote_account=PublicKey('7195f4d7a40ad7e31958ae96c4afed002962229675a4cae8dc8a18e290618981')
+	),
+	TransferTransaction(
+		transaction_hash=None,
+		height=0,
+		sender=PublicKey('22df5f43ee3739a10c346b3ec2d3878668c5514696be425f9067d3a11c777f1d'),
+		fee=150000,
+		timestamp=73397,
+		deadline=83397,
+		signature='0' * 128,
+		amount=1000000,
+		recipient=Address('NCOPERAWEWCD4A34NP5UQCCKEX44MW4SL3QYJYS5'),
+		mosaics=[
+			Mosaic(namespace_name='nem.xem', quantity=1000000),
+			Mosaic(namespace_name='root.mosaic', quantity=1000000),
+		],
+		message=Message(
+			payload='test message',
+			is_plain=1
+		)
+	),
+	MultisigAccountModificationTransaction(
+		transaction_hash=None,
+		height=0,
+		sender=PublicKey('22df5f43ee3739a10c346b3ec2d3878668c5514696be425f9067d3a11c777f1d'),
+		fee=150000,
+		timestamp=73397,
+		deadline=83397,
+		signature='0' * 128,
+		min_cosignatories=2,
+		modifications=[
+			Modification(1, PublicKey('1fbdbdde28daf828245e4533765726f0b7790e0b7146e2ce205df3e86366980b')),
+			Modification(1, PublicKey('f94e8702eb1943b23570b1b83be1b81536df35538978820e98bfce8f999e2d37'))
+		]
+	),
+	NamespaceRegistrationTransaction(
+		transaction_hash=None,
+		height=0,
+		sender=PublicKey('22df5f43ee3739a10c346b3ec2d3878668c5514696be425f9067d3a11c777f1d'),
+		fee=150000,
+		timestamp=73397,
+		deadline=83397,
+		signature='0' * 128,
+		rental_fee_sink=Address('NAMESPACEWH4MKFMBCVFERDPOOP4FK7MTBXDPZZA'),
+		rental_fee=100000000,
+		parent=None,
+		namespace='namespace'
+	),
+	MosaicDefinitionTransaction(
+		transaction_hash=None,
+		height=0,
+		sender=PublicKey('22df5f43ee3739a10c346b3ec2d3878668c5514696be425f9067d3a11c777f1d'),
+		fee=150000,
+		timestamp=73397,
+		deadline=83397,
+		signature='0' * 128,
+		creation_fee=10000000,
+		creation_fee_sink=Address('NBMOSAICOD4F54EE5CDMR23CCBGOAM2XSIUX6TRS'),
+		creator=PublicKey('22df5f43ee3739a10c346b3ec2d3878668c5514696be425f9067d3a11c777f1d'),
+		description='NEM namespace test',
+		properties=MosaicProperties(4, 3100000, False, True),
+		levy=MosaicLevy(500, Address('NBRYCNWZINEVNITUESKUMFIENWKYCRUGNFZV25AV'), 1, 'nem.xem'),
+		namespace_name='namespace.test'
+	),
+	MosaicSupplyChangeTransaction(
+		transaction_hash=None,
+		height=0,
+		sender=PublicKey('22df5f43ee3739a10c346b3ec2d3878668c5514696be425f9067d3a11c777f1d'),
+		fee=150000,
+		timestamp=73397,
+		deadline=83397,
+		signature='0' * 128,
+		supply_type=2,
+		delta=500000,
+		namespace_name='namespace.test'
+	),
+	MultisigTransaction(
+		transaction_hash=None,
+		height=0,
+		sender=PublicKey('aa455d831430872feb0c6ae14265209182546c985a321c501be7fdc96ed04757'),
+		fee=500000,
+		timestamp=73397,
+		deadline=83397,
+		signature='0' * 128,
+		signatures=[
+			CosignSignatureTransaction(
+				timestamp=261593985,
+				other_hash='0' * 64,
+				other_account=Address('NAGJG3QFWYZ37LMI7IQPSGQNYADGSJZGJRD2DIYA'),
+				sender=PublicKey('ae6754c70b7e3ba0c51617c8f9efd462d0bf680d45e09c3444e817643d277826'),
+				fee=500000,
+				deadline=261680385,
+				signature='0' * 128
+			)
+		],
+		other_transaction=TransferTransaction(
+			transaction_hash=None,
+			height=None,
+			sender=PublicKey('fbae41931de6a0cc25153781321f3de0806c7ba9a191474bb9a838118c8de4d3'),
+			fee=750000,
+			timestamp=73397,
+			deadline=83397,
+			signature=None,
+			amount=150000000000,
+			recipient=Address('NBUH72UCGBIB64VYTAAJ7QITJ62BLISFFQOHVP65'),
+			mosaics=None,
+			message=None
+		),
+		inner_hash='0' * 64
+	)
+]
+
+
+def _create_unconfirmed_transaction_view(transaction_type, to_address, value):
+	return TransactionView(
+		transaction_hash=None,
+		transaction_type=transaction_type,
+		from_address='NBKQWJJGPOHL462DBVMTYOAERXGG2BOS5WFSIGHT',
+		to_address=to_address,
+		value=value,
+		embedded_transactions=None,
+		fee=0.15,
+		height=0,
+		timestamp='2015-03-29 20:29:42',
+		deadline='2015-03-29 23:16:22',
+		signature='0' * 128
+	)
+
+
+UNCONFIRMED_TRANSACTION_VIEWS = [
+	_create_unconfirmed_transaction_view(
+		transaction_type='ACCOUNT_KEY_LINK',
+		to_address=None,
+		value=[
+			{
+				'mode': 1,
+				'remoteAccount': '7195F4D7A40AD7E31958AE96C4AFED002962229675A4CAE8DC8A18E290618981'
+			}
+		]
+	),
+	_create_unconfirmed_transaction_view(
+		transaction_type='TRANSFER',
+		to_address='NCOPERAWEWCD4A34NP5UQCCKEX44MW4SL3QYJYS5',
+		value=[
+			{
+				'message': {
+					'isPlain': 1,
+					'payload': 'test message'
+				}
+			},
+			{
+				'namespace': 'nem.xem',
+				'amount': 1.0
+			},
+			{
+				'namespace': 'root.mosaic',
+				'amount': 1000000.0
+			}
+		]
+	),
+	_create_unconfirmed_transaction_view(
+		transaction_type='MULTISIG_ACCOUNT_MODIFICATION',
+		to_address=None,
+		value=[{
+			'minCosignatories': 2,
+			'modifications': [
+				{
+					'cosignatoryAccount': 'NADMEHCFJD45GPTDL4HZP2LJLZVAZRLYWYPNEMLY',
+					'modificationType': 1
+				},
+				{
+					'cosignatoryAccount': 'NANIBAXPVLBP37YXSGREVD77NXIFZML5FDE7F3ZN',
+					'modificationType': 1
+				}
+			]
+		}]
+	),
+	_create_unconfirmed_transaction_view(
+		transaction_type='NAMESPACE_REGISTRATION',
+		to_address='NAMESPACEWH4MKFMBCVFERDPOOP4FK7MTBXDPZZA',
+		value=[{
+			'sinkFee': 100.0,
+			'parent': None,
+			'namespaceName': 'namespace'
+		}]
+	),
+	_create_unconfirmed_transaction_view(
+		transaction_type='MOSAIC_DEFINITION',
+		to_address='NBMOSAICOD4F54EE5CDMR23CCBGOAM2XSIUX6TRS',
+		value=[{
+			'sinkFee': 10.0,
+			'mosaicNamespaceName': 'namespace.test'
+		}]
+	),
+	_create_unconfirmed_transaction_view(
+		transaction_type='MOSAIC_SUPPLY_CHANGE',
+		to_address=None,
+		value=[{
+			'supplyType': 2,
+			'delta': 500000,
+			'namespaceName': 'namespace.test'
+		}]
+	),
+	TransactionView(
+		transaction_hash=None,
+		transaction_type='MULTISIG',
+		from_address='NAGJG3QFWYZ37LMI7IQPSGQNYADGSJZGJRD2DIYA',
+		to_address='NBUH72UCGBIB64VYTAAJ7QITJ62BLISFFQOHVP65',
+		value=None,
+		embedded_transactions=[{
+			'initiator': 'NCTWKWGD564GIQQCZ5X5TC4YM46VXWLT3QWD5NLZ',
+			'transactionHash': None,
+			'transactionType': 'TRANSFER',
+			'signatures': [{
+				'fee': 0.5,
+				'signature': '0' * 128,
+				'signer': 'NBEM6SFOHU5PORIGAVG3NNJIMCG73R2TWEEIDAZ5'
+			}],
+			'fee': 0.75,
+			'value': [{
+				'namespace': 'nem.xem',
+				'amount': 150000.0
+			}]
+		}],
+		fee=0.5,
+		height=0,
+		timestamp='2015-03-29 20:29:42',
+		deadline='2015-03-29 23:16:22',
+		signature='0' * 128
+	)
+]
 
 # endregion
 
@@ -437,5 +698,16 @@ class NemDatabaseTest(DatabaseTestBase):  # pylint: disable=too-many-public-meth
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc', self._make_transaction_query(mosaic='nonexistent.mosaic'), []
 		)
+
+	# endregion
+
+	# region unconfirmed transactions
+
+	def test_can_format_unconfirmed_transaction(self):
+		# Act:
+		unconfirmed_transaction_views = self.nem_db.get_unconfirmed_transactions(NEM_CONNECTOR_UNCONFIRMED_TRANSACTIONS)
+
+		# Assert:
+		self.assertEqual(UNCONFIRMED_TRANSACTION_VIEWS, unconfirmed_transaction_views)
 
 	# endregion

--- a/explorer/rest/tests/facade/test_NemRestFacade.py
+++ b/explorer/rest/tests/facade/test_NemRestFacade.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from symbollightapi.model.Exceptions import NodeException
 
@@ -255,6 +255,21 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 		self.assertEqual(EXPECTED_BLOCK_2['timestamp'], result['lastDBSyncedAt'])
 		self.assertEqual(EXPECTED_BLOCK_2['height'], result['lastDBHeight'])
 		self.assertEqual([{'type': 'synchronization', 'message': 'Connection refused'}], result['errors'])
+
+	# endregion
+
+	# region unconfirmed transactions
+
+	@patch('rest.facade.NemRestFacade.NemConnector.get_unconfirmed_transactions')
+	def test_can_retrieve_empty_unconfirmed_transactions(self, mock_get_unconfirmed_transactions):
+		# Arrange:
+		mock_get_unconfirmed_transactions.return_value = AsyncMock(return_value=[])
+
+		# Act:
+		result = asyncio.run(self.nem_rest_facade.get_unconfirmed_transactions())
+
+		# Assert:
+		self.assertEqual([], result)
 
 	# endregion
 

--- a/explorer/rest/tests/test_rest.py
+++ b/explorer/rest/tests/test_rest.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 import testing.postgresql
@@ -412,6 +412,24 @@ def test_api_nem_health_node_fails(mock_chain_height, client):  # pylint: disabl
 		'lastDBHeight': EXPECTED_BLOCK_VIEW_2.height,
 		'errors': [{'type': 'synchronization', 'message': 'Connection refused'}]
 	} == response.json
+
+# endregion
+
+# region /transactions/unconfirmed
+
+
+@patch('rest.facade.NemRestFacade.NemConnector.get_unconfirmed_transactions')
+def test_api_transactions_unconfirmed(mock_get_unconfirmed_transactions, client):  # pylint: disable=redefined-outer-name
+	# Arrange:
+	mock_get_unconfirmed_transactions.return_value = AsyncMock(return_value=[])
+
+	# Act:
+	response = client.get('/api/nem/transactions/unconfirmed')
+
+	# Assert:
+	_assert_status_code_and_headers(response, 200)
+	assert [] == response.json
+
 
 # endregion
 


### PR DESCRIPTION
Problem: Missing unconfirmed transaction in the endpoint.
Solution: 
- Query unconfirmed transactions from the node connector.
- Converted node connector response to DB query result, so that it can reuse the existing method to create a transaction view.
- Unconfirmed transactions weren't stored in the DB.