### PR TITLE
[Explorer] feat: transaction size and schema version.

### DIFF
--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -236,7 +236,9 @@ class NemDatabase(DatabaseConnection):
 				deadline timestamp NOT NULL,
 				signature bytea,
 				is_inner boolean NOT NULL,
-				payload jsonb
+				payload jsonb,
+				size int NOT NULL,
+				schema_version int NOT NULL
 			)
 			'''
 		)
@@ -649,9 +651,11 @@ class NemDatabase(DatabaseConnection):
 				deadline,
 				signature,
 				is_inner,
-				payload
+				payload,
+				size,
+				schema_version
 			)
-			VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+			VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 			RETURNING id
 			''',
 			(
@@ -666,7 +670,9 @@ class NemDatabase(DatabaseConnection):
 				transaction.deadline,
 				unhexlify(transaction.signature) if transaction.signature else None,
 				transaction.is_inner,
-				json.dumps(transaction.payload) if transaction.payload else None
+				json.dumps(transaction.payload) if transaction.payload else None,
+				transaction.size,
+				transaction.schema_version
 			)
 		)
 

--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -238,7 +238,7 @@ class NemDatabase(DatabaseConnection):
 				is_inner boolean NOT NULL,
 				payload jsonb,
 				size int NOT NULL,
-				schema_version int NOT NULL
+				version int NOT NULL
 			)
 			'''
 		)
@@ -653,7 +653,7 @@ class NemDatabase(DatabaseConnection):
 				is_inner,
 				payload,
 				size,
-				schema_version
+				version
 			)
 			VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 			RETURNING id
@@ -672,7 +672,7 @@ class NemDatabase(DatabaseConnection):
 				transaction.is_inner,
 				json.dumps(transaction.payload) if transaction.payload else None,
 				transaction.size,
-				transaction.schema_version
+				transaction.version
 			)
 		)
 

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -83,7 +83,7 @@ TransactionRecord = namedtuple('TransactionRecord', [
 	'recipient_address',
 	'payload',
 	'size',
-	'schema_version'
+	'version'
 ])
 DatabaseConfig = namedtuple('DatabaseConfig', ['database', 'user', 'password', 'host', 'port'])
 
@@ -520,7 +520,7 @@ class NemPuller:
 			recipient_address=recipient_address,
 			payload=payload,
 			size=transaction.size,
-			schema_version=transaction.schema_version
+			version=transaction.version
 		)
 
 	def _process_transaction(self, cursor, transaction, block_height, is_inner):

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -81,7 +81,9 @@ TransactionRecord = namedtuple('TransactionRecord', [
 	'is_inner',
 	'sender_address',
 	'recipient_address',
-	'payload'
+	'payload',
+	'size',
+	'schema_version'
 ])
 DatabaseConfig = namedtuple('DatabaseConfig', ['database', 'user', 'password', 'host', 'port'])
 
@@ -516,7 +518,9 @@ class NemPuller:
 			is_inner=is_inner,
 			sender_address=self._convert_public_key_to_address(transaction.sender),
 			recipient_address=recipient_address,
-			payload=payload
+			payload=payload,
+			size=transaction.size,
+			schema_version=transaction.schema_version
 		)
 
 	def _process_transaction(self, cursor, transaction, block_height, is_inner):

--- a/explorer/puller/tests/db/test_NemDatabase.py
+++ b/explorer/puller/tests/db/test_NemDatabase.py
@@ -95,7 +95,9 @@ TRANSACTIONS = [
 		is_inner=False,
 		sender_address=Address('TCJLCZSOQ6RGWHTPSV2DW467WZSHK4NBSITND4OF'),
 		recipient_address=Address('TBZWVEKB2XMTO4F3RAOEIBWRBMPQ5N23G56ZJM4I'),
-		payload='{}'
+		payload='{}',
+		size=184,
+		schema_version=1
 	)
 ]
 
@@ -982,7 +984,9 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 					deadline,
 					encode(signature, 'hex'),
 					is_inner,
-					payload
+					payload,
+					size,
+					schema_version
 				FROM transactions
 				WHERE id = %s
 				''',
@@ -1004,7 +1008,9 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			datetime.datetime(2015, 3, 29, 20, 34, 19),
 			TRANSACTIONS[0].signature,
 			False,
-			'{}'
+			'{}',
+			184,
+			1
 		))
 
 	def test_insert_transaction_mosaic(self):

--- a/explorer/puller/tests/db/test_NemDatabase.py
+++ b/explorer/puller/tests/db/test_NemDatabase.py
@@ -97,7 +97,7 @@ TRANSACTIONS = [
 		recipient_address=Address('TBZWVEKB2XMTO4F3RAOEIBWRBMPQ5N23G56ZJM4I'),
 		payload='{}',
 		size=184,
-		schema_version=1
+		version=1
 	)
 ]
 
