### PR TITLE
[explorer/rest] fix: display multisig transaction in recipient and multisgi account list.

### DIFF
--- a/explorer/rest/rest/db/NemDatabase.py
+++ b/explorer/rest/rest/db/NemDatabase.py
@@ -831,6 +831,22 @@ class NemDatabase(DatabaseConnectionPool):
 			order_condition=order_condition
 		)
 
+	@staticmethod
+	def _create_multisig_inner_filter(address_condition):
+		"""Creates a filter for multisig inner transactions."""
+
+		return (
+			' OR ('
+			f' t.transaction_type = {TransactionType.MULTISIG.value}'
+			' AND EXISTS ('
+			' SELECT 1 FROM transactions it'
+			' WHERE it.is_inner = true'
+			" AND it.transaction_hash = decode(t.payload->>'inner_hash', 'hex')"
+			f' AND {address_condition}'
+			' )'
+			' )'
+		)
+
 	def get_transactions(self, pagination, sort, transaction_query):
 		"""Gets transactions pagination."""
 
@@ -849,16 +865,39 @@ class NemDatabase(DatabaseConnectionPool):
 			filter_params.append(tuple(transaction_query.transaction_types))
 
 		if transaction_query.address:
-			where_condition += ' AND (t.sender_address = %s OR t.recipient_address = %s)'
-			filter_params.extend([transaction_query.address.bytes, transaction_query.address.bytes])
+			multisig_inner_filter = self._create_multisig_inner_filter('(it.sender_address = %s OR it.recipient_address = %s)')
+			where_condition += (
+				' AND (t.sender_address = %s OR t.recipient_address = %s'
+				f'{multisig_inner_filter})'
+			)
+			filter_params.extend([
+				transaction_query.address.bytes,
+				transaction_query.address.bytes,
+				transaction_query.address.bytes,
+				transaction_query.address.bytes
+			])
 		else:
 			if transaction_query.sender_address:
-				where_condition += ' AND t.sender_address = %s'
-				filter_params.append(transaction_query.sender_address.bytes)
+				multisig_inner_filter = self._create_multisig_inner_filter('it.sender_address = %s')
+				where_condition += (
+					' AND (t.sender_address = %s'
+					f'{multisig_inner_filter})'
+				)
+				filter_params.extend([
+					transaction_query.sender_address.bytes,
+					transaction_query.sender_address.bytes
+				])
 
 			if transaction_query.recipient_address:
-				where_condition += ' AND t.recipient_address = %s'
-				filter_params.append(transaction_query.recipient_address.bytes)
+				multisig_inner_filter = self._create_multisig_inner_filter('it.recipient_address = %s')
+				where_condition += (
+					' AND (t.recipient_address = %s'
+					f'{multisig_inner_filter})'
+				)
+				filter_params.extend([
+					transaction_query.recipient_address.bytes,
+					transaction_query.recipient_address.bytes
+				])
 
 		if transaction_query.mosaic:
 			where_condition += (

--- a/explorer/rest/rest/db/NemDatabase.py
+++ b/explorer/rest/rest/db/NemDatabase.py
@@ -864,10 +864,14 @@ class NemDatabase(DatabaseConnectionPool):
 			where_condition += ' AND t.transaction_type IN %s'
 			filter_params.append(tuple(transaction_query.transaction_types))
 
+		# Exclude multisig wrappers when matching by initiator.
+		non_multisig_sender_filter = f'(t.transaction_type != {TransactionType.MULTISIG.value} AND t.sender_address = %s)'
+
 		if transaction_query.address:
 			multisig_inner_filter = self._create_multisig_inner_filter('(it.sender_address = %s OR it.recipient_address = %s)')
 			where_condition += (
-				' AND (t.sender_address = %s OR t.recipient_address = %s'
+				f' AND ({non_multisig_sender_filter}'
+				' OR t.recipient_address = %s'
 				f'{multisig_inner_filter})'
 			)
 			filter_params.extend([
@@ -880,7 +884,7 @@ class NemDatabase(DatabaseConnectionPool):
 			if transaction_query.sender_address:
 				multisig_inner_filter = self._create_multisig_inner_filter('it.sender_address = %s')
 				where_condition += (
-					' AND (t.sender_address = %s'
+					f' AND ({non_multisig_sender_filter}'
 					f'{multisig_inner_filter})'
 				)
 				filter_params.extend([

--- a/explorer/rest/rest/db/NemDatabase.py
+++ b/explorer/rest/rest/db/NemDatabase.py
@@ -874,12 +874,7 @@ class NemDatabase(DatabaseConnectionPool):
 				' OR t.recipient_address = %s'
 				f'{multisig_inner_filter})'
 			)
-			filter_params.extend([
-				transaction_query.address.bytes,
-				transaction_query.address.bytes,
-				transaction_query.address.bytes,
-				transaction_query.address.bytes
-			])
+			filter_params.extend([transaction_query.address.bytes] * 4)
 		else:
 			if transaction_query.sender_address:
 				multisig_inner_filter = self._create_multisig_inner_filter('it.sender_address = %s')
@@ -887,10 +882,7 @@ class NemDatabase(DatabaseConnectionPool):
 					f' AND ({non_multisig_sender_filter}'
 					f'{multisig_inner_filter})'
 				)
-				filter_params.extend([
-					transaction_query.sender_address.bytes,
-					transaction_query.sender_address.bytes
-				])
+				filter_params.extend([transaction_query.sender_address.bytes] * 2)
 
 			if transaction_query.recipient_address:
 				multisig_inner_filter = self._create_multisig_inner_filter('it.recipient_address = %s')
@@ -898,10 +890,7 @@ class NemDatabase(DatabaseConnectionPool):
 					' AND (t.recipient_address = %s'
 					f'{multisig_inner_filter})'
 				)
-				filter_params.extend([
-					transaction_query.recipient_address.bytes,
-					transaction_query.recipient_address.bytes
-				])
+				filter_params.extend([transaction_query.recipient_address.bytes] * 2)
 
 		if transaction_query.mosaic:
 			where_condition += (

--- a/explorer/rest/tests/db/test_NemDatabase.py
+++ b/explorer/rest/tests/db/test_NemDatabase.py
@@ -667,7 +667,13 @@ class NemDatabaseTest(DatabaseTestBase):  # pylint: disable=too-many-public-meth
 	def test_can_query_transactions_filtered_by_address_as_recipient(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc', self._make_transaction_query(address=TRANSACTIONS[0].recipient_address),
-			[TRANSACTIONS_VIEWS[5], TRANSACTIONS_VIEWS[6], TRANSACTIONS_VIEWS[0], TRANSACTIONS_VIEWS[1]]
+			[
+				TRANSACTIONS_VIEWS[4],
+				TRANSACTIONS_VIEWS[5],
+				TRANSACTIONS_VIEWS[6],
+				TRANSACTIONS_VIEWS[0],
+				TRANSACTIONS_VIEWS[1]
+			]
 		)
 
 	def test_can_query_transactions_filtered_by_sender_address(self):
@@ -679,7 +685,45 @@ class NemDatabaseTest(DatabaseTestBase):  # pylint: disable=too-many-public-meth
 	def test_can_query_transactions_filtered_by_recipient_address(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc', self._make_transaction_query(recipient_address=TRANSACTIONS[0].recipient_address),
-			[TRANSACTIONS_VIEWS[5], TRANSACTIONS_VIEWS[6], TRANSACTIONS_VIEWS[0], TRANSACTIONS_VIEWS[1]]
+			[
+				TRANSACTIONS_VIEWS[4],
+				TRANSACTIONS_VIEWS[5],
+				TRANSACTIONS_VIEWS[6],
+				TRANSACTIONS_VIEWS[0],
+				TRANSACTIONS_VIEWS[1]
+			]
+		)
+
+	def test_can_query_multisig_transaction_filtered_by_initiator_address(self):
+		self._assert_can_query_transactions_with_filter(
+			Pagination(10, 0), 'desc', self._make_transaction_query(sender_address=TRANSACTIONS[4].sender_address),
+			[TRANSACTIONS_VIEWS[4]]
+		)
+
+	def test_can_query_multisig_transaction_filtered_by_inner_sender_address(self):
+		self._assert_can_query_transactions_with_filter(
+			Pagination(10, 0), 'desc', self._make_transaction_query(sender_address=TRANSACTIONS[5].sender_address),
+			[
+				TRANSACTIONS_VIEWS[4],
+				TRANSACTIONS_VIEWS[6],
+				TRANSACTIONS_VIEWS[7],
+				TRANSACTIONS_VIEWS[3],
+				TRANSACTIONS_VIEWS[5],
+				TRANSACTIONS_VIEWS[1],
+				TRANSACTIONS_VIEWS[0]
+			]
+		)
+
+	def test_can_query_multisig_transaction_filtered_by_inner_recipient_address(self):
+		self._assert_can_query_transactions_with_filter(
+			Pagination(10, 0), 'desc', self._make_transaction_query(recipient_address=TRANSACTIONS[5].recipient_address),
+			[
+				TRANSACTIONS_VIEWS[4],
+				TRANSACTIONS_VIEWS[5],
+				TRANSACTIONS_VIEWS[6],
+				TRANSACTIONS_VIEWS[0],
+				TRANSACTIONS_VIEWS[1]
+			]
 		)
 
 	def test_can_query_transactions_filtered_by_mosaic_nem_xem(self):

--- a/explorer/rest/tests/db/test_NemDatabase.py
+++ b/explorer/rest/tests/db/test_NemDatabase.py
@@ -30,11 +30,15 @@ from ..test.DatabaseTestUtils import (
 	NAMESPACE_VIEWS,
 	TRANSACTION_DAILY_STATISTIC_VIEW,
 	TRANSACTION_MONTH_STATISTIC_VIEW,
+	TRANSACTION_NAMES_FILTERED_BY_MULTISIG_INNER_SENDER,
+	TRANSACTION_NAMES_SORTED_BY_HEIGHT_ASC,
 	TRANSACTION_STATISTIC_VIEW,
 	TRANSACTIONS,
-	TRANSACTIONS_VIEWS,
-	DatabaseTestBase
+	DatabaseTestBase,
+	transaction_hash
 )
+from ..test.DatabaseTestUtils import transaction_view as expected_transaction_view
+from ..test.DatabaseTestUtils import transaction_views
 
 # region test data
 
@@ -520,59 +524,59 @@ class NemDatabaseTest(DatabaseTestBase):  # pylint: disable=too-many-public-meth
 
 	def test_can_query_transfer_by_hash(self):
 		# Act:
-		transaction_view = self.nem_db.get_transaction_by_hash('0' * 63 + '1')
+		transaction_view = self.nem_db.get_transaction_by_hash(transaction_hash('transfer'))
 
 		# Assert:
-		self.assertEqual(TRANSACTIONS_VIEWS[0], transaction_view)
+		self.assertEqual(expected_transaction_view('transfer'), transaction_view)
 
 	def test_can_query_transfer_v2_by_hash(self):
 		# Act:
-		transaction_view = self.nem_db.get_transaction_by_hash('0' * 63 + '2')
+		transaction_view = self.nem_db.get_transaction_by_hash(transaction_hash('transfer_v2'))
 
 		# Assert:
-		self.assertEqual(TRANSACTIONS_VIEWS[1], transaction_view)
+		self.assertEqual(expected_transaction_view('transfer_v2'), transaction_view)
 
 	def test_can_query_account_link_by_hash(self):
 		# Act:
-		transaction_view = self.nem_db.get_transaction_by_hash('0' * 63 + '3')
+		transaction_view = self.nem_db.get_transaction_by_hash(transaction_hash('account_key_link'))
 
 		# Assert:
-		self.assertEqual(TRANSACTIONS_VIEWS[2], transaction_view)
+		self.assertEqual(expected_transaction_view('account_key_link'), transaction_view)
 
 	def test_can_query_multisig_account_modification_by_hash(self):
 		# Act:
-		transaction_view = self.nem_db.get_transaction_by_hash('0' * 63 + '4')
+		transaction_view = self.nem_db.get_transaction_by_hash(transaction_hash('multisig_account_modification'))
 
 		# Assert:
-		self.assertEqual(TRANSACTIONS_VIEWS[3], transaction_view)
+		self.assertEqual(expected_transaction_view('multisig_account_modification'), transaction_view)
 
 	def test_can_query_multisig_by_hash(self):
 		# Act:
-		transaction_view = self.nem_db.get_transaction_by_hash('0' * 63 + '5')
+		transaction_view = self.nem_db.get_transaction_by_hash(transaction_hash('multisig'))
 
 		# Assert:
-		self.assertEqual(TRANSACTIONS_VIEWS[4], transaction_view)
+		self.assertEqual(expected_transaction_view('multisig'), transaction_view)
 
 	def test_can_query_namespace_registration_by_hash(self):
 		# Act:
-		transaction_view = self.nem_db.get_transaction_by_hash('0' * 63 + '7')
+		transaction_view = self.nem_db.get_transaction_by_hash(transaction_hash('namespace_registration'))
 
 		# Assert:
-		self.assertEqual(TRANSACTIONS_VIEWS[5], transaction_view)
+		self.assertEqual(expected_transaction_view('namespace_registration'), transaction_view)
 
 	def test_can_query_mosaic_definition_by_hash(self):
 		# Act:
-		transaction_view = self.nem_db.get_transaction_by_hash('0' * 63 + '8')
+		transaction_view = self.nem_db.get_transaction_by_hash(transaction_hash('mosaic_definition'))
 
 		# Assert:
-		self.assertEqual(TRANSACTIONS_VIEWS[6], transaction_view)
+		self.assertEqual(expected_transaction_view('mosaic_definition'), transaction_view)
 
 	def test_can_query_mosaic_supply_change_by_hash(self):
 		# Act:
-		transaction_view = self.nem_db.get_transaction_by_hash('0' * 63 + '9')
+		transaction_view = self.nem_db.get_transaction_by_hash(transaction_hash('mosaic_supply_change'))
 
 		# Assert:
-		self.assertEqual(TRANSACTIONS_VIEWS[7], transaction_view)
+		self.assertEqual(expected_transaction_view('mosaic_supply_change'), transaction_view)
 
 	# endregion
 
@@ -611,43 +615,43 @@ class NemDatabaseTest(DatabaseTestBase):  # pylint: disable=too-many-public-meth
 		self.assertEqual(TRANSACTION_MONTH_STATISTIC_VIEW, transaction_statistics)
 	# region transactions
 
-	def _assert_can_query_transactions_with_filter(self, pagination, sort, transaction_query, expected_transactions):
+	def _assert_can_query_transactions_with_filter(self, pagination, sort, transaction_query, expected_transaction_names):
 		# Act:
 		transactions_view = self.nem_db.get_transactions(pagination, sort, transaction_query)
 
 		# Assert:
-		self.assertEqual(expected_transactions, transactions_view)
+		self.assertEqual(transaction_views(*expected_transaction_names), transactions_view)
 
 	def test_can_query_transactions_filtered_limit_offset_0(self):
 		self._assert_can_query_transactions_with_filter(
-			Pagination(1, 0), 'desc', self._make_transaction_query(), [TRANSACTIONS_VIEWS[2]]
+			Pagination(1, 0), 'desc', self._make_transaction_query(), ('account_key_link', )
 		)
 
 	def test_can_query_transactions_filtered_limit_offset_1(self):
 		self._assert_can_query_transactions_with_filter(
-			Pagination(2, 1), 'desc', self._make_transaction_query(), [TRANSACTIONS_VIEWS[2], TRANSACTIONS_VIEWS[4]]
+			Pagination(2, 1), 'desc', self._make_transaction_query(), ('account_key_link', 'multisig')
 		)
 
 	def test_can_query_transactions_sorted_by_height_asc(self):
 		self._assert_can_query_transactions_with_filter(
-			Pagination(10, 0), 'asc', self._make_transaction_query(), list(TRANSACTIONS_VIEWS)
+			Pagination(10, 0), 'asc', self._make_transaction_query(), TRANSACTION_NAMES_SORTED_BY_HEIGHT_ASC
 		)
 
 	def test_can_query_transactions_sorted_by_height_desc(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(3, 0), 'desc', self._make_transaction_query(),
-			[TRANSACTIONS_VIEWS[3], TRANSACTIONS_VIEWS[2], TRANSACTIONS_VIEWS[4]]
+			('multisig_account_modification', 'account_key_link', 'multisig')
 		)
 
 	def test_can_query_transactions_filtered_by_height(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc', self._make_transaction_query(height=1),
-			[TRANSACTIONS_VIEWS[0], TRANSACTIONS_VIEWS[1]]
+			('transfer', 'transfer_v2')
 		)
 
 	def test_can_query_transactions_filtered_by_nonexistent_height(self):
 		self._assert_can_query_transactions_with_filter(
-			Pagination(10, 0), 'desc', self._make_transaction_query(height=999), []
+			Pagination(10, 0), 'desc', self._make_transaction_query(height=999), ()
 		)
 
 	def test_can_query_transactions_filtered_by_multiple_transaction_types(self):
@@ -655,94 +659,69 @@ class NemDatabaseTest(DatabaseTestBase):  # pylint: disable=too-many-public-meth
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc',
 			self._make_transaction_query(transaction_types=[257, 2049]),
-			[TRANSACTIONS_VIEWS[2], TRANSACTIONS_VIEWS[0], TRANSACTIONS_VIEWS[1]]
+			('account_key_link', 'transfer', 'transfer_v2')
 		)
 
 	def test_can_query_transactions_filtered_by_address_as_sender(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(2, 0), 'desc', self._make_transaction_query(address=TRANSACTIONS[2].sender_address),
-			[TRANSACTIONS_VIEWS[2]]
+			('account_key_link', )
 		)
 
 	def test_can_query_transactions_filtered_by_address_as_recipient(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc', self._make_transaction_query(address=TRANSACTIONS[0].recipient_address),
-			[
-				TRANSACTIONS_VIEWS[4],
-				TRANSACTIONS_VIEWS[5],
-				TRANSACTIONS_VIEWS[6],
-				TRANSACTIONS_VIEWS[0],
-				TRANSACTIONS_VIEWS[1]
-			]
+			('multisig', 'namespace_registration', 'mosaic_definition', 'transfer', 'transfer_v2')
 		)
 
 	def test_can_query_transactions_filtered_by_sender_address(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc', self._make_transaction_query(sender_address=TRANSACTIONS[2].sender_address),
-			[TRANSACTIONS_VIEWS[2]]
+			('account_key_link', )
 		)
 
 	def test_can_query_transactions_filtered_by_recipient_address(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc', self._make_transaction_query(recipient_address=TRANSACTIONS[0].recipient_address),
-			[
-				TRANSACTIONS_VIEWS[4],
-				TRANSACTIONS_VIEWS[5],
-				TRANSACTIONS_VIEWS[6],
-				TRANSACTIONS_VIEWS[0],
-				TRANSACTIONS_VIEWS[1]
-			]
+			('multisig', 'namespace_registration', 'mosaic_definition', 'transfer', 'transfer_v2')
 		)
 
 	def test_can_exclude_multisig_transaction_for_initiator_account_from_address_filter(self):
 		self._assert_can_query_transactions_with_filter(
-			Pagination(10, 0), 'desc', self._make_transaction_query(address=TRANSACTIONS[4].sender_address), []
+			Pagination(10, 0), 'desc', self._make_transaction_query(address=TRANSACTIONS[4].sender_address), ()
 		)
 		self._assert_can_query_transactions_with_filter(
-			Pagination(10, 0), 'desc', self._make_transaction_query(sender_address=TRANSACTIONS[4].sender_address), []
+			Pagination(10, 0), 'desc', self._make_transaction_query(sender_address=TRANSACTIONS[4].sender_address), ()
 		)
 
 	def test_can_query_multisig_transaction_filtered_by_inner_sender_address(self):
 		self._assert_can_query_transactions_with_filter(
-			Pagination(10, 0), 'desc', self._make_transaction_query(sender_address=TRANSACTIONS[5].sender_address),
-			[
-				TRANSACTIONS_VIEWS[4],
-				TRANSACTIONS_VIEWS[6],
-				TRANSACTIONS_VIEWS[7],
-				TRANSACTIONS_VIEWS[3],
-				TRANSACTIONS_VIEWS[5],
-				TRANSACTIONS_VIEWS[1],
-				TRANSACTIONS_VIEWS[0]
-			]
+			Pagination(10, 0), 'desc',
+			self._make_transaction_query(sender_address=TRANSACTIONS[5].sender_address),
+			TRANSACTION_NAMES_FILTERED_BY_MULTISIG_INNER_SENDER
 		)
 
 	def test_can_query_multisig_transaction_filtered_by_inner_recipient_address(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc', self._make_transaction_query(recipient_address=TRANSACTIONS[5].recipient_address),
-			[
-				TRANSACTIONS_VIEWS[4],
-				TRANSACTIONS_VIEWS[5],
-				TRANSACTIONS_VIEWS[6],
-				TRANSACTIONS_VIEWS[0],
-				TRANSACTIONS_VIEWS[1]
-			]
+			('multisig', 'namespace_registration', 'mosaic_definition', 'transfer', 'transfer_v2')
 		)
 
 	def test_can_query_transactions_filtered_by_mosaic_nem_xem(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc', self._make_transaction_query(mosaic='nem.xem'),
-			[TRANSACTIONS_VIEWS[0], TRANSACTIONS_VIEWS[1]]
+			('transfer', 'transfer_v2')
 		)
 
 	def test_can_query_transactions_filtered_by_mosaic_other(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc', self._make_transaction_query(mosaic='root.mosaic'),
-			[TRANSACTIONS_VIEWS[1]]
+			('transfer_v2', )
 		)
 
 	def test_can_query_transactions_filtered_by_nonexistent_mosaic(self):
 		self._assert_can_query_transactions_with_filter(
-			Pagination(10, 0), 'desc', self._make_transaction_query(mosaic='nonexistent.mosaic'), []
+			Pagination(10, 0), 'desc', self._make_transaction_query(mosaic='nonexistent.mosaic'), ()
 		)
 
 	# endregion

--- a/explorer/rest/tests/db/test_NemDatabase.py
+++ b/explorer/rest/tests/db/test_NemDatabase.py
@@ -694,10 +694,12 @@ class NemDatabaseTest(DatabaseTestBase):  # pylint: disable=too-many-public-meth
 			]
 		)
 
