### PR TITLE
[explorer/rest] fix: refactor unit test, added helper method

### DIFF
--- a/explorer/rest/tests/db/test_NemDatabase.py
+++ b/explorer/rest/tests/db/test_NemDatabase.py
@@ -32,8 +32,9 @@ from ..test.DatabaseTestUtils import (
 	TRANSACTION_MONTH_STATISTIC_VIEW,
 	TRANSACTION_STATISTIC_VIEW,
 	TRANSACTIONS,
-	TRANSACTIONS_VIEWS,
-	DatabaseTestBase
+	DatabaseTestBase,
+	transaction_view as expected_transaction_view,
+	transaction_views
 )
 
 # region test data
@@ -523,56 +524,56 @@ class NemDatabaseTest(DatabaseTestBase):  # pylint: disable=too-many-public-meth
 		transaction_view = self.nem_db.get_transaction_by_hash('0' * 63 + '1')
 
 		# Assert:
-		self.assertEqual(TRANSACTIONS_VIEWS[0], transaction_view)
+		self.assertEqual(expected_transaction_view('1'), transaction_view)
 
 	def test_can_query_transfer_v2_by_hash(self):
 		# Act:
 		transaction_view = self.nem_db.get_transaction_by_hash('0' * 63 + '2')
 
 		# Assert:
-		self.assertEqual(TRANSACTIONS_VIEWS[1], transaction_view)
+		self.assertEqual(expected_transaction_view('2'), transaction_view)
 
 	def test_can_query_account_link_by_hash(self):
 		# Act:
 		transaction_view = self.nem_db.get_transaction_by_hash('0' * 63 + '3')
 
 		# Assert:
-		self.assertEqual(TRANSACTIONS_VIEWS[2], transaction_view)
+		self.assertEqual(expected_transaction_view('3'), transaction_view)
 
 	def test_can_query_multisig_account_modification_by_hash(self):
 		# Act:
 		transaction_view = self.nem_db.get_transaction_by_hash('0' * 63 + '4')
 
 		# Assert:
-		self.assertEqual(TRANSACTIONS_VIEWS[3], transaction_view)
+		self.assertEqual(expected_transaction_view('4'), transaction_view)
 
 	def test_can_query_multisig_by_hash(self):
 		# Act:
 		transaction_view = self.nem_db.get_transaction_by_hash('0' * 63 + '5')
 
 		# Assert:
-		self.assertEqual(TRANSACTIONS_VIEWS[4], transaction_view)
+		self.assertEqual(expected_transaction_view('5'), transaction_view)
 
 	def test_can_query_namespace_registration_by_hash(self):
 		# Act:
 		transaction_view = self.nem_db.get_transaction_by_hash('0' * 63 + '7')
 
 		# Assert:
-		self.assertEqual(TRANSACTIONS_VIEWS[5], transaction_view)
+		self.assertEqual(expected_transaction_view('7'), transaction_view)
 
 	def test_can_query_mosaic_definition_by_hash(self):
 		# Act:
 		transaction_view = self.nem_db.get_transaction_by_hash('0' * 63 + '8')
 
 		# Assert:
-		self.assertEqual(TRANSACTIONS_VIEWS[6], transaction_view)
+		self.assertEqual(expected_transaction_view('8'), transaction_view)
 
 	def test_can_query_mosaic_supply_change_by_hash(self):
 		# Act:
 		transaction_view = self.nem_db.get_transaction_by_hash('0' * 63 + '9')
 
 		# Assert:
-		self.assertEqual(TRANSACTIONS_VIEWS[7], transaction_view)
+		self.assertEqual(expected_transaction_view('9'), transaction_view)
 
 	# endregion
 
@@ -620,29 +621,29 @@ class NemDatabaseTest(DatabaseTestBase):  # pylint: disable=too-many-public-meth
 
 	def test_can_query_transactions_filtered_limit_offset_0(self):
 		self._assert_can_query_transactions_with_filter(
-			Pagination(1, 0), 'desc', self._make_transaction_query(), [TRANSACTIONS_VIEWS[2]]
+			Pagination(1, 0), 'desc', self._make_transaction_query(), transaction_views('3')
 		)
 
 	def test_can_query_transactions_filtered_limit_offset_1(self):
 		self._assert_can_query_transactions_with_filter(
-			Pagination(2, 1), 'desc', self._make_transaction_query(), [TRANSACTIONS_VIEWS[2], TRANSACTIONS_VIEWS[4]]
+			Pagination(2, 1), 'desc', self._make_transaction_query(), transaction_views('3', '5')
 		)
 
 	def test_can_query_transactions_sorted_by_height_asc(self):
 		self._assert_can_query_transactions_with_filter(
-			Pagination(10, 0), 'asc', self._make_transaction_query(), list(TRANSACTIONS_VIEWS)
+			Pagination(10, 0), 'asc', self._make_transaction_query(), transaction_views('1', '2', '3', '4', '5', '7', '8', '9')
 		)
 
 	def test_can_query_transactions_sorted_by_height_desc(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(3, 0), 'desc', self._make_transaction_query(),
-			[TRANSACTIONS_VIEWS[3], TRANSACTIONS_VIEWS[2], TRANSACTIONS_VIEWS[4]]
+			transaction_views('4', '3', '5')
 		)
 
 	def test_can_query_transactions_filtered_by_height(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc', self._make_transaction_query(height=1),
-			[TRANSACTIONS_VIEWS[0], TRANSACTIONS_VIEWS[1]]
+			transaction_views('1', '2')
 		)
 
 	def test_can_query_transactions_filtered_by_nonexistent_height(self):
@@ -655,43 +656,31 @@ class NemDatabaseTest(DatabaseTestBase):  # pylint: disable=too-many-public-meth
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc',
 			self._make_transaction_query(transaction_types=[257, 2049]),
-			[TRANSACTIONS_VIEWS[2], TRANSACTIONS_VIEWS[0], TRANSACTIONS_VIEWS[1]]
+			transaction_views('3', '1', '2')
 		)
 
 	def test_can_query_transactions_filtered_by_address_as_sender(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(2, 0), 'desc', self._make_transaction_query(address=TRANSACTIONS[2].sender_address),
-			[TRANSACTIONS_VIEWS[2]]
+			transaction_views('3')
 		)
 
 	def test_can_query_transactions_filtered_by_address_as_recipient(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc', self._make_transaction_query(address=TRANSACTIONS[0].recipient_address),
-			[
-				TRANSACTIONS_VIEWS[4],
-				TRANSACTIONS_VIEWS[5],
-				TRANSACTIONS_VIEWS[6],
-				TRANSACTIONS_VIEWS[0],
-				TRANSACTIONS_VIEWS[1]
-			]
+			transaction_views('5', '7', '8', '1', '2')
 		)
 
 	def test_can_query_transactions_filtered_by_sender_address(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc', self._make_transaction_query(sender_address=TRANSACTIONS[2].sender_address),
-			[TRANSACTIONS_VIEWS[2]]
+			transaction_views('3')
 		)
 
 	def test_can_query_transactions_filtered_by_recipient_address(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc', self._make_transaction_query(recipient_address=TRANSACTIONS[0].recipient_address),
-			[
-				TRANSACTIONS_VIEWS[4],
-				TRANSACTIONS_VIEWS[5],
-				TRANSACTIONS_VIEWS[6],
-				TRANSACTIONS_VIEWS[0],
-				TRANSACTIONS_VIEWS[1]
-			]
+			transaction_views('5', '7', '8', '1', '2')
 		)
 
 	def test_can_exclude_multisig_transaction_for_initiator_account_from_address_filter(self):
