### PR TITLE
Align NEM DB schema constraints with live data and standardize index names

### DIFF
--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -19,28 +19,28 @@ class NemDatabase(DatabaseConnection):
 		# Create indexes for accounts table
 		cursor.execute(
 			'''
-			CREATE INDEX IF NOT EXISTS idx_accounts_address
+			CREATE INDEX IF NOT EXISTS accounts_address_idx
 				ON accounts (address)
 			'''
 		)
 
 		cursor.execute(
 			'''
-			CREATE INDEX IF NOT EXISTS idx_accounts_balance
+			CREATE INDEX IF NOT EXISTS accounts_balance_idx
 				ON accounts(balance DESC);
 			'''
 		)
 
 		cursor.execute(
 			'''
-			CREATE INDEX IF NOT EXISTS idx_accounts_public_key
+			CREATE INDEX IF NOT EXISTS accounts_public_key_idx
 				ON accounts (public_key)
 			'''
 		)
 
 		cursor.execute(
 			'''
-			CREATE INDEX IF NOT EXISTS idx_accounts_mosaics_gin
+			CREATE INDEX IF NOT EXISTS accounts_mosaics_idx
 				ON accounts USING GIN (mosaics)
 			'''
 		)
@@ -48,13 +48,13 @@ class NemDatabase(DatabaseConnection):
 		# Create indexes for blocks table
 		cursor.execute(
 			'''
-			CREATE INDEX IF NOT EXISTS idx_blocks_height_desc ON blocks(height DESC);
+			CREATE INDEX IF NOT EXISTS blocks_height_idx ON blocks(height DESC);
 			'''
 		)
 
 		cursor.execute(
 			'''
-			CREATE INDEX IF NOT EXISTS idx_blocks_timestamp
+			CREATE INDEX IF NOT EXISTS blocks_timestamp_idx
 				ON blocks(timestamp)
 			'''
 		)
@@ -62,7 +62,7 @@ class NemDatabase(DatabaseConnection):
 		# Create indexes for namespaces table
 		cursor.execute(
 			'''
-			CREATE INDEX IF NOT EXISTS idx_namespaces_root_namespace
+			CREATE INDEX IF NOT EXISTS namespaces_root_namespace_idx
 				ON namespaces (root_namespace)
 			'''
 		)
@@ -70,7 +70,7 @@ class NemDatabase(DatabaseConnection):
 		# Create indexes for mosaics table
 		cursor.execute(
 			'''
-			CREATE INDEX IF NOT EXISTS idx_mosaic_name
+			CREATE INDEX IF NOT EXISTS mosaics_namespace_name_idx
 				ON mosaics (namespace_name)
 			'''
 		)
