### PR TITLE
[explorer/puller] feat: Added refresh account workflow

### DIFF
--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -1,7 +1,12 @@
 import json
 from binascii import unhexlify
+from collections import namedtuple
+
+from symbolchain.nem.Network import Address
 
 from .DatabaseConnection import DatabaseConnection
+
+AccountRefreshRecord = namedtuple('AccountRefreshRecord', ['id', 'address'])
 
 
 class NemDatabase(DatabaseConnection):
@@ -288,6 +293,25 @@ class NemDatabase(DatabaseConnection):
 		results = cursor.fetchone()
 		return 0 if results[0] is None else results[0]
 
+	def get_accounts_for_refresh(self, limit, last_account_id):
+		"""Gets account addresses that should have vested balance and importance refreshed."""
+
+		cursor = self.connection.cursor()
+		cursor.execute(
+			'''
+			SELECT id, address
+			FROM accounts
+			WHERE id > %s
+				AND (balance > 0 OR vested_balance > 0 OR importance > 0)
+			ORDER BY id ASC
+			LIMIT %s
+			''',
+			(last_account_id, limit)
+		)
+		results = cursor.fetchall()
+
+		return [AccountRefreshRecord(record[0], Address(record[1])) for record in results]
+
 	@staticmethod
 	def upsert_account(cursor, account_info):
 		"""Insert or update account information."""
@@ -335,6 +359,25 @@ class NemDatabase(DatabaseConnection):
 				account_info.min_cosignatories,
 				[address.bytes for address in account_info.cosignatory_of] if len(account_info.cosignatory_of) > 0 else None,
 				[address.bytes for address in account_info.cosignatories] if len(account_info.cosignatories) > 0 else None,
+			)
+		)
+
+	@staticmethod
+	def update_vested_balance_and_importance(cursor, account_info):
+		"""Updates vested balance and importance for an account."""
+
+		cursor.execute(
+			'''
+			UPDATE accounts
+			SET vested_balance = %s,
+				importance = %s,
+				updated_at = CURRENT_TIMESTAMP
+			WHERE address = %s
+			''',
+			(
+				account_info.vested_balance,
+				account_info.importance,
+				account_info.address.bytes
 			)
 		)
 

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -299,6 +299,29 @@ class NemPuller:
 				last_height
 			)
 
+	async def refresh_accounts(self, batch_size):
+		"""Refresh vested balance and importance for stored accounts."""
+
+		cursor = self.nem_db.connection.cursor()
+		last_account_id = 0
+		total_refreshed = 0
+
+		while True:
+			accounts = self.nem_db.get_accounts_for_refresh(batch_size, last_account_id)
+			if not accounts:
+				break
+
+			for account in accounts:
+				account_info = await self._retry_get_account_info(str(account.address))
+				self.nem_db.update_vested_balance_and_importance(cursor, account_info)
+				last_account_id = account.id
+				total_refreshed += 1
+
+			self.nem_db.connection.commit()
+			log.info(f'Refreshed {len(accounts)} accounts in current batch, {total_refreshed} total')
+
+		return total_refreshed
+
 	def _process_root_namespace(self, cursor, transaction, block_height):
 		"""Process root namespace data."""
 

--- a/explorer/puller/puller/workflows/refresh_nem_accounts.py
+++ b/explorer/puller/puller/workflows/refresh_nem_accounts.py
@@ -1,0 +1,41 @@
+import argparse
+from asyncio import run
+
+from zenlog import log
+
+from puller.facade.NemPuller import NemPuller
+
+
+def parse_args():
+	"""Parse command line arguments."""
+
+	parser = argparse.ArgumentParser(description='refresh NEM account vested balance and importance')
+	parser.add_argument('--nem-node', help='NEM node(local) url', default='http://localhost:7890')
+	parser.add_argument('--network', help='mainnet or testnet', choices=['mainnet', 'testnet'], default='mainnet')
+	parser.add_argument('--db-config', help='database config file *.ini', default='config.ini')
+	parser.add_argument('--batch-size', help='number of accounts to refresh per database batch', type=int, default=500)
+
+	args = parser.parse_args()
+	if args.batch_size <= 0:
+		parser.error('--batch-size must be greater than 0')
+
+	return args
+
+
+async def main():
+	args = parse_args()
+
+	facade = NemPuller(args.nem_node, args.db_config, args.network)
+
+	log.info(f'Node URL: {args.nem_node}')
+	log.info(f'Network: {args.network}')
+	log.info(f'Batch size: {args.batch_size}')
+
+	with facade.nem_db:
+		total_refreshed = await facade.refresh_accounts(args.batch_size)
+
+	log.info(f'Refreshed {total_refreshed} accounts')
+
+
+if __name__ == '__main__':
+	run(main())