@@ -705,39 +694,25 @@ class NemDatabaseTest(DatabaseTestBase):  # pylint: disable=too-many-public-meth
 	def test_can_query_multisig_transaction_filtered_by_inner_sender_address(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc', self._make_transaction_query(sender_address=TRANSACTIONS[5].sender_address),
-			[
-				TRANSACTIONS_VIEWS[4],
-				TRANSACTIONS_VIEWS[6],
-				TRANSACTIONS_VIEWS[7],
-				TRANSACTIONS_VIEWS[3],
-				TRANSACTIONS_VIEWS[5],
-				TRANSACTIONS_VIEWS[1],
-				TRANSACTIONS_VIEWS[0]
-			]
+			transaction_views('5', '8', '9', '4', '7', '2', '1')
 		)
 
 	def test_can_query_multisig_transaction_filtered_by_inner_recipient_address(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc', self._make_transaction_query(recipient_address=TRANSACTIONS[5].recipient_address),
-			[
-				TRANSACTIONS_VIEWS[4],
-				TRANSACTIONS_VIEWS[5],
-				TRANSACTIONS_VIEWS[6],
-				TRANSACTIONS_VIEWS[0],
-				TRANSACTIONS_VIEWS[1]
-			]
+			transaction_views('5', '7', '8', '1', '2')
 		)
 
 	def test_can_query_transactions_filtered_by_mosaic_nem_xem(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc', self._make_transaction_query(mosaic='nem.xem'),
-			[TRANSACTIONS_VIEWS[0], TRANSACTIONS_VIEWS[1]]
+			transaction_views('1', '2')
 		)
 
 	def test_can_query_transactions_filtered_by_mosaic_other(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc', self._make_transaction_query(mosaic='root.mosaic'),
-			[TRANSACTIONS_VIEWS[1]]
+			transaction_views('2')
 		)
 
 	def test_can_query_transactions_filtered_by_nonexistent_mosaic(self):

--- a/explorer/rest/tests/db/test_NemDatabase.py
+++ b/explorer/rest/tests/db/test_NemDatabase.py
@@ -30,12 +30,15 @@ from ..test.DatabaseTestUtils import (
 	NAMESPACE_VIEWS,
 	TRANSACTION_DAILY_STATISTIC_VIEW,
 	TRANSACTION_MONTH_STATISTIC_VIEW,
+	TRANSACTION_NAMES_FILTERED_BY_MULTISIG_INNER_SENDER,
+	TRANSACTION_NAMES_SORTED_BY_HEIGHT_ASC,
 	TRANSACTION_STATISTIC_VIEW,
 	TRANSACTIONS,
 	DatabaseTestBase,
-	transaction_view as expected_transaction_view,
-	transaction_views
+	transaction_hash
 )
+from ..test.DatabaseTestUtils import transaction_view as expected_transaction_view
+from ..test.DatabaseTestUtils import transaction_views
 
 # region test data
 
@@ -521,59 +524,59 @@ class NemDatabaseTest(DatabaseTestBase):  # pylint: disable=too-many-public-meth
 
 	def test_can_query_transfer_by_hash(self):
 		# Act:
-		transaction_view = self.nem_db.get_transaction_by_hash('0' * 63 + '1')
+		transaction_view = self.nem_db.get_transaction_by_hash(transaction_hash('transfer'))
 
 		# Assert:
-		self.assertEqual(expected_transaction_view('1'), transaction_view)
+		self.assertEqual(expected_transaction_view('transfer'), transaction_view)
 
 	def test_can_query_transfer_v2_by_hash(self):
 		# Act:
-		transaction_view = self.nem_db.get_transaction_by_hash('0' * 63 + '2')
+		transaction_view = self.nem_db.get_transaction_by_hash(transaction_hash('transfer_v2'))
 
 		# Assert:
-		self.assertEqual(expected_transaction_view('2'), transaction_view)
+		self.assertEqual(expected_transaction_view('transfer_v2'), transaction_view)
 
 	def test_can_query_account_link_by_hash(self):
 		# Act:
-		transaction_view = self.nem_db.get_transaction_by_hash('0' * 63 + '3')
+		transaction_view = self.nem_db.get_transaction_by_hash(transaction_hash('account_key_link'))
 
 		# Assert:
-		self.assertEqual(expected_transaction_view('3'), transaction_view)
+		self.assertEqual(expected_transaction_view('account_key_link'), transaction_view)
 
 	def test_can_query_multisig_account_modification_by_hash(self):
 		# Act:
-		transaction_view = self.nem_db.get_transaction_by_hash('0' * 63 + '4')
+		transaction_view = self.nem_db.get_transaction_by_hash(transaction_hash('multisig_account_modification'))
 
 		# Assert:
-		self.assertEqual(expected_transaction_view('4'), transaction_view)
+		self.assertEqual(expected_transaction_view('multisig_account_modification'), transaction_view)
 
 	def test_can_query_multisig_by_hash(self):
 		# Act:
-		transaction_view = self.nem_db.get_transaction_by_hash('0' * 63 + '5')
+		transaction_view = self.nem_db.get_transaction_by_hash(transaction_hash('multisig'))
 
 		# Assert:
-		self.assertEqual(expected_transaction_view('5'), transaction_view)
+		self.assertEqual(expected_transaction_view('multisig'), transaction_view)
 
 	def test_can_query_namespace_registration_by_hash(self):
 		# Act:
-		transaction_view = self.nem_db.get_transaction_by_hash('0' * 63 + '7')
+		transaction_view = self.nem_db.get_transaction_by_hash(transaction_hash('namespace_registration'))
 
 		# Assert:
-		self.assertEqual(expected_transaction_view('7'), transaction_view)
+		self.assertEqual(expected_transaction_view('namespace_registration'), transaction_view)
 
 	def test_can_query_mosaic_definition_by_hash(self):
 		# Act:
-		transaction_view = self.nem_db.get_transaction_by_hash('0' * 63 + '8')
+		transaction_view = self.nem_db.get_transaction_by_hash(transaction_hash('mosaic_definition'))
 
 		# Assert:
-		self.assertEqual(expected_transaction_view('8'), transaction_view)
+		self.assertEqual(expected_transaction_view('mosaic_definition'), transaction_view)
 
 	def test_can_query_mosaic_supply_change_by_hash(self):
 		# Act:
-		transaction_view = self.nem_db.get_transaction_by_hash('0' * 63 + '9')
+		transaction_view = self.nem_db.get_transaction_by_hash(transaction_hash('mosaic_supply_change'))
 
 		# Assert:
-		self.assertEqual(expected_transaction_view('9'), transaction_view)
+		self.assertEqual(expected_transaction_view('mosaic_supply_change'), transaction_view)
 
 	# endregion
 
@@ -612,43 +615,43 @@ class NemDatabaseTest(DatabaseTestBase):  # pylint: disable=too-many-public-meth
 		self.assertEqual(TRANSACTION_MONTH_STATISTIC_VIEW, transaction_statistics)
 	# region transactions
 
-	def _assert_can_query_transactions_with_filter(self, pagination, sort, transaction_query, expected_transactions):
+	def _assert_can_query_transactions_with_filter(self, pagination, sort, transaction_query, expected_transaction_names):
 		# Act:
 		transactions_view = self.nem_db.get_transactions(pagination, sort, transaction_query)
 
 		# Assert:
-		self.assertEqual(expected_transactions, transactions_view)
+		self.assertEqual(transaction_views(*expected_transaction_names), transactions_view)
 
 	def test_can_query_transactions_filtered_limit_offset_0(self):
 		self._assert_can_query_transactions_with_filter(
-			Pagination(1, 0), 'desc', self._make_transaction_query(), transaction_views('3')
+			Pagination(1, 0), 'desc', self._make_transaction_query(), ('account_key_link', )
 		)
 
 	def test_can_query_transactions_filtered_limit_offset_1(self):
 		self._assert_can_query_transactions_with_filter(
-			Pagination(2, 1), 'desc', self._make_transaction_query(), transaction_views('3', '5')
+			Pagination(2, 1), 'desc', self._make_transaction_query(), ('account_key_link', 'multisig')
 		)
 
 	def test_can_query_transactions_sorted_by_height_asc(self):
 		self._assert_can_query_transactions_with_filter(
-			Pagination(10, 0), 'asc', self._make_transaction_query(), transaction_views('1', '2', '3', '4', '5', '7', '8', '9')
+			Pagination(10, 0), 'asc', self._make_transaction_query(), TRANSACTION_NAMES_SORTED_BY_HEIGHT_ASC
 		)
 
 	def test_can_query_transactions_sorted_by_height_desc(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(3, 0), 'desc', self._make_transaction_query(),
-			transaction_views('4', '3', '5')
+			('multisig_account_modification', 'account_key_link', 'multisig')
 		)
 
 	def test_can_query_transactions_filtered_by_height(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc', self._make_transaction_query(height=1),
-			transaction_views('1', '2')
+			('transfer', 'transfer_v2')
 		)
 
 	def test_can_query_transactions_filtered_by_nonexistent_height(self):
 		self._assert_can_query_transactions_with_filter(
-			Pagination(10, 0), 'desc', self._make_transaction_query(height=999), []
+			Pagination(10, 0), 'desc', self._make_transaction_query(height=999), ()
 		)
 
 	def test_can_query_transactions_filtered_by_multiple_transaction_types(self):
@@ -656,68 +659,69 @@ class NemDatabaseTest(DatabaseTestBase):  # pylint: disable=too-many-public-meth
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc',
 			self._make_transaction_query(transaction_types=[257, 2049]),
-			transaction_views('3', '1', '2')
+			('account_key_link', 'transfer', 'transfer_v2')
 		)
 
 	def test_can_query_transactions_filtered_by_address_as_sender(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(2, 0), 'desc', self._make_transaction_query(address=TRANSACTIONS[2].sender_address),
-			transaction_views('3')
+			('account_key_link', )
 		)
 
 	def test_can_query_transactions_filtered_by_address_as_recipient(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc', self._make_transaction_query(address=TRANSACTIONS[0].recipient_address),
-			transaction_views('5', '7', '8', '1', '2')
+			('multisig', 'namespace_registration', 'mosaic_definition', 'transfer', 'transfer_v2')
 		)
 
 	def test_can_query_transactions_filtered_by_sender_address(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc', self._make_transaction_query(sender_address=TRANSACTIONS[2].sender_address),
-			transaction_views('3')
+			('account_key_link', )
 		)
 
 	def test_can_query_transactions_filtered_by_recipient_address(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc', self._make_transaction_query(recipient_address=TRANSACTIONS[0].recipient_address),
-			transaction_views('5', '7', '8', '1', '2')
+			('multisig', 'namespace_registration', 'mosaic_definition', 'transfer', 'transfer_v2')
 		)
 
 	def test_can_exclude_multisig_transaction_for_initiator_account_from_address_filter(self):
 		self._assert_can_query_transactions_with_filter(
-			Pagination(10, 0), 'desc', self._make_transaction_query(address=TRANSACTIONS[4].sender_address), []
+			Pagination(10, 0), 'desc', self._make_transaction_query(address=TRANSACTIONS[4].sender_address), ()
 		)
 		self._assert_can_query_transactions_with_filter(
-			Pagination(10, 0), 'desc', self._make_transaction_query(sender_address=TRANSACTIONS[4].sender_address), []
+			Pagination(10, 0), 'desc', self._make_transaction_query(sender_address=TRANSACTIONS[4].sender_address), ()
 		)
 
 	def test_can_query_multisig_transaction_filtered_by_inner_sender_address(self):
 		self._assert_can_query_transactions_with_filter(
-			Pagination(10, 0), 'desc', self._make_transaction_query(sender_address=TRANSACTIONS[5].sender_address),
-			transaction_views('5', '8', '9', '4', '7', '2', '1')
+			Pagination(10, 0), 'desc',
+			self._make_transaction_query(sender_address=TRANSACTIONS[5].sender_address),
+			TRANSACTION_NAMES_FILTERED_BY_MULTISIG_INNER_SENDER
 		)
 
 	def test_can_query_multisig_transaction_filtered_by_inner_recipient_address(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc', self._make_transaction_query(recipient_address=TRANSACTIONS[5].recipient_address),
-			transaction_views('5', '7', '8', '1', '2')
+			('multisig', 'namespace_registration', 'mosaic_definition', 'transfer', 'transfer_v2')
 		)
 
 	def test_can_query_transactions_filtered_by_mosaic_nem_xem(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc', self._make_transaction_query(mosaic='nem.xem'),
-			transaction_views('1', '2')
+			('transfer', 'transfer_v2')
 		)
 
 	def test_can_query_transactions_filtered_by_mosaic_other(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc', self._make_transaction_query(mosaic='root.mosaic'),
-			transaction_views('2')
+			('transfer_v2', )
 		)
 
 	def test_can_query_transactions_filtered_by_nonexistent_mosaic(self):
 		self._assert_can_query_transactions_with_filter(
-			Pagination(10, 0), 'desc', self._make_transaction_query(mosaic='nonexistent.mosaic'), []
+			Pagination(10, 0), 'desc', self._make_transaction_query(mosaic='nonexistent.mosaic'), ()
 		)
 
 	# endregion

--- a/explorer/rest/tests/facade/test_NemRestFacade.py
+++ b/explorer/rest/tests/facade/test_NemRestFacade.py
@@ -15,6 +15,7 @@ from ..test.DatabaseTestUtils import (
 	NAMESPACE_VIEWS,
 	TRANSACTION_DAILY_STATISTIC_VIEW,
 	TRANSACTION_MONTH_STATISTIC_VIEW,
+	TRANSACTION_NAMES_FILTERED_BY_MULTISIG_INNER_SENDER,
 	TRANSACTION_STATISTIC_VIEW,
 	DatabaseTestBase,
 	transaction_dict,
@@ -417,7 +418,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 	def test_can_retrieve_transaction_by_hash(self):
 		self._assert_can_retrieve_transaction_by_hash(
 			transaction_hash='0' * 63 + '1',
-			expected_transaction=transaction_dict('1')
+			expected_transaction=transaction_dict('transfer')
 		)
 
 	def test_returns_none_for_nonexistent_transaction_hash(self):
@@ -463,19 +464,19 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 		self.assertEqual(EXPECTED_TRANSACTION_MONTH_STATISTICS, transaction_statistics)
 	# region transactions
 
-	def _assert_can_retrieve_transactions(self, pagination, sort, transaction_query, expected_transactions):
+	def _assert_can_retrieve_transactions(self, pagination, sort, transaction_query, expected_transaction_names):
 		# Act:
 		transactions = self.nem_rest_facade.get_transactions(pagination, sort, transaction_query)
 
 		# Assert:
-		self.assertEqual(expected_transactions, transactions)
+		self.assertEqual(transaction_dicts(*expected_transaction_names), transactions)
 
 	def test_can_retrieve_transactions_filtered_by_limit(self):
 		self._assert_can_retrieve_transactions(
 			pagination=Pagination(1, 0),
 			sort='DESC',
 			transaction_query=self._make_transaction_query(),
-			expected_transactions=transaction_dicts('3')
+			expected_transaction_names=('account_key_link', )
 		)
 
 	def test_can_retrieve_transactions_filtered_by_offset(self):
@@ -483,7 +484,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			pagination=Pagination(1, 1),
 			sort='DESC',
 			transaction_query=self._make_transaction_query(),
-			expected_transactions=transaction_dicts('4')
+			expected_transaction_names=('multisig_account_modification', )
 		)
 
 	def test_can_retrieve_transactions_filtered_by_height(self):