-	def test_can_query_multisig_transaction_filtered_by_initiator_address(self):
+	def test_can_exclude_multisig_transaction_for_initiator_account_from_address_filter(self):
 		self._assert_can_query_transactions_with_filter(
-			Pagination(10, 0), 'desc', self._make_transaction_query(sender_address=TRANSACTIONS[4].sender_address),
-			[TRANSACTIONS_VIEWS[4]]
+			Pagination(10, 0), 'desc', self._make_transaction_query(address=TRANSACTIONS[4].sender_address), []
+		)
+		self._assert_can_query_transactions_with_filter(
+			Pagination(10, 0), 'desc', self._make_transaction_query(sender_address=TRANSACTIONS[4].sender_address), []
 		)
 
 	def test_can_query_multisig_transaction_filtered_by_inner_sender_address(self):

--- a/explorer/rest/tests/facade/test_NemRestFacade.py
+++ b/explorer/rest/tests/facade/test_NemRestFacade.py
@@ -62,9 +62,13 @@ EXPECTED_TRANSACTION_3 = TRANSACTIONS_VIEWS[2].to_dict()
 
 EXPECTED_TRANSACTION_4 = TRANSACTIONS_VIEWS[3].to_dict()
 
+EXPECTED_TRANSACTION_5 = TRANSACTIONS_VIEWS[4].to_dict()
+
 EXPECTED_TRANSACTION_7 = TRANSACTIONS_VIEWS[5].to_dict()
 
 EXPECTED_TRANSACTION_8 = TRANSACTIONS_VIEWS[6].to_dict()
