### PR TITLE
[explorer/frontend] fix: preserve embedded transaction value

### DIFF
--- a/explorer/frontend/__tests__/test-utils/transactions.js
+++ b/explorer/frontend/__tests__/test-utils/transactions.js
@@ -218,7 +218,7 @@ export const transactionPageResponse = [
 			'7A4F8F82B6A144E568F5B33DE055D35E9F8D3EE2FC200F0DE9D2571DF5957FF942B8E5A99ED1726D3F459218CF9F27EA3F264011B04122BB9E3E391E72EE930D',
 		timestamp: '2024-03-29 13:45:29',
 		toAddress: 'NCYAVMNQOZ3MZETEBD34ACMAX3S57WUSWAZWY3DW',
-		transactionHash: '6675175F8339DA8350E4F29B1B6224B12417983720DAC55BC256C2362D471F75',
+		transactionHash: '5C03FB14113E6E41F3FD40426793F766A02F784F1C41462F2CB0102519C25B83',
 		transactionType: 'MULTISIG',
 		value: null
 	},
@@ -850,7 +850,7 @@ export const transactionPageResult = {
 		{
 			type: 'MULTISIG',
 			group: 'confirmed',
-			hash: '6675175F8339DA8350E4F29B1B6224B12417983720DAC55BC256C2362D471F75',
+			hash: '5C03FB14113E6E41F3FD40426793F766A02F784F1C41462F2CB0102519C25B83',
 			timestamp: '2024-03-29 13:45:29',
 			deadline: '2024-03-29 14:06:28',
 			signer: 'ND2RSOCXYGMABR6LESAW5ENC22Z34G3IL63ABALN',
@@ -1818,60 +1818,6 @@ export const transactionAccountPageResult = {
 			group: 'confirmed',
 			hash: '6675175F8339DA8350E4F29B1B6224B12417983720DAC55BC256C2362D471F75',
 			timestamp: '2024-03-29 13:45:29',
-			deadline: '2024-03-29 14:06:28',
-			signer: 'ND2RSOCXYGMABR6LESAW5ENC22Z34G3IL63ABALN',
-			sender: 'NCLT5BCPEVF5EZOS3OJOCL4DWSTJM4EFFF7A5MPG',
-			recipient: 'NCYAVMNQOZ3MZETEBD34ACMAX3S57WUSWAZWY3DW',
-			account: 'NCLT5BCPEVF5EZOS3OJOCL4DWSTJM4EFFF7A5MPG',
-			direction: null,
-			height: 4694401,
-			signature:
-				'7A4F8F82B6A144E568F5B33DE055D35E9F8D3EE2FC200F0DE9D2571DF5957FF942B8E5A99ED1726D3F459218CF9F27EA3F264011B04122BB9E3E391E72EE930D',
-			fee: 0.43,
-			amount: 0,
-			value: [],
-			body: [
-				{
-					type: 'MULTISIG_ACCOUNT_MODIFICATION',
-					sender: 'NCLT5BCPEVF5EZOS3OJOCL4DWSTJM4EFFF7A5MPG',
-					targetAccount: 'NCLT5BCPEVF5EZOS3OJOCL4DWSTJM4EFFF7A5MPG',
-					cosignatoryAdditions: ['NDK3QVT3N42HFL6NMGTRGFRJE74NP2KSNZH26EDT'],
-					cosignatoryDeletions: [],
-					minCosignatories: 1
-				}
-			],
-			signatures: [
-				{
-					fee: 0.15,
-					signature:
-						'31acdafac004c7045247cf3c57eb06e7f504af5dbaa3dc427ee39ddc6bc1365947b42bd18bb8c79c2c86dc8faf3e31aacfe289112649bc0920dfc73f178b7f07',
-					signer: 'NDIVJFQIJR3VWXJRDSNFK6U37HM4DZNORXI3IRTV'
-				}
-			],
-			feesBreakdown: [
-				{
-					type: 'multisigFee',
-					amount: 0.15
-				},
-				{
-					type: 'embeddedTransactionsFee',
-					amount: 0.13
-				},
-				{
-					type: 'signaturesFee',
-					amount: 0.15
-				},
-				{
-					type: 'totalFee',
-					amount: 0.43
-				}
-			]
-		},
-		{
-			type: 'MULTISIG',
-			group: 'confirmed',
-			hash: '6675175F8339DA8350E4F29B1B6224B12417983720DAC55BC256C2362D471F75',
-			timestamp: '2024-03-29 13:45:29',
 			deadline: '2024-03-29 14:06:29',
 			signer: 'ND2RSOCXYGMABR6LESAW5ENC22Z34G3IL63ABALN',
 			sender: 'NCLT5BCPEVF5EZOS3OJOCL4DWSTJM4EFFF7A5MPG',
@@ -2451,6 +2397,12 @@ export const transactionAccountPageResult = {
 	],
 	pageNumber: 3
 };
+
+transactionAccountPageResult.data.splice(
+	transactionAccountPageResult.data.findIndex(item => item.hash === '6675175F8339DA8350E4F29B1B6224B12417983720DAC55BC256C2362D471F75'),
+	0,
+	transactionPageResult.data.find(item => item.hash === '5C03FB14113E6E41F3FD40426793F766A02F784F1C41462F2CB0102519C25B83')
+);
 
 export const transactionInfoResponse = {
 	deadline: '2024-03-29 19:13:31',

--- a/explorer/frontend/__tests__/test-utils/transactions.js
+++ b/explorer/frontend/__tests__/test-utils/transactions.js
@@ -178,6 +178,45 @@ export const transactionPageResponse = [
 		value: null
 	},
 	{
+		deadline: '2024-03-29 14:06:28',
+		embeddedTransactions: [
+			{
+				fee: 0.13,
+				initiator: 'ND2RSOCXYGMABR6LESAW5ENC22Z34G3IL63ABALN',
+				signatures: [
+					{
+						fee: 0.15,
+						signature:
+							'31acdafac004c7045247cf3c57eb06e7f504af5dbaa3dc427ee39ddc6bc1365947b42bd18bb8c79c2c86dc8faf3e31aacfe289112649bc0920dfc73f178b7f07',
+						signer: 'NDIVJFQIJR3VWXJRDSNFK6U37HM4DZNORXI3IRTV'
+					}
+				],
+				transactionType: 'MULTISIG_ACCOUNT_MODIFICATION',
+				value: [
+					{
+						minCosignatories: 1,
+						modifications: [
+							{
+								cosignatoryAccount: 'NDK3QVT3N42HFL6NMGTRGFRJE74NP2KSNZH26EDT',
+								modificationType: 1
+							}
+						]
+					}
+				]
+			}
+		],
+		fee: 0.15,
+		fromAddress: 'NCLT5BCPEVF5EZOS3OJOCL4DWSTJM4EFFF7A5MPG',
+		height: 4694401,
+		signature:
+			'7A4F8F82B6A144E568F5B33DE055D35E9F8D3EE2FC200F0DE9D2571DF5957FF942B8E5A99ED1726D3F459218CF9F27EA3F264011B04122BB9E3E391E72EE930D',
+		timestamp: '2024-03-29 13:45:29',
+		toAddress: 'NCYAVMNQOZ3MZETEBD34ACMAX3S57WUSWAZWY3DW',
+		transactionHash: '6675175F8339DA8350E4F29B1B6224B12417983720DAC55BC256C2362D471F75',
+		transactionType: 'MULTISIG',
+		value: null
+	},
+	{
 		deadline: '2024-03-29 14:06:29',
 		embeddedTransactions: [
 			{
@@ -793,6 +832,62 @@ export const transactionPageResult = {
 				{
 					type: 'totalFee',
 					amount: 0.45
+				}
+			]
+		},
+		{
+			type: 'MULTISIG',
+			group: 'confirmed',
+			hash: '6675175F8339DA8350E4F29B1B6224B12417983720DAC55BC256C2362D471F75',
+			timestamp: '2024-03-29 13:45:29',
+			deadline: '2024-03-29 14:06:28',
+			signer: 'ND2RSOCXYGMABR6LESAW5ENC22Z34G3IL63ABALN',
+			sender: 'NCLT5BCPEVF5EZOS3OJOCL4DWSTJM4EFFF7A5MPG',
+			recipient: 'NCYAVMNQOZ3MZETEBD34ACMAX3S57WUSWAZWY3DW',
+			account: 'NCLT5BCPEVF5EZOS3OJOCL4DWSTJM4EFFF7A5MPG',
+			direction: null,
+
+			height: 4694401,
+
+			signature:
+				'7A4F8F82B6A144E568F5B33DE055D35E9F8D3EE2FC200F0DE9D2571DF5957FF942B8E5A99ED1726D3F459218CF9F27EA3F264011B04122BB9E3E391E72EE930D',
+			fee: 0.43,
+			amount: 0,
+			value: [],
+			body: [
+				{
+					type: 'MULTISIG_ACCOUNT_MODIFICATION',
+					sender: 'NCLT5BCPEVF5EZOS3OJOCL4DWSTJM4EFFF7A5MPG',
+					targetAccount: 'NCLT5BCPEVF5EZOS3OJOCL4DWSTJM4EFFF7A5MPG',
+					cosignatoryAdditions: ['NDK3QVT3N42HFL6NMGTRGFRJE74NP2KSNZH26EDT'],
+					cosignatoryDeletions: [],
+					minCosignatories: 1
+				}
+			],
+			signatures: [
+				{
+					fee: 0.15,
+					signature:
+						'31acdafac004c7045247cf3c57eb06e7f504af5dbaa3dc427ee39ddc6bc1365947b42bd18bb8c79c2c86dc8faf3e31aacfe289112649bc0920dfc73f178b7f07',
+					signer: 'NDIVJFQIJR3VWXJRDSNFK6U37HM4DZNORXI3IRTV'
+				}
+			],
+			feesBreakdown: [
+				{
+					type: 'multisigFee',
+					amount: 0.15
+				},
+				{
+					type: 'embeddedTransactionsFee',
+					amount: 0.13
+				},
+				{
+					type: 'signaturesFee',
+					amount: 0.15
+				},
+				{
+					type: 'totalFee',
+					amount: 0.43
 				}
 			]
 		},
@@ -1697,6 +1792,60 @@ export const transactionAccountPageResult = {
 				{
 					type: 'totalFee',
 					amount: 0.45
+				}
+			]
+		},
+		{
+			type: 'MULTISIG',
+			group: 'confirmed',
+			hash: '6675175F8339DA8350E4F29B1B6224B12417983720DAC55BC256C2362D471F75',
+			timestamp: '2024-03-29 13:45:29',
+			deadline: '2024-03-29 14:06:28',
+			signer: 'ND2RSOCXYGMABR6LESAW5ENC22Z34G3IL63ABALN',
+			sender: 'NCLT5BCPEVF5EZOS3OJOCL4DWSTJM4EFFF7A5MPG',
+			recipient: 'NCYAVMNQOZ3MZETEBD34ACMAX3S57WUSWAZWY3DW',
+			account: 'NCLT5BCPEVF5EZOS3OJOCL4DWSTJM4EFFF7A5MPG',
+			direction: null,
+			height: 4694401,
+			signature:
+				'7A4F8F82B6A144E568F5B33DE055D35E9F8D3EE2FC200F0DE9D2571DF5957FF942B8E5A99ED1726D3F459218CF9F27EA3F264011B04122BB9E3E391E72EE930D',
+			fee: 0.43,
+			amount: 0,
+			value: [],
+			body: [
+				{
+					type: 'MULTISIG_ACCOUNT_MODIFICATION',
+					sender: 'NCLT5BCPEVF5EZOS3OJOCL4DWSTJM4EFFF7A5MPG',
+					targetAccount: 'NCLT5BCPEVF5EZOS3OJOCL4DWSTJM4EFFF7A5MPG',
+					cosignatoryAdditions: ['NDK3QVT3N42HFL6NMGTRGFRJE74NP2KSNZH26EDT'],
+					cosignatoryDeletions: [],
+					minCosignatories: 1
+				}
+			],
+			signatures: [
+				{
+					fee: 0.15,
+					signature:
+						'31acdafac004c7045247cf3c57eb06e7f504af5dbaa3dc427ee39ddc6bc1365947b42bd18bb8c79c2c86dc8faf3e31aacfe289112649bc0920dfc73f178b7f07',
+					signer: 'NDIVJFQIJR3VWXJRDSNFK6U37HM4DZNORXI3IRTV'
+				}
+			],
+			feesBreakdown: [
+				{
+					type: 'multisigFee',
+					amount: 0.15
+				},
+				{
+					type: 'embeddedTransactionsFee',
+					amount: 0.13
+				},
+				{
+					type: 'signaturesFee',
+					amount: 0.15
+				},
+				{
+					type: 'totalFee',
+					amount: 0.43
 				}
 			]
 		},

--- a/explorer/frontend/__tests__/test-utils/transactions.js
+++ b/explorer/frontend/__tests__/test-utils/transactions.js
@@ -163,7 +163,13 @@ export const transactionPageResponse = [
 						signer: 'NDIVJFQIJR3VWXJRDSNFK6U37HM4DZNORXI3IRTV'
 					}
 				],
-				transactionType: 'NAMESPACE_REGISTRATION'
+				transactionType: 'NAMESPACE_REGISTRATION',
+				value: [
+					{
+						namespaceName: 'holo',
+						sinkFee: 100.0
+					}
+				]
 			}
 		],
 		fee: 0.15,
@@ -794,10 +800,12 @@ export const transactionPageResult = {
 			signature:
 				'7A4F8F82B6A144E568F5B33DE055D35E9F8D3EE2FC200F0DE9D2571DF5957FF942B8E5A99ED1726D3F459218CF9F27EA3F264011B04122BB9E3E391E72EE930D',
 			fee: 0.45,
+			amount: 100,
 			value: [
 				{
 					id: 'nem.xem',
-					name: 'nem.xem'
+					name: 'nem.xem',
+					amount: 100
 				}
 			],
 			body: [
@@ -805,7 +813,11 @@ export const transactionPageResult = {
 					type: 'NAMESPACE_REGISTRATION',
 					sender: 'NCLT5BCPEVF5EZOS3OJOCL4DWSTJM4EFFF7A5MPG',
 					recipient: 'NCYAVMNQOZ3MZETEBD34ACMAX3S57WUSWAZWY3DW',
-					namespace: {}
+					namespace: {
+						name: 'holo',
+						id: 'holo'
+					},
+					rentalFee: 100
 				}
 			],
 			signatures: [
@@ -1754,10 +1766,12 @@ export const transactionAccountPageResult = {
 			signature:
 				'7A4F8F82B6A144E568F5B33DE055D35E9F8D3EE2FC200F0DE9D2571DF5957FF942B8E5A99ED1726D3F459218CF9F27EA3F264011B04122BB9E3E391E72EE930D',
 			fee: 0.45,
+			amount: 100,
 			value: [
 				{
 					id: 'nem.xem',
-					name: 'nem.xem'
+					name: 'nem.xem',
+					amount: 100
 				}
 			],
 			body: [
@@ -1765,7 +1779,11 @@ export const transactionAccountPageResult = {
 					type: 'NAMESPACE_REGISTRATION',
 					sender: 'NCLT5BCPEVF5EZOS3OJOCL4DWSTJM4EFFF7A5MPG',
 					recipient: 'NCYAVMNQOZ3MZETEBD34ACMAX3S57WUSWAZWY3DW',
-					namespace: {}
+					namespace: {
+						name: 'holo',
+						id: 'holo'
+					},
+					rentalFee: 100
 				}
 			],
 			signatures: [

--- a/explorer/frontend/__tests__/utils/common.test.js
+++ b/explorer/frontend/__tests__/utils/common.test.js
@@ -412,7 +412,8 @@ describe('utils/common', () => {
 		it('returns formatted data row containing transaction info', () => {
 			// Arrange:
 			const formatter = formatTransactionCSV;
-			const dataRow = transactionPageResult.data[15];
+			const dataRow = transactionPageResult.data.find(item =>
+				item.hash === '455DEFE751CBD146A094F4717219E6687ED49A838D028D95E4C5F52938E0B285');
 			const expectedResult = {
 				translated_table_field_type: 'translated_transactionType_TRANSFER',
 				translated_table_field_sender: 'NBFQ6XFBKB3DHJCFDKCMJI5MZ53HFQ56AKDLY4JK',

--- a/explorer/frontend/api/transactions.js
+++ b/explorer/frontend/api/transactions.js
@@ -335,21 +335,18 @@ const formatAccountKeyLink = (data, filter) => {
 
 const formatMultisigTransaction = (data, filter) => {
 	const embeddedTransaction = data.embeddedTransactions[0];
-	const rawEmbeddedTransaction = {
+	const flatEmbeddedTransaction = {
 		...data,
-		transactionType: embeddedTransaction.transactionType,
-		fee: embeddedTransaction.fee
+		...embeddedTransaction
 	};
-	if (rawEmbeddedTransaction.transactionType === TRANSACTION_TYPE.TRANSFER) {
+	if (flatEmbeddedTransaction.transactionType === TRANSACTION_TYPE.TRANSFER) {
 		const { mosaics, message } = extractTransferTransactionValue(embeddedTransaction.value);
 
-		rawEmbeddedTransaction.value = embeddedTransaction.value || [{ message: message }, mosaics];
-	} else {
-		rawEmbeddedTransaction.value = data.embeddedTransactions;
+		flatEmbeddedTransaction.value = embeddedTransaction.value || [{ message: message }, ...mosaics];
 	}
 
 	const formattedTransaction = formatBaseTransaction(data, filter);
-	const formattedEmbeddedTransaction = transactionFromDTO(rawEmbeddedTransaction, filter.address);
+	const formattedEmbeddedTransaction = transactionFromDTO(flatEmbeddedTransaction, filter);
 
 	// Fees breakdown
 	const multisigFee = truncateDecimals(formattedTransaction.fee, config.NATIVE_MOSAIC_DIVISIBILITY);


### PR DESCRIPTION
Problem: The page returns a 500 error when formatting a multisig transaction whose embedded transaction value is not preserved.
Solution: 
- Preserve the embedded transaction value as flat payload data when formatting frontend transaction responses.
- Patched fixtures as well