@@ -493,7 +494,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			transaction_query=self._make_transaction_query(
 				height=1
 			),
-			expected_transactions=transaction_dicts('1', '2')
+			expected_transaction_names=('transfer', 'transfer_v2')
 		)
 
 	def test_can_retrieve_transactions_sorted_by_height_desc(self):
@@ -501,7 +502,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			pagination=Pagination(2, 0),
 			sort='DESC',
 			transaction_query=self._make_transaction_query(),
-			expected_transactions=transaction_dicts('3', '4')
+			expected_transaction_names=('account_key_link', 'multisig_account_modification')
 		)
 
 	def test_can_retrieve_transactions_sorted_by_height_asc(self):
@@ -509,7 +510,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			pagination=Pagination(2, 0),
 			sort='ASC',
 			transaction_query=self._make_transaction_query(),
-			expected_transactions=transaction_dicts('2', '1')
+			expected_transaction_names=('transfer_v2', 'transfer')
 		)
 
 	def test_can_retrieve_transactions_filtered_by_sender_public_key(self):
@@ -519,7 +520,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			transaction_query=self._make_transaction_query(
 				sender='9ca54cd15edf88a9df9173375d4a0d706f7a9ddcf57d7547dff8110ddd2adeb9'
 			),
-			expected_transactions=transaction_dicts('3')
+			expected_transaction_names=('account_key_link', )
 		)
 
 	def test_can_exclude_multisig_transaction_for_initiator_account_from_address_filter(self):
@@ -529,7 +530,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			transaction_query=self._make_transaction_query(
 				address='NANEMOABLAGR72AZ2RV3V4ZHDCXW25XQ73O7OBT5'
 			),
-			expected_transactions=[]
+			expected_transaction_names=()
 		)
 		self._assert_can_retrieve_transactions(
 			pagination=Pagination(10, 0),
@@ -537,7 +538,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			transaction_query=self._make_transaction_query(
 				sender_address='NANEMOABLAGR72AZ2RV3V4ZHDCXW25XQ73O7OBT5'
 			),
-			expected_transactions=[]
+			expected_transaction_names=()
 		)
 
 	def test_can_retrieve_transactions_filtered_by_recipient_address(self):
@@ -547,7 +548,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			transaction_query=self._make_transaction_query(
 				recipient_address='NBFWZ4IVRHEIBRCGHLYDS62FSFTBM3VDFA7E6LSQ'
 			),
-			expected_transactions=transaction_dicts('5', '7', '8', '1', '2')
+			expected_transaction_names=('multisig', 'namespace_registration', 'mosaic_definition', 'transfer', 'transfer_v2')
 		)
 
 	def test_can_retrieve_transactions_filtered_by_sender_address(self):
@@ -557,7 +558,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			transaction_query=self._make_transaction_query(
 				sender_address='NBNR6XNZQIGQVXII6L3FPJTUGF6NFGLZHBN52R3V'
 			),
-			expected_transactions=transaction_dicts('3')
+			expected_transaction_names=('account_key_link', )
 		)
 
 	def test_can_retrieve_multisig_transaction_filtered_by_inner_sender_address(self):
@@ -567,7 +568,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			transaction_query=self._make_transaction_query(
 				sender_address='NALICEPFLZQRZGPRIJTMJOCPWDNECXTNNG7QLSG3'
 			),
-			expected_transactions=transaction_dicts('5', '8', '9', '4', '7', '2', '1')
+			expected_transaction_names=TRANSACTION_NAMES_FILTERED_BY_MULTISIG_INNER_SENDER
 		)
 
 	def test_can_retrieve_transactions_filtered_by_transaction_types(self):
@@ -577,7 +578,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			transaction_query=self._make_transaction_query(
 				transaction_types=[257, 2049]
 			),
-			expected_transactions=transaction_dicts('3', '1', '2')
+			expected_transaction_names=('account_key_link', 'transfer', 'transfer_v2')
 		)
 
 	def test_can_retrieve_transactions_filtered_by_mosaic(self):
@@ -587,7 +588,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			transaction_query=self._make_transaction_query(
 				mosaic='root.mosaic'
 			),
-			expected_transactions=transaction_dicts('2')
+			expected_transaction_names=('transfer_v2', )
 		)
 
 	# endregion

--- a/explorer/rest/tests/facade/test_NemRestFacade.py
+++ b/explorer/rest/tests/facade/test_NemRestFacade.py
@@ -16,8 +16,9 @@ from ..test.DatabaseTestUtils import (
 	TRANSACTION_DAILY_STATISTIC_VIEW,
 	TRANSACTION_MONTH_STATISTIC_VIEW,
 	TRANSACTION_STATISTIC_VIEW,
-	TRANSACTIONS_VIEWS,
-	DatabaseTestBase
+	DatabaseTestBase,
+	transaction_dict,
+	transaction_dicts
 )
 
 # region test data
@@ -53,22 +54,6 @@ EXPECTED_MOSAIC_3 = MOSAIC_VIEWS[2].to_dict()
 EXPECTED_MOSAIC_RICH_LIST_1 = MOSAIC_RICH_LIST_VIEWS[0].to_dict()
 
 EXPECTED_MOSAIC_RICH_LIST_2 = MOSAIC_RICH_LIST_VIEWS[1].to_dict()
-
-EXPECTED_TRANSACTION_1 = TRANSACTIONS_VIEWS[0].to_dict()
-
-EXPECTED_TRANSACTION_2 = TRANSACTIONS_VIEWS[1].to_dict()
-
-EXPECTED_TRANSACTION_3 = TRANSACTIONS_VIEWS[2].to_dict()
-
-EXPECTED_TRANSACTION_4 = TRANSACTIONS_VIEWS[3].to_dict()
-
-EXPECTED_TRANSACTION_5 = TRANSACTIONS_VIEWS[4].to_dict()
-
-EXPECTED_TRANSACTION_7 = TRANSACTIONS_VIEWS[5].to_dict()
-
-EXPECTED_TRANSACTION_8 = TRANSACTIONS_VIEWS[6].to_dict()
-
-EXPECTED_TRANSACTION_9 = TRANSACTIONS_VIEWS[7].to_dict()
 
 # endregion
 
