### PR TITLE
[explorer/puller] feat: sync Symbol receipts and compute block reward

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ __pycache__/
 build/
 dist/
 *.mo
+.coverage
 
 # other build artifacts
 _generated/

--- a/explorer/common/tests/PostgresTestUtils.py
+++ b/explorer/common/tests/PostgresTestUtils.py
@@ -40,6 +40,7 @@ def drop_symbol_block_tables_if_present(database):
 	cursor.execute('DROP TABLE IF EXISTS symbol_transaction_mosaics')
 	cursor.execute('DROP TABLE IF EXISTS symbol_transaction_addresses')
 	cursor.execute('DROP TABLE IF EXISTS symbol_transactions')
+	cursor.execute('DROP TABLE IF EXISTS symbol_receipts')
 	cursor.execute('DROP TABLE IF EXISTS symbol_blocks')
 	cursor.execute('DROP TABLE IF EXISTS symbol_sync_state')
 	cursor.execute('DROP SEQUENCE IF EXISTS symbol_transaction_list_sequence_seq')

--- a/explorer/puller/puller/db/SymbolDatabase.py
+++ b/explorer/puller/puller/db/SymbolDatabase.py
@@ -66,7 +66,7 @@ SYMBOL_BLOCK_DEFINITIONS = [
 	'harvesting_eligible_accounts_count int',
 	'total_voting_balance bigint',
 	'previous_importance_block_hash bytea',
-	'block_reward numeric',
+	'block_reward int',
 	'raw_payload jsonb NOT NULL',
 	'created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP',
 	'updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP'
@@ -127,7 +127,7 @@ SYMBOL_RECEIPT_DEFINITIONS = [
 	'recipient_address bytea',
 	'target_address bytea',
 	'mosaic_id varchar(16)',
-	'amount numeric NOT NULL DEFAULT 0',
+	'amount bigint NOT NULL DEFAULT 0',
 	'artifact_id varchar(16)',
 	'raw_payload jsonb NOT NULL'
 ]

--- a/explorer/puller/puller/db/SymbolDatabase.py
+++ b/explorer/puller/puller/db/SymbolDatabase.py
@@ -1,6 +1,7 @@
 from psycopg2.extras import Json
 
 from puller.model.symbol.Block import BLOCK_TYPE_VALUES
+from puller.model.symbol.Receipt import RECEIPT_TYPE_LABELS
 from puller.model.symbol.Transaction import MESSAGE_TYPE_LABELS, TRANSACTION_TYPE_LABELS
 
 from .DatabaseConnection import DatabaseConnection
@@ -16,6 +17,8 @@ SYNC_STATE_COLUMNS = [
 	'last_synced_block_hash'
 ]
 
+SYMBOL_RECEIPT_TYPE_VALUES = tuple(RECEIPT_TYPE_LABELS.values())
+SYMBOL_RECEIPT_GROUP_VALUES = ('balanceChange', 'balanceTransfer', 'artifactExpiry', 'inflation')
 SYNC_STATE_STATUS_VALUES = ('initialized', 'healthy', 'repairing', 'unhealthy')
 SYMBOL_TRANSACTION_TYPE_VALUES = tuple(TRANSACTION_TYPE_LABELS.values())
 SYMBOL_TRANSACTION_MOSAIC_ROLE_VALUES = ('transfer', 'hash_lock', 'secret_lock', 'revocation', 'restriction', 'definition')
@@ -115,8 +118,8 @@ SYMBOL_TRANSACTION_ADDRESS_DEFINITIONS = [
 SYMBOL_RECEIPT_DEFINITIONS = [
 	'id bigserial PRIMARY KEY',
 	'height bigint NOT NULL REFERENCES symbol_blocks(height)',
-	'receipt_type int NOT NULL',
-	'receipt_group varchar NOT NULL',
+	'receipt_type symbol_receipt_type NOT NULL',
+	'receipt_group symbol_receipt_group NOT NULL',
 	'version int NOT NULL',
 	'source_primary_id bigint',
 	'source_secondary_id bigint',
@@ -167,6 +170,8 @@ class SymbolDatabase(DatabaseConnection):
 
 		cursor = self.connection.cursor()
 		_create_enum_type(cursor, 'symbol_block_type', BLOCK_TYPE_VALUES)
+		_create_enum_type(cursor, 'symbol_receipt_type', SYMBOL_RECEIPT_TYPE_VALUES)
+		_create_enum_type(cursor, 'symbol_receipt_group', SYMBOL_RECEIPT_GROUP_VALUES)
 		_create_enum_type(cursor, 'symbol_sync_state_status', SYNC_STATE_STATUS_VALUES)
 		_create_enum_type(cursor, 'symbol_transaction_type', SYMBOL_TRANSACTION_TYPE_VALUES)
 		_create_enum_type(cursor, 'symbol_transaction_mosaic_role', SYMBOL_TRANSACTION_MOSAIC_ROLE_VALUES)

--- a/explorer/puller/puller/db/SymbolDatabase.py
+++ b/explorer/puller/puller/db/SymbolDatabase.py
@@ -63,6 +63,7 @@ SYMBOL_BLOCK_DEFINITIONS = [
 	'harvesting_eligible_accounts_count int',
 	'total_voting_balance bigint',
 	'previous_importance_block_hash bytea',
+	'block_reward numeric',
 	'raw_payload jsonb NOT NULL',
 	'created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP',
 	'updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP'
@@ -111,6 +112,33 @@ SYMBOL_TRANSACTION_ADDRESS_DEFINITIONS = [
 	'role symbol_transaction_address_role NOT NULL',
 	'PRIMARY KEY (transaction_id, address, role)'
 ]
+SYMBOL_RECEIPT_DEFINITIONS = [
+	'id bigserial PRIMARY KEY',
+	'height bigint NOT NULL REFERENCES symbol_blocks(height)',
+	'receipt_type int NOT NULL',
+	'receipt_group varchar NOT NULL',
+	'version int NOT NULL',
+	'source_primary_id bigint',
+	'source_secondary_id bigint',
+	'sender_address bytea',
+	'recipient_address bytea',
+	'target_address bytea',
+	'mosaic_id varchar(16)',
+	'amount numeric NOT NULL DEFAULT 0',
+	'artifact_id varchar(16)',
+	'raw_payload jsonb NOT NULL'
+]
+SYMBOL_RECEIPT_INDEXES = [
+	'CREATE INDEX IF NOT EXISTS idx_symbol_receipts_height_type ON symbol_receipts(height DESC, receipt_type)',
+	'CREATE INDEX IF NOT EXISTS idx_symbol_receipts_type_height ON symbol_receipts(receipt_type, height DESC)',
+	'CREATE INDEX IF NOT EXISTS idx_symbol_receipts_group_height ON symbol_receipts(receipt_group, height DESC)',
+	'CREATE INDEX IF NOT EXISTS idx_symbol_receipts_target ON symbol_receipts(target_address)',
+	'CREATE INDEX IF NOT EXISTS idx_symbol_receipts_target_group_height ON symbol_receipts(target_address, receipt_group, height DESC)',
+	'CREATE INDEX IF NOT EXISTS idx_symbol_receipts_target_type_height ON symbol_receipts(target_address, receipt_type, height DESC)',
+	'CREATE INDEX IF NOT EXISTS idx_symbol_receipts_sender_group_height ON symbol_receipts(sender_address, receipt_group, height DESC)',
+	'CREATE INDEX IF NOT EXISTS idx_symbol_receipts_recipient_group_height ON symbol_receipts(recipient_address, receipt_group, height DESC)',
+	'CREATE INDEX IF NOT EXISTS idx_symbol_receipts_mosaic ON symbol_receipts(mosaic_id)'
+]
 
 
 def _create_enum_type(cursor, name, values):
@@ -150,6 +178,7 @@ class SymbolDatabase(DatabaseConnection):
 		_create_table(cursor, 'symbol_transactions', SYMBOL_TRANSACTION_DEFINITIONS)
 		_create_table(cursor, 'symbol_transaction_mosaics', SYMBOL_TRANSACTION_MOSAIC_DEFINITIONS)
 		_create_table(cursor, 'symbol_transaction_addresses', SYMBOL_TRANSACTION_ADDRESS_DEFINITIONS)
+		_create_table(cursor, 'symbol_receipts', SYMBOL_RECEIPT_DEFINITIONS)
 		cursor.execute('CREATE INDEX IF NOT EXISTS idx_symbol_blocks_height_desc ON symbol_blocks(height DESC)')
 		cursor.execute('CREATE INDEX IF NOT EXISTS idx_symbol_blocks_timestamp ON symbol_blocks(timestamp)')
 		cursor.execute('CREATE INDEX IF NOT EXISTS idx_symbol_blocks_signer_address ON symbol_blocks(signer_address)')
@@ -190,6 +219,8 @@ class SymbolDatabase(DatabaseConnection):
 			ON symbol_transaction_addresses(address, height DESC, transaction_id)
 		''')
 		cursor.execute('CREATE INDEX IF NOT EXISTS idx_symbol_transaction_addresses_height ON symbol_transaction_addresses(height)')
+		for index_sql in SYMBOL_RECEIPT_INDEXES:
+			cursor.execute(index_sql)
 		self.connection.commit()
 
 	def check_connection(self):
@@ -296,6 +327,7 @@ class SymbolDatabase(DatabaseConnection):
 		cursor.execute('DELETE FROM symbol_transaction_mosaics WHERE height >= %s', (height,))
 		cursor.execute('DELETE FROM symbol_transaction_addresses WHERE height >= %s', (height,))
 		cursor.execute('DELETE FROM symbol_transactions WHERE height >= %s', (height,))
+		cursor.execute('DELETE FROM symbol_receipts WHERE height >= %s', (height,))
 		cursor.execute('DELETE FROM symbol_blocks WHERE height >= %s', (height,))
 
 	def upsert_transactions_for_height(self, height, transaction_entries):
@@ -408,6 +440,51 @@ class SymbolDatabase(DatabaseConnection):
 			params)
 
 		return cursor.fetchone()[0]
+
+	def upsert_receipts_for_height(self, height, receipts, block_reward):
+		"""Replaces receipts for a height and updates its block reward."""
+
+		cursor = self.connection.cursor()
+		cursor.execute('DELETE FROM symbol_receipts WHERE height = %s', (height,))
+		for receipt in receipts:
+			cursor.execute(
+				'''
+				INSERT INTO symbol_receipts (
+					height,
+					receipt_type,
+					receipt_group,
+					version,
+					source_primary_id,
+					source_secondary_id,
+					sender_address,
+					recipient_address,
+					target_address,
+					mosaic_id,
+					amount,
+					artifact_id,
+					raw_payload
+				)
+				VALUES (
+					%(height)s,
+					%(receipt_type)s,
+					%(receipt_group)s,
+					%(version)s,
+					%(source_primary_id)s,
+					%(source_secondary_id)s,
+					%(sender_address)s,
+					%(recipient_address)s,
+					%(target_address)s,
+					%(mosaic_id)s,
+					%(amount)s,
+					%(artifact_id)s,
+					%(raw_payload)s
+				)
+				''',
+				{**receipt, 'raw_payload': Json(receipt['raw_payload'])})
+		cursor.execute(
+			'UPDATE symbol_blocks SET block_reward = %s, updated_at = CURRENT_TIMESTAMP WHERE height = %s',
+			(block_reward, height))
+		self.connection.commit()
 
 	def upsert_blocks(self, blocks):
 		"""Upserts Symbol block rows."""

--- a/explorer/puller/puller/facade/SymbolPuller.py
+++ b/explorer/puller/puller/facade/SymbolPuller.py
@@ -280,11 +280,9 @@ class SymbolPuller:
 
 				if len(blocks) < MAX_PAGE_SIZE:
 					await self._sync_block_batch(batch_rows, epoch_adjustment_seconds)
-					await self._sync_receipts_for_batch(batch_rows)
 					return last_synced_height, last_synced_block_hash
 
 			await self._sync_block_batch(batch_rows, epoch_adjustment_seconds)
-			await self._sync_receipts_for_batch(batch_rows)
 
 		return last_synced_height, last_synced_block_hash
 
@@ -294,8 +292,10 @@ class SymbolPuller:
 			batch_rows[-1]['height'],
 			epoch_adjustment_seconds
 		)
+		receipt_rows_by_height = await self._get_receipt_rows_by_height(batch_rows[0]['height'], batch_rows[-1]['height'])
 		self.symbol_db.upsert_blocks(batch_rows)
 		self._upsert_transactions_for_batch(batch_rows, transaction_rows_by_height)
+		self._upsert_receipts_for_batch(batch_rows, receipt_rows_by_height)
 
 	def _upsert_transactions_for_batch(self, block_rows, rows_by_height):
 		for row in block_rows:
@@ -337,6 +337,9 @@ class SymbolPuller:
 				f'/statements/transaction?fromHeight={start_height}&toHeight={end_height}'
 				f'&pageSize={MAX_PAGE_SIZE}&pageNumber={page_number}'
 			)
+			if not isinstance(response, dict) or 'data' not in response:
+				raise ValueError('Malformed Symbol statement page response')
+
 			items = response['data']
 			statement_items.extend(items)
 			if len(items) < MAX_PAGE_SIZE:
@@ -355,8 +358,7 @@ class SymbolPuller:
 	def _calculate_block_reward(receipts):
 		return sum(receipt['amount'] for receipt in receipts if INFLATION_RECEIPT_TYPE == receipt['receipt_type'])
 
-	async def _sync_receipts_for_batch(self, block_rows):
-		rows_by_height = await self._get_receipt_rows_by_height(block_rows[0]['height'], block_rows[-1]['height'])
+	def _upsert_receipts_for_batch(self, block_rows, rows_by_height):
 		for row in block_rows:
 			receipt_rows = rows_by_height.get(row['height'], [])
 			block_reward = self._calculate_block_reward(receipt_rows)

--- a/explorer/puller/puller/facade/SymbolPuller.py
+++ b/explorer/puller/puller/facade/SymbolPuller.py
@@ -18,7 +18,6 @@ from puller.model.symbol.Transaction import create_transaction_row
 DatabaseConfiguration = namedtuple('DatabaseConfiguration', ['database', 'user', 'password', 'host', 'port'])
 MAX_PAGE_SIZE = 100
 BLOCK_PAGE_FETCH_CONCURRENCY = 10
-STATEMENT_PAGE_SIZE = 100
 
 
 def _get_symbol_network(network_type):
@@ -336,11 +335,11 @@ class SymbolPuller:
 		while True:
 			response = await self.get_symbol_node(
 				f'/statements/transaction?fromHeight={start_height}&toHeight={end_height}'
-				f'&pageSize={STATEMENT_PAGE_SIZE}&pageNumber={page_number}'
+				f'&pageSize={MAX_PAGE_SIZE}&pageNumber={page_number}'
 			)
 			items = response['data']
 			statement_items.extend(items)
-			if len(items) < STATEMENT_PAGE_SIZE:
+			if len(items) < MAX_PAGE_SIZE:
 				break
 
 			page_number += 1

--- a/explorer/puller/puller/facade/SymbolPuller.py
+++ b/explorer/puller/puller/facade/SymbolPuller.py
@@ -1,6 +1,6 @@
 import asyncio
 import configparser
-from collections import namedtuple
+from collections import defaultdict, namedtuple
 from urllib.parse import urlparse
 
 from common.symbol.NodeConfiguration import SymbolNodeConfiguration
@@ -12,11 +12,13 @@ from zenlog import log
 
 from puller.db.SymbolDatabase import SymbolDatabase
 from puller.model.symbol.Block import create_block_row
+from puller.model.symbol.Receipt import INFLATION_RECEIPT_TYPE, create_receipt_rows
 from puller.model.symbol.Transaction import create_transaction_row
 
 DatabaseConfiguration = namedtuple('DatabaseConfiguration', ['database', 'user', 'password', 'host', 'port'])
 MAX_PAGE_SIZE = 100
 BLOCK_PAGE_FETCH_CONCURRENCY = 10
+STATEMENT_PAGE_SIZE = 100
 
 
 def _get_symbol_network(network_type):
@@ -279,9 +281,11 @@ class SymbolPuller:
 
 				if len(blocks) < MAX_PAGE_SIZE:
 					await self._sync_block_batch(batch_rows, epoch_adjustment_seconds)
+					await self._sync_receipts_for_batch(batch_rows)
 					return last_synced_height, last_synced_block_hash
 
 			await self._sync_block_batch(batch_rows, epoch_adjustment_seconds)
+			await self._sync_receipts_for_batch(batch_rows)
 
 		return last_synced_height, last_synced_block_hash
 
@@ -325,6 +329,39 @@ class SymbolPuller:
 			raise ValueError('Malformed Symbol block page response')
 
 		return response['data']
+
+	async def _get_receipt_rows_by_height(self, start_height, end_height):
+		statement_items = []
+		page_number = 1
+		while True:
+			response = await self.get_symbol_node(
+				f'/statements/transaction?fromHeight={start_height}&toHeight={end_height}'
+				f'&pageSize={STATEMENT_PAGE_SIZE}&pageNumber={page_number}'
+			)
+			items = response['data']
+			statement_items.extend(items)
+			if len(items) < STATEMENT_PAGE_SIZE:
+				break
+
+			page_number += 1
+
+		rows_by_height = defaultdict(list)
+		for statement_item in statement_items:
+			for row in create_receipt_rows(statement_item):
+				rows_by_height[row['height']].append(row)
+
+		return dict(rows_by_height)
+
+	@staticmethod
+	def _calculate_block_reward(receipts):
+		return sum(receipt['amount'] for receipt in receipts if INFLATION_RECEIPT_TYPE == receipt['receipt_type'])
+
+	async def _sync_receipts_for_batch(self, block_rows):
+		rows_by_height = await self._get_receipt_rows_by_height(block_rows[0]['height'], block_rows[-1]['height'])
+		for row in block_rows:
+			receipt_rows = rows_by_height.get(row['height'], [])
+			block_reward = self._calculate_block_reward(receipt_rows)
+			self.symbol_db.upsert_receipts_for_height(row['height'], receipt_rows, block_reward)
 
 	@staticmethod
 	def _parse_epoch_adjustment(network_properties):

--- a/explorer/puller/puller/model/symbol/Receipt.py
+++ b/explorer/puller/puller/model/symbol/Receipt.py
@@ -41,6 +41,7 @@ RECEIPT_TYPE_GROUPS = {
 	**{receipt_type.value: 'artifactExpiry' for receipt_type in ARTIFACT_EXPIRY_RECEIPT_TYPES},
 	ReceiptType.INFLATION.value: 'inflation'
 }
+assert set(RECEIPT_TYPE_LABELS) == set(RECEIPT_TYPE_GROUPS), 'RECEIPT_TYPE_LABELS and RECEIPT_TYPE_GROUPS must cover the same receipt types'
 INFLATION_RECEIPT_TYPE = RECEIPT_TYPE_LABELS[ReceiptType.INFLATION.value]
 
 

--- a/explorer/puller/puller/model/symbol/Receipt.py
+++ b/explorer/puller/puller/model/symbol/Receipt.py
@@ -1,5 +1,7 @@
 from symbolchain.sc import ReceiptType
 
+from puller.model.symbol.format import bytes_from_hex_or_none, str_or_none
+
 BALANCE_CHANGE_RECEIPT_TYPES = (
 	ReceiptType.HARVEST_FEE,
 	ReceiptType.LOCK_HASH_CREATED,
@@ -42,14 +44,6 @@ RECEIPT_TYPE_GROUPS = {
 INFLATION_RECEIPT_TYPE = RECEIPT_TYPE_LABELS[ReceiptType.INFLATION.value]
 
 
-def _address_bytes_or_none(value):
-	return bytes.fromhex(value) if value else None
-
-
-def _str_or_none(value):
-	return str(value) if value is not None else None
-
-
 def _create_base_receipt_row(statement, source, receipt):
 	receipt_type = int(receipt['type'])
 
@@ -71,7 +65,7 @@ def _create_base_receipt_row(statement, source, receipt):
 
 
 def _add_mosaic_fields(row, receipt):
-	row['mosaic_id'] = _str_or_none(receipt.get('mosaicId'))
+	row['mosaic_id'] = str_or_none(receipt.get('mosaicId'))
 	row['amount'] = int(receipt.get('amount', 0))
 
 
@@ -89,15 +83,15 @@ def create_receipt_rows(statement_item):
 		row = _create_base_receipt_row(statement, source, receipt)
 		if 'balanceChange' == row['receipt_group']:
 			_add_mosaic_fields(row, receipt)
-			row['target_address'] = _address_bytes_or_none(receipt.get('targetAddress'))
+			row['target_address'] = bytes_from_hex_or_none(receipt.get('targetAddress'))
 		elif 'balanceTransfer' == row['receipt_group']:
 			_add_mosaic_fields(row, receipt)
-			row['sender_address'] = _address_bytes_or_none(receipt.get('senderAddress'))
-			row['recipient_address'] = _address_bytes_or_none(receipt.get('recipientAddress'))
+			row['sender_address'] = bytes_from_hex_or_none(receipt.get('senderAddress'))
+			row['recipient_address'] = bytes_from_hex_or_none(receipt.get('recipientAddress'))
 		elif 'inflation' == row['receipt_group']:
 			_add_mosaic_fields(row, receipt)
 		elif 'artifactExpiry' == row['receipt_group']:
-			row['artifact_id'] = _str_or_none(receipt.get('artifactId'))
+			row['artifact_id'] = str_or_none(receipt.get('artifactId'))
 
 		rows.append(row)
 

--- a/explorer/puller/puller/model/symbol/Receipt.py
+++ b/explorer/puller/puller/model/symbol/Receipt.py
@@ -18,13 +18,28 @@ ARTIFACT_EXPIRY_RECEIPT_TYPES = (
 	ReceiptType.NAMESPACE_EXPIRED,
 	ReceiptType.NAMESPACE_DELETED
 )
+RECEIPT_TYPE_LABELS = {
+	ReceiptType.MOSAIC_RENTAL_FEE.value: 'mosaicRentalFee',
+	ReceiptType.NAMESPACE_RENTAL_FEE.value: 'namespaceRentalFee',
+	ReceiptType.HARVEST_FEE.value: 'harvestFee',
+	ReceiptType.LOCK_HASH_COMPLETED.value: 'lockHashCompleted',
+	ReceiptType.LOCK_HASH_EXPIRED.value: 'lockHashExpired',
+	ReceiptType.LOCK_SECRET_COMPLETED.value: 'lockSecretCompleted',
+	ReceiptType.LOCK_SECRET_EXPIRED.value: 'lockSecretExpired',
+	ReceiptType.LOCK_HASH_CREATED.value: 'lockHashCreated',
+	ReceiptType.LOCK_SECRET_CREATED.value: 'lockSecretCreated',
+	ReceiptType.MOSAIC_EXPIRED.value: 'mosaicExpired',
+	ReceiptType.NAMESPACE_EXPIRED.value: 'namespaceExpired',
+	ReceiptType.NAMESPACE_DELETED.value: 'namespaceDeleted',
+	ReceiptType.INFLATION.value: 'inflation'
+}
 RECEIPT_TYPE_GROUPS = {
 	**{receipt_type.value: 'balanceChange' for receipt_type in BALANCE_CHANGE_RECEIPT_TYPES},
 	**{receipt_type.value: 'balanceTransfer' for receipt_type in BALANCE_TRANSFER_RECEIPT_TYPES},
 	**{receipt_type.value: 'artifactExpiry' for receipt_type in ARTIFACT_EXPIRY_RECEIPT_TYPES},
 	ReceiptType.INFLATION.value: 'inflation'
 }
-INFLATION_RECEIPT_TYPE = ReceiptType.INFLATION.value
+INFLATION_RECEIPT_TYPE = RECEIPT_TYPE_LABELS[ReceiptType.INFLATION.value]
 
 
 def _address_bytes_or_none(value):
@@ -40,7 +55,7 @@ def _create_base_receipt_row(statement, source, receipt):
 
 	return {
 		'height': int(statement['height']),
-		'receipt_type': receipt_type,
+		'receipt_type': RECEIPT_TYPE_LABELS[receipt_type],
 		'receipt_group': RECEIPT_TYPE_GROUPS[receipt_type],
 		'version': int(receipt['version']),
 		'source_primary_id': int(source['primaryId']),

--- a/explorer/puller/puller/model/symbol/Receipt.py
+++ b/explorer/puller/puller/model/symbol/Receipt.py
@@ -1,0 +1,89 @@
+from symbolchain.sc import ReceiptType
+
+BALANCE_CHANGE_RECEIPT_TYPES = (
+	ReceiptType.HARVEST_FEE,
+	ReceiptType.LOCK_HASH_CREATED,
+	ReceiptType.LOCK_HASH_COMPLETED,
+	ReceiptType.LOCK_HASH_EXPIRED,
+	ReceiptType.LOCK_SECRET_CREATED,
+	ReceiptType.LOCK_SECRET_COMPLETED,
+	ReceiptType.LOCK_SECRET_EXPIRED
+)
+BALANCE_TRANSFER_RECEIPT_TYPES = (
+	ReceiptType.MOSAIC_RENTAL_FEE,
+	ReceiptType.NAMESPACE_RENTAL_FEE
+)
+ARTIFACT_EXPIRY_RECEIPT_TYPES = (
+	ReceiptType.MOSAIC_EXPIRED,
+	ReceiptType.NAMESPACE_EXPIRED,
+	ReceiptType.NAMESPACE_DELETED
+)
+RECEIPT_TYPE_GROUPS = {
+	**{receipt_type.value: 'balanceChange' for receipt_type in BALANCE_CHANGE_RECEIPT_TYPES},
+	**{receipt_type.value: 'balanceTransfer' for receipt_type in BALANCE_TRANSFER_RECEIPT_TYPES},
+	**{receipt_type.value: 'artifactExpiry' for receipt_type in ARTIFACT_EXPIRY_RECEIPT_TYPES},
+	ReceiptType.INFLATION.value: 'inflation'
+}
+INFLATION_RECEIPT_TYPE = ReceiptType.INFLATION.value
+
+
+def _address_bytes_or_none(value):
+	return bytes.fromhex(value) if value else None
+
+
+def _str_or_none(value):
+	return str(value) if value is not None else None
+
+
+def _create_base_receipt_row(statement, source, receipt):
+	receipt_type = int(receipt['type'])
+
+	return {
+		'height': int(statement['height']),
+		'receipt_type': receipt_type,
+		'receipt_group': RECEIPT_TYPE_GROUPS[receipt_type],
+		'version': int(receipt['version']),
+		'source_primary_id': int(source['primaryId']),
+		'source_secondary_id': int(source['secondaryId']),
+		'sender_address': None,
+		'recipient_address': None,
+		'target_address': None,
+		'mosaic_id': None,
+		'amount': int(receipt.get('amount', 0)),
+		'artifact_id': None,
+		'raw_payload': receipt
+	}
+
+
+def _add_mosaic_fields(row, receipt):
+	row['mosaic_id'] = _str_or_none(receipt.get('mosaicId'))
+	row['amount'] = int(receipt.get('amount', 0))
+
+
+def create_receipt_rows(statement_item):
+	"""Creates persisted Symbol receipt rows from one transaction statement item."""
+
+	statement = statement_item['statement']
+	source = statement['source']
+	rows = []
+	for receipt in statement['receipts']:
+		receipt_type = int(receipt['type'])
+		if receipt_type not in RECEIPT_TYPE_GROUPS:
+			continue
+
+		row = _create_base_receipt_row(statement, source, receipt)
+		if 'balanceChange' == row['receipt_group']:
+			_add_mosaic_fields(row, receipt)
+			row['target_address'] = _address_bytes_or_none(receipt.get('targetAddress'))
+		elif 'balanceTransfer' == row['receipt_group']:
+			_add_mosaic_fields(row, receipt)
+			row['sender_address'] = _address_bytes_or_none(receipt.get('senderAddress'))
+			row['recipient_address'] = _address_bytes_or_none(receipt.get('recipientAddress'))
+		elif 'inflation' == row['receipt_group']:
+			_add_mosaic_fields(row, receipt)
+		elif 'artifactExpiry' == row['receipt_group']:
+			row['artifact_id'] = _str_or_none(receipt.get('artifactId'))
+
+		rows.append(row)
+
+	return rows

--- a/explorer/puller/puller/model/symbol/format.py
+++ b/explorer/puller/puller/model/symbol/format.py
@@ -13,6 +13,11 @@ def bytes_from_hex_or_none(value):
 	return bytes.fromhex(value) if value else None
 
 
+def str_or_none(value):
+	"""Converts an optional value to a str."""
+	return str(value) if value is not None else None
+
+
 def address_from_public_key(public_key, network):
 	"""Derives a Symbol address from raw public key bytes using the given network."""
 

--- a/explorer/puller/tests/db/test_SymbolDatabase.py
+++ b/explorer/puller/tests/db/test_SymbolDatabase.py
@@ -7,6 +7,7 @@ from unittest import TestCase
 from common.tests.PostgresTestUtils import PostgresTestDatabase, drop_symbol_block_tables_if_present
 from psycopg2 import Error as PsycopgError
 from psycopg2.extras import Json
+from symbolchain.sc import ReceiptType
 
 from puller.db.SymbolDatabase import SymbolDatabase
 
@@ -79,6 +80,27 @@ def _create_sync_state(**overrides):
 	return sync_state
 
 
+def _create_receipt(height, receipt_type=ReceiptType.INFLATION.value, **overrides):
+	receipt = {
+		'height': height,
+		'receipt_type': receipt_type,
+		'receipt_group': 'inflation',
+		'version': 1,
+		'source_primary_id': 0,
+		'source_secondary_id': 0,
+		'sender_address': None,
+		'recipient_address': None,
+		'target_address': None,
+		'mosaic_id': '72C0212E67A08BCE',
+		'amount': 100,
+		'artifact_id': None,
+		'raw_payload': {'type': receipt_type}
+	}
+	receipt.update(overrides)
+
+	return receipt
+
+
 class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 	def setUp(self):
 		self.exit_stack = ExitStack()
@@ -129,6 +151,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 
 		self.assertEqual([
 			'symbol_blocks',
+			'symbol_receipts',
 			'symbol_sync_state',
 			'symbol_transaction_addresses',
 			'symbol_transaction_mosaics',
@@ -225,6 +248,72 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		self.assertIn('idx_symbol_blocks_signer_address', indexes)
 		self.assertIn('idx_symbol_blocks_timestamp', indexes)
 
+	def test_create_tables_creates_symbol_receipt_indexes(self):
+		# Arrange:
+		database = self._create_uninitialized_database()
+		cursor = database.connection.cursor()
+
+		# Act:
+		database.create_tables()
+
+		# Assert:
+		cursor.execute(
+			'''
+			SELECT indexname, indexdef
+			FROM pg_indexes
+			WHERE schemaname = 'public'
+				AND tablename = 'symbol_receipts'
+			ORDER BY indexname
+			'''
+		)
+		indexes = cursor.fetchall()
+
+		self.assertEqual([
+			(
+				'idx_symbol_receipts_group_height',
+				'CREATE INDEX idx_symbol_receipts_group_height ON public.symbol_receipts USING btree (receipt_group, height DESC)'
+			),
+			(
+				'idx_symbol_receipts_height_type',
+				'CREATE INDEX idx_symbol_receipts_height_type ON public.symbol_receipts USING btree (height DESC, receipt_type)'
+			),
+			(
+				'idx_symbol_receipts_mosaic',
+				'CREATE INDEX idx_symbol_receipts_mosaic ON public.symbol_receipts USING btree (mosaic_id)'
+			),
+			(
+				'idx_symbol_receipts_recipient_group_height',
+				'CREATE INDEX idx_symbol_receipts_recipient_group_height ON public.symbol_receipts '
+				'USING btree (recipient_address, receipt_group, height DESC)'
+			),
+			(
+				'idx_symbol_receipts_sender_group_height',
+				'CREATE INDEX idx_symbol_receipts_sender_group_height ON public.symbol_receipts '
+				'USING btree (sender_address, receipt_group, height DESC)'
+			),
+			(
+				'idx_symbol_receipts_target',
+				'CREATE INDEX idx_symbol_receipts_target ON public.symbol_receipts USING btree (target_address)'
+			),
+			(
+				'idx_symbol_receipts_target_group_height',
+				'CREATE INDEX idx_symbol_receipts_target_group_height ON public.symbol_receipts '
+				'USING btree (target_address, receipt_group, height DESC)'
+			),
+			(
+				'idx_symbol_receipts_target_type_height',
+				'CREATE INDEX idx_symbol_receipts_target_type_height ON public.symbol_receipts USING btree (target_address, receipt_type, height DESC)'
+			),
+			(
+				'idx_symbol_receipts_type_height',
+				'CREATE INDEX idx_symbol_receipts_type_height ON public.symbol_receipts USING btree (receipt_type, height DESC)'
+			),
+			(
+				'symbol_receipts_pkey',
+				'CREATE UNIQUE INDEX symbol_receipts_pkey ON public.symbol_receipts USING btree (id)'
+			)
+		], indexes)
+
 	def test_create_tables_creates_symbol_block_columns_and_constraints(self):
 		# Arrange:
 		database = self._create_uninitialized_database()
@@ -288,6 +377,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 			('harvesting_eligible_accounts_count', 'int4', 'YES', None),
 			('total_voting_balance', 'int8', 'YES', None),
 			('previous_importance_block_hash', 'bytea', 'YES', None),
+			('block_reward', 'numeric', 'YES', None),
 			('raw_payload', 'jsonb', 'NO', None),
 			('created_at', 'timestamp', 'NO', 'CURRENT_TIMESTAMP'),
 			('updated_at', 'timestamp', 'NO', 'CURRENT_TIMESTAMP')
@@ -513,6 +603,61 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		sequences = cursor.fetchall()
 
 		self.assertEqual([('symbol_transaction_list_sequence_seq',)], sequences)
+
+	def test_create_tables_creates_symbol_receipt_columns_and_constraints(self):
+		# Arrange:
+		database = self._create_uninitialized_database()
+		cursor = database.connection.cursor()
+
+		# Act:
+		database.create_tables()
+
+		# Assert:
+		cursor.execute(
+			'''
+			SELECT column_name, udt_name, is_nullable, column_default
+			FROM information_schema.columns
+			WHERE table_name = 'symbol_receipts'
+			ORDER BY ordinal_position
+			'''
+		)
+		columns = cursor.fetchall()
+
+		cursor.execute(
+			'''
+			SELECT constraint_type, column_name
+			FROM information_schema.table_constraints
+			JOIN information_schema.key_column_usage USING (
+				constraint_name,
+				table_schema,
+				table_name
+			)
+			WHERE table_name = 'symbol_receipts'
+			ORDER BY constraint_type, column_name
+			'''
+		)
+		key_constraints = cursor.fetchall()
+
+		self.assertEqual([
+			('id', 'int8', 'NO', "nextval('symbol_receipts_id_seq'::regclass)"),
+			('height', 'int8', 'NO', None),
+			('receipt_type', 'int4', 'NO', None),
+			('receipt_group', 'varchar', 'NO', None),
+			('version', 'int4', 'NO', None),
+			('source_primary_id', 'int8', 'YES', None),
+			('source_secondary_id', 'int8', 'YES', None),
+			('sender_address', 'bytea', 'YES', None),
+			('recipient_address', 'bytea', 'YES', None),
+			('target_address', 'bytea', 'YES', None),
+			('mosaic_id', 'varchar', 'YES', None),
+			('amount', 'numeric', 'NO', '0'),
+			('artifact_id', 'varchar', 'YES', None),
+			('raw_payload', 'jsonb', 'NO', None)
+		], columns)
+		self.assertEqual([
+			('FOREIGN KEY', 'height'),
+			('PRIMARY KEY', 'id')
+		], key_constraints)
 
 	def test_check_connection_returns_true_when_sync_state_exists(self):
 		# Arrange:
@@ -752,6 +897,67 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		with self.assertRaises(PsycopgError):
 			database.upsert_blocks([_create_block(2, block_hash=b'same hash')])
 
+	def test_rejects_receipt_without_existing_block(self):
+		# Arrange:
+		database = self._create_database()
+
+		# Act + Assert:
+		with self.assertRaises(PsycopgError):
+			database.upsert_receipts_for_height(7, [_create_receipt(7)], 100)
+
+	def test_upsert_receipts_for_height_replaces_rows_and_updates_block_reward(self):
+		# Arrange:
+		database = self._create_database()
+		database.upsert_blocks([_create_block(1), _create_block(2)])
+		database.upsert_receipts_for_height(1, [
+			_create_receipt(1, amount=50),
+			_create_receipt(1, receipt_type=ReceiptType.MOSAIC_EXPIRED.value, receipt_group='artifactExpiry', mosaic_id=None, amount=0)
+		], 50)
+
+		# Act:
+		database.upsert_receipts_for_height(1, [
+			_create_receipt(1, amount=75, raw_payload={'type': ReceiptType.INFLATION.value, 'amount': '75'})
+		], 75)
+
+		# Assert:
+		cursor = database.connection.cursor()
+		cursor.execute(
+			'''
+			SELECT height, receipt_type, receipt_group, source_primary_id, source_secondary_id, mosaic_id, amount, raw_payload
+			FROM symbol_receipts
+			ORDER BY id
+			'''
+		)
+		receipts = cursor.fetchall()
+		cursor.execute('SELECT block_reward FROM symbol_blocks WHERE height = 1')
+		block_reward = cursor.fetchone()[0]
+
+		self.assertEqual([
+			(1, ReceiptType.INFLATION.value, 'inflation', 0, 0, '72C0212E67A08BCE', 75, {'type': ReceiptType.INFLATION.value, 'amount': '75'})
+		], [
+			(height, receipt_type, receipt_group, source_primary_id, source_secondary_id, mosaic_id, int(amount), raw_payload)
+			for height, receipt_type, receipt_group, source_primary_id, source_secondary_id, mosaic_id, amount, raw_payload in receipts
+		])
+		self.assertEqual(75, int(block_reward))
+
+	def test_upsert_receipts_for_height_stores_empty_height_with_zero_reward(self):
+		# Arrange:
+		database = self._create_database()
+		database.upsert_blocks([_create_block(1)])
+
+		# Act:
+		database.upsert_receipts_for_height(1, [], 0)
+
+		# Assert:
+		cursor = database.connection.cursor()
+		cursor.execute('SELECT COUNT(*) FROM symbol_receipts')
+		receipt_count = cursor.fetchone()[0]
+		cursor.execute('SELECT block_reward FROM symbol_blocks WHERE height = 1')
+		block_reward = cursor.fetchone()[0]
+
+		self.assertEqual(0, receipt_count)
+		self.assertEqual(0, int(block_reward))
+
 	def test_can_delete_blocks_from_height(self):
 		# Arrange:
 		database = self._create_database()
@@ -760,6 +966,8 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 			_create_block(2),
 			_create_block(3)
 		])
+		database.upsert_receipts_for_height(2, [_create_receipt(2)], 100)
+		database.upsert_receipts_for_height(3, [_create_receipt(3)], 100)
 
 		# Act:
 		database.delete_blocks_from_height(2)
@@ -767,9 +975,12 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		# Assert:
 		cursor = database.connection.cursor()
 		cursor.execute('SELECT height FROM symbol_blocks ORDER BY height')
-		results = cursor.fetchall()
+		block_results = cursor.fetchall()
+		cursor.execute('SELECT height FROM symbol_receipts ORDER BY height')
+		receipt_results = cursor.fetchall()
 
-		self.assertEqual([(1,)], results)
+		self.assertEqual([(1,)], block_results)
+		self.assertEqual([], receipt_results)
 
 	def test_upsert_transactions_for_height_computes_effective_fee(self):
 		# Arrange:
@@ -1010,6 +1221,8 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 			mosaic_rows=[{'mosaic_id': '1111111111111111', 'amount': 10, 'role': 'transfer', 'position': 0}],
 			address_rows=[{'address': b'rollbacked address', 'role': 'signer'}]
 		)])
+		database.upsert_receipts_for_height(2, [_create_receipt(2)], 100)
+		database.upsert_receipts_for_height(3, [_create_receipt(3)], 100)
 
 		# Act:
 		database.repair_rollback_from_height(2, _create_sync_state(
@@ -1028,12 +1241,15 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		mosaic_results = cursor.fetchall()
 		cursor.execute('SELECT height, encode(address, \'escape\'), role FROM symbol_transaction_addresses ORDER BY height')
 		address_results = cursor.fetchall()
+		cursor.execute('SELECT height FROM symbol_receipts ORDER BY height')
+		receipt_results = cursor.fetchall()
 		sync_state = database.get_sync_state()
 
 		self.assertEqual([(1,)], block_results)
 		self.assertEqual([(1, 'hash-kept')], transaction_results)
 		self.assertEqual([(1, '2222222222222222', 20, 'transfer')], mosaic_results)
 		self.assertEqual([(1, 'kept address', 'signer')], address_results)
+		self.assertEqual([], receipt_results)
 		self.assertEqual('repairing', sync_state['status'])
 		self.assertEqual(1, sync_state['last_synced_height'])
 		self.assertEqual(

--- a/explorer/puller/tests/db/test_SymbolDatabase.py
+++ b/explorer/puller/tests/db/test_SymbolDatabase.py
@@ -80,7 +80,7 @@ def _create_sync_state(**overrides):
 	return sync_state
 
 
-def _create_receipt(height, receipt_type=ReceiptType.INFLATION.value, **overrides):
+def _create_receipt(height, receipt_type='inflation', **overrides):
 	receipt = {
 		'height': height,
 		'receipt_type': receipt_type,
@@ -94,7 +94,7 @@ def _create_receipt(height, receipt_type=ReceiptType.INFLATION.value, **override
 		'mosaic_id': '72C0212E67A08BCE',
 		'amount': 100,
 		'artifact_id': None,
-		'raw_payload': {'type': receipt_type}
+		'raw_payload': {'type': ReceiptType.INFLATION.value}
 	}
 	receipt.update(overrides)
 
@@ -187,20 +187,6 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		)
 		status_type, status_default = cursor.fetchone()
 
-		cursor.execute(
-			'''
-			SELECT pg_type.typname, enumlabel
-			FROM pg_enum
-			JOIN pg_type ON pg_type.oid = pg_enum.enumtypid
-			WHERE pg_type.typname IN (
-				'symbol_block_type',
-				'symbol_sync_state_status'
-			)
-			ORDER BY pg_type.typname, enumsortorder
-			'''
-		)
-		enum_values = cursor.fetchall()
-
 		self.assertEqual([
 			('id', 'int4'),
 			('status', 'symbol_sync_state_status'),
@@ -215,10 +201,53 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		], sync_state_columns)
 		self.assertEqual('symbol_sync_state_status', status_type)
 		self.assertIsNone(status_default)
+
+	def test_create_tables_creates_enum_types(self):
+		# Arrange:
+		database = self._create_uninitialized_database()
+		cursor = database.connection.cursor()
+
+		# Act:
+		database.create_tables()
+
+		# Assert:
+		cursor.execute(
+			'''
+			SELECT pg_type.typname, enumlabel
+			FROM pg_enum
+			JOIN pg_type ON pg_type.oid = pg_enum.enumtypid
+			WHERE pg_type.typname IN (
+				'symbol_block_type',
+				'symbol_receipt_group',
+				'symbol_receipt_type',
+				'symbol_sync_state_status'
+			)
+			ORDER BY pg_type.typname, enumsortorder
+			'''
+		)
+		enum_values = cursor.fetchall()
+
 		self.assertEqual([
 			('symbol_block_type', 'nemesis'),
 			('symbol_block_type', 'importance'),
 			('symbol_block_type', 'normal'),
+			('symbol_receipt_group', 'balanceChange'),
+			('symbol_receipt_group', 'balanceTransfer'),
+			('symbol_receipt_group', 'artifactExpiry'),
+			('symbol_receipt_group', 'inflation'),
+			('symbol_receipt_type', 'mosaicRentalFee'),
+			('symbol_receipt_type', 'namespaceRentalFee'),
+			('symbol_receipt_type', 'harvestFee'),
+			('symbol_receipt_type', 'lockHashCompleted'),
+			('symbol_receipt_type', 'lockHashExpired'),
+			('symbol_receipt_type', 'lockSecretCompleted'),
+			('symbol_receipt_type', 'lockSecretExpired'),
+			('symbol_receipt_type', 'lockHashCreated'),
+			('symbol_receipt_type', 'lockSecretCreated'),
+			('symbol_receipt_type', 'mosaicExpired'),
+			('symbol_receipt_type', 'namespaceExpired'),
+			('symbol_receipt_type', 'namespaceDeleted'),
+			('symbol_receipt_type', 'inflation'),
 			('symbol_sync_state_status', 'initialized'),
 			('symbol_sync_state_status', 'healthy'),
 			('symbol_sync_state_status', 'repairing'),
@@ -641,8 +670,8 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		self.assertEqual([
 			('id', 'int8', 'NO', "nextval('symbol_receipts_id_seq'::regclass)"),
 			('height', 'int8', 'NO', None),
-			('receipt_type', 'int4', 'NO', None),
-			('receipt_group', 'varchar', 'NO', None),
+			('receipt_type', 'symbol_receipt_type', 'NO', None),
+			('receipt_group', 'symbol_receipt_group', 'NO', None),
 			('version', 'int4', 'NO', None),
 			('source_primary_id', 'int8', 'YES', None),
 			('source_secondary_id', 'int8', 'YES', None),
@@ -905,13 +934,31 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		with self.assertRaises(PsycopgError):
 			database.upsert_receipts_for_height(7, [_create_receipt(7)], 100)
 
+	def test_rejects_invalid_receipt_type(self):
+		# Arrange:
+		database = self._create_database()
+		database.upsert_blocks([_create_block(1)])
+
+		# Act + Assert:
+		with self.assertRaises(PsycopgError):
+			database.upsert_receipts_for_height(1, [_create_receipt(1, receipt_type='invalid')], 100)
+
+	def test_rejects_invalid_receipt_group(self):
+		# Arrange:
+		database = self._create_database()
+		database.upsert_blocks([_create_block(1)])
+
+		# Act + Assert:
+		with self.assertRaises(PsycopgError):
+			database.upsert_receipts_for_height(1, [_create_receipt(1, receipt_group='invalid')], 100)
+
 	def test_upsert_receipts_for_height_replaces_rows_and_updates_block_reward(self):
 		# Arrange:
 		database = self._create_database()
 		database.upsert_blocks([_create_block(1), _create_block(2)])
 		database.upsert_receipts_for_height(1, [
 			_create_receipt(1, amount=50),
-			_create_receipt(1, receipt_type=ReceiptType.MOSAIC_EXPIRED.value, receipt_group='artifactExpiry', mosaic_id=None, amount=0)
+			_create_receipt(1, receipt_type='mosaicExpired', receipt_group='artifactExpiry', mosaic_id=None, amount=0)
 		], 50)
 
 		# Act:
@@ -933,7 +980,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		block_reward = cursor.fetchone()[0]
 
 		self.assertEqual([
-			(1, ReceiptType.INFLATION.value, 'inflation', 0, 0, '72C0212E67A08BCE', 75, {'type': ReceiptType.INFLATION.value, 'amount': '75'})
+			(1, 'inflation', 'inflation', 0, 0, '72C0212E67A08BCE', 75, {'type': ReceiptType.INFLATION.value, 'amount': '75'})
 		], [
 			(height, receipt_type, receipt_group, source_primary_id, source_secondary_id, mosaic_id, int(amount), raw_payload)
 			for height, receipt_type, receipt_group, source_primary_id, source_secondary_id, mosaic_id, amount, raw_payload in receipts

--- a/explorer/puller/tests/db/test_SymbolDatabase.py
+++ b/explorer/puller/tests/db/test_SymbolDatabase.py
@@ -1265,6 +1265,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 			mosaic_rows=[{'mosaic_id': '1111111111111111', 'amount': 10, 'role': 'transfer', 'position': 0}],
 			address_rows=[{'address': b'rollbacked address', 'role': 'signer'}]
 		)])
+		database.upsert_receipts_for_height(1, [_create_receipt(1)], 100)
 		database.upsert_receipts_for_height(2, [_create_receipt(2)], 100)
 		database.upsert_receipts_for_height(3, [_create_receipt(3)], 100)
 
@@ -1287,13 +1288,16 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		address_results = cursor.fetchall()
 		cursor.execute('SELECT height FROM symbol_receipts ORDER BY height')
 		receipt_results = cursor.fetchall()
+		cursor.execute('SELECT height, block_reward FROM symbol_blocks ORDER BY height')
+		block_reward_results = cursor.fetchall()
 		sync_state = database.get_sync_state()
 
 		self.assertEqual([(1,)], block_results)
 		self.assertEqual([(1, 'hash-kept')], transaction_results)
 		self.assertEqual([(1, '2222222222222222', 20, 'transfer')], mosaic_results)
 		self.assertEqual([(1, 'kept address', 'signer')], address_results)
-		self.assertEqual([], receipt_results)
+		self.assertEqual([(1,)], receipt_results)
+		self.assertEqual([(1, 100)], block_reward_results)
 		self.assertEqual('repairing', sync_state['status'])
 		self.assertEqual(1, sync_state['last_synced_height'])
 		self.assertEqual(

--- a/explorer/puller/tests/db/test_SymbolDatabase.py
+++ b/explorer/puller/tests/db/test_SymbolDatabase.py
@@ -406,7 +406,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 			('harvesting_eligible_accounts_count', 'int4', 'YES', None),
 			('total_voting_balance', 'int8', 'YES', None),
 			('previous_importance_block_hash', 'bytea', 'YES', None),
-			('block_reward', 'numeric', 'YES', None),
+			('block_reward', 'int4', 'YES', None),
 			('raw_payload', 'jsonb', 'NO', None),
 			('created_at', 'timestamp', 'NO', 'CURRENT_TIMESTAMP'),
 			('updated_at', 'timestamp', 'NO', 'CURRENT_TIMESTAMP')
@@ -679,7 +679,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 			('recipient_address', 'bytea', 'YES', None),
 			('target_address', 'bytea', 'YES', None),
 			('mosaic_id', 'varchar', 'YES', None),
-			('amount', 'numeric', 'NO', '0'),
+			('amount', 'int8', 'NO', '0'),
 			('artifact_id', 'varchar', 'YES', None),
 			('raw_payload', 'jsonb', 'NO', None)
 		], columns)
@@ -981,11 +981,8 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 
 		self.assertEqual([
 			(1, 'inflation', 'inflation', 0, 0, '72C0212E67A08BCE', 75, {'type': ReceiptType.INFLATION.value, 'amount': '75'})
-		], [
-			(height, receipt_type, receipt_group, source_primary_id, source_secondary_id, mosaic_id, int(amount), raw_payload)
-			for height, receipt_type, receipt_group, source_primary_id, source_secondary_id, mosaic_id, amount, raw_payload in receipts
-		])
-		self.assertEqual(75, int(block_reward))
+		], receipts)
+		self.assertEqual(75, block_reward)
 
 	def test_upsert_receipts_for_height_stores_empty_height_with_zero_reward(self):
 		# Arrange:
@@ -1003,7 +1000,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		block_reward = cursor.fetchone()[0]
 
 		self.assertEqual(0, receipt_count)
-		self.assertEqual(0, int(block_reward))
+		self.assertEqual(0, block_reward)
 
 	def test_can_delete_blocks_from_height(self):
 		# Arrange:

--- a/explorer/puller/tests/facade/symbol/puller_test_utils.py
+++ b/explorer/puller/tests/facade/symbol/puller_test_utils.py
@@ -370,7 +370,7 @@ class SymbolPullerTestBase(TestCase):
 		cursor.execute('SELECT block_reward FROM symbol_blocks WHERE height = %s', (height,))
 
 		result = cursor.fetchone()
-		return result[0] if result and result[0] is not None else None
+		return result[0] if result else None
 
 	@staticmethod
 	def _fetch_receipts(database):

--- a/explorer/puller/tests/facade/symbol/puller_test_utils.py
+++ b/explorer/puller/tests/facade/symbol/puller_test_utils.py
@@ -6,9 +6,9 @@ from unittest import TestCase
 
 from common.symbol.NodeConfiguration import SymbolNodeConfiguration
 from common.tests.PostgresTestUtils import PostgresTestDatabase, drop_symbol_block_tables_if_present
-from symbolchain.sc import TransactionType
+from symbolchain.sc import ReceiptType, TransactionType
 
-from puller.facade.SymbolPuller import DatabaseConfiguration, SymbolPuller
+from puller.facade.SymbolPuller import STATEMENT_PAGE_SIZE, DatabaseConfiguration, SymbolPuller
 from puller.model.symbol.Block import create_block_row
 from tests.test.SymbolTestConstants import BENEFICIARY_ADDRESS, RECIPIENT_ADDRESS, SIGNER_PUBLIC_KEY
 
@@ -203,6 +203,30 @@ def transaction_path(start_height, end_height, page_number=1):
 	)
 
 
+def statement_path(start_height, end_height, page_number=1):
+	return (
+		f'statements/transaction?fromHeight={start_height}&toHeight={end_height}'
+		f'&pageSize={STATEMENT_PAGE_SIZE}&pageNumber={page_number}'
+	)
+
+
+def create_statement_item(height, amount, receipt_type=ReceiptType.INFLATION.value):
+	return {
+		'statement': {
+			'height': str(height),
+			'source': {'primaryId': height, 'secondaryId': 0},
+			'receipts': [{
+				'version': 1,
+				'type': receipt_type,
+				'mosaicId': '72C0212E67A08BCE',
+				'amount': str(amount)
+			}]
+		},
+		'id': f'statement-{height}-{amount}',
+		'meta': {'timestamp': '0'}
+	}
+
+
 def create_sync_state(**overrides):
 	sync_state = {
 		'status': 'healthy',
@@ -236,19 +260,21 @@ def create_network_properties(epoch_adjustment='100s'):
 
 
 class FakeConnector:
-	def __init__(
+	def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
 		self,
 		chain_height,
 		pages,
 		block_by_height=None,
 		finalized_height=1,
-		transactions_by_path=None
+		transactions_by_path=None,
+		statement_pages=None
 	):  # pylint: disable=too-many-arguments,too-many-positional-arguments
 		self.chain_height = chain_height
 		self.pages = pages
 		self.block_by_height = block_by_height or {}
 		self.finalized_height = finalized_height
 		self.transactions_by_path = transactions_by_path or {}
+		self.statement_pages = statement_pages or {}
 		self.paths = []
 
 	async def get(self, url_path, *_):
@@ -275,6 +301,8 @@ class FakeConnector:
 				raise response
 
 			return response
+		if url_path.startswith('statements/transaction?'):
+			return self.statement_pages.get(url_path, {'data': []})
 
 		raise KeyError(url_path)
 
@@ -335,6 +363,45 @@ class SymbolPullerTestBase(TestCase):
 		)
 
 		return cursor.fetchone()
+
+	@staticmethod
+	def _fetch_block_reward(database, height):
+		cursor = database.connection.cursor()
+		cursor.execute('SELECT block_reward FROM symbol_blocks WHERE height = %s', (height,))
+
+		result = cursor.fetchone()
+		return int(result[0]) if result and result[0] is not None else None
+
+	@staticmethod
+	def _fetch_receipts(database):
+		cursor = database.connection.cursor()
+		cursor.execute(
+			'''
+			SELECT
+				height,
+				receipt_type,
+				receipt_group,
+				source_primary_id,
+				source_secondary_id,
+				mosaic_id,
+				amount
+			FROM symbol_receipts
+			ORDER BY height, id
+			'''
+		)
+
+		return [
+			(
+				height,
+				receipt_type,
+				receipt_group,
+				source_primary_id,
+				source_secondary_id,
+				mosaic_id,
+				int(amount)
+			)
+			for height, receipt_type, receipt_group, source_primary_id, source_secondary_id, mosaic_id, amount in cursor.fetchall()
+		]
 
 	def _seed_blocks(self, database, heights, block_hashes=None):
 		block_hashes = block_hashes or {}

--- a/explorer/puller/tests/facade/symbol/puller_test_utils.py
+++ b/explorer/puller/tests/facade/symbol/puller_test_utils.py
@@ -370,7 +370,7 @@ class SymbolPullerTestBase(TestCase):
 		cursor.execute('SELECT block_reward FROM symbol_blocks WHERE height = %s', (height,))
 
 		result = cursor.fetchone()
-		return int(result[0]) if result and result[0] is not None else None
+		return result[0] if result and result[0] is not None else None
 
 	@staticmethod
 	def _fetch_receipts(database):
@@ -390,18 +390,7 @@ class SymbolPullerTestBase(TestCase):
 			'''
 		)
 
-		return [
-			(
-				height,
-				receipt_type,
-				receipt_group,
-				source_primary_id,
-				source_secondary_id,
-				mosaic_id,
-				int(amount)
-			)
-			for height, receipt_type, receipt_group, source_primary_id, source_secondary_id, mosaic_id, amount in cursor.fetchall()
-		]
+		return cursor.fetchall()
 
 	def _seed_blocks(self, database, heights, block_hashes=None):
 		block_hashes = block_hashes or {}

--- a/explorer/puller/tests/facade/symbol/puller_test_utils.py
+++ b/explorer/puller/tests/facade/symbol/puller_test_utils.py
@@ -8,7 +8,7 @@ from common.symbol.NodeConfiguration import SymbolNodeConfiguration
 from common.tests.PostgresTestUtils import PostgresTestDatabase, drop_symbol_block_tables_if_present
 from symbolchain.sc import ReceiptType, TransactionType
 
-from puller.facade.SymbolPuller import STATEMENT_PAGE_SIZE, DatabaseConfiguration, SymbolPuller
+from puller.facade.SymbolPuller import MAX_PAGE_SIZE, DatabaseConfiguration, SymbolPuller
 from puller.model.symbol.Block import create_block_row
 from tests.test.SymbolTestConstants import BENEFICIARY_ADDRESS, RECIPIENT_ADDRESS, SIGNER_PUBLIC_KEY
 
@@ -206,7 +206,7 @@ def transaction_path(start_height, end_height, page_number=1):
 def statement_path(start_height, end_height, page_number=1):
 	return (
 		f'statements/transaction?fromHeight={start_height}&toHeight={end_height}'
-		f'&pageSize={STATEMENT_PAGE_SIZE}&pageNumber={page_number}'
+		f'&pageSize={MAX_PAGE_SIZE}&pageNumber={page_number}'
 	)
 
 

--- a/explorer/puller/tests/facade/symbol/test_PullerRollback.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerRollback.py
@@ -1,8 +1,6 @@
 # pylint: disable=duplicate-code
 import asyncio
 
-from symbolchain.sc import ReceiptType
-
 from puller.facade.SymbolPuller import SymbolRollbackError
 
 from ...test.SymbolTestConstants import RECIPIENT_ADDRESS, SIGNER_ADDRESS
@@ -82,7 +80,7 @@ class SymbolPullerRollbackTest(SymbolPullerTestBase):
 		)
 		self.puller.symbol_db.upsert_receipts_for_height(2, [{
 			'height': 2,
-			'receipt_type': ReceiptType.INFLATION.value,
+			'receipt_type': 'inflation',
 			'receipt_group': 'inflation',
 			'version': 1,
 			'source_primary_id': 0,
@@ -113,8 +111,8 @@ class SymbolPullerRollbackTest(SymbolPullerTestBase):
 			block_hash
 		)
 		self.assertEqual([
-			(2, ReceiptType.INFLATION.value, 'inflation', 2, 0, '72C0212E67A08BCE', 222),
-			(3, ReceiptType.INFLATION.value, 'inflation', 3, 0, '72C0212E67A08BCE', 333)
+			(2, 'inflation', 'inflation', 2, 0, '72C0212E67A08BCE', 222),
+			(3, 'inflation', 'inflation', 3, 0, '72C0212E67A08BCE', 333)
 		], receipts)
 		self.assertEqual('healthy', sync_state['status'])
 		self.assertEqual(3, sync_state['last_synced_height'])

--- a/explorer/puller/tests/facade/symbol/test_PullerRollback.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerRollback.py
@@ -78,6 +78,8 @@ class SymbolPullerRollbackTest(SymbolPullerTestBase):
 			[1, 2, 3],
 			{2: b'local mismatch'.hex()}
 		)
+		# amount=999 here is a stale value that must be replaced by the real amount=222
+		# after repair — the full-list assertion below fails if this row survives.
 		self.puller.symbol_db.upsert_receipts_for_height(2, [{
 			'height': 2,
 			'receipt_type': 'inflation',

--- a/explorer/puller/tests/facade/symbol/test_PullerRollback.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerRollback.py
@@ -1,6 +1,8 @@
 # pylint: disable=duplicate-code
 import asyncio
 
+from symbolchain.sc import ReceiptType
+
 from puller.facade.SymbolPuller import SymbolRollbackError
 
 from ...test.SymbolTestConstants import RECIPIENT_ADDRESS, SIGNER_ADDRESS
@@ -10,8 +12,10 @@ from .puller_test_utils import (
 	SymbolPullerTestBase,
 	create_node_block,
 	create_node_transaction,
+	create_statement_item,
 	create_sync_state,
 	set_symbol_connector,
+	statement_path,
 	transaction_path
 )
 
@@ -61,13 +65,36 @@ class SymbolPullerRollbackTest(SymbolPullerTestBase):
 		connector = FakeConnector(
 			3,
 			{1: [create_node_block(2), create_node_block(3)]},
-			{2: create_node_block(2)}
+			{2: create_node_block(2)},
+			statement_pages={
+				statement_path(2, 3): {
+					'data': [
+						create_statement_item(2, 222),
+						create_statement_item(3, 333)
+					]
+				}
+			}
 		)
 		self._seed_blocks(
 			self.puller.symbol_db,
 			[1, 2, 3],
 			{2: b'local mismatch'.hex()}
 		)
+		self.puller.symbol_db.upsert_receipts_for_height(2, [{
+			'height': 2,
+			'receipt_type': ReceiptType.INFLATION.value,
+			'receipt_group': 'inflation',
+			'version': 1,
+			'source_primary_id': 0,
+			'source_secondary_id': 0,
+			'sender_address': None,
+			'recipient_address': None,
+			'target_address': None,
+			'mosaic_id': '72C0212E67A08BCE',
+			'amount': 999,
+			'artifact_id': None,
+			'raw_payload': {'amount': '999'}
+		}], 999)
 		self.puller.symbol_db.upsert_sync_state(create_sync_state())
 		set_symbol_connector(self.puller, connector)
 
@@ -77,6 +104,7 @@ class SymbolPullerRollbackTest(SymbolPullerTestBase):
 		# Assert:
 		block_heights = self._fetch_block_heights(self.puller.symbol_db)
 		block_hash = self._fetch_block_hash(self.puller.symbol_db, 2)
+		receipts = self._fetch_receipts(self.puller.symbol_db)
 		sync_state = self.puller.symbol_db.get_sync_state()
 
 		self.assertEqual([1, 2, 3], block_heights)
@@ -84,6 +112,10 @@ class SymbolPullerRollbackTest(SymbolPullerTestBase):
 			bytes.fromhex(f'{2:064X}'),
 			block_hash
 		)
+		self.assertEqual([
+			(2, ReceiptType.INFLATION.value, 'inflation', 2, 0, '72C0212E67A08BCE', 222),
+			(3, ReceiptType.INFLATION.value, 'inflation', 3, 0, '72C0212E67A08BCE', 333)
+		], receipts)
 		self.assertEqual('healthy', sync_state['status'])
 		self.assertEqual(3, sync_state['last_synced_height'])
 

--- a/explorer/puller/tests/facade/symbol/test_PullerSync.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerSync.py
@@ -122,12 +122,14 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 		# Assert:
 		block_paths = [path for path in connector.paths if path.startswith('blocks?')]
 		transaction_paths = [path for path in connector.paths if path.startswith('transactions/confirmed?')]
+		statement_paths = [path for path in connector.paths if path.startswith('statements/transaction?')]
 		self.assertEqual([
 			'blocks?pageSize=100&offset=0&orderBy=height',
 			'blocks?pageSize=100&offset=100&orderBy=height',
 			'blocks?pageSize=100&offset=200&orderBy=height'
 		], block_paths)
 		self.assertEqual(1, len(transaction_paths))
+		self.assertEqual([statement_path(1, 201)], statement_paths)
 		self.assertEqual(list(range(1, 202)), block_heights)
 		self.assertEqual(201, sync_state['last_synced_height'])
 
@@ -154,8 +156,10 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 		# Assert:
 		block_paths = [path for path in connector.paths if path.startswith('blocks?')]
 		transaction_paths = [path for path in connector.paths if path.startswith('transactions/confirmed?')]
+		statement_paths = [path for path in connector.paths if path.startswith('statements/transaction?')]
 		self.assertEqual(11, len(block_paths))
 		self.assertEqual(2, len(transaction_paths))
+		self.assertEqual([statement_path(1, 1000), statement_path(1001, chain_height)], statement_paths)
 		self.assertEqual(list(range(1, chain_height + 1)), block_heights)
 		self.assertEqual(chain_height, sync_state['last_synced_height'])
 		self.assertEqual('healthy', sync_state['status'])

--- a/explorer/puller/tests/facade/symbol/test_PullerSync.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerSync.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock
 from symbolchain.sc import ReceiptType
 from symbollightapi.model.Exceptions import NodeException
 
-from puller.facade.SymbolPuller import BLOCK_PAGE_FETCH_CONCURRENCY, STATEMENT_PAGE_SIZE
+from puller.facade.SymbolPuller import BLOCK_PAGE_FETCH_CONCURRENCY, MAX_PAGE_SIZE
 
 from .puller_test_utils import (
 	FakeConnector,
@@ -311,7 +311,7 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 			create_statement_item(2, 20),
 			*[
 				create_statement_item(3, index, ReceiptType.ADDRESS_ALIAS_RESOLUTION.value)
-				for index in range(STATEMENT_PAGE_SIZE - 2)
+				for index in range(MAX_PAGE_SIZE - 2)
 			]
 		]
 		connector = ResponseConnector({

--- a/explorer/puller/tests/facade/symbol/test_PullerSync.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerSync.py
@@ -336,6 +336,7 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 	def test_sync_block_batch_upserts_empty_heights_and_queries_batch_range(self):
 		# Arrange:
 		connector = ResponseConnector({
+			transaction_path(5, 7): {'data': []},
 			statement_path(5, 7): {'data': [create_statement_item(6, 600)]}
 		})
 		self._seed_blocks(self.puller.symbol_db, [5, 6, 7])
@@ -349,7 +350,7 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 		asyncio.run(self.puller._sync_block_batch(block_rows, 100))  # pylint: disable=protected-access
 
 		# Assert:
-		self.assertEqual([statement_path(5, 7)], connector.paths)
+		self.assertEqual([transaction_path(5, 7), statement_path(5, 7)], connector.paths)
 		self.assertEqual([
 			(6, 'inflation', 'inflation', 6, 0, '72C0212E67A08BCE', 600)
 		], self._fetch_receipts(self.puller.symbol_db))
@@ -371,6 +372,7 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 			},
 			'network/properties': {'network': {'epochAdjustment': '100s'}},
 			'blocks?pageSize=100&offset=0&orderBy=height': {'data': [create_node_block(1)]},
+			transaction_path(1, 1): {'data': []},
 			statement_path(1, 1): {'pagination': {'pageNumber': 1}}
 		})
 
@@ -421,6 +423,7 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 			},
 			'network/properties': {'network': {'epochAdjustment': '100s'}},
 			'blocks?pageSize=100&offset=0&orderBy=height': {'data': [create_node_block(1)]},
+			transaction_path(1, 1): {'data': []},
 			statement_path(1, 1): {
 				'code': 'InternalError',
 				'message': 'statement range failed'

--- a/explorer/puller/tests/facade/symbol/test_PullerSync.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerSync.py
@@ -351,7 +351,7 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 		# Assert:
 		self.assertEqual([statement_path(5, 7)], connector.paths)
 		self.assertEqual([
-			(6, ReceiptType.INFLATION.value, 'inflation', 6, 0, '72C0212E67A08BCE', 600)
+			(6, 'inflation', 'inflation', 6, 0, '72C0212E67A08BCE', 600)
 		], self._fetch_receipts(self.puller.symbol_db))
 		self.assertEqual(0, self._fetch_block_reward(self.puller.symbol_db, 5))
 		self.assertEqual(600, self._fetch_block_reward(self.puller.symbol_db, 6))
@@ -360,9 +360,9 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 	def test_calculate_block_reward_sums_only_inflation_receipts(self):
 		# Arrange:
 		receipts = [
-			{'receipt_type': ReceiptType.INFLATION.value, 'amount': 11},
-			{'receipt_type': ReceiptType.HARVEST_FEE.value, 'amount': 100},
-			{'receipt_type': ReceiptType.INFLATION.value, 'amount': 22}
+			{'receipt_type': 'inflation', 'amount': 11},
+			{'receipt_type': 'harvestFee', 'amount': 100},
+			{'receipt_type': 'inflation', 'amount': 22}
 		]
 
 		# Act:
@@ -374,7 +374,7 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 	def test_calculate_block_reward_returns_zero_when_inflation_receipts_are_absent(self):
 		# Arrange:
 		receipts = [
-			{'receipt_type': ReceiptType.HARVEST_FEE.value, 'amount': 100}
+			{'receipt_type': 'harvestFee', 'amount': 100}
 		]
 
 		# Act:

--- a/explorer/puller/tests/facade/symbol/test_PullerSync.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerSync.py
@@ -1,15 +1,21 @@
 import asyncio
 from unittest.mock import AsyncMock
 
-from puller.facade.SymbolPuller import BLOCK_PAGE_FETCH_CONCURRENCY
+from symbolchain.sc import ReceiptType
+from symbollightapi.model.Exceptions import NodeException
+
+from puller.facade.SymbolPuller import BLOCK_PAGE_FETCH_CONCURRENCY, STATEMENT_PAGE_SIZE
 
 from .puller_test_utils import (
 	FakeConnector,
+	ResponseConnector,
 	SymbolPullerTestBase,
 	create_node_block,
+	create_statement_item,
 	create_sync_state,
 	set_symbol_connector,
 	set_sync_block_pages,
+	statement_path,
 	transaction_path
 )
 
@@ -33,7 +39,8 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 			'chain/info',
 			'network/properties',
 			'blocks?pageSize=100&offset=0&orderBy=height',
-			transaction_path(1, 2)
+			transaction_path(1, 2),
+			statement_path(1, 2)
 		], connector.paths)
 
 	def test_sync_block_headers_persists_synced_block_watermark(self):
@@ -171,7 +178,8 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 			'chain/info',
 			'network/properties',
 			'blocks?pageSize=100&offset=0&orderBy=height',
-			transaction_path(1, 2)
+			transaction_path(1, 2),
+			statement_path(1, 2)
 		], connector.paths)
 		self.assertEqual([1, 2], block_heights)
 		self.assertEqual('healthy', sync_state['status'])
