### PR TITLE
[lightapi/python] fix: throw error when `relativeChange` is missing

### DIFF
--- a/lightapi/python/symbollightapi/connector/NemBlockCalculator.py
+++ b/lightapi/python/symbollightapi/connector/NemBlockCalculator.py
@@ -169,7 +169,8 @@ class NemBlockCalculator:
 		}
 
 		if schema_version == 2:
-			transaction['min_approval_delta'] = tx_json['minCosignatories']['relativeChange']
+			min_cosignatories = tx_json['minCosignatories']
+			transaction['min_approval_delta'] = min_cosignatories.get('relativeChange', 0)
 
 		return transaction
 

--- a/lightapi/python/tests/connector/test_NemBlockCalculator.py
+++ b/lightapi/python/tests/connector/test_NemBlockCalculator.py
@@ -101,13 +101,11 @@ def test_can_calculate_multisig_account_modification_transaction_v1():
 	_assert_transaction_size(tx_json, 176)
 
 
-def test_can_calculate_multisig_account_modification_transaction_v2():
+def _assert_multisig_account_modification_transaction_v2_size(minCosignatories):
 	# Arrange:
 	tx_json = {
 		**transaction_base,
-		"minCosignatories": {
-			"relativeChange": 2
-		},
+		"minCosignatories": minCosignatories,
 		"modifications": [
 			{
 				"modificationType": 1,
@@ -119,6 +117,16 @@ def test_can_calculate_multisig_account_modification_transaction_v2():
 	}
 
 	_assert_transaction_size(tx_json, 184)
+
+
+def test_can_calculate_multisig_account_modification_transaction_v2():
+	_assert_multisig_account_modification_transaction_v2_size({
+		"relativeChange": 2
+	})
+
+
+def test_can_calculate_multisig_account_modification_transaction_v2_without_relative_change():
+	_assert_multisig_account_modification_transaction_v2_size({})
 
 
 def test_can_calculate_namespace_registration_with_root_transaction_v1():


### PR DESCRIPTION
Problem: In multisig_account_modification transactions, the minCosignatories field can be either {} or contain relativeChange.

Solution: Handle missing relativeChange by defaulting min_approval_delta to 0.