@@ -432,7 +417,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 	def test_can_retrieve_transaction_by_hash(self):
 		self._assert_can_retrieve_transaction_by_hash(
 			transaction_hash='0' * 63 + '1',
-			expected_transaction=EXPECTED_TRANSACTION_1
+			expected_transaction=transaction_dict('1')
 		)
 
 	def test_returns_none_for_nonexistent_transaction_hash(self):
@@ -490,7 +475,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			pagination=Pagination(1, 0),
 			sort='DESC',
 			transaction_query=self._make_transaction_query(),
-			expected_transactions=[EXPECTED_TRANSACTION_3]
+			expected_transactions=transaction_dicts('3')
 		)
 
 	def test_can_retrieve_transactions_filtered_by_offset(self):
@@ -498,7 +483,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			pagination=Pagination(1, 1),
 			sort='DESC',
 			transaction_query=self._make_transaction_query(),
-			expected_transactions=[EXPECTED_TRANSACTION_4]
+			expected_transactions=transaction_dicts('4')
 		)
 
 	def test_can_retrieve_transactions_filtered_by_height(self):
@@ -508,7 +493,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			transaction_query=self._make_transaction_query(
 				height=1
 			),
-			expected_transactions=[EXPECTED_TRANSACTION_1, EXPECTED_TRANSACTION_2]
+			expected_transactions=transaction_dicts('1', '2')
 		)
 
 	def test_can_retrieve_transactions_sorted_by_height_desc(self):
@@ -516,7 +501,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			pagination=Pagination(2, 0),
 			sort='DESC',
 			transaction_query=self._make_transaction_query(),
-			expected_transactions=[EXPECTED_TRANSACTION_3, EXPECTED_TRANSACTION_4]
+			expected_transactions=transaction_dicts('3', '4')
 		)
 
 	def test_can_retrieve_transactions_sorted_by_height_asc(self):
@@ -524,7 +509,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			pagination=Pagination(2, 0),
 			sort='ASC',
 			transaction_query=self._make_transaction_query(),
-			expected_transactions=[EXPECTED_TRANSACTION_2, EXPECTED_TRANSACTION_1]
+			expected_transactions=transaction_dicts('2', '1')
 		)
 
 	def test_can_retrieve_transactions_filtered_by_sender_public_key(self):
@@ -534,7 +519,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			transaction_query=self._make_transaction_query(
 				sender='9ca54cd15edf88a9df9173375d4a0d706f7a9ddcf57d7547dff8110ddd2adeb9'
 			),
-			expected_transactions=[EXPECTED_TRANSACTION_3]
+			expected_transactions=transaction_dicts('3')
 		)
 
 	def test_can_exclude_multisig_transaction_for_initiator_account_from_address_filter(self):
@@ -562,13 +547,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			transaction_query=self._make_transaction_query(
 				recipient_address='NBFWZ4IVRHEIBRCGHLYDS62FSFTBM3VDFA7E6LSQ'
 			),
-			expected_transactions=[
-				EXPECTED_TRANSACTION_5,
-				EXPECTED_TRANSACTION_7,
-				EXPECTED_TRANSACTION_8,
-				EXPECTED_TRANSACTION_1,
-				EXPECTED_TRANSACTION_2
-			]
+			expected_transactions=transaction_dicts('5', '7', '8', '1', '2')
 		)
 
 	def test_can_retrieve_transactions_filtered_by_sender_address(self):
@@ -578,7 +557,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			transaction_query=self._make_transaction_query(
 				sender_address='NBNR6XNZQIGQVXII6L3FPJTUGF6NFGLZHBN52R3V'
 			),
-			expected_transactions=[EXPECTED_TRANSACTION_3]
+			expected_transactions=transaction_dicts('3')
 		)
 
 	def test_can_retrieve_multisig_transaction_filtered_by_inner_sender_address(self):
@@ -588,15 +567,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			transaction_query=self._make_transaction_query(
 				sender_address='NALICEPFLZQRZGPRIJTMJOCPWDNECXTNNG7QLSG3'
 			),
-			expected_transactions=[
-				EXPECTED_TRANSACTION_5,
-				EXPECTED_TRANSACTION_8,
-				EXPECTED_TRANSACTION_9,
-				EXPECTED_TRANSACTION_4,
-				EXPECTED_TRANSACTION_7,
-				EXPECTED_TRANSACTION_2,
-				EXPECTED_TRANSACTION_1
-			]
+			expected_transactions=transaction_dicts('5', '8', '9', '4', '7', '2', '1')
 		)
 
 	def test_can_retrieve_transactions_filtered_by_transaction_types(self):
@@ -606,7 +577,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			transaction_query=self._make_transaction_query(
 				transaction_types=[257, 2049]
 			),
-			expected_transactions=[EXPECTED_TRANSACTION_3, EXPECTED_TRANSACTION_1, EXPECTED_TRANSACTION_2]
+			expected_transactions=transaction_dicts('3', '1', '2')
 		)
 
 	def test_can_retrieve_transactions_filtered_by_mosaic(self):
@@ -616,7 +587,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			transaction_query=self._make_transaction_query(
 				mosaic='root.mosaic'
 			),
-			expected_transactions=[EXPECTED_TRANSACTION_2]
+			expected_transactions=transaction_dicts('2')
 		)
 
 	# endregion

--- a/explorer/rest/tests/routes/nem/test_routes.py
+++ b/explorer/rest/tests/routes/nem/test_routes.py
@@ -19,9 +19,11 @@ from ...test.DatabaseTestUtils import (
 	TRANSACTION_DAILY_STATISTIC_VIEW,
 	TRANSACTION_MONTH_STATISTIC_VIEW,
 	TRANSACTION_STATISTIC_VIEW,
-	TRANSACTIONS_VIEWS,
 	DatabaseConfig,
-	initialize_database
+	initialize_database,
+	transaction_dict,
+	transaction_dicts,
+	transaction_view
 )
 
 DATABASE_CONFIG_INI = 'db_config.ini'
@@ -641,11 +643,11 @@ def test_api_mosaic_rich_list_applies_offset(client):  # pylint: disable=redefin
 
 def test_api_nem_transaction_by_hash(client):  # pylint: disable=redefined-outer-name
 	# Act:
-	response = client.get('/api/nem/transaction/' + TRANSACTIONS_VIEWS[0].transaction_hash)
+	response = client.get('/api/nem/transaction/' + transaction_view('1').transaction_hash)
 
 	# Assert:
 	_assert_status_code_and_headers(response, 200)
-	assert TRANSACTIONS_VIEWS[0].to_dict() == response.json
+	assert transaction_dict('1') == response.json
 
 
 def test_api_nem_transaction_by_hash_invalid_hash(client):  # pylint: disable=redefined-outer-name, invalid-name
@@ -761,91 +763,43 @@ def _assert_get_api_nem_transactions(client, expected_status_code, expected_resu
 
 
 def test_api_transactions_without_params(client):  # pylint: disable=redefined-outer-name
-	_assert_get_api_nem_transactions(client, 200, [
-		TRANSACTIONS_VIEWS[7].to_dict(),
-		TRANSACTIONS_VIEWS[5].to_dict(),
-		TRANSACTIONS_VIEWS[6].to_dict(),
-		TRANSACTIONS_VIEWS[2].to_dict(),
-		TRANSACTIONS_VIEWS[3].to_dict(),
-		TRANSACTIONS_VIEWS[4].to_dict(),
-		TRANSACTIONS_VIEWS[1].to_dict(),
-		TRANSACTIONS_VIEWS[0].to_dict()
-	])
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts('9', '7', '8', '3', '4', '5', '2', '1'))
 
 
 def test_api_transactions_applies_limit(client):  # pylint: disable=redefined-outer-name