@@ -226,7 +234,8 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 			'network/properties',
 			'blocks/2',
 			'blocks?pageSize=100&offset=2&orderBy=height',
-			transaction_path(3, 4)
+			transaction_path(3, 4),
+			statement_path(3, 4)
 		], connector.paths)
 		self.assertEqual([1, 2, 3, 4], block_heights)
 		self.assertEqual('healthy', sync_state['status'])
@@ -287,6 +296,113 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 			'Unable to determine finalized hash for height 2'
 		):
 			asyncio.run(self.puller.sync_block_headers(max_height=2))
+
+		# Assert:
+		self.assertIsNone(self.puller.symbol_db.get_sync_state())
+
+	def test_get_receipt_rows_by_height_groups_rows_after_reading_all_pages(self):
+		# Arrange:
+		first_page = [
+			create_statement_item(1, 10),
+			create_statement_item(2, 20),
+			*[
+				create_statement_item(3, index, ReceiptType.ADDRESS_ALIAS_RESOLUTION.value)
+				for index in range(STATEMENT_PAGE_SIZE - 2)
+			]
+		]
+		connector = ResponseConnector({
+			statement_path(1, 3, 1): {'data': first_page},
+			statement_path(1, 3, 2): {'data': [create_statement_item(2, 30)]}
+		})
+		set_symbol_connector(self.puller, connector)
+
+		# Act:
+		rows_by_height = asyncio.run(self.puller._get_receipt_rows_by_height(1, 3))  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual([
+			statement_path(1, 3, 1),
+			statement_path(1, 3, 2)
+		], connector.paths)
+		self.assertEqual([1, 2], sorted(rows_by_height.keys()))
+		self.assertEqual([10], [row['amount'] for row in rows_by_height[1]])
+		self.assertEqual([20, 30], [row['amount'] for row in rows_by_height[2]])
+
+	def test_sync_receipts_for_batch_upserts_empty_heights_and_queries_batch_range(self):
+		# Arrange:
+		connector = ResponseConnector({
+			statement_path(5, 7): {'data': [create_statement_item(6, 600)]}
+		})
+		self._seed_blocks(self.puller.symbol_db, [5, 6, 7])
+		set_symbol_connector(self.puller, connector)
+		block_rows = [
+			{'height': 5},
+			{'height': 6},
+			{'height': 7}
+		]
+
+		# Act:
+		asyncio.run(self.puller._sync_receipts_for_batch(block_rows))  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual([statement_path(5, 7)], connector.paths)
+		self.assertEqual([
+			(6, ReceiptType.INFLATION.value, 'inflation', 6, 0, '72C0212E67A08BCE', 600)
+		], self._fetch_receipts(self.puller.symbol_db))
+		self.assertEqual(0, self._fetch_block_reward(self.puller.symbol_db, 5))
+		self.assertEqual(600, self._fetch_block_reward(self.puller.symbol_db, 6))
+		self.assertEqual(0, self._fetch_block_reward(self.puller.symbol_db, 7))
+
+	def test_calculate_block_reward_sums_only_inflation_receipts(self):
+		# Arrange:
+		receipts = [
+			{'receipt_type': ReceiptType.INFLATION.value, 'amount': 11},
+			{'receipt_type': ReceiptType.HARVEST_FEE.value, 'amount': 100},
+			{'receipt_type': ReceiptType.INFLATION.value, 'amount': 22}
+		]
+
+		# Act:
+		block_reward = self.puller._calculate_block_reward(receipts)  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual(33, block_reward)
+
+	def test_calculate_block_reward_returns_zero_when_inflation_receipts_are_absent(self):
+		# Arrange:
+		receipts = [
+			{'receipt_type': ReceiptType.HARVEST_FEE.value, 'amount': 100}
+		]
+
+		# Act:
+		block_reward = self.puller._calculate_block_reward(receipts)  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual(0, block_reward)
+
+	def test_sync_block_headers_does_not_advance_watermark_when_receipt_range_fetch_fails(self):
+		# Arrange:
+		connector = ResponseConnector({
+			'chain/info': {
+				'height': '1',
+				'latestFinalizedBlock': {
+					'finalizationEpoch': 4,
+					'finalizationPoint': 5,
+					'height': '1',
+					'hash': f'{1:064X}'
+				}
+			},
+			'network/properties': {'network': {'epochAdjustment': '100s'}},
+			'blocks?pageSize=100&offset=0&orderBy=height': {'data': [create_node_block(1)]},
+			statement_path(1, 1): {
+				'code': 'InternalError',
+				'message': 'statement range failed'
+			}
+		})
+		set_symbol_connector(self.puller, connector)
+
+		# Act / Assert:
+		with self.assertRaisesRegex(NodeException, 'InternalError: statement range failed'):
+			asyncio.run(self.puller.sync_block_headers())
 
 		# Assert:
 		self.assertIsNone(self.puller.symbol_db.get_sync_state())