--- a/explorer/puller/tests/db/test_NemDatabase.py
+++ b/explorer/puller/tests/db/test_NemDatabase.py
@@ -98,7 +98,7 @@ TRANSACTIONS = [
 # endregion
 
 
-class NemDatabaseTest(unittest.TestCase):
+class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-methods
 
 	def setUp(self):
 		self.postgresql = testing.postgresql.Postgresql()
@@ -366,6 +366,103 @@ class NemDatabaseTest(unittest.TestCase):
 			'0.1234560000',
 			2000000,
 			99999,
+			[],
+			0,
+			10,
+			'INACTIVE',
+			0,
+			None,
+			None,
+			None)
+		)
+
+	def test_can_get_accounts_for_refresh(self):
+		# Arrange:
+		accounts = [
+			ACCOUNTS[0]._replace(
+				address=Address('TBZWVEKB2XMTO4F3RAOEIBWRBMPQ5N23G56ZJM4I'),
+				balance=1000000,
+				vested_balance=0,
+				importance=0
+			),
+			ACCOUNTS[0]._replace(
+				address=Address('TCJLCZSOQ6RGWHTPSV2DW467WZSHK4NBSITND4OF'),
+				balance=0,
+				vested_balance=1000000,
+				importance=0
+			),
+			ACCOUNTS[0]._replace(
+				address=Address('TALICE6XEEEOBFJVY3ZCENZ7WBG6LB4KB7P7KMQX'),
+				balance=0,
+				vested_balance=0,
+				importance=0.1
+			),
+			ACCOUNTS[0]._replace(
+				address=Address('TBEM6SFOHU5PORIGAVG3NNJIMCG73R2TWH35O2VF'),
+				balance=0,
+				vested_balance=0,
+				importance=0
+			)
+		]
+
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+
+			cursor = nem_database.connection.cursor()
+			for account in accounts:
+				nem_database.upsert_account(cursor, account)
+
+			nem_database.connection.commit()
+
+			# Act:
+			first_batch = nem_database.get_accounts_for_refresh(2, 0)
+			second_batch = nem_database.get_accounts_for_refresh(2, first_batch[-1].id)
+
+		# Assert:
+		self.assertEqual([str(account.address) for account in first_batch], [
+			'TBZWVEKB2XMTO4F3RAOEIBWRBMPQ5N23G56ZJM4I',
+			'TCJLCZSOQ6RGWHTPSV2DW467WZSHK4NBSITND4OF'
+		])
+		self.assertEqual([str(account.address) for account in second_batch], [
+			'TALICE6XEEEOBFJVY3ZCENZ7WBG6LB4KB7P7KMQX'
+		])
+
+	def test_can_update_vested_balance_and_importance(self):
+		# Arrange:
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+
+			cursor = nem_database.connection.cursor()
+
+			nem_database.upsert_account(
+				cursor,
+				ACCOUNTS[0]
+			)
+
+			# Act:
+			nem_database.update_vested_balance_and_importance(
+				cursor,
+				ACCOUNTS[0]._replace(
+					importance=0.654321,
+					balance=2000000,
+					vested_balance=88888,
+					remote_status='ACTIVE',
+					harvested_blocks=99
+				)
+			)
+
+			nem_database.connection.commit()
+			result = self._fetch_account_from_db(cursor, ACCOUNTS[0].address)
+
+		# Assert:
+		self.assertIsNotNone(result)
+		self.assertEqual(result, (
+			ACCOUNTS[0].address.bytes.hex(),
+			ACCOUNTS[0].public_key.bytes.hex(),
+			None,
+			'0.6543210000',
+			1000000,
+			88888,
 			[],
 			0,
 			10,

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -26,6 +26,7 @@ from symbollightapi.model.Transaction import (
 	TransferTransaction
 )
 
+from puller.db.NemDatabase import AccountRefreshRecord
 from puller.facade.NemPuller import AccountRecord, DatabaseConfig, MosaicRecord, NamespaceRecord, NemPuller, TransactionRecord
 
 # region test data
@@ -791,6 +792,65 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			59200000,
 			3
 		))