+
+EXPECTED_TRANSACTION_9 = TRANSACTIONS_VIEWS[7].to_dict()
 
 # endregion
 
@@ -533,6 +537,16 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			expected_transactions=[EXPECTED_TRANSACTION_3]
 		)
 
+	def test_can_retrieve_multisig_transaction_filtered_by_initiator_public_key(self):
+		self._assert_can_retrieve_transactions(
+			pagination=Pagination(10, 0),
+			sort='DESC',
+			transaction_query=self._make_transaction_query(
+				sender='8D07F90FB4BBE7715FA327C926770166A11BE2E494A970605F2E12557F66C9B9'
+			),
+			expected_transactions=[EXPECTED_TRANSACTION_5]
+		)
+
 	def test_can_retrieve_transactions_filtered_by_recipient_address(self):
 		self._assert_can_retrieve_transactions(
 			pagination=Pagination(10, 0),
@@ -540,7 +554,13 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			transaction_query=self._make_transaction_query(
 				recipient_address='NBFWZ4IVRHEIBRCGHLYDS62FSFTBM3VDFA7E6LSQ'
 			),
-			expected_transactions=[EXPECTED_TRANSACTION_7, EXPECTED_TRANSACTION_8, EXPECTED_TRANSACTION_1, EXPECTED_TRANSACTION_2]
+			expected_transactions=[
+				EXPECTED_TRANSACTION_5,
+				EXPECTED_TRANSACTION_7,
+				EXPECTED_TRANSACTION_8,
+				EXPECTED_TRANSACTION_1,
+				EXPECTED_TRANSACTION_2
+			]
 		)
 
 	def test_can_retrieve_transactions_filtered_by_sender_address(self):
@@ -551,6 +571,34 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 				sender_address='NBNR6XNZQIGQVXII6L3FPJTUGF6NFGLZHBN52R3V'
 			),
 			expected_transactions=[EXPECTED_TRANSACTION_3]
+		)
+
+	def test_can_retrieve_multisig_transaction_filtered_by_initiator_address(self):
+		self._assert_can_retrieve_transactions(
+			pagination=Pagination(10, 0),
+			sort='DESC',
+			transaction_query=self._make_transaction_query(
+				sender_address='NANEMOABLAGR72AZ2RV3V4ZHDCXW25XQ73O7OBT5'
+			),
+			expected_transactions=[EXPECTED_TRANSACTION_5]
+		)
+
+	def test_can_retrieve_multisig_transaction_filtered_by_inner_sender_address(self):
+		self._assert_can_retrieve_transactions(
+			pagination=Pagination(10, 0),
+			sort='DESC',
+			transaction_query=self._make_transaction_query(
+				sender_address='NALICEPFLZQRZGPRIJTMJOCPWDNECXTNNG7QLSG3'
+			),
+			expected_transactions=[
+				EXPECTED_TRANSACTION_5,
+				EXPECTED_TRANSACTION_8,
+				EXPECTED_TRANSACTION_9,
+				EXPECTED_TRANSACTION_4,
+				EXPECTED_TRANSACTION_7,
+				EXPECTED_TRANSACTION_2,
+				EXPECTED_TRANSACTION_1
+			]
 		)
 
 	def test_can_retrieve_transactions_filtered_by_transaction_types(self):

--- a/explorer/rest/tests/facade/test_NemRestFacade.py
+++ b/explorer/rest/tests/facade/test_NemRestFacade.py
@@ -15,9 +15,11 @@ from ..test.DatabaseTestUtils import (
 	NAMESPACE_VIEWS,
 	TRANSACTION_DAILY_STATISTIC_VIEW,
 	TRANSACTION_MONTH_STATISTIC_VIEW,
+	TRANSACTION_NAMES_FILTERED_BY_MULTISIG_INNER_SENDER,
 	TRANSACTION_STATISTIC_VIEW,
-	TRANSACTIONS_VIEWS,
-	DatabaseTestBase
+	DatabaseTestBase,
+	transaction_dict,
+	transaction_dicts
 )
 
 # region test data
@@ -53,22 +55,6 @@ EXPECTED_MOSAIC_3 = MOSAIC_VIEWS[2].to_dict()
 EXPECTED_MOSAIC_RICH_LIST_1 = MOSAIC_RICH_LIST_VIEWS[0].to_dict()
 
 EXPECTED_MOSAIC_RICH_LIST_2 = MOSAIC_RICH_LIST_VIEWS[1].to_dict()
-
-EXPECTED_TRANSACTION_1 = TRANSACTIONS_VIEWS[0].to_dict()
-
-EXPECTED_TRANSACTION_2 = TRANSACTIONS_VIEWS[1].to_dict()
-
-EXPECTED_TRANSACTION_3 = TRANSACTIONS_VIEWS[2].to_dict()
-
-EXPECTED_TRANSACTION_4 = TRANSACTIONS_VIEWS[3].to_dict()
-
-EXPECTED_TRANSACTION_5 = TRANSACTIONS_VIEWS[4].to_dict()
-
-EXPECTED_TRANSACTION_7 = TRANSACTIONS_VIEWS[5].to_dict()
-
-EXPECTED_TRANSACTION_8 = TRANSACTIONS_VIEWS[6].to_dict()
-
-EXPECTED_TRANSACTION_9 = TRANSACTIONS_VIEWS[7].to_dict()
 
 # endregion
 
@@ -432,7 +418,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 	def test_can_retrieve_transaction_by_hash(self):
 		self._assert_can_retrieve_transaction_by_hash(
 			transaction_hash='0' * 63 + '1',
-			expected_transaction=EXPECTED_TRANSACTION_1
+			expected_transaction=transaction_dict('transfer')
 		)
 
 	def test_returns_none_for_nonexistent_transaction_hash(self):
@@ -478,19 +464,19 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 		self.assertEqual(EXPECTED_TRANSACTION_MONTH_STATISTICS, transaction_statistics)
 	# region transactions
 
-	def _assert_can_retrieve_transactions(self, pagination, sort, transaction_query, expected_transactions):
+	def _assert_can_retrieve_transactions(self, pagination, sort, transaction_query, expected_transaction_names):
 		# Act:
 		transactions = self.nem_rest_facade.get_transactions(pagination, sort, transaction_query)
 
 		# Assert:
-		self.assertEqual(expected_transactions, transactions)
+		self.assertEqual(transaction_dicts(*expected_transaction_names), transactions)
 
 	def test_can_retrieve_transactions_filtered_by_limit(self):
 		self._assert_can_retrieve_transactions(
 			pagination=Pagination(1, 0),
 			sort='DESC',
 			transaction_query=self._make_transaction_query(),
-			expected_transactions=[EXPECTED_TRANSACTION_3]
+			expected_transaction_names=('account_key_link', )
 		)
 
 	def test_can_retrieve_transactions_filtered_by_offset(self):
@@ -498,7 +484,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			pagination=Pagination(1, 1),
 			sort='DESC',
 			transaction_query=self._make_transaction_query(),
-			expected_transactions=[EXPECTED_TRANSACTION_4]
+			expected_transaction_names=('multisig_account_modification', )
 		)
 
 	def test_can_retrieve_transactions_filtered_by_height(self):
@@ -508,7 +494,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			transaction_query=self._make_transaction_query(
 				height=1
 			),
-			expected_transactions=[EXPECTED_TRANSACTION_1, EXPECTED_TRANSACTION_2]
+			expected_transaction_names=('transfer', 'transfer_v2')
 		)
 
 	def test_can_retrieve_transactions_sorted_by_height_desc(self):
@@ -516,7 +502,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			pagination=Pagination(2, 0),
 			sort='DESC',
 			transaction_query=self._make_transaction_query(),
-			expected_transactions=[EXPECTED_TRANSACTION_3, EXPECTED_TRANSACTION_4]
+			expected_transaction_names=('account_key_link', 'multisig_account_modification')
 		)
 
 	def test_can_retrieve_transactions_sorted_by_height_asc(self):
@@ -524,7 +510,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			pagination=Pagination(2, 0),
 			sort='ASC',
 			transaction_query=self._make_transaction_query(),
-			expected_transactions=[EXPECTED_TRANSACTION_2, EXPECTED_TRANSACTION_1]
+			expected_transaction_names=('transfer_v2', 'transfer')
 		)
 
 	def test_can_retrieve_transactions_filtered_by_sender_public_key(self):
@@ -534,7 +520,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			transaction_query=self._make_transaction_query(
 				sender='9ca54cd15edf88a9df9173375d4a0d706f7a9ddcf57d7547dff8110ddd2adeb9'
 			),
-			expected_transactions=[EXPECTED_TRANSACTION_3]
+			expected_transaction_names=('account_key_link', )
 		)
 
 	def test_can_exclude_multisig_transaction_for_initiator_account_from_address_filter(self):
@@ -544,7 +530,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			transaction_query=self._make_transaction_query(
 				address='NANEMOABLAGR72AZ2RV3V4ZHDCXW25XQ73O7OBT5'
 			),
-			expected_transactions=[]
+			expected_transaction_names=()
 		)
 		self._assert_can_retrieve_transactions(
 			pagination=Pagination(10, 0),
@@ -552,7 +538,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			transaction_query=self._make_transaction_query(
 				sender_address='NANEMOABLAGR72AZ2RV3V4ZHDCXW25XQ73O7OBT5'
 			),
-			expected_transactions=[]
+			expected_transaction_names=()
 		)
 
 	def test_can_retrieve_transactions_filtered_by_recipient_address(self):
@@ -562,13 +548,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			transaction_query=self._make_transaction_query(
 				recipient_address='NBFWZ4IVRHEIBRCGHLYDS62FSFTBM3VDFA7E6LSQ'
 			),
-			expected_transactions=[
-				EXPECTED_TRANSACTION_5,
-				EXPECTED_TRANSACTION_7,
-				EXPECTED_TRANSACTION_8,
-				EXPECTED_TRANSACTION_1,
-				EXPECTED_TRANSACTION_2
-			]
+			expected_transaction_names=('multisig', 'namespace_registration', 'mosaic_definition', 'transfer', 'transfer_v2')
 		)
 
 	def test_can_retrieve_transactions_filtered_by_sender_address(self):
@@ -578,7 +558,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			transaction_query=self._make_transaction_query(
 				sender_address='NBNR6XNZQIGQVXII6L3FPJTUGF6NFGLZHBN52R3V'
 			),
-			expected_transactions=[EXPECTED_TRANSACTION_3]
+			expected_transaction_names=('account_key_link', )
 		)
 
 	def test_can_retrieve_multisig_transaction_filtered_by_inner_sender_address(self):
@@ -588,15 +568,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			transaction_query=self._make_transaction_query(
 				sender_address='NALICEPFLZQRZGPRIJTMJOCPWDNECXTNNG7QLSG3'
 			),
-			expected_transactions=[
-				EXPECTED_TRANSACTION_5,
-				EXPECTED_TRANSACTION_8,
-				EXPECTED_TRANSACTION_9,
-				EXPECTED_TRANSACTION_4,
-				EXPECTED_TRANSACTION_7,
-				EXPECTED_TRANSACTION_2,
-				EXPECTED_TRANSACTION_1
-			]
+			expected_transaction_names=TRANSACTION_NAMES_FILTERED_BY_MULTISIG_INNER_SENDER
 		)
 
 	def test_can_retrieve_transactions_filtered_by_transaction_types(self):
@@ -606,7 +578,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			transaction_query=self._make_transaction_query(
 				transaction_types=[257, 2049]
 			),
-			expected_transactions=[EXPECTED_TRANSACTION_3, EXPECTED_TRANSACTION_1, EXPECTED_TRANSACTION_2]
+			expected_transaction_names=('account_key_link', 'transfer', 'transfer_v2')
 		)
 
 	def test_can_retrieve_transactions_filtered_by_mosaic(self):
@@ -616,7 +588,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			transaction_query=self._make_transaction_query(
 				mosaic='root.mosaic'
 			),
-			expected_transactions=[EXPECTED_TRANSACTION_2]
+			expected_transaction_names=('transfer_v2', )
 		)
 
 	# endregion

--- a/explorer/rest/tests/facade/test_NemRestFacade.py
+++ b/explorer/rest/tests/facade/test_NemRestFacade.py
@@ -537,14 +537,22 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			expected_transactions=[EXPECTED_TRANSACTION_3]
 		)
 
-	def test_can_retrieve_multisig_transaction_filtered_by_initiator_public_key(self):
+	def test_can_exclude_multisig_transaction_for_initiator_account_from_address_filter(self):
 		self._assert_can_retrieve_transactions(
 			pagination=Pagination(10, 0),
 			sort='DESC',
 			transaction_query=self._make_transaction_query(
-				sender='8D07F90FB4BBE7715FA327C926770166A11BE2E494A970605F2E12557F66C9B9'
+				address='NANEMOABLAGR72AZ2RV3V4ZHDCXW25XQ73O7OBT5'
 			),
-			expected_transactions=[EXPECTED_TRANSACTION_5]
+			expected_transactions=[]
+		)
+		self._assert_can_retrieve_transactions(
+			pagination=Pagination(10, 0),
+			sort='DESC',
+			transaction_query=self._make_transaction_query(
+				sender_address='NANEMOABLAGR72AZ2RV3V4ZHDCXW25XQ73O7OBT5'
+			),
+			expected_transactions=[]
 		)
 
 	def test_can_retrieve_transactions_filtered_by_recipient_address(self):
@@ -571,16 +579,6 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 				sender_address='NBNR6XNZQIGQVXII6L3FPJTUGF6NFGLZHBN52R3V'
 			),
 			expected_transactions=[EXPECTED_TRANSACTION_3]