@@ -986,7 +986,7 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 					is_inner,
 					payload,
 					size,
-					schema_version
+					version
 				FROM transactions
 				WHERE id = %s
 				''',

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-function-args
 import asyncio
 import datetime
 import tempfile

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -1128,7 +1128,9 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			is_inner=False,
 			sender_address=self.puller.nem_facade.network.public_key_to_address(transaction.sender),
 			recipient_address=recipient_address,
-			payload=payload
+			payload=payload,
+			size=transaction.size,
+			schema_version=transaction.schema_version
 		))
 
 	def test_can_build_transaction_record_transfer(self):

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -1131,7 +1131,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			recipient_address=recipient_address,
 			payload=payload,
 			size=transaction.size,
-			schema_version=transaction.schema_version
+			version=transaction.version
 		))
 
 	def test_can_build_transaction_record_transfer(self):

--- a/explorer/rest/rest/db/NemDatabase.py
+++ b/explorer/rest/rest/db/NemDatabase.py
@@ -262,7 +262,9 @@ class NemDatabase(DatabaseConnectionPool):
 			height=transaction.height,
 			timestamp=str(transaction.timestamp),
 			deadline=str(transaction.deadline),
-			signature=_format_bytes(transaction.signature)
+			signature=_format_bytes(transaction.signature),
+			size=transaction.size,
+			schema_version=transaction.schema_version
 		)
 
 	@staticmethod
@@ -447,7 +449,9 @@ class NemDatabase(DatabaseConnectionPool):
 				t.signature,
 				t.recipient_address as to_address,
 				t.payload,
-				COALESCE(m.mosaics, '[]'::json) AS mosaics
+				COALESCE(m.mosaics, '[]'::json) AS mosaics,
+				t.size,
+				t.schema_version
 			FROM transactions t
 			LEFT JOIN LATERAL (
 				SELECT json_agg(json_build_object(
@@ -1050,7 +1054,9 @@ class NemDatabase(DatabaseConnectionPool):
 			signature=bytes.fromhex(transaction.signature) if transaction.signature else None,
 			to_address=recipient_address,
 			payload=payload,
-			mosaics=mosaics
+			mosaics=mosaics,
+			size=transaction.size,
+			schema_version=transaction.schema_version
 		)
 
 	def _get_mosaic_divisibility_by_names(self, names):

--- a/explorer/rest/rest/db/NemDatabase.py
+++ b/explorer/rest/rest/db/NemDatabase.py
@@ -264,7 +264,7 @@ class NemDatabase(DatabaseConnectionPool):
 			deadline=str(transaction.deadline),
 			signature=_format_bytes(transaction.signature),
 			size=transaction.size,
-			schema_version=transaction.schema_version
+			version=transaction.version
 		)
 
 	@staticmethod
@@ -451,7 +451,7 @@ class NemDatabase(DatabaseConnectionPool):
 				t.payload,
 				COALESCE(m.mosaics, '[]'::json) AS mosaics,
 				t.size,
-				t.schema_version
+				t.version
 			FROM transactions t
 			LEFT JOIN LATERAL (
 				SELECT json_agg(json_build_object(
@@ -1056,7 +1056,7 @@ class NemDatabase(DatabaseConnectionPool):
 			payload=payload,
 			mosaics=mosaics,
 			size=transaction.size,
-			schema_version=transaction.schema_version
+			version=transaction.version
 		)
 
 	def _get_mosaic_divisibility_by_names(self, names):

--- a/explorer/rest/rest/model/nem/Transaction.py
+++ b/explorer/rest/rest/model/nem/Transaction.py
@@ -22,7 +22,9 @@ TransactionRecord = namedtuple('TransactionRecord', [
 	'signature',
 	'to_address',
 	'payload',
-	'mosaics'
+	'mosaics',
+	'size',
+	'schema_version'
 ])
 
 
@@ -39,7 +41,9 @@ class TransactionView:  # pylint: disable=too-many-instance-attributes, too-many
 		height,
 		timestamp,
 		deadline,
-		signature
+		signature,
+		size,
+		schema_version
 	):
 		"""Create transaction list view."""
 
@@ -56,6 +60,8 @@ class TransactionView:  # pylint: disable=too-many-instance-attributes, too-many
 		self.timestamp = timestamp
 		self.deadline = deadline
 		self.signature = signature
+		self.size = size
+		self.schema_version = schema_version
 
 	def __eq__(self, other):
 		return isinstance(other, TransactionView) and all([
@@ -69,7 +75,9 @@ class TransactionView:  # pylint: disable=too-many-instance-attributes, too-many
 			self.height == other.height,
 			self.timestamp == other.timestamp,
 			self.deadline == other.deadline,
-			self.signature == other.signature
+			self.signature == other.signature,
+			self.size == other.size,
+			self.schema_version == other.schema_version
 		])
 
 	def to_dict(self):
@@ -87,4 +95,6 @@ class TransactionView:  # pylint: disable=too-many-instance-attributes, too-many
 			'timestamp': self.timestamp,
 			'deadline': self.deadline,
 			'signature': self.signature,
+			'size': self.size,
+			'schemaVersion': self.schema_version,
 		}

--- a/explorer/rest/rest/model/nem/Transaction.py
+++ b/explorer/rest/rest/model/nem/Transaction.py
@@ -24,7 +24,7 @@ TransactionRecord = namedtuple('TransactionRecord', [
 	'payload',
 	'mosaics',
 	'size',
-	'schema_version'
+	'version'
 ])
 
 
@@ -43,7 +43,7 @@ class TransactionView:  # pylint: disable=too-many-instance-attributes, too-many
 		deadline,
 		signature,
 		size,
-		schema_version
+		version
 	):
 		"""Create transaction list view."""
 
@@ -61,7 +61,7 @@ class TransactionView:  # pylint: disable=too-many-instance-attributes, too-many
 		self.deadline = deadline
 		self.signature = signature
 		self.size = size
-		self.schema_version = schema_version
+		self.version = version
 
 	def __eq__(self, other):
 		return isinstance(other, TransactionView) and all([
@@ -77,7 +77,7 @@ class TransactionView:  # pylint: disable=too-many-instance-attributes, too-many
 			self.deadline == other.deadline,
 			self.signature == other.signature,
 			self.size == other.size,
-			self.schema_version == other.schema_version
+			self.version == other.version
 		])
 
 	def to_dict(self):
@@ -96,5 +96,5 @@ class TransactionView:  # pylint: disable=too-many-instance-attributes, too-many
 			'deadline': self.deadline,
 			'signature': self.signature,
 			'size': self.size,
-			'schemaVersion': self.schema_version,
+			'schemaVersion': self.version,
 		}

--- a/explorer/rest/tests/db/test_NemDatabase.py
+++ b/explorer/rest/tests/db/test_NemDatabase.py
@@ -1,3 +1,4 @@
+# pylint: disable=unexpected-keyword-arg
 from symbolchain.CryptoTypes import PublicKey
 from symbolchain.nem.Network import Address
 from symbollightapi.model.Transaction import (

--- a/explorer/rest/tests/db/test_NemDatabase.py
+++ b/explorer/rest/tests/db/test_NemDatabase.py
@@ -202,7 +202,7 @@ NEM_CONNECTOR_UNCONFIRMED_TRANSACTIONS = [
 ]
 
 
-def _create_unconfirmed_transaction_view(transaction_type, to_address, value, size, schema_version=1):
+def _create_unconfirmed_transaction_view(transaction_type, to_address, value, size, version=1):
 	return TransactionView(
 		transaction_hash=None,
 		transaction_type=transaction_type,
@@ -216,7 +216,7 @@ def _create_unconfirmed_transaction_view(transaction_type, to_address, value, si
 		deadline='2015-03-29 23:16:22',
 		signature='0' * 128,
 		size=size,
-		schema_version=schema_version
+		version=version
 	)
 
 
@@ -252,7 +252,7 @@ UNCONFIRMED_TRANSACTION_VIEWS = [
 			}
 		],
 		size=202,
-		schema_version=2
+		version=2
 	),
 	_create_unconfirmed_transaction_view(
 		transaction_type='MULTISIG_ACCOUNT_MODIFICATION',
@@ -328,7 +328,7 @@ UNCONFIRMED_TRANSACTION_VIEWS = [
 		deadline='2015-03-29 23:16:22',
 		signature='0' * 128,
 		size=468,
-		schema_version=1
+		version=1
 	)
 ]
 

--- a/explorer/rest/tests/db/test_NemDatabase.py
+++ b/explorer/rest/tests/db/test_NemDatabase.py
@@ -201,7 +201,7 @@ NEM_CONNECTOR_UNCONFIRMED_TRANSACTIONS = [
 ]
 
 
-def _create_unconfirmed_transaction_view(transaction_type, to_address, value):
+def _create_unconfirmed_transaction_view(transaction_type, to_address, value, size, schema_version=1):
 	return TransactionView(
 		transaction_hash=None,
 		transaction_type=transaction_type,
@@ -213,7 +213,9 @@ def _create_unconfirmed_transaction_view(transaction_type, to_address, value):
 		height=0,
 		timestamp='2015-03-29 20:29:42',
 		deadline='2015-03-29 23:16:22',
-		signature='0' * 128
+		signature='0' * 128,
+		size=size,
+		schema_version=schema_version
 	)
 
 
@@ -226,7 +228,8 @@ UNCONFIRMED_TRANSACTION_VIEWS = [
 				'mode': 1,
 				'remoteAccount': '7195F4D7A40AD7E31958AE96C4AFED002962229675A4CAE8DC8A18E290618981'
 			}
-		]
+		],
+		size=168
 	),
 	_create_unconfirmed_transaction_view(
 		transaction_type='TRANSFER',
@@ -246,7 +249,9 @@ UNCONFIRMED_TRANSACTION_VIEWS = [
 				'namespace': 'root.mosaic',
 				'amount': 39.0
 			}
-		]
+		],
+		size=202,
+		schema_version=2
 	),
 	_create_unconfirmed_transaction_view(
 		transaction_type='MULTISIG_ACCOUNT_MODIFICATION',
@@ -263,7 +268,8 @@ UNCONFIRMED_TRANSACTION_VIEWS = [
 					'modificationType': 1
 				}
 			]
-		}]
+		}],
+		size=220
 	),
 	_create_unconfirmed_transaction_view(
 		transaction_type='NAMESPACE_REGISTRATION',
@@ -272,7 +278,8 @@ UNCONFIRMED_TRANSACTION_VIEWS = [
 			'sinkFee': 100.0,
 			'parent': None,
 			'namespaceName': 'namespace'
-		}]
+		}],
+		size=197
 	),
 	_create_unconfirmed_transaction_view(
 		transaction_type='MOSAIC_DEFINITION',
@@ -280,7 +287,8 @@ UNCONFIRMED_TRANSACTION_VIEWS = [
 		value=[{
 			'sinkFee': 10.0,
 			'mosaicNamespaceName': 'namespace.test'
-		}]
+		}],
+		size=464
 	),
 	_create_unconfirmed_transaction_view(
 		transaction_type='MOSAIC_SUPPLY_CHANGE',
@@ -289,7 +297,8 @@ UNCONFIRMED_TRANSACTION_VIEWS = [
 			'supplyType': 2,
 			'delta': 500000,
 			'namespaceName': 'namespace.test'
-		}]
+		}],
+		size=165
 	),
 	TransactionView(
 		transaction_hash=None,
@@ -316,7 +325,9 @@ UNCONFIRMED_TRANSACTION_VIEWS = [
 		height=0,
 		timestamp='2015-03-29 20:29:42',
 		deadline='2015-03-29 23:16:22',
-		signature='0' * 128
+		signature='0' * 128,
+		size=468,
+		schema_version=1
 	)
 ]
 

--- a/explorer/rest/tests/model/nem/test_Transaction.py
+++ b/explorer/rest/tests/model/nem/test_Transaction.py
@@ -24,7 +24,7 @@ class TransactionViewTest(unittest.TestCase):
 			deadline='2015-03-29 00:21:25',
 			signature='0' * 128,
 			size=184,
-			schema_version=1
+			version=1
 		)
 
 		if override:
@@ -49,7 +49,7 @@ class TransactionViewTest(unittest.TestCase):
 		self.assertEqual('2015-03-29 00:21:25', transaction_view.deadline)
 		self.assertEqual('0' * 128, transaction_view.signature)
 		self.assertEqual(184, transaction_view.size)
-		self.assertEqual(1, transaction_view.schema_version)
+		self.assertEqual(1, transaction_view.version)
 
 	def test_can_convert_to_simple_dict(self):
 		# Arrange:
@@ -95,4 +95,4 @@ class TransactionViewTest(unittest.TestCase):
 		self.assertNotEqual(transaction_view, self._create_default_transaction_view(('deadline', '2015-03-29 01:21:25')))
 		self.assertNotEqual(transaction_view, self._create_default_transaction_view(('signature', 'ABCDEF0123456789ABCDEF0123456789')))
 		self.assertNotEqual(transaction_view, self._create_default_transaction_view(('size', 200)))
-		self.assertNotEqual(transaction_view, self._create_default_transaction_view(('schema_version', 2)))
+		self.assertNotEqual(transaction_view, self._create_default_transaction_view(('version', 2)))

--- a/explorer/rest/tests/model/nem/test_Transaction.py
+++ b/explorer/rest/tests/model/nem/test_Transaction.py
@@ -22,7 +22,9 @@ class TransactionViewTest(unittest.TestCase):
 			height=1000,
 			timestamp='2015-03-29 00:06:25',
 			deadline='2015-03-29 00:21:25',
-			signature='0' * 128
+			signature='0' * 128,
+			size=184,
+			schema_version=1
 		)
 
 		if override:
@@ -46,6 +48,8 @@ class TransactionViewTest(unittest.TestCase):
 		self.assertEqual('2015-03-29 00:06:25', transaction_view.timestamp)
 		self.assertEqual('2015-03-29 00:21:25', transaction_view.deadline)
 		self.assertEqual('0' * 128, transaction_view.signature)
+		self.assertEqual(184, transaction_view.size)
+		self.assertEqual(1, transaction_view.schema_version)
 
 	def test_can_convert_to_simple_dict(self):
 		# Arrange:
@@ -67,6 +71,8 @@ class TransactionViewTest(unittest.TestCase):
 			'timestamp': '2015-03-29 00:06:25',
 			'deadline': '2015-03-29 00:21:25',
 			'signature': '0' * 128,
+			'size': 184,
+			'schemaVersion': 1,
 		}, transaction_view_dict)
 
 	def test_eq_is_supported(self):
@@ -88,3 +94,5 @@ class TransactionViewTest(unittest.TestCase):
 		self.assertNotEqual(transaction_view, self._create_default_transaction_view(('timestamp', '2015-03-29 01:06:25')))
 		self.assertNotEqual(transaction_view, self._create_default_transaction_view(('deadline', '2015-03-29 01:21:25')))
 		self.assertNotEqual(transaction_view, self._create_default_transaction_view(('signature', 'ABCDEF0123456789ABCDEF0123456789')))
+		self.assertNotEqual(transaction_view, self._create_default_transaction_view(('size', 200)))
+		self.assertNotEqual(transaction_view, self._create_default_transaction_view(('schema_version', 2)))

--- a/explorer/rest/tests/test/DatabaseTestUtils.py
+++ b/explorer/rest/tests/test/DatabaseTestUtils.py
@@ -87,7 +87,9 @@ Transaction = namedtuple('Transaction', [
 	'is_inner',
 	'sender_address',
 	'recipient_address',
-	'payload'
+	'payload',
+	'size',
+	'schema_version'
 ])
 TransactionMosaic = namedtuple('Transaction_Mosaic', [
 	'transaction_id',
@@ -257,7 +259,9 @@ TRANSACTIONS = [
 		recipient_address=Address('NBFWZ4IVRHEIBRCGHLYDS62FSFTBM3VDFA7E6LSQ'),
 		payload={
 			'message': None
-		}
+		},
+		size=184,
+		schema_version=1
 	),
 	Transaction(  # Transfer transaction v2
 		transaction_hash='0' * 63 + '2',
@@ -276,7 +280,9 @@ TRANSACTIONS = [
 				'payload': 'Test message',
 				'type': 1
 			}
-		}
+		},
+		size=202,
+		schema_version=2
 	),
 	Transaction(  # Account Link
 		transaction_hash='0' * 63 + '3',
@@ -293,7 +299,9 @@ TRANSACTIONS = [
 		payload={
 			'mode': 1,
 			'remote_account': 'a5f06d59b97aa40c82afb941a61fb6483bdb7491805cdb9dc47d92136983b9a5'
-		}
+		},
+		size=168,
+		schema_version=1
 	),
 	Transaction(  # Multisig account modification
 		transaction_hash='0' * 63 + '4',
@@ -315,7 +323,9 @@ TRANSACTIONS = [
 					'cosignatory_account': 'a5f06d59b97aa40c82afb941a61fb6483bdb7491805cdb9dc47d92136983b9a5'
 				}
 			]
-		}
+		},
+		size=176,
+		schema_version=1
 	),
 	Transaction(  # Multisig transaction
 		transaction_hash='0' * 63 + '5',
@@ -343,7 +353,9 @@ TRANSACTIONS = [
 					'signature': '0' * 128
 				}
 			]
-		}
+		},
+		size=468,
+		schema_version=1
 	),
 	Transaction(  # inner Transfer transaction
 		transaction_hash='0' * 63 + '6',
@@ -359,7 +371,9 @@ TRANSACTIONS = [
 		recipient_address=Address('NBFWZ4IVRHEIBRCGHLYDS62FSFTBM3VDFA7E6LSQ'),
 		payload={
 			'message': None
-		}
+		},
+		size=184,
+		schema_version=1
 	),
 	Transaction(  # Namespace registration
 		transaction_hash='0' * 63 + '7',
@@ -377,7 +391,9 @@ TRANSACTIONS = [
 			'rental_fee': 100000000,
 			'parent': 'test',
 			'namespace': 'namespace'
-		}
+		},
+		size=197,
+		schema_version=1
 	),
 	Transaction(  # Mosaic definition
 		transaction_hash='0' * 63 + '8',
@@ -408,7 +424,9 @@ TRANSACTIONS = [
 				'recipient': 'NAGHXD63C4V6REWGXCVKJ2SBS3GUAXGTRQZQXPRO',
 				'namespace_name': 'nem.xem'
 			}
-		}
+		},
+		size=464,
+		schema_version=1
 	),
 	Transaction(  # Mosaic supply change
 		transaction_hash='0' * 63 + '9',
@@ -426,7 +444,9 @@ TRANSACTIONS = [
 			'namespace_name': 'root.mosaic',
 			'supply_type': 1,
 			'delta': 1000000
-		}
+		},
+		size=165,
+		schema_version=1
 	)
 ]
 
@@ -693,7 +713,9 @@ TRANSACTIONS_VIEWS = [
 		height=TRANSACTIONS[0].height,
 		timestamp=TRANSACTIONS[0].timestamp,
 		deadline=TRANSACTIONS[0].deadline,
-		signature=TRANSACTIONS[0].signature.upper()
+		signature=TRANSACTIONS[0].signature.upper(),
+		size=TRANSACTIONS[0].size,
+		schema_version=TRANSACTIONS[0].schema_version
 	),
 	TransactionView(
 		transaction_hash='0' * 63 + '2',
@@ -721,7 +743,9 @@ TRANSACTIONS_VIEWS = [
 		height=TRANSACTIONS[1].height,
 		timestamp=TRANSACTIONS[1].timestamp,
 		deadline=TRANSACTIONS[1].deadline,
-		signature=TRANSACTIONS[1].signature.upper()
+		signature=TRANSACTIONS[1].signature.upper(),
+		size=TRANSACTIONS[1].size,
+		schema_version=TRANSACTIONS[1].schema_version
 	),
 	TransactionView(
 		transaction_hash='0' * 63 + '3',
@@ -737,7 +761,9 @@ TRANSACTIONS_VIEWS = [
 		height=TRANSACTIONS[2].height,
 		timestamp=TRANSACTIONS[2].timestamp,
 		deadline=TRANSACTIONS[2].deadline,
-		signature=TRANSACTIONS[2].signature.upper()
+		signature=TRANSACTIONS[2].signature.upper(),
+		size=TRANSACTIONS[2].size,
+		schema_version=TRANSACTIONS[2].schema_version
 	),
 	TransactionView(
 		transaction_hash='0' * 63 + '4',
@@ -756,7 +782,9 @@ TRANSACTIONS_VIEWS = [
 		height=TRANSACTIONS[3].height,
 		timestamp=TRANSACTIONS[3].timestamp,
 		deadline=TRANSACTIONS[3].deadline,
-		signature=TRANSACTIONS[3].signature.upper()
+		signature=TRANSACTIONS[3].signature.upper(),
+		size=TRANSACTIONS[3].size,
+		schema_version=TRANSACTIONS[3].schema_version
 	),
 	TransactionView(
 		transaction_hash='0' * 63 + '5',
@@ -783,7 +811,9 @@ TRANSACTIONS_VIEWS = [
 		height=TRANSACTIONS[4].height,
 		timestamp=TRANSACTIONS[4].timestamp,
 		deadline=TRANSACTIONS[4].deadline,
-		signature=TRANSACTIONS[4].signature.upper()
+		signature=TRANSACTIONS[4].signature.upper(),
+		size=TRANSACTIONS[4].size,
+		schema_version=TRANSACTIONS[4].schema_version
 	),
 	TransactionView(
 		transaction_hash='0' * 63 + '7',
@@ -800,7 +830,9 @@ TRANSACTIONS_VIEWS = [
 		height=TRANSACTIONS[6].height,
 		timestamp=TRANSACTIONS[6].timestamp,
 		deadline=TRANSACTIONS[6].deadline,
-		signature=TRANSACTIONS[6].signature.upper()
+		signature=TRANSACTIONS[6].signature.upper(),
+		size=TRANSACTIONS[6].size,
+		schema_version=TRANSACTIONS[6].schema_version
 	),
 	TransactionView(
 		transaction_hash='0' * 63 + '8',
@@ -816,7 +848,9 @@ TRANSACTIONS_VIEWS = [
 		height=TRANSACTIONS[7].height,
 		timestamp=TRANSACTIONS[7].timestamp,
 		deadline=TRANSACTIONS[7].deadline,
-		signature=TRANSACTIONS[7].signature.upper()
+		signature=TRANSACTIONS[7].signature.upper(),
+		size=TRANSACTIONS[7].size,
+		schema_version=TRANSACTIONS[7].schema_version
 	),
 	TransactionView(
 		transaction_hash='0' * 63 + '9',
@@ -833,7 +867,9 @@ TRANSACTIONS_VIEWS = [
 		height=TRANSACTIONS[8].height,
 		timestamp=TRANSACTIONS[8].timestamp,
 		deadline=TRANSACTIONS[8].deadline,
-		signature=TRANSACTIONS[8].signature.upper()
+		signature=TRANSACTIONS[8].signature.upper(),
+		size=TRANSACTIONS[8].size,
+		schema_version=TRANSACTIONS[8].schema_version
 	),
 ]
 
@@ -1001,7 +1037,9 @@ def initialize_database(db_config, network_name):
 				deadline timestamp NOT NULL,
 				signature bytea,
 				is_inner boolean NOT NULL,
-				payload jsonb
+				payload jsonb,
+				size int NOT NULL,
+				schema_version int NOT NULL
 			)
 			'''
 		)