+
+	@patch('puller.facade.NemPuller.NemPuller._retry_get_account_info')
+	@patch('puller.facade.NemPuller.NemDatabase.get_accounts_for_refresh')
+	@patch('puller.facade.NemPuller.NemDatabase.update_vested_balance_and_importance')
+	def test_can_refresh_accounts_in_batches(
+		self,
+		mock_update_vested_balance_and_importance,  # pylint: disable=invalid-name
+		mock_get_accounts_for_refresh,
+		mock_retry_get_account_info
+	):
+		# Arrange:
+		cursor = Mock()
+		self.puller.nem_db.connection = Mock()
+		self.puller.nem_db.connection.cursor.return_value = cursor
+
+		account_1 = AccountRefreshRecord(1, Address('TBZWVEKB2XMTO4F3RAOEIBWRBMPQ5N23G56ZJM4I'))
+		account_2 = AccountRefreshRecord(2, Address('TCJLCZSOQ6RGWHTPSV2DW467WZSHK4NBSITND4OF'))
+		account_3 = AccountRefreshRecord(5, Address('TALICE6XEEEOBFJVY3ZCENZ7WBG6LB4KB7P7KMQX'))
+
+		mock_get_accounts_for_refresh.side_effect = [
+			[account_1, account_2],
+			[account_3],
+			[]
+		]
+
+		account_info_1 = Mock()
+		account_info_2 = Mock()
+		account_info_3 = Mock()
+
+		mock_retry_get_account_info.side_effect = [
+			account_info_1,
+			account_info_2,
+			account_info_3
+		]
+
+		# Act:
+		result = asyncio.run(self.puller.refresh_accounts(2))
+
+		# Assert:
+		self.assertEqual(result, 3)
+
+		get_accounts_for_refresh_calls = mock_get_accounts_for_refresh.call_args_list
+		self.assertEqual(len(get_accounts_for_refresh_calls), 3)
+		self.assertEqual(get_accounts_for_refresh_calls[0][0], (2, 0))
+		self.assertEqual(get_accounts_for_refresh_calls[1][0], (2, 2))
+		self.assertEqual(get_accounts_for_refresh_calls[2][0], (2, 5))
+
+		retry_get_account_info_calls = mock_retry_get_account_info.call_args_list
+		self.assertEqual(len(retry_get_account_info_calls), 3)
+		self.assertEqual(retry_get_account_info_calls[0][0], (str(account_1.address),))
+		self.assertEqual(retry_get_account_info_calls[1][0], (str(account_2.address),))
+		self.assertEqual(retry_get_account_info_calls[2][0], (str(account_3.address),))
+
+		update_account_calls = mock_update_vested_balance_and_importance.call_args_list
+		self.assertEqual(len(update_account_calls), 3)
+		self.assertEqual(update_account_calls[0][0], (cursor, account_info_1))
+		self.assertEqual(update_account_calls[1][0], (cursor, account_info_2))
+		self.assertEqual(update_account_calls[2][0], (cursor, account_info_3))
+		self.assertEqual(self.puller.nem_db.connection.commit.call_count, 2)
 
 	@patch('puller.facade.NemPuller.NemDatabase.upsert_namespace')
 	def test_can_process_root_namespace(self, mock_upsert_namespace):

--- a/explorer/puller/tests/workflows/test_refresh_nem_accounts.py
+++ b/explorer/puller/tests/workflows/test_refresh_nem_accounts.py
@@ -1,0 +1,54 @@
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from workflow_test_utils import assert_common_args, create_facade_with_mock_db, create_main_args, parse_args_with_argv
+
+from puller.workflows.refresh_nem_accounts import main, parse_args
+
+
+class RefreshNemAccountsTest(unittest.TestCase):
+
+	def test_parse_args_with_defaults(self):
+		# Arrange + Act:
+		args = parse_args_with_argv('refresh_nem_accounts.py', parse_args)
+
+		# Assert:
+		assert_common_args(self, args)
+		self.assertEqual(args.batch_size, 500)
+
+	def test_parse_args_with_custom_values(self):
+		# Arrange + Act:
+		args = parse_args_with_argv(
+			'refresh_nem_accounts.py',
+			parse_args,
+			'--nem-node', 'http://localhost:7890',
+			'--network', 'testnet',
+			'--db-config', 'test_config.ini',
+			'--batch-size', '100')
+
+		# Assert:
+		assert_common_args(self, args, 'testnet', 'test_config.ini')
+		self.assertEqual(args.batch_size, 100)
+
+	def test_parse_args_rejects_invalid_batch_size(self):
+		# Arrange + Act + Assert:
+		with patch('sys.argv', ['refresh_nem_accounts.py', '--batch-size', '0']):
+			with self.assertRaises(SystemExit):
+				parse_args()
+
+	@patch('puller.workflows.refresh_nem_accounts.NemPuller')
+	@patch('puller.workflows.refresh_nem_accounts.parse_args')
+	def test_can_refresh_accounts(self, mock_parse_args, mock_nem_puller):
+		# Arrange:
+		mock_parse_args.return_value = create_main_args(batch_size=100)
+		mock_facade, _ = create_facade_with_mock_db(mock_nem_puller)
+		mock_facade.refresh_accounts = AsyncMock(return_value=3)
+
+		# Act:
+		result = asyncio.run(main())
+
+		# Assert:
+		self.assertIsNone(result)
+		mock_nem_puller.assert_called_once_with('http://localhost:7890', 'test_config.ini', 'testnet')
+		mock_facade.refresh_accounts.assert_called_once_with(100)