@@ -78,21 +78,21 @@ class NemDatabase(DatabaseConnection):
 		# Create indexes for transactions table
 		cursor.execute(
 			'''
-			CREATE INDEX IF NOT EXISTS idx_transactions_hash
+			CREATE INDEX IF NOT EXISTS transactions_transaction_hash_idx
 				ON transactions (transaction_hash)
 			'''
 		)
 
 		cursor.execute(
 			'''
-			CREATE INDEX IF NOT EXISTS idx_transaction_type
+			CREATE INDEX IF NOT EXISTS transactions_transaction_type_idx
 				ON transactions (transaction_type)
 			'''
 		)
 
 		cursor.execute(
 			'''
-			CREATE INDEX IF NOT EXISTS idx_transaction_height
+			CREATE INDEX IF NOT EXISTS transactions_height_is_inner_false_idx
 				ON transactions(height DESC)
 				WHERE is_inner = false
 			'''
@@ -100,21 +100,21 @@ class NemDatabase(DatabaseConnection):
 
 		cursor.execute(
 			'''
-			CREATE INDEX IF NOT EXISTS idx_tx_recipient
+			CREATE INDEX IF NOT EXISTS transactions_recipient_address_idx
 				ON transactions(recipient_address)
 			'''
 		)
 
 		cursor.execute(
 			'''
-			CREATE INDEX IF NOT EXISTS idx_tx_sender_address
+			CREATE INDEX IF NOT EXISTS transactions_sender_address_idx
 				ON transactions(sender_address)
 			'''
 		)
 
 		cursor.execute(
 			'''
-			CREATE INDEX IF NOT EXISTS idx_tx_is_inner
+			CREATE INDEX IF NOT EXISTS transactions_is_inner_idx
 				ON transactions(is_inner)
 			'''
 		)
@@ -122,14 +122,14 @@ class NemDatabase(DatabaseConnection):
 		# Create indexes for transactions_mosaic table
 		cursor.execute(
 			'''
-			CREATE INDEX IF NOT EXISTS idx_mosaic_tx_i
+			CREATE INDEX IF NOT EXISTS transactions_mosaic_transaction_id_idx
 				ON transactions_mosaic(transaction_id)
 			'''
 		)
 
 		cursor.execute(
 			'''
-			CREATE INDEX IF NOT EXISTS idx_mosaic_lookup
+			CREATE INDEX IF NOT EXISTS transactions_mosaic_namespace_name_idx
 				ON transactions_mosaic(namespace_name)
 			'''
 		)
@@ -148,18 +148,18 @@ class NemDatabase(DatabaseConnection):
 				height bigint NOT NULL,
 				public_key bytea,
 				remote_address bytea,
-				importance decimal(20, 10) DEFAULT 0,
-				balance bigint DEFAULT 0,
-				vested_balance bigint DEFAULT 0,
-				mosaics jsonb DEFAULT '[]'::jsonb,
-				harvested_fees bigint DEFAULT 0,
-				harvested_blocks bigint DEFAULT 0,
-				remote_status varchar(12) DEFAULT NULL,
-				last_harvested_height bigint DEFAULT 0,
-				min_cosignatories int DEFAULT NULL,
-				cosignatory_of bytea[] DEFAULT NULL,
-				cosignatories bytea[] DEFAULT NULL,
-				updated_at timestamp DEFAULT CURRENT_TIMESTAMP
+				importance decimal(20, 10) NOT NULL,
+				balance bigint NOT NULL,
+				vested_balance bigint NOT NULL,
+				mosaics jsonb NOT NULL,
+				harvested_fees bigint NOT NULL DEFAULT 0,
+				harvested_blocks bigint NOT NULL,
+				remote_status varchar(12),
+				last_harvested_height bigint NOT NULL DEFAULT 0,
+				min_cosignatories int,
+				cosignatory_of bytea[],
+				cosignatories bytea[],
+				updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
 			)
 			'''
 		)
@@ -171,14 +171,14 @@ class NemDatabase(DatabaseConnection):
 				id serial PRIMARY KEY,
 				height bigint NOT NULL UNIQUE,
 				timestamp timestamp NOT NULL,
-				total_fee bigint DEFAULT 0,
-				total_transactions int DEFAULT 0,
+				total_fee bigint NOT NULL,
+				total_transactions int NOT NULL,
 				difficulty bigint NOT NULL,
 				hash bytea NOT NULL,
 				beneficiary bytea NOT NULL,
 				signer bytea NOT NULL,
 				signature bytea NOT NULL,
-				size bigint DEFAULT 0
+				size bigint NOT NULL
 			)
 			'''
 		)
@@ -192,7 +192,7 @@ class NemDatabase(DatabaseConnection):
 				owner bytea NOT NULL,
 				registered_height bigint NOT NULL,
 				expiration_height bigint NOT NULL,
-				sub_namespaces VARCHAR(146)[] DEFAULT '{}'
+				sub_namespaces VARCHAR(146)[] NOT NULL DEFAULT '{}'
 			)
 			'''
 		)
@@ -204,14 +204,14 @@ class NemDatabase(DatabaseConnection):
 				id serial PRIMARY KEY,
 				root_namespace varchar(16) NOT NULL,
 				namespace_name varchar(146) NOT NULL UNIQUE,
-				description varchar(512),
+				description varchar(512) NOT NULL,
 				creator bytea NOT NULL,
 				registered_height bigint NOT NULL,
-				initial_supply bigint,
-				total_supply bigint,
+				initial_supply bigint NOT NULL,
+				total_supply bigint NOT NULL,
 				divisibility int NOT NULL,
-				supply_mutable boolean,
-				transferable boolean,
+				supply_mutable boolean NOT NULL,
+				transferable boolean NOT NULL,
 				levy_type int,
 				levy_namespace_name varchar(146),
 				levy_fee bigint,
@@ -231,11 +231,11 @@ class NemDatabase(DatabaseConnection):
 				sender_public_key bytea NOT NULL,
 				sender_address bytea NOT NULL,
 				recipient_address bytea,
-				fee bigint DEFAULT 0,
+				fee bigint NOT NULL,
 				timestamp timestamp NOT NULL,
 				deadline timestamp NOT NULL,
 				signature bytea,
-				is_inner boolean DEFAULT false,
+				is_inner boolean NOT NULL,
 				payload jsonb
 			)
 			'''
@@ -247,8 +247,8 @@ class NemDatabase(DatabaseConnection):
 			CREATE TABLE IF NOT EXISTS transactions_mosaic (
 				id serial PRIMARY KEY,
 				transaction_id int NOT NULL,
-				namespace_name varchar(146),
-				quantity bigint,
+				namespace_name varchar(146) NOT NULL,
+				quantity bigint NOT NULL,
 				FOREIGN KEY (transaction_id) REFERENCES transactions(id)
 				ON DELETE CASCADE
 			)

--- a/explorer/rest/tests/test/DatabaseTestUtils.py
+++ b/explorer/rest/tests/test/DatabaseTestUtils.py
@@ -859,19 +859,19 @@ def initialize_database(db_config, network_name):
 				height bigint NOT NULL,
 				public_key bytea,
 				remote_address bytea,
