### PR TITLE
[explorer/frontend] fix: transaction type filter query param

### DIFF
--- a/explorer/frontend/__tests__/api/transactions.test.js
+++ b/explorer/frontend/__tests__/api/transactions.test.js
@@ -68,6 +68,20 @@ describe('api/transactions', () => {
 			await runApiTest(fetchTransactionPage, searchCriteria, transactionPageResponse, expectedURL, expectedResult);
 		});
 
+		it('fetch transaction page with "types" filter', async () => {
+			// Arrange:
+			const searchCriteria = {
+				pageNumber: 3,
+				types: 'MULTISIG_ACCOUNT_MODIFICATION'
+			};
+			// eslint-disable-next-line max-len
+			const expectedURL = 'https://explorer.backend/transactions?limit=10&offset=20&transactionTypes=MULTISIG_ACCOUNT_MODIFICATION';
+			const expectedResult = transactionPageResult;
+
+			// Act + Assert:
+			await runApiTest(fetchTransactionPage, searchCriteria, transactionPageResponse, expectedURL, expectedResult);
+		});
+
 		it('fetch transaction page for specific account with "to" filter', async () => {
 			// Arrange:
 			const searchCriteria = {

--- a/explorer/frontend/api/transactions.js
+++ b/explorer/frontend/api/transactions.js
@@ -33,6 +33,10 @@ export const fetchTransactionPage = async searchParams => {
 		updatedFilter.recipientAddress = updatedFilter.to;
 		delete updatedFilter.to;
 	}
+	if (updatedFilter.types) {
+		updatedFilter.transactionTypes = updatedFilter.types;
+		delete updatedFilter.types;
+	}
 	searchCriteria.filter = updatedFilter;
 
 	let url;


### PR DESCRIPTION
Problem: Currently, the transaction type params are incorrect https://github.com/symbol/product/issues/2346. 
Solution: Handle the transaction type filter with the right parameter name 