--- a/explorer/puller/tests/workflows/test_sync_nem_block.py
+++ b/explorer/puller/tests/workflows/test_sync_nem_block.py
@@ -1,60 +1,39 @@
 import asyncio
 import unittest
-from collections import namedtuple
 from unittest.mock import AsyncMock, Mock, patch
 
-from puller.workflows.sync_nem_block import main, parse_args
+from workflow_test_utils import assert_common_args, create_facade_with_mock_db, create_main_args, parse_args_with_argv
 
-DatabaseConfig = namedtuple('DatabaseConfig', ['database', 'user', 'password', 'host', 'port'])
+from puller.workflows.sync_nem_block import main, parse_args
 
 
 class SyncNemBlockTest(unittest.TestCase):
 
 	def test_parse_args_with_defaults(self):
 		# Arrange + Act:
-		with patch('sys.argv', ['sync_nem_block.py']):
-			args = parse_args()
+		args = parse_args_with_argv('sync_nem_block.py', parse_args)
 
 		# Assert:
-		self.assertEqual(args.nem_node, 'http://localhost:7890')
-		self.assertEqual(args.network, 'mainnet')
-		self.assertEqual(args.db_config, 'config.ini')
+		assert_common_args(self, args)
 
 	def test_parse_args_with_custom_values(self):
-		# Arrange:
-		test_args = [
+		# Arrange + Act:
+		args = parse_args_with_argv(
 			'sync_nem_block.py',
+			parse_args,
 			'--nem-node', 'http://localhost:7890',
 			'--network', 'testnet',
-			'--db-config', 'test_config.ini'
-		]
-
-		# Act:
-		with patch('sys.argv', test_args):
-			args = parse_args()
+			'--db-config', 'test_config.ini')
 
 		# Assert:
-		self.assertEqual(args.nem_node, 'http://localhost:7890')
-		self.assertEqual(args.network, 'testnet')
-		self.assertEqual(args.db_config, 'test_config.ini')
+		assert_common_args(self, args, 'testnet', 'test_config.ini')
 
 	@patch('puller.workflows.sync_nem_block.NemPuller')
 	@patch('puller.workflows.sync_nem_block.parse_args')
 	def _run_main_test(self, mock_parse_args, mock_nem_puller, db_height):  # pylint: disable=no-self-use
 		# Arrange:
-		mock_args = Mock()
-		mock_args.nem_node = 'http://localhost:7890'
-		mock_args.network = 'testnet'
-		mock_args.db_config = 'test_config.ini'
-		mock_parse_args.return_value = mock_args
-
-		mock_facade = Mock()
-		mock_nem_puller.return_value = mock_facade
-
-		mock_db = Mock()
-		mock_facade.nem_db = mock_db
-		mock_facade.nem_db.__enter__ = Mock(return_value=mock_db)
-		mock_facade.nem_db.__exit__ = Mock(return_value=None)
+		mock_parse_args.return_value = create_main_args()
+		mock_facade, mock_db = create_facade_with_mock_db(mock_nem_puller)
 
 		mock_connector = Mock()
 		mock_facade.nem_connector = mock_connector

--- a/explorer/puller/tests/workflows/workflow_test_utils.py
+++ b/explorer/puller/tests/workflows/workflow_test_utils.py
@@ -1,0 +1,36 @@
+from unittest.mock import Mock, patch
+
+
+def parse_args_with_argv(script_name, parse_args, *argv):
+	with patch('sys.argv', [script_name, *argv]):
+		return parse_args()
+
+
+def assert_common_args(test_case, args, network='mainnet', db_config='config.ini'):
+	test_case.assertEqual(args.nem_node, 'http://localhost:7890')
+	test_case.assertEqual(args.network, network)
+	test_case.assertEqual(args.db_config, db_config)
+
+
+def create_main_args(batch_size=None):
+	args = Mock()
+	args.nem_node = 'http://localhost:7890'
+	args.network = 'testnet'
+	args.db_config = 'test_config.ini'
+
+	if None is not batch_size:
+		args.batch_size = batch_size
+
+	return args
+
+
+def create_facade_with_mock_db(mock_nem_puller):
+	mock_facade = Mock()
+	mock_nem_puller.return_value = mock_facade
+
+	mock_db = Mock()
+	mock_facade.nem_db = mock_db
+	mock_facade.nem_db.__enter__ = Mock(return_value=mock_db)
+	mock_facade.nem_db.__exit__ = Mock(return_value=None)
+
+	return mock_facade, mock_db


### PR DESCRIPTION
Problem: Vested balance and importance are recalculated by the node on a schedule. However, the puller does not update those accounts in the database if no transaction happens.

Solution: Added a new workflow script that can update accounts where balance, vested_balance, or importance is greater than 0. We can set up a cron job to run it daily.