### PR TITLE
[bridge] Start Otterscan searches from latest block height

### DIFF
--- a/bridge/bridge/ethereum/EthereumConnector.py
+++ b/bridge/bridge/ethereum/EthereumConnector.py
@@ -238,7 +238,10 @@ class EthereumConnector(BasicConnector):
 	async def incoming_transactions(self, account_address, start_id=None):
 		"""Gets incoming transactions for the specified account."""
 
-		request_json = make_rpc_request_json('ots_searchTransactionsBefore', [str(account_address), start_id or 0, 25])
+		if start_id is None:
+			start_id = await self.finalized_chain_height()
+
+		request_json = make_rpc_request_json('ots_searchTransactionsBefore', [str(account_address), start_id, 25])
 		result_json = await self._post_rpc(request_json)
 
 		transaction_hash_to_status = {

--- a/bridge/bridge/ethereum/EthereumConnector.py
+++ b/bridge/bridge/ethereum/EthereumConnector.py
@@ -239,7 +239,7 @@ class EthereumConnector(BasicConnector):
 		"""Gets incoming transactions for the specified account."""
 
 		if start_id is None:
-			start_id = await self.finalized_chain_height()
+			start_id = await self.chain_height() + 1
 
 		request_json = make_rpc_request_json('ots_searchTransactionsBefore', [str(account_address), start_id, 25])
 		result_json = await self._post_rpc(request_json)

--- a/bridge/tests/ethereum/test_EthereumConnector.py
+++ b/bridge/tests/ethereum/test_EthereumConnector.py
@@ -338,17 +338,15 @@ async def _assert_can_query_incoming_transactions(server, start_id, expected_sta
 		*([start_id] if start_id else []))
 
 	# Assert:
+	additional_expected_request_json_payloads = []
 	if start_id is None:
-		assert [f'{server.make_url("")}/'] * 2 == server.mock.urls
-		assert [
-			make_rpc_request_json('eth_blockNumber', []),
-			make_rpc_request_json('ots_searchTransactionsBefore', ['0xB668a7Cdc62108fAC00F65E1690591B67A1eF7c9', expected_start_id, 25])
-		] == server.mock.request_json_payloads
-	else:
-		assert [f'{server.make_url("")}/'] == server.mock.urls
-		assert [
-			make_rpc_request_json('ots_searchTransactionsBefore', ['0xB668a7Cdc62108fAC00F65E1690591B67A1eF7c9', expected_start_id, 25])
-		] == server.mock.request_json_payloads
+		additional_expected_request_json_payloads = [make_rpc_request_json('eth_blockNumber', [])]
+
+	assert [f'{server.make_url("")}/'] * (1 + len(additional_expected_request_json_payloads)) == server.mock.urls
+	assert [
+		*additional_expected_request_json_payloads,
+		make_rpc_request_json('ots_searchTransactionsBefore', ['0xB668a7Cdc62108fAC00F65E1690591B67A1eF7c9', expected_start_id, 25])
+	] == server.mock.request_json_payloads
 
 	hashes = [
 		'0x12dfb8047ec57ba5a34a4ce8b8206e5020da409e06cdcf4ad02cc1034aa178ed',
@@ -362,7 +360,7 @@ async def _assert_can_query_incoming_transactions(server, start_id, expected_sta
 	] == transactions
 
 
-async def test_can_query_incoming_transactions_with_default_start_id(server):  # pylint: disable=redefined-outer-name
+async def test_can_query_incoming_transactions_with_autodetected_start_id(server):  # pylint: disable=redefined-outer-name
 	await _assert_can_query_incoming_transactions(server, None, 0xAB124)
 
 

--- a/bridge/tests/ethereum/test_EthereumConnector.py
+++ b/bridge/tests/ethereum/test_EthereumConnector.py
@@ -341,7 +341,7 @@ async def _assert_can_query_incoming_transactions(server, start_id, expected_sta
 	if start_id is None:
 		assert [f'{server.make_url("")}/'] * 2 == server.mock.urls
 		assert [
-			make_rpc_request_json('eth_getBlockByNumber', ['finalized', False]),
+			make_rpc_request_json('eth_blockNumber', []),
 			make_rpc_request_json('ots_searchTransactionsBefore', ['0xB668a7Cdc62108fAC00F65E1690591B67A1eF7c9', expected_start_id, 25])
 		] == server.mock.request_json_payloads
 	else:
@@ -362,8 +362,8 @@ async def _assert_can_query_incoming_transactions(server, start_id, expected_sta
 	] == transactions
 
 
-async def test_can_query_incoming_transactions_from_beginning(server):  # pylint: disable=redefined-outer-name
-	await _assert_can_query_incoming_transactions(server, None, 0x112233)
+async def test_can_query_incoming_transactions_with_default_start_id(server):  # pylint: disable=redefined-outer-name
+	await _assert_can_query_incoming_transactions(server, None, 0xAB124)
 
 
 async def test_can_query_incoming_transactions_with_custom_start_id(server):  # pylint: disable=redefined-outer-name

--- a/bridge/tests/ethereum/test_EthereumConnector.py
+++ b/bridge/tests/ethereum/test_EthereumConnector.py
@@ -338,10 +338,17 @@ async def _assert_can_query_incoming_transactions(server, start_id, expected_sta
 		*([start_id] if start_id else []))
 
 	# Assert:
-	assert [f'{server.make_url("")}/'] == server.mock.urls
-	assert [
-		make_rpc_request_json('ots_searchTransactionsBefore', ['0xB668a7Cdc62108fAC00F65E1690591B67A1eF7c9', expected_start_id, 25])
-	] == server.mock.request_json_payloads
+	if start_id is None:
+		assert [f'{server.make_url("")}/'] * 2 == server.mock.urls
+		assert [
+			make_rpc_request_json('eth_getBlockByNumber', ['finalized', False]),
+			make_rpc_request_json('ots_searchTransactionsBefore', ['0xB668a7Cdc62108fAC00F65E1690591B67A1eF7c9', expected_start_id, 25])
+		] == server.mock.request_json_payloads
+	else:
+		assert [f'{server.make_url("")}/'] == server.mock.urls
+		assert [
+			make_rpc_request_json('ots_searchTransactionsBefore', ['0xB668a7Cdc62108fAC00F65E1690591B67A1eF7c9', expected_start_id, 25])
+		] == server.mock.request_json_payloads
 
 	hashes = [
 		'0x12dfb8047ec57ba5a34a4ce8b8206e5020da409e06cdcf4ad02cc1034aa178ed',
@@ -356,7 +363,7 @@ async def _assert_can_query_incoming_transactions(server, start_id, expected_sta
 
 
 async def test_can_query_incoming_transactions_from_beginning(server):  # pylint: disable=redefined-outer-name
-	await _assert_can_query_incoming_transactions(server, None, 0)
+	await _assert_can_query_incoming_transactions(server, None, 0x112233)
 
 
 async def test_can_query_incoming_transactions_with_custom_start_id(server):  # pylint: disable=redefined-outer-name


### PR DESCRIPTION
## Summary

- Replace the initial `ots_searchTransactionsBefore` start block from `0` with `eth_blockNumber + 1`.
- Avoid pruning errors on Erigon nodes where block `0` is treated literally instead of as the Otterscan “latest” sentinel.
- Keep pagination behavior unchanged for subsequent pages by continuing to use the extracted transaction height as `start_id`.

## Motivation

On Ethereum Sepolia, `ots_searchTransactionsBefore(address, 0, pageSize)` can fail on pruned Erigon nodes with:
```
old data not available due to pruning: requested block 0, history is available from block ...
```

## Notes
The get_incoming_transactions_from helper is left unchanged because start_id has different meanings across connectors:
- Ethereum: block height for Otterscan search
- Symbol: REST pagination offset
- NEM: transfer pagination id