--- a/explorer/puller/tests/facade/symbol/test_PullerSync.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerSync.py
@@ -5,6 +5,7 @@ from symbolchain.sc import ReceiptType
 from symbollightapi.model.Exceptions import NodeException
 
 from puller.facade.SymbolPuller import BLOCK_PAGE_FETCH_CONCURRENCY, MAX_PAGE_SIZE
+from puller.model.symbol.Block import create_block_row
 
 from .puller_test_utils import (
 	FakeConnector,
@@ -332,7 +333,7 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 		self.assertEqual([10], [row['amount'] for row in rows_by_height[1]])
 		self.assertEqual([20, 30], [row['amount'] for row in rows_by_height[2]])
 
-	def test_sync_receipts_for_batch_upserts_empty_heights_and_queries_batch_range(self):
+	def test_sync_block_batch_upserts_empty_heights_and_queries_batch_range(self):
 		# Arrange:
 		connector = ResponseConnector({
 			statement_path(5, 7): {'data': [create_statement_item(6, 600)]}
@@ -340,13 +341,12 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 		self._seed_blocks(self.puller.symbol_db, [5, 6, 7])
 		set_symbol_connector(self.puller, connector)
 		block_rows = [
-			{'height': 5},
-			{'height': 6},
-			{'height': 7}
+			create_block_row(create_node_block(height), 100, self.puller.symbol_facade.network)
+			for height in [5, 6, 7]
 		]
 
 		# Act:
-		asyncio.run(self.puller._sync_receipts_for_batch(block_rows))  # pylint: disable=protected-access
+		asyncio.run(self.puller._sync_block_batch(block_rows, 100))  # pylint: disable=protected-access
 
 		# Assert:
 		self.assertEqual([statement_path(5, 7)], connector.paths)
@@ -356,6 +356,30 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 		self.assertEqual(0, self._fetch_block_reward(self.puller.symbol_db, 5))
 		self.assertEqual(600, self._fetch_block_reward(self.puller.symbol_db, 6))
 		self.assertEqual(0, self._fetch_block_reward(self.puller.symbol_db, 7))
+
+	def test_sync_block_headers_rejects_malformed_statement_page_response(self):
+		# Arrange:
+		connector = ResponseConnector({
+			'chain/info': {
+				'height': '1',
+				'latestFinalizedBlock': {
+					'finalizationEpoch': 4,
+					'finalizationPoint': 5,
+					'height': '1',
+					'hash': f'{1:064X}'
+				}
+			},
+			'network/properties': {'network': {'epochAdjustment': '100s'}},
+			'blocks?pageSize=100&offset=0&orderBy=height': {'data': [create_node_block(1)]},
+			statement_path(1, 1): {'pagination': {'pageNumber': 1}}
+		})
+
+		# Act / Assert:
+		self._assert_sync_rejects_node_response(
+			connector,
+			ValueError,
+			'Malformed Symbol statement page response'
+		)
 
 	def test_calculate_block_reward_sums_only_inflation_receipts(self):
 		# Arrange:
@@ -409,4 +433,5 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 			asyncio.run(self.puller.sync_block_headers())
 
 		# Assert:
+		self.assertEqual([], self._fetch_block_heights(self.puller.symbol_db))
 		self.assertIsNone(self.puller.symbol_db.get_sync_state())

--- a/explorer/puller/tests/facade/symbol/test_PullerSync.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerSync.py
@@ -129,7 +129,7 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 			'blocks?pageSize=100&offset=100&orderBy=height',
 			'blocks?pageSize=100&offset=200&orderBy=height'
 		], block_paths)
-		self.assertEqual(1, len(transaction_paths))
+		self.assertEqual([transaction_path(1, 201)], transaction_paths)
 		self.assertEqual([statement_path(1, 201)], statement_paths)
 		self.assertEqual(list(range(1, 202)), block_heights)
 		self.assertEqual(201, sync_state['last_synced_height'])

--- a/explorer/puller/tests/facade/symbol/test_PullerTransactionSync.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerTransactionSync.py
@@ -10,6 +10,7 @@ from .puller_test_utils import (
 	create_node_transaction,
 	create_sync_state,
 	set_symbol_connector,
+	statement_path,
 	transaction_path
 )
 
@@ -27,6 +28,9 @@ class FakeTransactionDatabase:
 
 	def upsert_transactions_for_height(self, height, transaction_rows):
 		self.calls.append((height, transaction_rows))
+
+	def upsert_receipts_for_height(self, height, receipt_rows, block_reward):
+		pass
 
 
 class SymbolPullerTransactionSyncTest(SymbolPullerTestBase):
@@ -160,7 +164,7 @@ class SymbolPullerTransactionSyncTest(SymbolPullerTestBase):
 		asyncio.run(self.puller._sync_block_batch(block_rows, 100))  # pylint: disable=protected-access
 
 		# Assert:
-		self.assertEqual([transaction_path(10, 12)], connector.paths)
+		self.assertEqual([transaction_path(10, 12), statement_path(10, 12)], connector.paths)
 
 	def test_sync_block_headers_keeps_existing_watermark_when_transaction_fetch_fails(self):
 		# Arrange:

--- a/explorer/puller/tests/model/symbol/test_Receipt.py
+++ b/explorer/puller/tests/model/symbol/test_Receipt.py
@@ -1,8 +1,9 @@
+# pylint: disable=duplicate-code
 from unittest import TestCase
 
 from symbolchain.sc import ReceiptType
 
-from puller.model.symbol.Receipt import INFLATION_RECEIPT_TYPE, RECEIPT_TYPE_GROUPS, create_receipt_rows
+from puller.model.symbol.Receipt import INFLATION_RECEIPT_TYPE, RECEIPT_TYPE_GROUPS, RECEIPT_TYPE_LABELS, create_receipt_rows
 
 TARGET_ADDRESS = '98' * 24
 SENDER_ADDRESS = '99' * 24
@@ -39,7 +40,25 @@ class ReceiptTest(TestCase):
 			ReceiptType.NAMESPACE_DELETED.value: 'artifactExpiry',
 			ReceiptType.INFLATION.value: 'inflation'
 		}, RECEIPT_TYPE_GROUPS)