-		)
-
-	def test_can_retrieve_multisig_transaction_filtered_by_initiator_address(self):
-		self._assert_can_retrieve_transactions(
-			pagination=Pagination(10, 0),
-			sort='DESC',
-			transaction_query=self._make_transaction_query(
-				sender_address='NANEMOABLAGR72AZ2RV3V4ZHDCXW25XQ73O7OBT5'
-			),
-			expected_transactions=[EXPECTED_TRANSACTION_5]
 		)
 
 	def test_can_retrieve_multisig_transaction_filtered_by_inner_sender_address(self):

--- a/explorer/rest/tests/routes/nem/test_routes.py
+++ b/explorer/rest/tests/routes/nem/test_routes.py
@@ -863,10 +863,6 @@ def test_api_transactions_applies_recipient_address(client):  # pylint: disable=
 	], recipientAddress='NBFWZ4IVRHEIBRCGHLYDS62FSFTBM3VDFA7E6LSQ')
 
 
-def test_api_transactions_applies_multisig_initiator_address(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_transactions(client, 200, [], senderAddress='NANEMOABLAGR72AZ2RV3V4ZHDCXW25XQ73O7OBT5')
-
-
 def test_api_transactions_applies_multisig_inner_sender_address(client):  # pylint: disable=redefined-outer-name, invalid-name
 	_assert_get_api_nem_transactions(client, 200, [
 		TRANSACTIONS_VIEWS[4].to_dict(),

--- a/explorer/rest/tests/routes/nem/test_routes.py
+++ b/explorer/rest/tests/routes/nem/test_routes.py
@@ -848,13 +848,38 @@ def test_api_transactions_applies_sender_public_key(client):  # pylint: disable=
 	], senderPublicKey='9ca54cd15edf88a9df9173375d4a0d706f7a9ddcf57d7547dff8110ddd2adeb9')
 
 
+def test_api_transactions_applies_multisig_initiator_public_key(client):  # pylint: disable=redefined-outer-name, invalid-name
+	_assert_get_api_nem_transactions(client, 200, [
+		TRANSACTIONS_VIEWS[4].to_dict()
+	], senderPublicKey='8D07F90FB4BBE7715FA327C926770166A11BE2E494A970605F2E12557F66C9B9')
+
+
 def test_api_transactions_applies_recipient_address(client):  # pylint: disable=redefined-outer-name, invalid-name
 	_assert_get_api_nem_transactions(client, 200, [
+		TRANSACTIONS_VIEWS[4].to_dict(),
 		TRANSACTIONS_VIEWS[5].to_dict(),
 		TRANSACTIONS_VIEWS[6].to_dict(),
 		TRANSACTIONS_VIEWS[0].to_dict(),
 		TRANSACTIONS_VIEWS[1].to_dict()
 	], recipientAddress='NBFWZ4IVRHEIBRCGHLYDS62FSFTBM3VDFA7E6LSQ')
+
+
+def test_api_transactions_applies_multisig_initiator_address(client):  # pylint: disable=redefined-outer-name, invalid-name
+	_assert_get_api_nem_transactions(client, 200, [
+		TRANSACTIONS_VIEWS[4].to_dict()
+	], senderAddress='NANEMOABLAGR72AZ2RV3V4ZHDCXW25XQ73O7OBT5')
+
+
+def test_api_transactions_applies_multisig_inner_sender_address(client):  # pylint: disable=redefined-outer-name, invalid-name
+	_assert_get_api_nem_transactions(client, 200, [
+		TRANSACTIONS_VIEWS[4].to_dict(),
+		TRANSACTIONS_VIEWS[6].to_dict(),
+		TRANSACTIONS_VIEWS[7].to_dict(),
+		TRANSACTIONS_VIEWS[3].to_dict(),
+		TRANSACTIONS_VIEWS[5].to_dict(),
+		TRANSACTIONS_VIEWS[1].to_dict(),
+		TRANSACTIONS_VIEWS[0].to_dict()
+	], senderAddress='NALICEPFLZQRZGPRIJTMJOCPWDNECXTNNG7QLSG3')
 
 
 def test_api_transactions_applies_mosaic(client):  # pylint: disable=redefined-outer-name

--- a/explorer/rest/tests/routes/nem/test_routes.py
+++ b/explorer/rest/tests/routes/nem/test_routes.py
@@ -848,10 +848,9 @@ def test_api_transactions_applies_sender_public_key(client):  # pylint: disable=
 	], senderPublicKey='9ca54cd15edf88a9df9173375d4a0d706f7a9ddcf57d7547dff8110ddd2adeb9')
 
 
