### PR TITLE
[explorer/puller] fix: format vested balance to absolute when running refresh account method

### DIFF
--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -42,6 +42,11 @@ AccountRecord = namedtuple('AccountRecord', [
 	'cosignatory_of',
 	'cosignatories'
 ])
+AccountVestedBalanceRecord = namedtuple('AccountVestedBalanceRecord', [
+	'address',
+	'importance',
+	'vested_balance'
+])
 NamespaceRecord = namedtuple('NamespaceRecord', [
 	'root_namespace',
 	'owner',
@@ -268,6 +273,16 @@ class NemPuller:
 			account_info.cosignatories
 		)
 
+	@staticmethod
+	def _create_account_vested_balance_record(account_info):
+		"""Create account vested balance record."""
+
+		return AccountVestedBalanceRecord(
+			account_info.address,
+			account_info.importance,
+			_format_xem_absolute(account_info.vested_balance)
+		)
+
 	async def _process_account_batch(self, cursor, address_heights):
 		"""
 		Process a batch of addresses: fetch account info, mosaics, and upsert.
@@ -329,7 +344,8 @@ class NemPuller:
 
 			for account in accounts:
 				account_info = await self._retry_get_account_info(str(account.address))
-				self.nem_db.update_vested_balance_and_importance(cursor, account_info)
+				account_vested_balance = self._create_account_vested_balance_record(account_info)
+				self.nem_db.update_vested_balance_and_importance(cursor, account_vested_balance)
 				last_account_id = account.id
 				total_refreshed += 1
 

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -27,7 +27,15 @@ from symbollightapi.model.Transaction import (
 )
 
 from puller.db.NemDatabase import AccountRefreshRecord
-from puller.facade.NemPuller import AccountRecord, DatabaseConfig, MosaicRecord, NamespaceRecord, NemPuller, TransactionRecord
+from puller.facade.NemPuller import (
+	AccountRecord,
+	AccountVestedBalanceRecord,
+	DatabaseConfig,
+	MosaicRecord,
+	NamespaceRecord,
+	NemPuller,
+	TransactionRecord
+)
 
 # region test data
 
@@ -833,8 +841,19 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		]
 
 		account_info_1 = Mock()
+		account_info_1.address = account_1.address
+		account_info_1.importance = 0.1
+		account_info_1.vested_balance = 6449.201816
+
 		account_info_2 = Mock()
+		account_info_2.address = account_2.address
+		account_info_2.importance = 0.2
+		account_info_2.vested_balance = 1234.000001
+
 		account_info_3 = Mock()
+		account_info_3.address = account_3.address
+		account_info_3.importance = 0.3
+		account_info_3.vested_balance = 0
 
 		mock_retry_get_account_info.side_effect = [
 			account_info_1,
@@ -862,9 +881,18 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 
 		update_account_calls = mock_update_vested_balance_and_importance.call_args_list
 		self.assertEqual(len(update_account_calls), 3)
-		self.assertEqual(update_account_calls[0][0], (cursor, account_info_1))
-		self.assertEqual(update_account_calls[1][0], (cursor, account_info_2))
-		self.assertEqual(update_account_calls[2][0], (cursor, account_info_3))
+		self.assertEqual(update_account_calls[0][0], (
+			cursor,
+			AccountVestedBalanceRecord(account_1.address, 0.1, 6449201816)
+		))
+		self.assertEqual(update_account_calls[1][0], (
+			cursor,
+			AccountVestedBalanceRecord(account_2.address, 0.2, 1234000001)
+		))
+		self.assertEqual(update_account_calls[2][0], (
+			cursor,
+			AccountVestedBalanceRecord(account_3.address, 0.3, 0)
+		))
 		self.assertEqual(self.puller.nem_db.connection.commit.call_count, 2)
 
 	@patch('puller.facade.NemPuller.NemDatabase.upsert_namespace')

--- a/lightapi/python/symbollightapi/connector/NemConnector.py
+++ b/lightapi/python/symbollightapi/connector/NemConnector.py
@@ -424,6 +424,8 @@ class NemConnector(BasicConnector):
 				'hash': None,
 				'innerHash': None
 			}, 0) for tx in unconfirmed_transactions['data']
+			# skip standalone cosignatures, because already include parent multisig transactions.
+			if TransactionType.MULTISIG_COSIGNATURE.value != tx['type']
 		]
 
 	# endregion

--- a/lightapi/python/tests/connector/test_NemConnector.py
+++ b/lightapi/python/tests/connector/test_NemConnector.py
@@ -638,7 +638,20 @@ async def server(aiohttp_client):  # pylint: disable=too-many-statements
 							'message': {},
 							'version': 1744830465,
 							'signer': '8d07f90fb4bbe7715fa327c926770166a11be2e494a970605f2e12557f66c9b9'
-						},]
+						},
+						{
+							'timeStamp': 73398,
+							'otherHash': {
+								'data': '3245a17360c60c0c4b84e81d9401dd97cb86e84c7e72f29ae20ebfa117801117'
+							},
+							'otherAccount': 'TDJ3OZUV3VCGUUFGQLAIZRT4ISDZC4X2MZAZP534',
+							'signature': '1' * 128,
+							'fee': 150000,
+							'type': 4098,
+							'deadline': 83398,
+							'version': 1744830465,
+							'signer': '210e8bf27aef3f4890f8442c1ca5cab740aa2eebff7faae74a128d16a29deb42'
+						}]
 				}
 			})
 


### PR DESCRIPTION
Problem: Vested balance didn't convert to absolute when running refresh account method [Detail](https://github.com/symbol/product/issues/2340)

Solution: convert vested balance before update in db.