### PR TITLE
[explorer/frontend] Hide supernodes metric when SUPERNODE_API_URL is not configured

### DIFF
--- a/explorer/frontend/README.md
+++ b/explorer/frontend/README.md
@@ -36,7 +36,7 @@ These variables are exposed to the browser, meaning they can be accessed both on
 
 - **`API_BASE_URL`**: Explorer REST API endpoint. Example: `http://explorer-backend.com:4000/api/nem`.
 
-- **`SUPERNODE_API_URL`**: Supernodes API endpoint. Example: `https://nem.io/supernode/api`.
+- **`SUPERNODE_API_URL`**: Supernodes API endpoint. Example: `https://nem.io/supernode/api`. When omitted, the home page hides the supernodes metric.
 
 - **`NODELIST_URL`**: Node list endpoint. Example: `https://nodewatch.symbol.tools/api/nem/nodes`.
 

--- a/explorer/frontend/__tests__/api/stats.test.js
+++ b/explorer/frontend/__tests__/api/stats.test.js
@@ -27,6 +27,7 @@ import {
 	fetchTransactionChart,
 	fetchTransactionStats
 } from '@/api/stats';
+import config from '@/config';
 import * as utils from '@/utils/server';
 
 jest.mock('@/utils/server', () => {
@@ -174,6 +175,26 @@ describe('api/stats', () => {
 
 			// Act + Assert:
 			await runStatsTest(functionToTest, args, responseMap, expectedResult);
+		});
+
+		it('does not fetch supernode statistics when the endpoint is not configured', async () => {
+			// Arrange:
+			const originalSupernodeApiUrl = config.SUPERNODE_API_URL;
+			config.SUPERNODE_API_URL = '';
+			const functionToTest = fetchNodeStats;
+			const args = [];
+			const responseMap = {
+				'https://node.list': nodeListResponse
+			};
+			const expectedResult = {
+				total: 3,
+				supernodes: null
+			};
+
+			// Act + Assert:
+			await runStatsTest(functionToTest, args, responseMap, expectedResult);
+
+			config.SUPERNODE_API_URL = originalSupernodeApiUrl;
 		});
 	});
 

--- a/explorer/frontend/api/stats.js
+++ b/explorer/frontend/api/stats.js
@@ -100,14 +100,15 @@ export const fetchBlockStats = async () => {
 };
 
 export const fetchNodeStats = async () => {
-	const [nodewatchResponse, supernodeResponse] = await Promise.all([
-		fetchNodeList(),
-		makeRequest(`${config.SUPERNODE_API_URL}/statistics`)
-	]);
+	const nodewatchResponse = await fetchNodeList();
+	const supernodeApiUrl = config.SUPERNODE_API_URL?.trim();
+	const supernodes = supernodeApiUrl
+		? (await makeRequest(`${supernodeApiUrl}/statistics`)).participantCount
+		: null;
 
 	return {
 		total: nodewatchResponse.length,
-		supernodes: supernodeResponse.participantCount
+		supernodes
 	};
 };
 

--- a/explorer/frontend/pages/index.jsx
+++ b/explorer/frontend/pages/index.jsx
@@ -119,7 +119,7 @@ const Home = ({
 					<div className="layout-grid-row layout-flex-fill">
 						<div className="layout-flex-col layout-flex-fill">
 							<Field title={t('field_totalNodes')}>{nodeStats.total}</Field>
-							{nodeStats.supernodes != null && (
+							{nodeStats.supernodes !== null && (
 								<Field title={t('field_supernodes')}>{nodeStats.supernodes}</Field>
 							)}
 						</div>

--- a/explorer/frontend/pages/index.jsx
+++ b/explorer/frontend/pages/index.jsx
@@ -119,7 +119,9 @@ const Home = ({
 					<div className="layout-grid-row layout-flex-fill">
 						<div className="layout-flex-col layout-flex-fill">
 							<Field title={t('field_totalNodes')}>{nodeStats.total}</Field>
-							<Field title={t('field_supernodes')}>{nodeStats.supernodes}</Field>
+							{nodeStats.supernodes != null && (
+								<Field title={t('field_supernodes')}>{nodeStats.supernodes}</Field>
+							)}
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
## Summary
- Skip the supernode statistics API call when `SUPERNODE_API_URL` is not set
- Hide the **Supernodes** metric on the home page when no supernode count is available
- Document that `SUPERNODE_API_URL` is optional

Closes #2314

## Problem

The testnet Explorer home page displayed a mainnet supernode count (e.g. **Supernodes: 77**) alongside testnet node data (e.g. **Total Nodes: 6**). Supernodes exist only on mainnet, so this mixed mainnet and testnet metrics and misrepresented the network status.

The frontend always called `SUPERNODE_API_URL/statistics`, which points to the mainnet supernode API regardless of the deployed network.

## Solution

Treat `SUPERNODE_API_URL` as optional:
- When configured → fetch supernode statistics and display the metric (mainnet behavior)
- When omitted or empty → do not call the supernode API, return `supernodes: null`, and hide the metric in the UI
For testnet deployments, omit `SUPERNODE_API_URL` from the environment configuration.
