### PR TITLE
[explorer/fronted] fix: missing copy i18 config

### DIFF
--- a/explorer/frontend/Dockerfile
+++ b/explorer/frontend/Dockerfile
@@ -41,6 +41,7 @@ RUN chown nextjs:nodejs .next
 # https://nextjs.org/docs/advanced-features/output-file-tracing
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/next-i18next.config.js ./next-i18next.config.js
 
 USER nextjs
 


### PR DESCRIPTION
Problem: Frontend Docker images having the error
```sh
app-1  | ⨯ Error: next-i18next was unable to find a user config at /app/next-i18next.config.js
app-1  |     at new Promise (<anonymous>)
app-1  | react-i18next:: You will need to pass in an i18next instance by using initReactI18next
```
Solution: copy `next-i18next.config.js` to images