### PR TITLE
[lightapi/python] fix: remove status, the status is node specific

### DIFF
--- a/lightapi/python/symbollightapi/connector/NemConnector.py
+++ b/lightapi/python/symbollightapi/connector/NemConnector.py
@@ -41,7 +41,6 @@ class NemAccountInfo:  # pylint: disable=too-many-instance-attributes
 		self.harvested_blocks = 0
 
 		self.remote_status = None
-		self.status = None
 
 		self.min_cosignatories = None
 		self.cosignatories = []
@@ -197,7 +196,6 @@ class NemConnector(BasicConnector):
 
 		meta_json = response_json['meta']
 		account_info.remote_status = meta_json['remoteStatus']
-		account_info.status = meta_json['status']
 
 		account_info.cosignatories = [Address(cosignatories['address']) for cosignatories in meta_json['cosignatories']]
 		account_info.cosignatory_of = [Address(cosignatory_of['address']) for cosignatory_of in meta_json['cosignatoryOf']]

--- a/lightapi/python/tests/connector/test_NemConnector.py
+++ b/lightapi/python/tests/connector/test_NemConnector.py
@@ -887,7 +887,6 @@ def _assert_account_info_1(account_info):
 	assert 0.0019854120211438703 == account_info.importance
 	assert 54553 == account_info.harvested_blocks
 	assert 'ACTIVE' == account_info.remote_status
-	assert 'LOCKED' == account_info.status
 	assert account_info.min_cosignatories is None
 	assert [] == account_info.cosignatories
 	assert [] == account_info.cosignatory_of


### PR DESCRIPTION
Problem: The status is node-specific, which is not related to account status.
Solution: removed status