-	_assert_get_api_nem_transactions(client, 200, [TRANSACTIONS_VIEWS[2].to_dict()], limit=1)
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts('3'), limit=1)
 
 
 def test_api_transactions_applies_offset(client):  # pylint: disable=redefined-outer-name
-	_assert_get_api_nem_transactions(client, 200, [
-		TRANSACTIONS_VIEWS[5].to_dict(),
-		TRANSACTIONS_VIEWS[6].to_dict(),
-		TRANSACTIONS_VIEWS[2].to_dict(),
-		TRANSACTIONS_VIEWS[3].to_dict(),
-		TRANSACTIONS_VIEWS[4].to_dict(),
-		TRANSACTIONS_VIEWS[1].to_dict(),
-		TRANSACTIONS_VIEWS[0].to_dict()
-	], offset=1)
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts('7', '8', '3', '4', '5', '2', '1'), offset=1)
 
 
 def test_api_transactions_applies_sorted_by_height_asc(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_transactions(client, 200, [
-		TRANSACTIONS_VIEWS[0].to_dict(),
-		TRANSACTIONS_VIEWS[1].to_dict(),
-		TRANSACTIONS_VIEWS[2].to_dict(),
-		TRANSACTIONS_VIEWS[3].to_dict(),
-		TRANSACTIONS_VIEWS[4].to_dict(),
-		TRANSACTIONS_VIEWS[5].to_dict(),
-		TRANSACTIONS_VIEWS[6].to_dict(),
-		TRANSACTIONS_VIEWS[7].to_dict(),
-	], sort='ASC')
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts('1', '2', '3', '4', '5', '7', '8', '9'), sort='ASC')
 
 
 def test_api_transactions_applies_sorted_by_height_desc(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_transactions(client, 200, [
-		TRANSACTIONS_VIEWS[7].to_dict(),
-		TRANSACTIONS_VIEWS[5].to_dict(),
-		TRANSACTIONS_VIEWS[6].to_dict(),
-		TRANSACTIONS_VIEWS[2].to_dict(),
-		TRANSACTIONS_VIEWS[3].to_dict(),
-		TRANSACTIONS_VIEWS[4].to_dict(),
-		TRANSACTIONS_VIEWS[1].to_dict(),
-		TRANSACTIONS_VIEWS[0].to_dict()
-	], sort='DESC')
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts('9', '7', '8', '3', '4', '5', '2', '1'), sort='DESC')
 
 
 def test_api_transactions_applies_height(client):  # pylint: disable=redefined-outer-name
-	_assert_get_api_nem_transactions(client, 200, [
-		TRANSACTIONS_VIEWS[0].to_dict(),
-		TRANSACTIONS_VIEWS[1].to_dict()
-	], height=1)
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts('1', '2'), height=1)
 
 
 def test_api_transactions_applies_transaction_types(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_transactions(client, 200, [
-		TRANSACTIONS_VIEWS[2].to_dict(),
-		TRANSACTIONS_VIEWS[0].to_dict(),
-		TRANSACTIONS_VIEWS[1].to_dict()
-	], transactionTypes='transfer,account_key_link')
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts('3', '1', '2'), transactionTypes='transfer,account_key_link')
 
 
 def test_api_transactions_applies_address(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_transactions(client, 200, [
-		TRANSACTIONS_VIEWS[2].to_dict()
-	], address='NBNR6XNZQIGQVXII6L3FPJTUGF6NFGLZHBN52R3V')
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts('3'), address='NBNR6XNZQIGQVXII6L3FPJTUGF6NFGLZHBN52R3V')
 
 
 def test_api_transactions_applies_sender_address(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_transactions(client, 200, [
-		TRANSACTIONS_VIEWS[2].to_dict()
-	], senderAddress='NBNR6XNZQIGQVXII6L3FPJTUGF6NFGLZHBN52R3V')
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts('3'), senderAddress='NBNR6XNZQIGQVXII6L3FPJTUGF6NFGLZHBN52R3V')
 
 
 def test_api_transactions_applies_sender_public_key(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_transactions(client, 200, [
-		TRANSACTIONS_VIEWS[2].to_dict()
-	], senderPublicKey='9ca54cd15edf88a9df9173375d4a0d706f7a9ddcf57d7547dff8110ddd2adeb9')
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts('3'), senderPublicKey='9ca54cd15edf88a9df9173375d4a0d706f7a9ddcf57d7547dff8110ddd2adeb9')
 
 
 def test_api_transactions_excludes_multisig_for_initiator_from_address_filter(client):  # pylint: disable=redefined-outer-name, invalid-name
@@ -854,45 +808,23 @@ def test_api_transactions_excludes_multisig_for_initiator_from_address_filter(cl
 
 
 def test_api_transactions_applies_recipient_address(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_transactions(client, 200, [
-		TRANSACTIONS_VIEWS[4].to_dict(),
-		TRANSACTIONS_VIEWS[5].to_dict(),
-		TRANSACTIONS_VIEWS[6].to_dict(),
-		TRANSACTIONS_VIEWS[0].to_dict(),
-		TRANSACTIONS_VIEWS[1].to_dict()
-	], recipientAddress='NBFWZ4IVRHEIBRCGHLYDS62FSFTBM3VDFA7E6LSQ')
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts('5', '7', '8', '1', '2'), recipientAddress='NBFWZ4IVRHEIBRCGHLYDS62FSFTBM3VDFA7E6LSQ')
 
 
 def test_api_transactions_applies_multisig_inner_sender_address(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_transactions(client, 200, [
-		TRANSACTIONS_VIEWS[4].to_dict(),
-		TRANSACTIONS_VIEWS[6].to_dict(),
-		TRANSACTIONS_VIEWS[7].to_dict(),
-		TRANSACTIONS_VIEWS[3].to_dict(),
-		TRANSACTIONS_VIEWS[5].to_dict(),
-		TRANSACTIONS_VIEWS[1].to_dict(),
-		TRANSACTIONS_VIEWS[0].to_dict()
-	], senderAddress='NALICEPFLZQRZGPRIJTMJOCPWDNECXTNNG7QLSG3')
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts('5', '8', '9', '4', '7', '2', '1'), senderAddress='NALICEPFLZQRZGPRIJTMJOCPWDNECXTNNG7QLSG3')
 
 
 def test_api_transactions_applies_mosaic(client):  # pylint: disable=redefined-outer-name
-	_assert_get_api_nem_transactions(client, 200, [
-		TRANSACTIONS_VIEWS[1].to_dict()
-	], mosaic='root.mosaic')
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts('2'), mosaic='root.mosaic')
 
 
 def test_api_transactions_applies_address_ignore_other(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_transactions(client, 200, [
-		TRANSACTIONS_VIEWS[2].to_dict()
-	], address='NBNR6XNZQIGQVXII6L3FPJTUGF6NFGLZHBN52R3V', senderAddress='NALICEPFLZQRZGPRIJTMJOCPWDNECXTNNG7QLSG3')
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts('3'), address='NBNR6XNZQIGQVXII6L3FPJTUGF6NFGLZHBN52R3V', senderAddress='NALICEPFLZQRZGPRIJTMJOCPWDNECXTNNG7QLSG3')
 