-def test_api_transactions_applies_multisig_initiator_public_key(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_transactions(client, 200, [
-		TRANSACTIONS_VIEWS[4].to_dict()
-	], senderPublicKey='8D07F90FB4BBE7715FA327C926770166A11BE2E494A970605F2E12557F66C9B9')
+def test_api_transactions_excludes_multisig_for_initiator_from_address_filter(client):  # pylint: disable=redefined-outer-name, invalid-name
+	_assert_get_api_nem_transactions(client, 200, [], address='NANEMOABLAGR72AZ2RV3V4ZHDCXW25XQ73O7OBT5')
+	_assert_get_api_nem_transactions(client, 200, [], senderAddress='NANEMOABLAGR72AZ2RV3V4ZHDCXW25XQ73O7OBT5')
 
 
 def test_api_transactions_applies_recipient_address(client):  # pylint: disable=redefined-outer-name, invalid-name
@@ -865,9 +864,7 @@ def test_api_transactions_applies_recipient_address(client):  # pylint: disable=
 
 
 def test_api_transactions_applies_multisig_initiator_address(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_transactions(client, 200, [
-		TRANSACTIONS_VIEWS[4].to_dict()
-	], senderAddress='NANEMOABLAGR72AZ2RV3V4ZHDCXW25XQ73O7OBT5')
+	_assert_get_api_nem_transactions(client, 200, [], senderAddress='NANEMOABLAGR72AZ2RV3V4ZHDCXW25XQ73O7OBT5')
 
 
 def test_api_transactions_applies_multisig_inner_sender_address(client):  # pylint: disable=redefined-outer-name, invalid-name

--- a/explorer/rest/tests/routes/nem/test_routes.py
+++ b/explorer/rest/tests/routes/nem/test_routes.py
@@ -18,10 +18,14 @@ from ...test.DatabaseTestUtils import (
 	NAMESPACE_VIEWS,
 	TRANSACTION_DAILY_STATISTIC_VIEW,
 	TRANSACTION_MONTH_STATISTIC_VIEW,
+	TRANSACTION_NAMES_FILTERED_BY_MULTISIG_INNER_SENDER,
+	TRANSACTION_NAMES_SORTED_BY_HEIGHT_ASC,
 	TRANSACTION_STATISTIC_VIEW,
-	TRANSACTIONS_VIEWS,
 	DatabaseConfig,
-	initialize_database
+	initialize_database,
+	transaction_dict,
+	transaction_dicts,
+	transaction_hash
 )
 
 DATABASE_CONFIG_INI = 'db_config.ini'
@@ -641,11 +645,11 @@ def test_api_mosaic_rich_list_applies_offset(client):  # pylint: disable=redefin
 
 def test_api_nem_transaction_by_hash(client):  # pylint: disable=redefined-outer-name
 	# Act:
-	response = client.get('/api/nem/transaction/' + TRANSACTIONS_VIEWS[0].transaction_hash)
+	response = client.get('/api/nem/transaction/' + transaction_hash('transfer'))
 
 	# Assert:
 	_assert_status_code_and_headers(response, 200)
-	assert TRANSACTIONS_VIEWS[0].to_dict() == response.json
+	assert transaction_dict('transfer') == response.json
 
 
 def test_api_nem_transaction_by_hash_invalid_hash(client):  # pylint: disable=redefined-outer-name, invalid-name
@@ -761,138 +765,131 @@ def _assert_get_api_nem_transactions(client, expected_status_code, expected_resu
 
 
 def test_api_transactions_without_params(client):  # pylint: disable=redefined-outer-name
-	_assert_get_api_nem_transactions(client, 200, [
-		TRANSACTIONS_VIEWS[7].to_dict(),
-		TRANSACTIONS_VIEWS[5].to_dict(),
-		TRANSACTIONS_VIEWS[6].to_dict(),
-		TRANSACTIONS_VIEWS[2].to_dict(),
-		TRANSACTIONS_VIEWS[3].to_dict(),
-		TRANSACTIONS_VIEWS[4].to_dict(),
-		TRANSACTIONS_VIEWS[1].to_dict(),
-		TRANSACTIONS_VIEWS[0].to_dict()
-	])
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts(
+		'mosaic_supply_change',
+		'namespace_registration',
+		'mosaic_definition',
+		'account_key_link',
+		'multisig_account_modification',
+		'multisig',
+		'transfer_v2',
+		'transfer'
+	))
 
 
 def test_api_transactions_applies_limit(client):  # pylint: disable=redefined-outer-name
-	_assert_get_api_nem_transactions(client, 200, [TRANSACTIONS_VIEWS[2].to_dict()], limit=1)
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts('account_key_link'), limit=1)
 
 
 def test_api_transactions_applies_offset(client):  # pylint: disable=redefined-outer-name
-	_assert_get_api_nem_transactions(client, 200, [
-		TRANSACTIONS_VIEWS[5].to_dict(),
-		TRANSACTIONS_VIEWS[6].to_dict(),
-		TRANSACTIONS_VIEWS[2].to_dict(),
-		TRANSACTIONS_VIEWS[3].to_dict(),
-		TRANSACTIONS_VIEWS[4].to_dict(),
-		TRANSACTIONS_VIEWS[1].to_dict(),
-		TRANSACTIONS_VIEWS[0].to_dict()
-	], offset=1)
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts(
+		'namespace_registration',
+		'mosaic_definition',
+		'account_key_link',
+		'multisig_account_modification',
+		'multisig',
+		'transfer_v2',
+		'transfer'
+	), offset=1)
 
 
 def test_api_transactions_applies_sorted_by_height_asc(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_transactions(client, 200, [
-		TRANSACTIONS_VIEWS[0].to_dict(),
-		TRANSACTIONS_VIEWS[1].to_dict(),
-		TRANSACTIONS_VIEWS[2].to_dict(),
-		TRANSACTIONS_VIEWS[3].to_dict(),
-		TRANSACTIONS_VIEWS[4].to_dict(),
-		TRANSACTIONS_VIEWS[5].to_dict(),
-		TRANSACTIONS_VIEWS[6].to_dict(),
-		TRANSACTIONS_VIEWS[7].to_dict(),
-	], sort='ASC')
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts(*TRANSACTION_NAMES_SORTED_BY_HEIGHT_ASC), sort='ASC')
 
 
 def test_api_transactions_applies_sorted_by_height_desc(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_transactions(client, 200, [
-		TRANSACTIONS_VIEWS[7].to_dict(),
-		TRANSACTIONS_VIEWS[5].to_dict(),
-		TRANSACTIONS_VIEWS[6].to_dict(),
-		TRANSACTIONS_VIEWS[2].to_dict(),
-		TRANSACTIONS_VIEWS[3].to_dict(),
-		TRANSACTIONS_VIEWS[4].to_dict(),
-		TRANSACTIONS_VIEWS[1].to_dict(),
-		TRANSACTIONS_VIEWS[0].to_dict()
-	], sort='DESC')
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts(
+		'mosaic_supply_change',
+		'namespace_registration',
+		'mosaic_definition',
+		'account_key_link',
+		'multisig_account_modification',
+		'multisig',
+		'transfer_v2',
+		'transfer'
+	), sort='DESC')
 
 
 def test_api_transactions_applies_height(client):  # pylint: disable=redefined-outer-name
