### PR TITLE
[explorer] feat: add account height in database

### DIFF
--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -145,6 +145,7 @@ class NemDatabase(DatabaseConnection):
 			CREATE TABLE IF NOT EXISTS accounts (
 				id serial PRIMARY KEY,
 				address bytea NOT NULL UNIQUE,
+				registered_height bigint NOT NULL,
 				public_key bytea,
 				remote_address bytea,
 				importance decimal(20, 10) DEFAULT 0,
@@ -357,6 +358,7 @@ class NemDatabase(DatabaseConnection):
 			'''
 			INSERT INTO accounts (
 				address,
+				registered_height,
 				public_key,
 				remote_address,
 				importance,
@@ -369,7 +371,7 @@ class NemDatabase(DatabaseConnection):
 				cosignatory_of,
 				cosignatories
 			)
-			VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+			VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 			ON CONFLICT (address)
 			DO UPDATE SET
 				remote_address = EXCLUDED.remote_address,
@@ -385,6 +387,7 @@ class NemDatabase(DatabaseConnection):
 				updated_at = CURRENT_TIMESTAMP
 			''', (
 				account_info.address.bytes,
+				account_info.registered_height,
 				account_info.public_key.bytes if account_info.public_key else None,
 				account_info.remote_address.bytes if account_info.remote_address else None,
 				account_info.importance,

--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -145,7 +145,7 @@ class NemDatabase(DatabaseConnection):
 			CREATE TABLE IF NOT EXISTS accounts (
 				id serial PRIMARY KEY,
 				address bytea NOT NULL UNIQUE,
-				registered_height bigint NOT NULL,
+				height bigint NOT NULL,
 				public_key bytea,
 				remote_address bytea,
 				importance decimal(20, 10) DEFAULT 0,
@@ -358,7 +358,7 @@ class NemDatabase(DatabaseConnection):
 			'''
 			INSERT INTO accounts (
 				address,
-				registered_height,
+				height,
 				public_key,
 				remote_address,
 				importance,
@@ -387,7 +387,7 @@ class NemDatabase(DatabaseConnection):
 				updated_at = CURRENT_TIMESTAMP
 			''', (
 				account_info.address.bytes,
-				account_info.registered_height,
+				account_info.height,
 				account_info.public_key.bytes if account_info.public_key else None,
 				account_info.remote_address.bytes if account_info.remote_address else None,
 				account_info.importance,

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -29,7 +29,7 @@ BlockRecord = namedtuple('BlockRecord', [
 ])
 AccountRecord = namedtuple('AccountRecord', [
 	'address',
-	'registered_height',
+	'height',
 	'public_key',
 	'remote_address',
 	'importance',
@@ -243,12 +243,12 @@ class NemPuller:
 		]
 
 	@staticmethod
-	def _create_account_record(account_info, mosaics_json, registered_height, remote_address=None):
+	def _create_account_record(account_info, mosaics_json, height, remote_address=None):
 		"""Create AccountRecord from account info and mosaics."""
 
 		return AccountRecord(
 			account_info.address,
-			registered_height,
+			height,
 			account_info.public_key,
 			remote_address,
 			account_info.importance,
@@ -271,12 +271,12 @@ class NemPuller:
 		log.info(f'Processing batch of {len(address_heights)} addresses')
 
 		# Fetch account info for all addresses (both new and existing)
-		for address, registered_height in address_heights.items():
+		for address, height in address_heights.items():
 			account_info = await self._retry_get_account_info(address)
 			account_mosaics = await self._retry_get_account_mosaics(address)
 
 			mosaics_json = self._convert_mosaics_to_json(account_mosaics)
-			account = self._create_account_record(account_info, mosaics_json, registered_height)
+			account = self._create_account_record(account_info, mosaics_json, height)
 
 			self.nem_db.upsert_account(cursor, account)
 
@@ -286,7 +286,7 @@ class NemPuller:
 				main_account_mosaics = await self._retry_get_account_mosaics(str(main_account_info.address))
 
 				main_mosaics_json = self._convert_mosaics_to_json(main_account_mosaics)
-				main_account = self._create_account_record(main_account_info, main_mosaics_json, registered_height, remote_address=account.address)
+				main_account = self._create_account_record(main_account_info, main_mosaics_json, height, remote_address=account.address)
 
 				self.nem_db.upsert_account(cursor, main_account)
 

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -29,6 +29,7 @@ BlockRecord = namedtuple('BlockRecord', [
 ])
 AccountRecord = namedtuple('AccountRecord', [
 	'address',
+	'registered_height',
 	'public_key',
 	'remote_address',
 	'importance',
@@ -242,11 +243,12 @@ class NemPuller:
 		]
 
 	@staticmethod
-	def _create_account_record(account_info, mosaics_json, remote_address=None):
+	def _create_account_record(account_info, mosaics_json, registered_height, remote_address=None):
 		"""Create AccountRecord from account info and mosaics."""
 
 		return AccountRecord(
 			account_info.address,
+			registered_height,
 			account_info.public_key,
 			remote_address,
 			account_info.importance,
@@ -260,21 +262,21 @@ class NemPuller:
 			account_info.cosignatories
 		)
 
-	async def _process_account_batch(self, cursor, addresses):
+	async def _process_account_batch(self, cursor, address_heights):
 		"""
 		Process a batch of addresses: fetch account info, mosaics, and upsert.
 		Updates both new and existing accounts with latest information.
 		"""
 
-		log.info(f'Processing batch of {len(addresses)} addresses')
+		log.info(f'Processing batch of {len(address_heights)} addresses')
 
 		# Fetch account info for all addresses (both new and existing)
-		for address in addresses:
+		for address, registered_height in address_heights.items():
 			account_info = await self._retry_get_account_info(address)
 			account_mosaics = await self._retry_get_account_mosaics(address)
 
 			mosaics_json = self._convert_mosaics_to_json(account_mosaics)
-			account = self._create_account_record(account_info, mosaics_json)
+			account = self._create_account_record(account_info, mosaics_json, registered_height)
 
 			self.nem_db.upsert_account(cursor, account)
 
@@ -284,9 +286,17 @@ class NemPuller:
 				main_account_mosaics = await self._retry_get_account_mosaics(str(main_account_info.address))
 
 				main_mosaics_json = self._convert_mosaics_to_json(main_account_mosaics)
-				main_account = self._create_account_record(main_account_info, main_mosaics_json, remote_address=account.address)
+				main_account = self._create_account_record(main_account_info, main_mosaics_json, registered_height, remote_address=account.address)
 
 				self.nem_db.upsert_account(cursor, main_account)
+
+	@staticmethod
+	def _add_pending_addresses(pending_addresses, addresses, height):
+		"""Adds addresses to pending account processing with their earliest recovered height."""
+
+		for address in addresses:
+			if address not in pending_addresses:
+				pending_addresses[address] = height
 
 	def _process_harvested_fees(self, cursor, accounts_harvested_fee):  # pylint: disable=no-self-use
 		"""Process harvested fees for accounts."""
@@ -539,7 +549,7 @@ class NemPuller:
 		self._process_block(cursor, nemesis_block)
 
 		addresses = self._extract_addresses_from_block(nemesis_block)
-		await self._process_account_batch(cursor, addresses)
+		await self._process_account_batch(cursor, {address: nemesis_block.height for address in addresses})
 
 		self._process_transactions(cursor, nemesis_block.transactions, nemesis_block.height)
 
@@ -552,7 +562,7 @@ class NemPuller:
 
 		cursor = self.nem_db.connection.cursor()
 		processed = 0
-		pending_addresses = set()
+		pending_addresses = {}
 		accounts_harvested_fee = {}
 
 		log.info('DB writer thread started')
@@ -578,7 +588,7 @@ class NemPuller:
 
 			# Extract addresses for account processing
 			addresses = self._extract_addresses_from_block(block)
-			pending_addresses.update(addresses)
+			self._add_pending_addresses(pending_addresses, addresses, block.height)
 
 			# Track beneficiary harvested fees
 			current_fees, _ = accounts_harvested_fee.get(block.beneficiary, (0, 0))

--- a/explorer/puller/tests/db/test_NemDatabase.py
+++ b/explorer/puller/tests/db/test_NemDatabase.py
@@ -119,7 +119,7 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			'''
 			SELECT
 				encode(address, 'hex'),
-				registered_height,
+				height,
 				encode(public_key, 'hex'),
 				encode(remote_address, 'hex'),
 				importance::TEXT,
@@ -420,7 +420,7 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			None)
 		)
 
-	def test_account_registered_height_remains_unchanged_on_update(self):
+	def test_account_height_remains_unchanged_on_update(self):
 		# Arrange:
 		with NemDatabase(self.db_config) as nem_database:
 			nem_database.create_tables()
@@ -436,7 +436,7 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			# Act:
 			nem_database.upsert_account(
 				cursor,
-				ACCOUNTS[0]._replace(registered_height=3)
+				ACCOUNTS[0]._replace(height=3)
 			)
 
 			nem_database.connection.commit()

--- a/explorer/puller/tests/db/test_NemDatabase.py
+++ b/explorer/puller/tests/db/test_NemDatabase.py
@@ -45,6 +45,7 @@ BLOCKS = [
 ACCOUNTS = [
 	AccountRecord(
 		Address('TBZWVEKB2XMTO4F3RAOEIBWRBMPQ5N23G56ZJM4I'),
+		1,
 		PublicKey('5451f450416d214b14f0375ce06c3451eeb784f7bcd25ae1072ba7e403940a58'),
 		None,
 		0.123456,
@@ -118,6 +119,7 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			'''
 			SELECT
 				encode(address, 'hex'),
+				registered_height,
 				encode(public_key, 'hex'),
 				encode(remote_address, 'hex'),
 				importance::TEXT,
@@ -360,6 +362,7 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 		self.assertIsNotNone(result)
 		self.assertEqual(result, (
 			ACCOUNTS[0].address.bytes.hex(),
+			1,
 			ACCOUNTS[0].public_key.bytes.hex(),
 			None,
 			'0.1234560000',
@@ -401,6 +404,7 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 		self.assertIsNotNone(result)
 		self.assertEqual(result, (
 			ACCOUNTS[0].address.bytes.hex(),
+			1,
 			ACCOUNTS[0].public_key.bytes.hex(),
 			None,
 			'0.1234560000',
@@ -415,6 +419,31 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			None,
 			None)
 		)
+
+	def test_account_registered_height_remains_unchanged_on_update(self):
+		# Arrange:
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+
+			cursor = nem_database.connection.cursor()
+
+			# insert initial account
+			nem_database.upsert_account(
+				cursor,
+				ACCOUNTS[0]
+			)
+
+			# Act:
+			nem_database.upsert_account(
+				cursor,
+				ACCOUNTS[0]._replace(registered_height=3)
+			)
+
+			nem_database.connection.commit()
+			result = self._fetch_account_from_db(cursor, ACCOUNTS[0].address)
+
+		# Assert:
+		self.assertEqual(result[1], 1)
 
 	def test_can_get_accounts_for_refresh(self):
 		# Arrange:
@@ -498,6 +527,7 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 		self.assertIsNotNone(result)
 		self.assertEqual(result, (
 			ACCOUNTS[0].address.bytes.hex(),
+			1,
 			ACCOUNTS[0].public_key.bytes.hex(),
 			None,
 			'0.6543210000',
@@ -546,8 +576,8 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			result = self._fetch_account_from_db(cursor, ACCOUNTS[0].address)
 
 		# Assert:
-		self.assertEqual(result[7], 750000)  # harvested_fees
-		self.assertEqual(result[10], 20)      # last_harvested_height
+		self.assertEqual(result[8], 750000)  # harvested_fees
+		self.assertEqual(result[11], 20)      # last_harvested_height
 
 	def test_can_insert_namespace(self):
 		# Arrange:

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -701,7 +701,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		mock_upsert_account.assert_called_once_with(
 			cursor,
 			AccountRecord(
-				registered_height=3,
+				height=3,
 				mosaics=[{
 					'namespace_name': 'nem.xem',
 					'quantity': 8000000
@@ -755,7 +755,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		self.assertEqual(upsert_account_calls[0][0], (
 			cursor,
 			AccountRecord(
-				registered_height=3,
+				height=3,
 				mosaics=[{
 					'namespace_name': 'nem.xem',
 					'quantity': 0
@@ -767,7 +767,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		self.assertEqual(upsert_account_calls[1][0], (
 			cursor,
 			AccountRecord(
-				registered_height=3,
+				height=3,
 				mosaics=[{
 					'namespace_name': 'nem.xem',
 					'quantity': 1000000

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -412,8 +412,11 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			))
 
 			call_args = mock_process_account_batch.call_args_list[0]
-			addresses = call_args[0][1]
-			self.assertEqual(len(addresses), 19)
+			address_heights = call_args[0][1]
+			self.assertEqual(len(address_heights), 19)
+			self.assertIn(1, address_heights.values())
+			self.assertIn(2, address_heights.values())
+			self.assertIn(3, address_heights.values())
 
 			self.assertEqual(mock_process_transactions.call_count, 3)
 			process_transactions_calls = mock_process_transactions.call_args_list
@@ -685,12 +688,12 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		]
 
 		cursor = Mock()
-		addresses = {
-			str(NEM_CONNECTOR_RESPONSE_ACCOUNT_INFO.address),
+		address_heights = {
+			str(NEM_CONNECTOR_RESPONSE_ACCOUNT_INFO.address): 3,
 		}
 
 		# Act:
-		asyncio.run(self.puller._process_account_batch(cursor, addresses))  # pylint: disable=protected-access
+		asyncio.run(self.puller._process_account_batch(cursor, address_heights))  # pylint: disable=protected-access
 
 		# Assert:
 		mock_account_info.assert_called_once_with(str(NEM_CONNECTOR_RESPONSE_ACCOUNT_INFO.address), False)
@@ -698,6 +701,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		mock_upsert_account.assert_called_once_with(
 			cursor,
 			AccountRecord(
+				registered_height=3,
 				mosaics=[{
 					'namespace_name': 'nem.xem',
 					'quantity': 8000000
@@ -728,12 +732,12 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		]
 
 		cursor = Mock()
-		addresses = {
-			str(account.address),
+		address_heights = {
+			str(account.address): 3,
 		}
 
 		# Act:
-		asyncio.run(self.puller._process_account_batch(cursor, addresses))  # pylint: disable=protected-access
+		asyncio.run(self.puller._process_account_batch(cursor, address_heights))  # pylint: disable=protected-access
 
 		# Assert:
 		account_info_calls = mock_account_info.call_args_list
@@ -751,6 +755,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		self.assertEqual(upsert_account_calls[0][0], (
 			cursor,
 			AccountRecord(
+				registered_height=3,
 				mosaics=[{
 					'namespace_name': 'nem.xem',
 					'quantity': 0
@@ -762,6 +767,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		self.assertEqual(upsert_account_calls[1][0], (
 			cursor,
 			AccountRecord(
+				registered_height=3,
 				mosaics=[{
 					'namespace_name': 'nem.xem',
 					'quantity': 1000000

--- a/explorer/rest/rest/__init__.py
+++ b/explorer/rest/rest/__init__.py
@@ -147,8 +147,8 @@ def setup_nem_routes(app, nem_api_facade):  # pylint: disable=too-many-statement
 				raise ValueError('Limit and offset must be greater than or equal to 0')
 			if sort_order not in ['ASC', 'DESC']:
 				raise ValueError('Sort order must be either ASC or DESC')
-			if sort_field not in ['BALANCE']:
-				raise ValueError('Sort field must be BALANCE')
+			if sort_field not in ['BALANCE', 'HEIGHT']:
+				raise ValueError('Sort field must be BALANCE or HEIGHT')
 
 		except ValueError as error:
 			abort(400, error)

--- a/explorer/rest/rest/db/NemDatabase.py
+++ b/explorer/rest/rest/db/NemDatabase.py
@@ -76,6 +76,7 @@ class NemDatabase(DatabaseConnectionPool):
 	def _create_account_view(self, result):  # pylint: disable=too-many-locals
 		(
 			address,
+			height,
 			public_key,
 			remote_address,
 			importance,
@@ -94,6 +95,7 @@ class NemDatabase(DatabaseConnectionPool):
 
 		return AccountView(
 			address=_format_address_bytes_to_string(address),
+			height=height,
 			public_key=str(PublicKey(public_key)) if public_key else None,
 			remote_address=_format_address_bytes_to_string(remote_address) if remote_address else None,
 			importance=importance,
@@ -300,6 +302,7 @@ class NemDatabase(DatabaseConnectionPool):
 		return f'''
 			SELECT
 				a.address,
+				a.height,
 				public_key,
 				remote_address,
 				importance::float,

--- a/explorer/rest/rest/model/Account.py
+++ b/explorer/rest/rest/model/Account.py
@@ -2,6 +2,7 @@ class AccountView:  # pylint: disable=too-many-locals,too-many-instance-attribut
 	def __init__(
 		self,
 		address,
+		height,
 		public_key,
 		remote_address,
 		importance,
@@ -22,6 +23,7 @@ class AccountView:  # pylint: disable=too-many-locals,too-many-instance-attribut
 		# pylint: disable=too-many-arguments,too-many-positional-arguments
 
 		self.address = address
+		self.height = height
 		self.public_key = public_key
 		self.remote_address = remote_address
 		self.importance = importance
@@ -40,6 +42,7 @@ class AccountView:  # pylint: disable=too-many-locals,too-many-instance-attribut
 	def __eq__(self, other):
 		return isinstance(other, AccountView) and all([
 			self.address == other.address,
+			self.height == other.height,
 			self.public_key == other.public_key,
 			self.remote_address == other.remote_address,
 			self.importance == other.importance,
@@ -61,6 +64,7 @@ class AccountView:  # pylint: disable=too-many-locals,too-many-instance-attribut
 
 		return {
 			'address': self.address,
+			'height': self.height,
 			'publicKey': self.public_key,
 			'remoteAddress': self.remote_address,
 			'importance': self.importance,

--- a/explorer/rest/tests/model/test_Account.py
+++ b/explorer/rest/tests/model/test_Account.py
@@ -8,6 +8,7 @@ class AccountTest(unittest.TestCase):
 	def _create_default_account_view(override=None):
 		account_view = AccountView(
 			address='NCXIQA4FF5JB6AMQ53NQ3ZMRD3X3PJEWDJJJIGHT',
+			height=100,
 			public_key='107051C28A2C009A83AE0861CDBFF7C1CBAB387C964CC433F7D191D9C3115ED7',
 			remote_address='NA7HZVREMOJWCYQOHQYTMVVXOYFOFF4WX46FP65U',
 			importance=0.0477896226,
@@ -35,6 +36,7 @@ class AccountTest(unittest.TestCase):
 
 		# Assert:
 		self.assertEqual('NCXIQA4FF5JB6AMQ53NQ3ZMRD3X3PJEWDJJJIGHT', account_view.address)
+		self.assertEqual(100, account_view.height)
 		self.assertEqual('107051C28A2C009A83AE0861CDBFF7C1CBAB387C964CC433F7D191D9C3115ED7', account_view.public_key)
 		self.assertEqual('NA7HZVREMOJWCYQOHQYTMVVXOYFOFF4WX46FP65U', account_view.remote_address)
 		self.assertEqual(0.0477896226, account_view.importance)
@@ -60,6 +62,7 @@ class AccountTest(unittest.TestCase):
 		# Assert:
 		self.assertEqual({
 			'address': 'NCXIQA4FF5JB6AMQ53NQ3ZMRD3X3PJEWDJJJIGHT',
+			'height': 100,
 			'publicKey': '107051C28A2C009A83AE0861CDBFF7C1CBAB387C964CC433F7D191D9C3115ED7',
 			'remoteAddress': 'NA7HZVREMOJWCYQOHQYTMVVXOYFOFF4WX46FP65U',
 			'importance': 0.0477896226,
@@ -85,6 +88,7 @@ class AccountTest(unittest.TestCase):
 		self.assertNotEqual(account_view, None)
 		self.assertNotEqual(account_view, 'account_view')
 		self.assertNotEqual(account_view, self._create_default_account_view(('address', 'DIFFERENT_ADDRESS')))
+		self.assertNotEqual(account_view, self._create_default_account_view(('height', 200)))
 		self.assertNotEqual(account_view, self._create_default_account_view(('public_key', 'DIFFERENT_KEY')))
 		self.assertNotEqual(account_view, self._create_default_account_view(('remote_address', 'DIFFERENT_REMOTE')))
 		self.assertNotEqual(account_view, self._create_default_account_view(('importance', 0.002)))

--- a/explorer/rest/tests/test/DatabaseTestUtils.py
+++ b/explorer/rest/tests/test/DatabaseTestUtils.py
@@ -38,6 +38,7 @@ Block = namedtuple(
 )
 Account = namedtuple('Account', [
 	'address',
+	'height',
 	'public_key',
 	'remote_address',
 	'importance',
@@ -127,6 +128,7 @@ BLOCKS = [
 ACCOUNTS = [
 	Account(
 		Address('NAGHXD63C4V6REWGXCVKJ2SBS3GUAXGTRQZQXPRO'),
+		1,
 		PublicKey('b88221939ac920484753c738fafda87e82ff04b5e370c9456d85a0f12c6a5cca'),
 		None,
 		0.123456,
@@ -140,6 +142,7 @@ ACCOUNTS = [
 		None),
 	Account(
 		Address('NBFWZ4IVRHEIBRCGHLYDS62FSFTBM3VDFA7E6LSQ'),
+		2,
 		PublicKey('a5f06d59b97aa40c82afb941a61fb6483bdb7491805cdb9dc47d92136983b9a5'),
 		None,
 		0.123456,
@@ -466,6 +469,7 @@ BLOCK_VIEWS = [
 ACCOUNT_VIEWS = [
 	AccountView(
 		address=str(ACCOUNTS[0].address),
+		height=ACCOUNTS[0].height,
 		public_key=str(ACCOUNTS[0].public_key) if ACCOUNTS[0].public_key else None,
 		remote_address=None,
 		importance=0.123456,
@@ -493,6 +497,7 @@ ACCOUNT_VIEWS = [
 	),
 	AccountView(
 		address=str(ACCOUNTS[1].address),
+		height=ACCOUNTS[1].height,
 		public_key=str(ACCOUNTS[1].public_key) if ACCOUNTS[1].public_key else None,
 		remote_address=None,
 		importance=0.123456,
@@ -851,6 +856,7 @@ def initialize_database(db_config, network_name):
 			CREATE TABLE IF NOT EXISTS accounts (
 				id serial PRIMARY KEY,
 				address bytea NOT NULL UNIQUE,
+				height bigint NOT NULL,
 				public_key bytea,
 				remote_address bytea,
 				importance decimal(20, 10) DEFAULT 0,
@@ -987,6 +993,7 @@ def initialize_database(db_config, network_name):
 				'''
 				INSERT INTO accounts (
 					address,
+					height,
 					public_key,
 					remote_address,
 					importance,
@@ -999,9 +1006,10 @@ def initialize_database(db_config, network_name):
 					cosignatory_of,
 					cosignatories
 				)
-				VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+				VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 				''', (
 					account.address.bytes,
+					account.height,
 					account.public_key.bytes if account.public_key else None,
 					account.remote_address.bytes if account.remote_address else None,
 					account.importance,

--- a/explorer/rest/tests/test_rest.py
+++ b/explorer/rest/tests/test_rest.py
@@ -336,8 +336,28 @@ def test_api_nem_accounts_applies_sorted_by_balance_asc(client):  # pylint: disa
 	_assert_get_api_nem_accounts(client, 200, [ACCOUNT_VIEWS[0].to_dict(), ACCOUNT_VIEWS[1].to_dict()], sort_field='BALANCE', sort_order='ASC')
 
 
+def test_api_nem_accounts_applies_sorted_by_height_desc(client):  # pylint: disable=redefined-outer-name, invalid-name
+	_assert_get_api_nem_accounts(
+		client,
+		200,
+		[ACCOUNT_VIEWS[1].to_dict(), ACCOUNT_VIEWS[0].to_dict()],
+		sort_field='HEIGHT',
+		sort_order='DESC'
+	)
+
+
+def test_api_nem_accounts_applies_sorted_by_height_asc(client):  # pylint: disable=redefined-outer-name, invalid-name
+	_assert_get_api_nem_accounts(
+		client,
+		200,
+		[ACCOUNT_VIEWS[0].to_dict(), ACCOUNT_VIEWS[1].to_dict()],
+		sort_field='HEIGHT',
+		sort_order='ASC'
+	)
+
+
 def test_api_nem_accounts_invalid_sort_field(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_nem_accounts_bad_request(client, 'Sort field must be BALANCE', sort_field='INVALID')
+	_assert_get_nem_accounts_bad_request(client, 'Sort field must be BALANCE or HEIGHT', sort_field='INVALID')
 
 
 def test_api_nem_accounts_invalid_sort_order(client):  # pylint: disable=redefined-outer-name, invalid-name


### PR DESCRIPTION
Problem: The account table is missing account height.
Solution:
- Added `height` to the DB table.
- In the puller, it processes accounts with height.
- In the rest endpoint, the `/accounts` endpoint supports `height` in the sort field filter