-	_assert_get_api_nem_transactions(client, 200, [
-		TRANSACTIONS_VIEWS[2].to_dict()
-	], address='NBNR6XNZQIGQVXII6L3FPJTUGF6NFGLZHBN52R3V', recipientAddress='NALICEPFLZQRZGPRIJTMJOCPWDNECXTNNG7QLSG3')
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts('3'), address='NBNR6XNZQIGQVXII6L3FPJTUGF6NFGLZHBN52R3V', recipientAddress='NALICEPFLZQRZGPRIJTMJOCPWDNECXTNNG7QLSG3')
 
-	_assert_get_api_nem_transactions(client, 200, [
-		TRANSACTIONS_VIEWS[2].to_dict()
-	], address='NBNR6XNZQIGQVXII6L3FPJTUGF6NFGLZHBN52R3V', senderPublicKey='f9bd190dd0c364261f5c8a74870cc7f7374e631352293c62ecc437657e5de2cd')
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts('3'), address='NBNR6XNZQIGQVXII6L3FPJTUGF6NFGLZHBN52R3V', senderPublicKey='f9bd190dd0c364261f5c8a74870cc7f7374e631352293c62ecc437657e5de2cd')
 
 
 def _assert_transaction_invalid_params(client, expected_message, **query_params):  # pylint: disable=redefined-outer-name

--- a/explorer/rest/tests/routes/nem/test_routes.py
+++ b/explorer/rest/tests/routes/nem/test_routes.py
@@ -18,12 +18,14 @@ from ...test.DatabaseTestUtils import (
 	NAMESPACE_VIEWS,
 	TRANSACTION_DAILY_STATISTIC_VIEW,
 	TRANSACTION_MONTH_STATISTIC_VIEW,
+	TRANSACTION_NAMES_FILTERED_BY_MULTISIG_INNER_SENDER,
+	TRANSACTION_NAMES_SORTED_BY_HEIGHT_ASC,
 	TRANSACTION_STATISTIC_VIEW,
 	DatabaseConfig,
 	initialize_database,
 	transaction_dict,
 	transaction_dicts,
-	transaction_view
+	transaction_hash
 )
 
 DATABASE_CONFIG_INI = 'db_config.ini'
@@ -643,11 +645,11 @@ def test_api_mosaic_rich_list_applies_offset(client):  # pylint: disable=redefin
 
 def test_api_nem_transaction_by_hash(client):  # pylint: disable=redefined-outer-name
 	# Act:
-	response = client.get('/api/nem/transaction/' + transaction_view('1').transaction_hash)
+	response = client.get('/api/nem/transaction/' + transaction_hash('transfer'))
 
 	# Assert:
 	_assert_status_code_and_headers(response, 200)
-	assert transaction_dict('1') == response.json
+	assert transaction_dict('transfer') == response.json
 
 
 def test_api_nem_transaction_by_hash_invalid_hash(client):  # pylint: disable=redefined-outer-name, invalid-name
@@ -763,68 +765,131 @@ def _assert_get_api_nem_transactions(client, expected_status_code, expected_resu
 
 
 def test_api_transactions_without_params(client):  # pylint: disable=redefined-outer-name
-	_assert_get_api_nem_transactions(client, 200, transaction_dicts('9', '7', '8', '3', '4', '5', '2', '1'))
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts(
+		'mosaic_supply_change',
+		'namespace_registration',
+		'mosaic_definition',
+		'account_key_link',
+		'multisig_account_modification',
+		'multisig',
+		'transfer_v2',
+		'transfer'
+	))
 
 
 def test_api_transactions_applies_limit(client):  # pylint: disable=redefined-outer-name
-	_assert_get_api_nem_transactions(client, 200, transaction_dicts('3'), limit=1)
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts('account_key_link'), limit=1)
 
 
 def test_api_transactions_applies_offset(client):  # pylint: disable=redefined-outer-name
-	_assert_get_api_nem_transactions(client, 200, transaction_dicts('7', '8', '3', '4', '5', '2', '1'), offset=1)
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts(
+		'namespace_registration',
+		'mosaic_definition',
+		'account_key_link',
+		'multisig_account_modification',
+		'multisig',
+		'transfer_v2',
+		'transfer'
+	), offset=1)
 
 
 def test_api_transactions_applies_sorted_by_height_asc(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_transactions(client, 200, transaction_dicts('1', '2', '3', '4', '5', '7', '8', '9'), sort='ASC')
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts(*TRANSACTION_NAMES_SORTED_BY_HEIGHT_ASC), sort='ASC')
 
 
 def test_api_transactions_applies_sorted_by_height_desc(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_transactions(client, 200, transaction_dicts('9', '7', '8', '3', '4', '5', '2', '1'), sort='DESC')
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts(
+		'mosaic_supply_change',
+		'namespace_registration',
+		'mosaic_definition',
+		'account_key_link',
+		'multisig_account_modification',
+		'multisig',
+		'transfer_v2',
+		'transfer'
+	), sort='DESC')
 
 
 def test_api_transactions_applies_height(client):  # pylint: disable=redefined-outer-name