@@ -1160,9 +1198,11 @@ def initialize_database(db_config, network_name):
 					deadline,
 					signature,
 					is_inner,
-					payload
+					payload,
+					size,
+					schema_version
 				)
-				VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+				VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 				''',
 				(
 					unhexlify(transaction.transaction_hash),
@@ -1176,7 +1216,9 @@ def initialize_database(db_config, network_name):
 					transaction.deadline,
 					unhexlify(transaction.signature) if transaction.signature else None,
 					transaction.is_inner,
-					json.dumps(transaction.payload) if transaction.payload else None
+					json.dumps(transaction.payload) if transaction.payload else None,
+					transaction.size,
+					transaction.schema_version
 				)
 			)
 

--- a/explorer/rest/tests/test/DatabaseTestUtils.py
+++ b/explorer/rest/tests/test/DatabaseTestUtils.py
@@ -89,7 +89,7 @@ Transaction = namedtuple('Transaction', [
 	'recipient_address',
 	'payload',
 	'size',
-	'schema_version'
+	'version'
 ])
 TransactionMosaic = namedtuple('Transaction_Mosaic', [
 	'transaction_id',
@@ -261,7 +261,7 @@ TRANSACTIONS = [
 			'message': None
 		},
 		size=184,
-		schema_version=1
+		version=1
 	),
 	Transaction(  # Transfer transaction v2
 		transaction_hash='0' * 63 + '2',
@@ -282,7 +282,7 @@ TRANSACTIONS = [
 			}
 		},
 		size=202,
-		schema_version=2
+		version=2
 	),
 	Transaction(  # Account Link
 		transaction_hash='0' * 63 + '3',
@@ -301,7 +301,7 @@ TRANSACTIONS = [
 			'remote_account': 'a5f06d59b97aa40c82afb941a61fb6483bdb7491805cdb9dc47d92136983b9a5'
 		},
 		size=168,
-		schema_version=1
+		version=1
 	),
 	Transaction(  # Multisig account modification
 		transaction_hash='0' * 63 + '4',
@@ -325,7 +325,7 @@ TRANSACTIONS = [
 			]
 		},
 		size=176,
-		schema_version=1
+		version=1
 	),
 	Transaction(  # Multisig transaction
 		transaction_hash='0' * 63 + '5',
@@ -355,7 +355,7 @@ TRANSACTIONS = [
 			]
 		},
 		size=468,
-		schema_version=1
+		version=1
 	),
 	Transaction(  # inner Transfer transaction
 		transaction_hash='0' * 63 + '6',
@@ -373,7 +373,7 @@ TRANSACTIONS = [
 			'message': None
 		},
 		size=184,
-		schema_version=1
+		version=1
 	),
 	Transaction(  # Namespace registration
 		transaction_hash='0' * 63 + '7',
@@ -393,7 +393,7 @@ TRANSACTIONS = [
 			'namespace': 'namespace'
 		},
 		size=197,
-		schema_version=1
+		version=1
 	),
 	Transaction(  # Mosaic definition
 		transaction_hash='0' * 63 + '8',
@@ -426,7 +426,7 @@ TRANSACTIONS = [
 			}
 		},
 		size=464,
-		schema_version=1
+		version=1
 	),
 	Transaction(  # Mosaic supply change
 		transaction_hash='0' * 63 + '9',
@@ -446,7 +446,7 @@ TRANSACTIONS = [
 			'delta': 1000000
 		},
 		size=165,
-		schema_version=1
+		version=1
 	)
 ]
 
@@ -715,7 +715,7 @@ TRANSACTIONS_VIEWS = [
 		deadline=TRANSACTIONS[0].deadline,
 		signature=TRANSACTIONS[0].signature.upper(),
 		size=TRANSACTIONS[0].size,
-		schema_version=TRANSACTIONS[0].schema_version
+		version=TRANSACTIONS[0].version
 	),
 	TransactionView(
 		transaction_hash='0' * 63 + '2',
@@ -745,7 +745,7 @@ TRANSACTIONS_VIEWS = [
 		deadline=TRANSACTIONS[1].deadline,
 		signature=TRANSACTIONS[1].signature.upper(),
 		size=TRANSACTIONS[1].size,
-		schema_version=TRANSACTIONS[1].schema_version
+		version=TRANSACTIONS[1].version
 	),
 	TransactionView(
 		transaction_hash='0' * 63 + '3',
@@ -763,7 +763,7 @@ TRANSACTIONS_VIEWS = [
 		deadline=TRANSACTIONS[2].deadline,
 		signature=TRANSACTIONS[2].signature.upper(),
 		size=TRANSACTIONS[2].size,
-		schema_version=TRANSACTIONS[2].schema_version
+		version=TRANSACTIONS[2].version
 	),
 	TransactionView(
 		transaction_hash='0' * 63 + '4',
@@ -784,7 +784,7 @@ TRANSACTIONS_VIEWS = [
 		deadline=TRANSACTIONS[3].deadline,
 		signature=TRANSACTIONS[3].signature.upper(),
 		size=TRANSACTIONS[3].size,
-		schema_version=TRANSACTIONS[3].schema_version
+		version=TRANSACTIONS[3].version
 	),
 	TransactionView(
 		transaction_hash='0' * 63 + '5',
@@ -813,7 +813,7 @@ TRANSACTIONS_VIEWS = [
 		deadline=TRANSACTIONS[4].deadline,
 		signature=TRANSACTIONS[4].signature.upper(),
 		size=TRANSACTIONS[4].size,
-		schema_version=TRANSACTIONS[4].schema_version
+		version=TRANSACTIONS[4].version
 	),
 	TransactionView(
 		transaction_hash='0' * 63 + '7',
@@ -832,7 +832,7 @@ TRANSACTIONS_VIEWS = [
 		deadline=TRANSACTIONS[6].deadline,
 		signature=TRANSACTIONS[6].signature.upper(),
 		size=TRANSACTIONS[6].size,
-		schema_version=TRANSACTIONS[6].schema_version
+		version=TRANSACTIONS[6].version
 	),
 	TransactionView(
 		transaction_hash='0' * 63 + '8',
@@ -850,7 +850,7 @@ TRANSACTIONS_VIEWS = [
 		deadline=TRANSACTIONS[7].deadline,
 		signature=TRANSACTIONS[7].signature.upper(),
 		size=TRANSACTIONS[7].size,
-		schema_version=TRANSACTIONS[7].schema_version
+		version=TRANSACTIONS[7].version
 	),
 	TransactionView(
 		transaction_hash='0' * 63 + '9',
@@ -869,7 +869,7 @@ TRANSACTIONS_VIEWS = [
 		deadline=TRANSACTIONS[8].deadline,
 		signature=TRANSACTIONS[8].signature.upper(),
 		size=TRANSACTIONS[8].size,
-		schema_version=TRANSACTIONS[8].schema_version
+		version=TRANSACTIONS[8].version
 	),
 ]
 
@@ -1039,7 +1039,7 @@ def initialize_database(db_config, network_name):
 				is_inner boolean NOT NULL,
 				payload jsonb,
 				size int NOT NULL,
-				schema_version int NOT NULL
+				version int NOT NULL
 			)
 			'''
 		)
@@ -1200,7 +1200,7 @@ def initialize_database(db_config, network_name):
 					is_inner,
 					payload,
 					size,
-					schema_version
+					version
 				)
 				VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 				''',
@@ -1218,7 +1218,7 @@ def initialize_database(db_config, network_name):
 					transaction.is_inner,
 					json.dumps(transaction.payload) if transaction.payload else None,
 					transaction.size,
-					transaction.schema_version
+					transaction.version
 				)
 			)
 


### PR DESCRIPTION
Problem: The current transaction didn't have a size and schema version https://github.com/symbol/product/issues/2321
Solution: 
- Added size and version in `lightapi/python`
- Added size and version column in DB schema
- Added size and version in REST endpoint.