-		self.assertEqual(ReceiptType.INFLATION.value, INFLATION_RECEIPT_TYPE)
+
+	def test_receipt_type_labels_maps_supported_types_to_documented_labels(self):
+		# Arrange / Act / Assert:
+		self.assertEqual({
+			ReceiptType.MOSAIC_RENTAL_FEE.value: 'mosaicRentalFee',
+			ReceiptType.NAMESPACE_RENTAL_FEE.value: 'namespaceRentalFee',
+			ReceiptType.HARVEST_FEE.value: 'harvestFee',
+			ReceiptType.LOCK_HASH_COMPLETED.value: 'lockHashCompleted',
+			ReceiptType.LOCK_HASH_EXPIRED.value: 'lockHashExpired',
+			ReceiptType.LOCK_SECRET_COMPLETED.value: 'lockSecretCompleted',
+			ReceiptType.LOCK_SECRET_EXPIRED.value: 'lockSecretExpired',
+			ReceiptType.LOCK_HASH_CREATED.value: 'lockHashCreated',
+			ReceiptType.LOCK_SECRET_CREATED.value: 'lockSecretCreated',
+			ReceiptType.MOSAIC_EXPIRED.value: 'mosaicExpired',
+			ReceiptType.NAMESPACE_EXPIRED.value: 'namespaceExpired',
+			ReceiptType.NAMESPACE_DELETED.value: 'namespaceDeleted',
+			ReceiptType.INFLATION.value: 'inflation'
+		}, RECEIPT_TYPE_LABELS)
+		self.assertEqual('inflation', INFLATION_RECEIPT_TYPE)
 
 	def test_create_receipt_rows_populates_balance_change_fields(self):
 		# Arrange:
@@ -57,7 +76,7 @@ class ReceiptTest(TestCase):
 		# Assert:
 		self.assertEqual([{
 			'height': 12,
-			'receipt_type': ReceiptType.HARVEST_FEE.value,
+			'receipt_type': 'harvestFee',
 			'receipt_group': 'balanceChange',
 			'version': 1,
 			'source_primary_id': 7,
@@ -103,7 +122,7 @@ class ReceiptTest(TestCase):
 		# Assert:
 		self.assertEqual([{
 			'height': 12,
-			'receipt_type': ReceiptType.MOSAIC_RENTAL_FEE.value,
+			'receipt_type': 'mosaicRentalFee',
 			'receipt_group': 'balanceTransfer',
 			'version': 1,
 			'source_primary_id': 7,
@@ -131,7 +150,7 @@ class ReceiptTest(TestCase):
 		# Assert:
 		self.assertEqual([{
 			'height': 12,
-			'receipt_type': ReceiptType.NAMESPACE_EXPIRED.value,
+			'receipt_type': 'namespaceExpired',
 			'receipt_group': 'artifactExpiry',
 			'version': 1,
 			'source_primary_id': 7,
@@ -160,7 +179,7 @@ class ReceiptTest(TestCase):
 		# Assert:
 		self.assertEqual([{
 			'height': 12,
-			'receipt_type': ReceiptType.INFLATION.value,
+			'receipt_type': 'inflation',
 			'receipt_group': 'inflation',
 			'version': 1,
 			'source_primary_id': 7,

--- a/explorer/puller/tests/model/symbol/test_Receipt.py
+++ b/explorer/puller/tests/model/symbol/test_Receipt.py
@@ -1,0 +1,216 @@
+from unittest import TestCase
+
+from symbolchain.sc import ReceiptType
+
+from puller.model.symbol.Receipt import INFLATION_RECEIPT_TYPE, RECEIPT_TYPE_GROUPS, create_receipt_rows
+
+TARGET_ADDRESS = '98' * 24
+SENDER_ADDRESS = '99' * 24
+RECIPIENT_ADDRESS = '9A' * 24
+
+
+def _create_statement_item(receipts, **overrides):
+	statement = {
+		'height': '12',
+		'source': {'primaryId': 7, 'secondaryId': 3},
+		'receipts': receipts
+	}
+	statement.update(overrides)
+
+	return {'statement': statement, 'id': 'statement-id', 'meta': {'timestamp': '0'}}
+
+
+class ReceiptTest(TestCase):
+
+	def test_receipt_type_groups_maps_supported_types_to_documented_groups(self):
+		# Arrange / Act / Assert:
+		self.assertEqual({
+			ReceiptType.HARVEST_FEE.value: 'balanceChange',
+			ReceiptType.LOCK_HASH_CREATED.value: 'balanceChange',
+			ReceiptType.LOCK_HASH_COMPLETED.value: 'balanceChange',
+			ReceiptType.LOCK_HASH_EXPIRED.value: 'balanceChange',
+			ReceiptType.LOCK_SECRET_CREATED.value: 'balanceChange',
+			ReceiptType.LOCK_SECRET_COMPLETED.value: 'balanceChange',
+			ReceiptType.LOCK_SECRET_EXPIRED.value: 'balanceChange',
+			ReceiptType.MOSAIC_RENTAL_FEE.value: 'balanceTransfer',
+			ReceiptType.NAMESPACE_RENTAL_FEE.value: 'balanceTransfer',
+			ReceiptType.MOSAIC_EXPIRED.value: 'artifactExpiry',
+			ReceiptType.NAMESPACE_EXPIRED.value: 'artifactExpiry',
+			ReceiptType.NAMESPACE_DELETED.value: 'artifactExpiry',
+			ReceiptType.INFLATION.value: 'inflation'
+		}, RECEIPT_TYPE_GROUPS)
+		self.assertEqual(ReceiptType.INFLATION.value, INFLATION_RECEIPT_TYPE)
+
+	def test_create_receipt_rows_populates_balance_change_fields(self):
+		# Arrange:
+		statement_item = _create_statement_item([{
+			'version': 1,
+			'type': ReceiptType.HARVEST_FEE.value,
+			'targetAddress': TARGET_ADDRESS,
+			'mosaicId': '72C0212E67A08BCE',
+			'amount': '123'
+		}])
+
+		# Act:
+		rows = create_receipt_rows(statement_item)
+
+		# Assert:
+		self.assertEqual([{
+			'height': 12,
+			'receipt_type': ReceiptType.HARVEST_FEE.value,
+			'receipt_group': 'balanceChange',
+			'version': 1,
+			'source_primary_id': 7,
+			'source_secondary_id': 3,
+			'sender_address': None,
+			'recipient_address': None,
+			'target_address': bytes.fromhex(TARGET_ADDRESS),
+			'mosaic_id': '72C0212E67A08BCE',
+			'amount': 123,
+			'artifact_id': None,
+			'raw_payload': statement_item['statement']['receipts'][0]
+		}], rows)
+
+	def test_create_receipt_rows_allows_missing_balance_change_address(self):
+		# Arrange:
+		statement_item = _create_statement_item([{
+			'version': 1,
+			'type': ReceiptType.HARVEST_FEE.value,
+			'mosaicId': '72C0212E67A08BCE',
+			'amount': '123'
+		}])
+
+		# Act:
+		rows = create_receipt_rows(statement_item)
+
+		# Assert:
+		self.assertIsNone(rows[0]['target_address'])
+
+	def test_create_receipt_rows_populates_balance_transfer_fields(self):
+		# Arrange:
+		statement_item = _create_statement_item([{
+			'version': 1,
+			'type': ReceiptType.MOSAIC_RENTAL_FEE.value,
+			'senderAddress': SENDER_ADDRESS,
+			'recipientAddress': RECIPIENT_ADDRESS,
+			'mosaicId': '72C0212E67A08BCE',
+			'amount': '456'
+		}])
+
+		# Act:
+		rows = create_receipt_rows(statement_item)
+
+		# Assert:
+		self.assertEqual([{
+			'height': 12,
+			'receipt_type': ReceiptType.MOSAIC_RENTAL_FEE.value,
+			'receipt_group': 'balanceTransfer',
+			'version': 1,
+			'source_primary_id': 7,
+			'source_secondary_id': 3,
+			'sender_address': bytes.fromhex(SENDER_ADDRESS),
+			'recipient_address': bytes.fromhex(RECIPIENT_ADDRESS),
+			'target_address': None,
+			'mosaic_id': '72C0212E67A08BCE',
+			'amount': 456,
+			'artifact_id': None,
+			'raw_payload': statement_item['statement']['receipts'][0]
+		}], rows)
+
+	def test_create_receipt_rows_populates_artifact_expiry_fields(self):
+		# Arrange:
+		statement_item = _create_statement_item([{
+			'version': 1,
+			'type': ReceiptType.NAMESPACE_EXPIRED.value,
+			'artifactId': 'ABCDEF0123456789'
+		}])
+
+		# Act:
+		rows = create_receipt_rows(statement_item)
+
+		# Assert:
+		self.assertEqual([{
+			'height': 12,
+			'receipt_type': ReceiptType.NAMESPACE_EXPIRED.value,
+			'receipt_group': 'artifactExpiry',
+			'version': 1,
+			'source_primary_id': 7,
+			'source_secondary_id': 3,
+			'sender_address': None,
+			'recipient_address': None,
+			'target_address': None,
+			'mosaic_id': None,
+			'amount': 0,
+			'artifact_id': 'ABCDEF0123456789',
+			'raw_payload': statement_item['statement']['receipts'][0]
+		}], rows)
+
+	def test_create_receipt_rows_populates_inflation_fields(self):
+		# Arrange:
+		statement_item = _create_statement_item([{
+			'version': 1,
+			'type': ReceiptType.INFLATION.value,
+			'mosaicId': '72C0212E67A08BCE',
+			'amount': '789'
+		}])
+
+		# Act:
+		rows = create_receipt_rows(statement_item)
+
+		# Assert:
+		self.assertEqual([{
+			'height': 12,
+			'receipt_type': ReceiptType.INFLATION.value,
+			'receipt_group': 'inflation',
+			'version': 1,
+			'source_primary_id': 7,
+			'source_secondary_id': 3,
+			'sender_address': None,
+			'recipient_address': None,
+			'target_address': None,
+			'mosaic_id': '72C0212E67A08BCE',
+			'amount': 789,
+			'artifact_id': None,
+			'raw_payload': statement_item['statement']['receipts'][0]
+		}], rows)
+
+	def test_create_receipt_rows_skips_unsupported_receipts(self):
+		# Arrange:
+		statement_item = _create_statement_item([{
+			'version': 1,
+			'type': ReceiptType.ADDRESS_ALIAS_RESOLUTION.value
+		}])
+
+		# Act:
+		rows = create_receipt_rows(statement_item)
+
+		# Assert:
+		self.assertEqual([], rows)
+
+	def test_create_receipt_rows_uses_statement_source_for_all_receipts(self):
+		# Arrange:
+		statement_item = _create_statement_item([
+			{
+				'version': 1,
+				'type': ReceiptType.INFLATION.value,
+				'mosaicId': '72C0212E67A08BCE',
+				'amount': '1'
+			},
+			{
+				'version': 1,
+				'type': ReceiptType.MOSAIC_EXPIRED.value,
+				'artifactId': 'ABCDEF0123456789'
+			}
+		])
+
+		# Act:
+		rows = create_receipt_rows(statement_item)
+
+		# Assert:
+		self.assertEqual([
+			(7, 3),
+			(7, 3)
+		], [
+			(row['source_primary_id'], row['source_secondary_id'])
+			for row in rows
+		])

--- a/explorer/puller/tests/model/symbol/test_Receipt.py
+++ b/explorer/puller/tests/model/symbol/test_Receipt.py
@@ -227,9 +227,9 @@ class ReceiptTest(TestCase):
 
 		# Assert:
 		self.assertEqual([
-			(7, 3),
-			(7, 3)
+			(12, 7, 3),
+			(12, 7, 3)
 		], [
-			(row['source_primary_id'], row['source_secondary_id'])
+			(row['height'], row['source_primary_id'], row['source_secondary_id'])
 			for row in rows
 		])

--- a/explorer/puller/tests/model/symbol/test_format.py
+++ b/explorer/puller/tests/model/symbol/test_format.py
@@ -9,6 +9,7 @@ from puller.model.symbol.format import (
 	camel_case_enum_name,
 	int_or_none,
 	label_for_type,
+	str_or_none,
 	timestamp_from_network_value
 )
 from tests.test.SymbolTestConstants import SIGNER_ADDRESS, SIGNER_PUBLIC_KEY
@@ -25,6 +26,11 @@ class SymbolFormatTest(TestCase):
 		self.assertEqual(bytes.fromhex('0a0b'), bytes_from_hex_or_none('0a0b'))
 		self.assertIsNone(bytes_from_hex_or_none(None))
 		self.assertIsNone(bytes_from_hex_or_none(''))
+
+	def test_can_convert_optional_str(self):
+		# Act + Assert:
+		self.assertEqual('123', str_or_none(123))
+		self.assertIsNone(str_or_none(None))
 
 	def test_can_camel_case_multi_word_enum_name(self):
 		# Act + Assert:


### PR DESCRIPTION
## Summary

- Add a `symbol_receipts` table and `puller/model/symbol/Receipt.py` to　persist receipts from Symbol Node's `/statements/transaction` endpoint.　Each receipt is classified into one of four groups　(`balanceChange`/`balanceTransfer`/`artifactExpiry`/`inflation`) based on its Symbol receipt type, with group-specific fields populated (mosaic/amount, sender/recipient/target address, or artifact id)
- Add `symbol_blocks.block_reward`, computed as the sum of a height's inflation-receipt amounts and written back once that height's receipts are synced
- Sync receipts as part of the existing block-sync loop: after each batch of blocks is persisted, fetch and group the corresponding receipt statements by height. Statement pages are fully accumulated before grouping, so a height whose statements span two pages isn't split
- Extend rollback to delete `symbol_receipts` rows before `symbol_blocks` (the foreign key has no cascading delete, so the deletion order matters)
- `receipt_type`/`receipt_group` are Postgres enum columns rather than freeform text/int; `amount`/`block_reward` are integer columns, not `numeric`, since Symbol raw-unit amounts fit comfortably in a 64-bit integer without the overhead of arbitrary-precision arithmetic
- Consolidate the page-size constant used for both block and statement pagination into a single `MAX_PAGE_SIZE`, and reuse a shared optional-value formatting module instead of duplicating small string/bytes conversion helpers

## Note on base branch

This PR targets `explorer/backend/symbol-block-model-refactor` instead of `dev` because it depends on that branch's block-row/format-helper extraction (`puller/model/symbol/Block.py`, `puller/model/symbol/format.py`), which hasn't merged to `dev` yet (see #2379 ). Once that PR merges, GitHub will offer to retarget this PR's base to `dev` automatically.
