### PR TITLE
[explorer] fix: account and transaction detail pages return 404 instead of 500 for invalid identifiers

### DIFF
--- a/explorer/frontend/__tests__/pages/AccountInfo.test.js
+++ b/explorer/frontend/__tests__/pages/AccountInfo.test.js
@@ -35,7 +35,7 @@ beforeEach(() => {
 
 describe('AccountInfo', () => {
 	describe('getServerSideProps', () => {
-		const runTest = async (accountInfo, expectedResult) => {
+		const runTest = async (accountInfo, expectedResult, isTransactionPageFetched) => {
 			// Arrange:
 			const locale = 'en';
 			const params = { address: accountInfoResult.address };
@@ -49,7 +49,10 @@ describe('AccountInfo', () => {
 
 			// Assert:
 			expect(fetchAccountInfo).toHaveBeenCalledWith(params.address);
-			expect(fetchTransactionPage).toHaveBeenCalledWith({ address: params.address });
+			if (isTransactionPageFetched)
+				expect(fetchTransactionPage).toHaveBeenCalledWith({ address: params.address });
+			else
+				expect(fetchTransactionPage).not.toHaveBeenCalled();
 			expect(result).toEqual(expectedResult);
 		};
 
@@ -64,10 +67,10 @@ describe('AccountInfo', () => {
 			};
 
 			// Act + Assert:
-			await runTest(accountInfo, expectedResult);
+			await runTest(accountInfo, expectedResult, true);
 		});
 
-		it('returns not found', async () => {
+		it('returns not found without fetching transactions', async () => {
 			// Arrange:
 			const accountInfo = null;
 			const expectedResult = {
@@ -75,7 +78,7 @@ describe('AccountInfo', () => {
 			};
 
 			// Act + Assert:
-			await runTest(accountInfo, expectedResult);
+			await runTest(accountInfo, expectedResult, false);
 		});
 	});
 

--- a/explorer/frontend/pages/accounts/[address].jsx
+++ b/explorer/frontend/pages/accounts/[address].jsx
@@ -32,13 +32,14 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 
 export const getServerSideProps = async ({ locale, params }) => {
 	const accountInfo = await fetchAccountInfo(params.address);
-	const transactionsPage = await fetchTransactionPage({ address: params.address });
 
 	if (!accountInfo) {
 		return {
 			notFound: true
 		};
 	}
+
+	const transactionsPage = await fetchTransactionPage({ address: params.address });
 
 	return {
 		props: {

--- a/explorer/rest/rest/routes/nem.py
+++ b/explorer/rest/rest/routes/nem.py
@@ -3,7 +3,7 @@ from datetime import date
 from pathlib import Path
 
 from flask import abort, jsonify, request
-from symbolchain.CryptoTypes import PublicKey
+from symbolchain.CryptoTypes import Hash256, PublicKey
 from symbolchain.nc import TransactionType
 from zenlog import log
 
@@ -230,6 +230,11 @@ def setup_nem_routes(app, nem_api_facade):  # pylint: disable=too-many-statement
 
 	@app.route('/api/nem/transaction/<transaction_hash>')
 	def api_get_nem_transaction_by_hash(transaction_hash):
+		try:
+			Hash256(transaction_hash)
+		except ValueError:
+			abort(400, 'Invalid transaction hash format')
+
 		result = nem_api_facade.get_transaction_by_hash(transaction_hash)
 
 		if not result:

--- a/explorer/rest/tests/routes/nem/test_routes.py
+++ b/explorer/rest/tests/routes/nem/test_routes.py
@@ -648,7 +648,7 @@ def test_api_nem_transaction_by_hash(client):  # pylint: disable=redefined-outer
 	assert TRANSACTIONS_VIEWS[0].to_dict() == response.json
 
 
-def test_api_nem_transaction_by_hash_invalid_hash(client):  # pylint: disable=redefined-outer-name
+def test_api_nem_transaction_by_hash_invalid_hash(client):  # pylint: disable=redefined-outer-name, invalid-name
 	# Act:
 	response = client.get('/api/nem/transaction/XXX')
 

--- a/explorer/rest/tests/routes/nem/test_routes.py
+++ b/explorer/rest/tests/routes/nem/test_routes.py
@@ -648,6 +648,14 @@ def test_api_nem_transaction_by_hash(client):  # pylint: disable=redefined-outer
 	assert TRANSACTIONS_VIEWS[0].to_dict() == response.json
 
 
+def test_api_nem_transaction_by_hash_invalid_hash(client):  # pylint: disable=redefined-outer-name
+	# Act:
+	response = client.get('/api/nem/transaction/XXX')
+
+	# Assert:
+	_assert_status_code_400(response, 'Invalid transaction hash format')
+
+
 # endregion
 
 # region /account/statistics


### PR DESCRIPTION
## Summary
Account and transaction detail pages returned a **500 Internal Server Error** for invalid identifiers, unlike block, mosaic, namespace, and node pages which already render **404**. This PR fixes both the REST API and the frontend so all detail pages behave consistently.

Issue description: https://github.com/symbol/product/issues/2345