### PR TITLE
[explorer] fix: change 0 to represent no expiration and update the page

### DIFF
--- a/explorer/frontend/__tests__/pages/NamespaceInfo.test.js
+++ b/explorer/frontend/__tests__/pages/NamespaceInfo.test.js
@@ -134,6 +134,7 @@ describe('NamespaceInfo', () => {
 
 			// Act + Assert:
 			await runStatusTest(chainHeight, expirationHeight, isUnlimitedDuration, expectedText);
+			expect(screen.queryByText('field_expirationHeight')).not.toBeInTheDocument();
 		});
 	});
 });

--- a/explorer/frontend/__tests__/pages/NamespaceList.test.js
+++ b/explorer/frontend/__tests__/pages/NamespaceList.test.js
@@ -69,5 +69,20 @@ describe('NamespaceList', () => {
 			// Act + Assert:
 			runTest();
 		});
+
+		it('renders never expired namespace on desktop', () => {
+			// Arrange:
+			const namespaces = [{
+				...namespacePageResult.data[0],
+				expirationHeight: 0,
+				isUnlimitedDuration: true
+			}];
+
+			// Act:
+			render(<NamespaceList namespaces={namespaces} />);
+
+			// Assert:
+			expect(screen.getByText('value_neverExpired')).toBeInTheDocument();
+		});
 	});
 });

--- a/explorer/frontend/pages/namespaces/[id].jsx
+++ b/explorer/frontend/pages/namespaces/[id].jsx
@@ -42,6 +42,7 @@ const NamespaceInfo = ({ namespaceInfo }) => {
 	const [chainHeight, setChainHeight] = useState(0);
 	const [expirationText, setExpirationText] = useState(null);
 	const [progressType, setProgressType] = useState('');
+	const isExpirationShown = !namespaceInfo.isUnlimitedDuration;
 
 	const tableColumns = [
 		{
@@ -111,14 +112,16 @@ const NamespaceInfo = ({ namespaceInfo }) => {
 						<Field title={t('field_expiration')} description={t('field_namespaceExpiration_description')}>
 							{nullableValueToText(expirationText)}
 						</Field>
-						<Progress
-							titleLeft={t('field_registrationHeight')}
-							titleRight={t('field_expirationHeight')}
-							valueLeft={namespaceInfo.registrationHeight}
-							valueRight={namespaceInfo.expirationHeight}
-							value={chainHeight}
-							type={progressType}
-						/>
+						{isExpirationShown && (
+							<Progress
+								titleLeft={t('field_registrationHeight')}
+								titleRight={t('field_expirationHeight')}
+								valueLeft={namespaceInfo.registrationHeight}
+								valueRight={namespaceInfo.expirationHeight}
+								value={chainHeight}
+								type={progressType}
+							/>
+						)}
 					</div>
 				</Section>
 			</div>

--- a/explorer/frontend/pages/namespaces/index.jsx
+++ b/explorer/frontend/pages/namespaces/index.jsx
@@ -62,7 +62,7 @@ const Blocks = ({ namespaces }) => {
 		{
 			key: 'expirationHeight',
 			size: '10rem',
-			renderValue: value => value
+			renderValue: (value, row) => row.isUnlimitedDuration ? t('value_neverExpired') : value
 		}
 	];
 

--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -288,7 +288,7 @@ class NemDatabase(DatabaseConnection):
 				'nem',
 				signer.bytes,
 				1,
-				9223372036854775807  # max bigint value to represent no expiration
+				0  # no expiration
 			)
 		)
 

--- a/explorer/puller/tests/db/test_NemDatabase.py
+++ b/explorer/puller/tests/db/test_NemDatabase.py
@@ -269,7 +269,7 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			'nem',
 			BLOCKS[0].signer.bytes.hex(),
 			1,
-			9223372036854775807,
+			0,
 			[]
 		))
 
@@ -328,7 +328,7 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			'nem',
 			BLOCKS[0].signer.bytes.hex(),
 			1,
-			9223372036854775807,
+			0,
 			[]
 		))
 		self.assertEqual(mosaic_result, (


### PR DESCRIPTION
Problem: 
- I just noticed, in the frontend, it uses `0` as a presentation of no expiration.
- Namespace page didn't handle an expired namespace

Solution: update `seed_network_currency`, and handle namespace page and listing.

<img width="1193" height="72" alt="Screenshot 2026-06-25 at 2 06 25 AM" src="https://github.com/user-attachments/assets/86b70600-bf41-4d57-9cdc-cc4f88e6a030" />
<img width="866" height="349" alt="Screenshot 2026-06-25 at 2 06 15 AM" src="https://github.com/user-attachments/assets/43fa938a-8690-4371-9684-f5c3a1512c16" />