-	_assert_get_api_nem_transactions(client, 200, [
-		TRANSACTIONS_VIEWS[0].to_dict(),
-		TRANSACTIONS_VIEWS[1].to_dict()
-	], height=1)
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts('transfer', 'transfer_v2'), height=1)
 
 
 def test_api_transactions_applies_transaction_types(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_transactions(client, 200, [
-		TRANSACTIONS_VIEWS[2].to_dict(),
-		TRANSACTIONS_VIEWS[0].to_dict(),
-		TRANSACTIONS_VIEWS[1].to_dict()
-	], transactionTypes='transfer,account_key_link')
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts(
+		'account_key_link',
+		'transfer',
+		'transfer_v2'
+	), transactionTypes='transfer,account_key_link')
 
 
 def test_api_transactions_applies_address(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_transactions(client, 200, [
-		TRANSACTIONS_VIEWS[2].to_dict()
-	], address='NBNR6XNZQIGQVXII6L3FPJTUGF6NFGLZHBN52R3V')
+	_assert_get_api_nem_transactions(
+		client,
+		200,
+		transaction_dicts('account_key_link'),
+		address='NBNR6XNZQIGQVXII6L3FPJTUGF6NFGLZHBN52R3V'
+	)
 
 
 def test_api_transactions_applies_sender_address(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_transactions(client, 200, [
-		TRANSACTIONS_VIEWS[2].to_dict()
-	], senderAddress='NBNR6XNZQIGQVXII6L3FPJTUGF6NFGLZHBN52R3V')
+	_assert_get_api_nem_transactions(
+		client,
+		200,
+		transaction_dicts('account_key_link'),
+		senderAddress='NBNR6XNZQIGQVXII6L3FPJTUGF6NFGLZHBN52R3V'
+	)
 
 
 def test_api_transactions_applies_sender_public_key(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_transactions(client, 200, [
-		TRANSACTIONS_VIEWS[2].to_dict()
-	], senderPublicKey='9ca54cd15edf88a9df9173375d4a0d706f7a9ddcf57d7547dff8110ddd2adeb9')
+	_assert_get_api_nem_transactions(
+		client,
+		200,
+		transaction_dicts('account_key_link'),
+		senderPublicKey='9ca54cd15edf88a9df9173375d4a0d706f7a9ddcf57d7547dff8110ddd2adeb9'
+	)
 
 
 def test_api_transactions_excludes_multisig_for_initiator_from_address_filter(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_transactions(client, 200, [], address='NANEMOABLAGR72AZ2RV3V4ZHDCXW25XQ73O7OBT5')
-	_assert_get_api_nem_transactions(client, 200, [], senderAddress='NANEMOABLAGR72AZ2RV3V4ZHDCXW25XQ73O7OBT5')
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts(), address='NANEMOABLAGR72AZ2RV3V4ZHDCXW25XQ73O7OBT5')
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts(), senderAddress='NANEMOABLAGR72AZ2RV3V4ZHDCXW25XQ73O7OBT5')
 
 
 def test_api_transactions_applies_recipient_address(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_transactions(client, 200, [
-		TRANSACTIONS_VIEWS[4].to_dict(),
-		TRANSACTIONS_VIEWS[5].to_dict(),
-		TRANSACTIONS_VIEWS[6].to_dict(),
-		TRANSACTIONS_VIEWS[0].to_dict(),
-		TRANSACTIONS_VIEWS[1].to_dict()
-	], recipientAddress='NBFWZ4IVRHEIBRCGHLYDS62FSFTBM3VDFA7E6LSQ')
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts(
+		'multisig',
+		'namespace_registration',
+		'mosaic_definition',
+		'transfer',
+		'transfer_v2'
+	), recipientAddress='NBFWZ4IVRHEIBRCGHLYDS62FSFTBM3VDFA7E6LSQ')
 
 
 def test_api_transactions_applies_multisig_inner_sender_address(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_transactions(client, 200, [
-		TRANSACTIONS_VIEWS[4].to_dict(),
-		TRANSACTIONS_VIEWS[6].to_dict(),
-		TRANSACTIONS_VIEWS[7].to_dict(),
-		TRANSACTIONS_VIEWS[3].to_dict(),
-		TRANSACTIONS_VIEWS[5].to_dict(),
-		TRANSACTIONS_VIEWS[1].to_dict(),
-		TRANSACTIONS_VIEWS[0].to_dict()
-	], senderAddress='NALICEPFLZQRZGPRIJTMJOCPWDNECXTNNG7QLSG3')
+	_assert_get_api_nem_transactions(
+		client,
+		200,
+		transaction_dicts(*TRANSACTION_NAMES_FILTERED_BY_MULTISIG_INNER_SENDER),
+		senderAddress='NALICEPFLZQRZGPRIJTMJOCPWDNECXTNNG7QLSG3'
+	)
 
 
 def test_api_transactions_applies_mosaic(client):  # pylint: disable=redefined-outer-name
-	_assert_get_api_nem_transactions(client, 200, [
-		TRANSACTIONS_VIEWS[1].to_dict()
-	], mosaic='root.mosaic')
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts('transfer_v2'), mosaic='root.mosaic')
 
 
 def test_api_transactions_applies_address_ignore_other(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_transactions(client, 200, [
-		TRANSACTIONS_VIEWS[2].to_dict()
-	], address='NBNR6XNZQIGQVXII6L3FPJTUGF6NFGLZHBN52R3V', senderAddress='NALICEPFLZQRZGPRIJTMJOCPWDNECXTNNG7QLSG3')
-
-	_assert_get_api_nem_transactions(client, 200, [
-		TRANSACTIONS_VIEWS[2].to_dict()
-	], address='NBNR6XNZQIGQVXII6L3FPJTUGF6NFGLZHBN52R3V', recipientAddress='NALICEPFLZQRZGPRIJTMJOCPWDNECXTNNG7QLSG3')
-
-	_assert_get_api_nem_transactions(client, 200, [
-		TRANSACTIONS_VIEWS[2].to_dict()
-	], address='NBNR6XNZQIGQVXII6L3FPJTUGF6NFGLZHBN52R3V', senderPublicKey='f9bd190dd0c364261f5c8a74870cc7f7374e631352293c62ecc437657e5de2cd')
+	for query_params in [
+		{'senderAddress': 'NALICEPFLZQRZGPRIJTMJOCPWDNECXTNNG7QLSG3'},
+		{'recipientAddress': 'NALICEPFLZQRZGPRIJTMJOCPWDNECXTNNG7QLSG3'},
+		{'senderPublicKey': 'f9bd190dd0c364261f5c8a74870cc7f7374e631352293c62ecc437657e5de2cd'}
+	]:
+		_assert_get_api_nem_transactions(
+			client,
+			200,
+			transaction_dicts('account_key_link'),
+			address='NBNR6XNZQIGQVXII6L3FPJTUGF6NFGLZHBN52R3V',
+			**query_params
+		)
 
 
 def _assert_transaction_invalid_params(client, expected_message, **query_params):  # pylint: disable=redefined-outer-name

--- a/explorer/rest/tests/test/DatabaseTestUtils.py
+++ b/explorer/rest/tests/test/DatabaseTestUtils.py
@@ -837,6 +837,60 @@ TRANSACTIONS_VIEWS = [
 	),
 ]
 
+TRANSACTION_HASHES = {
+	'transfer': '0' * 63 + '1',
+	'transfer_v2': '0' * 63 + '2',
+	'account_key_link': '0' * 63 + '3',
+	'multisig_account_modification': '0' * 63 + '4',
+	'multisig': '0' * 63 + '5',
+	'namespace_registration': '0' * 63 + '7',
+	'mosaic_definition': '0' * 63 + '8',
+	'mosaic_supply_change': '0' * 63 + '9'
+}
+
+TRANSACTION_NAMES_SORTED_BY_HEIGHT_ASC = (
+	'transfer',
+	'transfer_v2',
+	'account_key_link',
+	'multisig_account_modification',
+	'multisig',
+	'namespace_registration',
+	'mosaic_definition',
+	'mosaic_supply_change'
+)
+
+TRANSACTION_NAMES_FILTERED_BY_MULTISIG_INNER_SENDER = (
+	'multisig',
+	'mosaic_definition',
+	'mosaic_supply_change',
+	'multisig_account_modification',
+	'namespace_registration',
+	'transfer_v2',
+	'transfer'
+)
+
+TRANSACTION_VIEWS_BY_HASH = {transaction_view.transaction_hash: transaction_view for transaction_view in TRANSACTIONS_VIEWS}
+
+
+def transaction_hash(transaction_name):
+	return TRANSACTION_HASHES[transaction_name]
+
+
+def transaction_view(transaction_name):
+	return TRANSACTION_VIEWS_BY_HASH[transaction_hash(transaction_name)]
+
+
+def transaction_views(*transaction_names):
+	return [transaction_view(transaction_name) for transaction_name in transaction_names]
+
+
+def transaction_dict(transaction_name):
+	return transaction_view(transaction_name).to_dict()
+
+
+def transaction_dicts(*transaction_names):
+	return [view.to_dict() for view in transaction_views(*transaction_names)]
+
 # endregion
 
 

--- a/explorer/rest/tests/test/DatabaseTestUtils.py
+++ b/explorer/rest/tests/test/DatabaseTestUtils.py
@@ -320,14 +320,14 @@ TRANSACTIONS = [
 	Transaction(  # Multisig transaction
 		transaction_hash='0' * 63 + '5',
 		height=2,
-		sender_public_key=PublicKey('f9bd190dd0c364261f5c8a74870cc7f7374e631352293c62ecc437657e5de2cd'),
+		sender_public_key=PublicKey('8D07F90FB4BBE7715FA327C926770166A11BE2E494A970605F2E12557F66C9B9'),
 		fee=150000,
 		timestamp='2015-03-29 00:06:25',
 		deadline='2015-03-29 20:34:19',
 		signature='0' * 128,
 		transaction_type=4100,
 		is_inner=False,
-		sender_address=Address('NALICEPFLZQRZGPRIJTMJOCPWDNECXTNNG7QLSG3'),
+		sender_address=Address('NANEMOABLAGR72AZ2RV3V4ZHDCXW25XQ73O7OBT5'),
 		recipient_address=None,
 		payload={
 			'inner_hash': '0' * 63 + '6',
@@ -765,7 +765,7 @@ TRANSACTIONS_VIEWS = [
 		to_address=str(TRANSACTIONS[5].recipient_address),
 		value=None,
 		embedded_transactions=[{
-			'initiator': 'NALICEPFLZQRZGPRIJTMJOCPWDNECXTNNG7QLSG3',
+			'initiator': 'NANEMOABLAGR72AZ2RV3V4ZHDCXW25XQ73O7OBT5',
 			'transactionHash': '0' * 63 + '6',
 			'transactionType': 'TRANSFER',
 			'signatures': [{


### PR DESCRIPTION
Problem: Multisig transactions only appear in the `Initiator account` transaction list. For a better user experience, it should appear in `multisig account` and `recipient account` as well. https://github.com/symbol/product/issues/2320

Solution: Added a multisig inner filter query when searching for the account detail, and excluded multisig tx for the initiator