-				importance decimal(20, 10) DEFAULT 0,
-				balance bigint DEFAULT 0,
-				vested_balance bigint DEFAULT 0,
-				mosaics jsonb DEFAULT '[]'::jsonb,
-				harvested_fees bigint DEFAULT 0,
-				harvested_blocks bigint DEFAULT 0,
-				status varchar(8) DEFAULT NULL,
-				remote_status varchar(12) DEFAULT NULL,
-				last_harvested_height bigint DEFAULT 0,
-				min_cosignatories int DEFAULT NULL,
-				cosignatory_of bytea[] DEFAULT NULL,
-				cosignatories bytea[] DEFAULT NULL,
-				updated_at timestamp DEFAULT CURRENT_TIMESTAMP
+				importance decimal(20, 10) NOT NULL,
+				balance bigint NOT NULL,
+				vested_balance bigint NOT NULL,
+				mosaics jsonb NOT NULL,
+				harvested_fees bigint NOT NULL DEFAULT 0,
+				harvested_blocks bigint NOT NULL,
+				status varchar(8),
+				remote_status varchar(12),
+				last_harvested_height bigint NOT NULL DEFAULT 0,
+				min_cosignatories int,
+				cosignatory_of bytea[],
+				cosignatories bytea[],
+				updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
 			)
 			'''
 		)
@@ -881,14 +881,14 @@ def initialize_database(db_config, network_name):
 				id serial NOT NULL PRIMARY KEY,
 				height bigint NOT NULL,
 				timestamp timestamp NOT NULL,
-				total_fee bigint DEFAULT 0,
-				total_transactions int DEFAULT 0,
+				total_fee bigint NOT NULL,
+				total_transactions int NOT NULL,
 				difficulty bigInt NOT NULL,
 				hash bytea NOT NULL,
 				beneficiary bytea NOT NULL,
 				signer bytea NOT NULL,
 				signature bytea NOT NULL,
-				size bigint DEFAULT 0
+				size bigint NOT NULL
 		)
 		''')
 
@@ -900,7 +900,7 @@ def initialize_database(db_config, network_name):
 				owner bytea NOT NULL,
 				registered_height bigint NOT NULL,
 				expiration_height bigint NOT NULL,
-				sub_namespaces VARCHAR(146)[] DEFAULT '{}'
+				sub_namespaces VARCHAR(146)[] NOT NULL DEFAULT '{}'
 			)
 			'''
 		)
@@ -911,14 +911,14 @@ def initialize_database(db_config, network_name):
 				id serial PRIMARY KEY,
 				root_namespace varchar(16) NOT NULL,
 				namespace_name varchar(146) NOT NULL UNIQUE,
-				description varchar(512),
+				description varchar(512) NOT NULL,
 				creator bytea NOT NULL,
 				registered_height bigint NOT NULL,
-				initial_supply bigint,
-				total_supply bigint,
+				initial_supply bigint NOT NULL,
+				total_supply bigint NOT NULL,
 				divisibility int NOT NULL,
-				supply_mutable boolean,
-				transferable boolean,
+				supply_mutable boolean NOT NULL,
+				transferable boolean NOT NULL,
 				levy_type int,
 				levy_namespace_name varchar(146),
 				levy_fee bigint,
@@ -930,8 +930,7 @@ def initialize_database(db_config, network_name):
 		cursor.execute(
 			'''
 			CREATE TABLE IF NOT EXISTS account_remark (
-				id serial PRIMARY KEY,
-				address bytea UNIQUE,
+				address bytea PRIMARY KEY,
 				remark varchar NOT NULL
 			)
 			'''
@@ -947,11 +946,11 @@ def initialize_database(db_config, network_name):
 				sender_public_key bytea NOT NULL,
 				sender_address bytea NOT NULL,
 				recipient_address bytea,
-				fee bigint DEFAULT 0,
+				fee bigint NOT NULL,
 				timestamp timestamp NOT NULL,
 				deadline timestamp NOT NULL,
 				signature bytea,
-				is_inner boolean DEFAULT false,
+				is_inner boolean NOT NULL,
 				payload jsonb
 			)
 			'''
@@ -962,8 +961,8 @@ def initialize_database(db_config, network_name):
 			CREATE TABLE IF NOT EXISTS transactions_mosaic (
 				id serial PRIMARY KEY,
 				transaction_id int NOT NULL,
-				namespace_name varchar(146),
-				quantity numeric
+				namespace_name varchar(146) NOT NULL,
+				quantity bigint NOT NULL
 			)
 			'''
 		)


### PR DESCRIPTION
## Summary

- Standardized custom index names in NemDatabase to the <table_name>_<column_name>_idx convention, including a clearer name for the partial transactions height index.
- Tightened schema nullability based on production data verification for accounts, blocks, namespaces, mosaics, transactions, and transactions_mosaic.
- Removed unnecessary defaults where values are always provided explicitly by inserts/updates, while keeping required defaults.