-	_assert_get_api_nem_transactions(client, 200, transaction_dicts('1', '2'), height=1)
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts('transfer', 'transfer_v2'), height=1)
 
 
 def test_api_transactions_applies_transaction_types(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_transactions(client, 200, transaction_dicts('3', '1', '2'), transactionTypes='transfer,account_key_link')
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts(
+		'account_key_link',
+		'transfer',
+		'transfer_v2'
+	), transactionTypes='transfer,account_key_link')
 
 
 def test_api_transactions_applies_address(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_transactions(client, 200, transaction_dicts('3'), address='NBNR6XNZQIGQVXII6L3FPJTUGF6NFGLZHBN52R3V')
+	_assert_get_api_nem_transactions(
+		client,
+		200,
+		transaction_dicts('account_key_link'),
+		address='NBNR6XNZQIGQVXII6L3FPJTUGF6NFGLZHBN52R3V'
+	)
 
 
 def test_api_transactions_applies_sender_address(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_transactions(client, 200, transaction_dicts('3'), senderAddress='NBNR6XNZQIGQVXII6L3FPJTUGF6NFGLZHBN52R3V')
+	_assert_get_api_nem_transactions(
+		client,
+		200,
+		transaction_dicts('account_key_link'),
+		senderAddress='NBNR6XNZQIGQVXII6L3FPJTUGF6NFGLZHBN52R3V'
+	)
 
 
 def test_api_transactions_applies_sender_public_key(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_transactions(client, 200, transaction_dicts('3'), senderPublicKey='9ca54cd15edf88a9df9173375d4a0d706f7a9ddcf57d7547dff8110ddd2adeb9')
+	_assert_get_api_nem_transactions(
+		client,
+		200,
+		transaction_dicts('account_key_link'),
+		senderPublicKey='9ca54cd15edf88a9df9173375d4a0d706f7a9ddcf57d7547dff8110ddd2adeb9'
+	)
 
 
 def test_api_transactions_excludes_multisig_for_initiator_from_address_filter(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_transactions(client, 200, [], address='NANEMOABLAGR72AZ2RV3V4ZHDCXW25XQ73O7OBT5')
-	_assert_get_api_nem_transactions(client, 200, [], senderAddress='NANEMOABLAGR72AZ2RV3V4ZHDCXW25XQ73O7OBT5')
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts(), address='NANEMOABLAGR72AZ2RV3V4ZHDCXW25XQ73O7OBT5')
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts(), senderAddress='NANEMOABLAGR72AZ2RV3V4ZHDCXW25XQ73O7OBT5')
 
 
 def test_api_transactions_applies_recipient_address(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_transactions(client, 200, transaction_dicts('5', '7', '8', '1', '2'), recipientAddress='NBFWZ4IVRHEIBRCGHLYDS62FSFTBM3VDFA7E6LSQ')
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts(
+		'multisig',
+		'namespace_registration',
+		'mosaic_definition',
+		'transfer',
+		'transfer_v2'
+	), recipientAddress='NBFWZ4IVRHEIBRCGHLYDS62FSFTBM3VDFA7E6LSQ')
 
 
 def test_api_transactions_applies_multisig_inner_sender_address(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_transactions(client, 200, transaction_dicts('5', '8', '9', '4', '7', '2', '1'), senderAddress='NALICEPFLZQRZGPRIJTMJOCPWDNECXTNNG7QLSG3')
+	_assert_get_api_nem_transactions(
+		client,
+		200,
+		transaction_dicts(*TRANSACTION_NAMES_FILTERED_BY_MULTISIG_INNER_SENDER),
+		senderAddress='NALICEPFLZQRZGPRIJTMJOCPWDNECXTNNG7QLSG3'
+	)
 
 
 def test_api_transactions_applies_mosaic(client):  # pylint: disable=redefined-outer-name
-	_assert_get_api_nem_transactions(client, 200, transaction_dicts('2'), mosaic='root.mosaic')
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts('transfer_v2'), mosaic='root.mosaic')
 
 
 def test_api_transactions_applies_address_ignore_other(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_transactions(client, 200, transaction_dicts('3'), address='NBNR6XNZQIGQVXII6L3FPJTUGF6NFGLZHBN52R3V', senderAddress='NALICEPFLZQRZGPRIJTMJOCPWDNECXTNNG7QLSG3')
-
-	_assert_get_api_nem_transactions(client, 200, transaction_dicts('3'), address='NBNR6XNZQIGQVXII6L3FPJTUGF6NFGLZHBN52R3V', recipientAddress='NALICEPFLZQRZGPRIJTMJOCPWDNECXTNNG7QLSG3')
-
-	_assert_get_api_nem_transactions(client, 200, transaction_dicts('3'), address='NBNR6XNZQIGQVXII6L3FPJTUGF6NFGLZHBN52R3V', senderPublicKey='f9bd190dd0c364261f5c8a74870cc7f7374e631352293c62ecc437657e5de2cd')
+	for query_params in [
+		{'senderAddress': 'NALICEPFLZQRZGPRIJTMJOCPWDNECXTNNG7QLSG3'},
+		{'recipientAddress': 'NALICEPFLZQRZGPRIJTMJOCPWDNECXTNNG7QLSG3'},
+		{'senderPublicKey': 'f9bd190dd0c364261f5c8a74870cc7f7374e631352293c62ecc437657e5de2cd'}
+	]:
+		_assert_get_api_nem_transactions(
+			client,
+			200,
+			transaction_dicts('account_key_link'),
+			address='NBNR6XNZQIGQVXII6L3FPJTUGF6NFGLZHBN52R3V',
+			**query_params
+		)
 
 
 def _assert_transaction_invalid_params(client, expected_message, **query_params):  # pylint: disable=redefined-outer-name

--- a/explorer/rest/tests/test/DatabaseTestUtils.py
+++ b/explorer/rest/tests/test/DatabaseTestUtils.py
@@ -837,6 +837,24 @@ TRANSACTIONS_VIEWS = [
 	),
 ]
 
+TRANSACTION_VIEWS_BY_HASH = {transaction_view.transaction_hash: transaction_view for transaction_view in TRANSACTIONS_VIEWS}
+
+
+def transaction_view(transaction_hash_suffix):
+	return TRANSACTION_VIEWS_BY_HASH['0' * 63 + transaction_hash_suffix]
+
+
+def transaction_views(*transaction_hash_suffixes):
+	return [transaction_view(transaction_hash_suffix) for transaction_hash_suffix in transaction_hash_suffixes]
+
+
+def transaction_dict(transaction_hash_suffix):
+	return transaction_view(transaction_hash_suffix).to_dict()
+
+
+def transaction_dicts(*transaction_hash_suffixes):
+	return [view.to_dict() for view in transaction_views(*transaction_hash_suffixes)]
+
 # endregion
 
 

--- a/explorer/rest/tests/test/DatabaseTestUtils.py
+++ b/explorer/rest/tests/test/DatabaseTestUtils.py
@@ -837,23 +837,59 @@ TRANSACTIONS_VIEWS = [
 	),
 ]
 
+TRANSACTION_HASHES = {
+	'transfer': '0' * 63 + '1',
+	'transfer_v2': '0' * 63 + '2',
+	'account_key_link': '0' * 63 + '3',
+	'multisig_account_modification': '0' * 63 + '4',
+	'multisig': '0' * 63 + '5',
+	'namespace_registration': '0' * 63 + '7',
+	'mosaic_definition': '0' * 63 + '8',
+	'mosaic_supply_change': '0' * 63 + '9'
+}
+
+TRANSACTION_NAMES_SORTED_BY_HEIGHT_ASC = (
+	'transfer',
+	'transfer_v2',
+	'account_key_link',
+	'multisig_account_modification',
+	'multisig',
+	'namespace_registration',
+	'mosaic_definition',
+	'mosaic_supply_change'
+)
+
+TRANSACTION_NAMES_FILTERED_BY_MULTISIG_INNER_SENDER = (
+	'multisig',
+	'mosaic_definition',
+	'mosaic_supply_change',
+	'multisig_account_modification',
+	'namespace_registration',
+	'transfer_v2',
+	'transfer'
+)
+
 TRANSACTION_VIEWS_BY_HASH = {transaction_view.transaction_hash: transaction_view for transaction_view in TRANSACTIONS_VIEWS}
 
 
-def transaction_view(transaction_hash_suffix):
-	return TRANSACTION_VIEWS_BY_HASH['0' * 63 + transaction_hash_suffix]
+def transaction_hash(transaction_name):
+	return TRANSACTION_HASHES[transaction_name]
 
 
-def transaction_views(*transaction_hash_suffixes):
-	return [transaction_view(transaction_hash_suffix) for transaction_hash_suffix in transaction_hash_suffixes]
+def transaction_view(transaction_name):
+	return TRANSACTION_VIEWS_BY_HASH[transaction_hash(transaction_name)]
 
 
-def transaction_dict(transaction_hash_suffix):
-	return transaction_view(transaction_hash_suffix).to_dict()
+def transaction_views(*transaction_names):
+	return [transaction_view(transaction_name) for transaction_name in transaction_names]
 
 
-def transaction_dicts(*transaction_hash_suffixes):
-	return [view.to_dict() for view in transaction_views(*transaction_hash_suffixes)]
+def transaction_dict(transaction_name):
+	return transaction_view(transaction_name).to_dict()
+
+
+def transaction_dicts(*transaction_names):
+	return [view.to_dict() for view in transaction_views(*transaction_names)]
 
 # endregion
 


### PR DESCRIPTION
Problem: I found it hard to read when using the index to view transaction information.
Solution: Added a helper, reading the hash instead of index