### PR TITLE
[explorer/frontend] Fix fractional average transactions per block display

### DIFF
--- a/explorer/frontend/__tests__/test-utils/stats.js
+++ b/explorer/frontend/__tests__/test-utils/stats.js
@@ -435,7 +435,7 @@ export const blockStatisticsResult = {
 };
 
 export const transactionStatisticsResult = {
-	averagePerBlock: 1,
+	averagePerBlock: 0.2,
 	total: 10667593,
 	last30Days: 17457,
 	last24Hours: 630

--- a/explorer/frontend/__tests__/utils/common.test.js
+++ b/explorer/frontend/__tests__/utils/common.test.js
@@ -11,6 +11,7 @@ import {
 	formatMosaicCSV,
 	formatTransactionCSV,
 	formatTransactionChart,
+	formatTransactionsPerBlock,
 	getRootNamespaceName,
 	nullableValueToText,
 	numberToShortString,
@@ -220,6 +221,39 @@ describe('utils/common', () => {
 			runTruncateDecimalsTest(value3, decimal3, expectedResult3);
 			runTruncateDecimalsTest(value4, decimal4, expectedResult4);
 			runTruncateDecimalsTest(value5, decimal5, expectedResult5);
+		});
+	});
+
+	describe('formatTransactionsPerBlock', () => {
+		const runFormatTransactionsPerBlockTest = (value, expectedResult) => {
+			// Act:
+			const result = formatTransactionsPerBlock(value);
+
+			//Assert:
+			expect(result).toBe(expectedResult);
+		};
+
+		it('keeps two decimals for values below one', () => {
+			runFormatTransactionsPerBlockTest(0.0042, 0);
+			runFormatTransactionsPerBlockTest(0.2, 0.2);
+			runFormatTransactionsPerBlockTest(0.239, 0.23);
+		});
+
+		it('keeps one decimal for values between one and five', () => {
+			runFormatTransactionsPerBlockTest(1, 1);
+			runFormatTransactionsPerBlockTest(2.37, 2.3);
+			runFormatTransactionsPerBlockTest(4.99, 4.9);
+		});
+
+		it('rounds to an integer for values of five or more', () => {
+			runFormatTransactionsPerBlockTest(5, 5);
+			runFormatTransactionsPerBlockTest(12.6, 13);
+			runFormatTransactionsPerBlockTest(120.4, 120);
+		});
+
+		it('returns an empty string for non-numeric values', () => {
+			runFormatTransactionsPerBlockTest(NaN, '');
+			runFormatTransactionsPerBlockTest(undefined, '');
 		});
 	});
 

--- a/explorer/frontend/api/stats.js
+++ b/explorer/frontend/api/stats.js
@@ -2,7 +2,7 @@ import { fetchAccountPage } from './accounts';
 import { fetchBlockPage } from './blocks';
 import { fetchNodeList } from './nodes';
 import config from '@/config';
-import { transactionChartFilterToType, truncateDecimals } from '@/utils/common';
+import { formatTransactionsPerBlock, transactionChartFilterToType, truncateDecimals } from '@/utils/common';
 import { createApiUrl, makeRequest } from '@/utils/server';
 
 export const fetchAccountStats = async () => {
@@ -64,7 +64,7 @@ export const fetchTransactionStats = async () => {
 	const stats = await makeRequest(createApiUrl('transaction/statistics'));
 	const blocks = (await fetchBlockPage({ pageSize: 240 })).data;
 	const total240Blocks = blocks.reduce((partialSum, block) => partialSum + block.transactionCount, 0);
-	const averagePerBlock = blocks.length ? truncateDecimals(total240Blocks / blocks.length, 2) : 0;
+	const averagePerBlock = blocks.length ? formatTransactionsPerBlock(total240Blocks / blocks.length) : 0;
 
 	return {
 		averagePerBlock,

--- a/explorer/frontend/api/stats.js
+++ b/explorer/frontend/api/stats.js
@@ -64,7 +64,7 @@ export const fetchTransactionStats = async () => {
 	const stats = await makeRequest(createApiUrl('transaction/statistics'));
 	const blocks = (await fetchBlockPage({ pageSize: 240 })).data;
 	const total240Blocks = blocks.reduce((partialSum, block) => partialSum + block.transactionCount, 0);
-	const averagePerBlock = Math.ceil(total240Blocks / blocks.length);
+	const averagePerBlock = blocks.length ? truncateDecimals(total240Blocks / blocks.length, 2) : 0;
 
 	return {
 		averagePerBlock,

--- a/explorer/frontend/utils/common.js
+++ b/explorer/frontend/utils/common.js
@@ -138,6 +138,29 @@ export const truncateDecimals = (num, decimal) => {
 };
 
 /**
+ * Formats an average transaction-per-block value with precision that scales down as the value grows.
+ * Small averages keep decimals to avoid overstating low activity, while larger ones are shown as integers.
+ * @param {number} num - Average value.
+ * @returns {number} Formatted average.
+ * @example
+ * formatTransactionsPerBlock(0.0042); // 0
+ * formatTransactionsPerBlock(2.37); // 2.3
+ * formatTransactionsPerBlock(12.6); // 13
+ */
+export const formatTransactionsPerBlock = num => {
+	if (!isNumeric(num))
+		return '';
+
+	if (num < 1)
+		return truncateDecimals(num, 2);
+
+	if (num < 5)
+		return truncateDecimals(num, 1);
+
+	return Math.round(num);
+};
+
+/**
  * Truncates a string.
  * @param {string} str - String.
  * @param {string} type - Type.


### PR DESCRIPTION
## Summary
- Fix `averagePerBlock` calculation in `fetchTransactionStats` to show a fractional average instead of always rounding up
- Add a safe fallback when the block list is empty
- Update the related test expectation

## Why
The dashboard metric for transactions per block was inflated on low-activity chains.
For example, an average of `0.2` was displayed as `1` because of `Math.ceil`.

Issue: https://github.com/symbol/product/issues/2348