### PR TITLE
[lightapi] feat: Keep NEM transfer message semantics in lightapi by exposing the original message type

### DIFF
--- a/lightapi/python/symbollightapi/model/Transaction.py
+++ b/lightapi/python/symbollightapi/model/Transaction.py
@@ -1,12 +1,12 @@
 from collections import namedtuple
 
 from symbolchain.CryptoTypes import PublicKey
-from symbolchain.nc import MessageType, TransactionType
+from symbolchain.nc import TransactionType
 from symbolchain.nem.Network import Address
 
 from ..model.Exceptions import UnknownTransactionType
 
-Message = namedtuple('Message', ['payload', 'is_plain'])
+Message = namedtuple('Message', ['payload', 'type'])
 Mosaic = namedtuple('Mosaic', ['namespace_name', 'quantity'])
 Modification = namedtuple('Modification', ['modification_type', 'cosignatory_account'])
 MosaicLevy = namedtuple('MosaicLevy', ['fee', 'recipient', 'type', 'namespace_name'])
@@ -447,7 +447,7 @@ class TransactionHandler:
 		if message:
 			message = Message(
 				message['payload'],
-				message.get('type') == MessageType.PLAIN.value
+				message['type']
 			)
 		else:
 			message = None

--- a/lightapi/python/symbollightapi/model/Transaction.py
+++ b/lightapi/python/symbollightapi/model/Transaction.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 
 from symbolchain.CryptoTypes import PublicKey
-from symbolchain.nc import TransactionType
+from symbolchain.nc import MessageType, TransactionType
 from symbolchain.nem.Network import Address
 
 from ..model.Exceptions import UnknownTransactionType
@@ -447,7 +447,7 @@ class TransactionHandler:
 		if message:
 			message = Message(
 				message['payload'],
-				message['type']
+				message.get('type') == MessageType.PLAIN.value
 			)
 		else:
 			message = None

--- a/lightapi/python/tests/connector/test_NemConnector.py
+++ b/lightapi/python/tests/connector/test_NemConnector.py
@@ -6,7 +6,7 @@ import pytest
 from aiohttp import web
 from symbolchain.CryptoTypes import Hash256, PublicKey
 from symbolchain.facade.NemFacade import NemFacade
-from symbolchain.nc import Signature
+from symbolchain.nc import MessageType, Signature
 from symbolchain.nem.Network import Address, Network
 
 from symbollightapi.connector.NemConnector import NemConnector
@@ -1273,7 +1273,7 @@ EXPECTED_BLOCK_2 = Block(
 			1,
 			180000040000000,
 			Address('NCOPERAWEWCD4A34NP5UQCCKEX44MW4SL3QYJYS5'),
-			Message('476f6f64206c75636b21', True),
+			Message('476f6f64206c75636b21', MessageType.PLAIN.value),
 			None
 		),
 		MultisigAccountModificationTransaction(

--- a/lightapi/python/tests/connector/test_NemConnector.py
+++ b/lightapi/python/tests/connector/test_NemConnector.py
@@ -18,6 +18,7 @@ from symbollightapi.model.NodeInfo import NodeInfo
 from symbollightapi.model.Transaction import (
 	AccountKeyLinkTransaction,
 	CosignSignatureTransaction,
+	Message,
 	MosaicDefinitionTransaction,
 	MosaicSupplyChangeTransaction,
 	MultisigAccountModificationTransaction,
@@ -1272,7 +1273,7 @@ EXPECTED_BLOCK_2 = Block(
 			1,
 			180000040000000,
 			Address('NCOPERAWEWCD4A34NP5UQCCKEX44MW4SL3QYJYS5'),
-			('476f6f64206c75636b21', 1),
+			Message('476f6f64206c75636b21', True),
 			None
 		),
 		MultisigAccountModificationTransaction(

--- a/lightapi/python/tests/model/test_Transaction.py
+++ b/lightapi/python/tests/model/test_Transaction.py
@@ -420,19 +420,19 @@ class TransactionHandlerTest(unittest.TestCase):
 		}
 		return TransactionHandler().map[TransactionType.TRANSFER.value](tx_json)
 
-	def test_maps_plain_message_type_to_is_plain_true(self):
+	def test_maps_plain_message_type(self):
 		# Arrange + Act:
 		mapped_args = self._map_transfer({'payload': '48656C6C6F', 'type': MessageType.PLAIN.value})
 
 		# Assert:
-		self.assertEqual(Message('48656C6C6F', True), mapped_args['message'])
+		self.assertEqual(Message('48656C6C6F', MessageType.PLAIN.value), mapped_args['message'])
 
-	def test_maps_encrypted_message_type_to_is_plain_false(self):
+	def test_maps_encrypted_message_type(self):
 		# Arrange + Act:
 		mapped_args = self._map_transfer({'payload': 'ABCD', 'type': MessageType.ENCRYPTED.value})
 
 		# Assert:
-		self.assertEqual(Message('ABCD', False), mapped_args['message'])
+		self.assertEqual(Message('ABCD', MessageType.ENCRYPTED.value), mapped_args['message'])
 
 	def test_maps_missing_message_to_none(self):
 		# Arrange + Act:

--- a/lightapi/python/tests/model/test_Transaction.py
+++ b/lightapi/python/tests/model/test_Transaction.py
@@ -1,6 +1,6 @@
 import unittest
 
-from symbolchain.nc import TransactionType
+from symbolchain.nc import MessageType, TransactionType
 
 from symbollightapi.model.Exceptions import UnknownTransactionType
 from symbollightapi.model.Transaction import (
@@ -17,6 +17,7 @@ from symbollightapi.model.Transaction import (
 	MultisigTransaction,
 	NamespaceRegistrationTransaction,
 	TransactionFactory,
+	TransactionHandler,
 	TransferTransaction
 )
 
@@ -407,3 +408,39 @@ class TransactionFactoryTest(unittest.TestCase):
 		# Arrange + Act:
 		with self.assertRaises(UnknownTransactionType):
 			TransactionFactory.create_transaction(123, COMMON_ARGS, {})
+
+
+class TransactionHandlerTest(unittest.TestCase):
+	def test_map_transfer_args_sets_is_plain_true_when_message_type_is_1(self):
+		# Arrange:
+		tx_json = {
+			'amount': 1,
+			'recipient': 'NCOPERAWEWCD4A34NP5UQCCKEX44MW4SL3QYJYS5',
+			'message': {
+				'payload': '48656C6C6F',
+				'type': MessageType.PLAIN.value
+			}
+		}
+
+		# Act:
+		mapped_args = TransactionHandler._map_transfer_args(tx_json)
+
+		# Assert:
+		self.assertEqual(Message('48656C6C6F', True), mapped_args['message'])
+
+	def test_map_transfer_args_sets_is_plain_false_for_non_plain_type(self):
+		# Arrange:
+		tx_json = {
+			'amount': 1,
+			'recipient': 'NCOPERAWEWCD4A34NP5UQCCKEX44MW4SL3QYJYS5',
+			'message': {
+				'payload': 'ABCD',
+				'type': MessageType.ENCRYPTED.value
+			}
+		}
+
+		# Act:
+		mapped_args = TransactionHandler._map_transfer_args(tx_json)
+
+		# Assert:
+		self.assertEqual(Message('ABCD', False), mapped_args['message'])

--- a/lightapi/python/tests/model/test_Transaction.py
+++ b/lightapi/python/tests/model/test_Transaction.py
@@ -411,36 +411,32 @@ class TransactionFactoryTest(unittest.TestCase):
 
 
 class TransactionHandlerTest(unittest.TestCase):
-	def test_map_transfer_args_sets_is_plain_true_when_message_type_is_1(self):
-		# Arrange:
+	@staticmethod
+	def _map_transfer(message):
 		tx_json = {
 			'amount': 1,
 			'recipient': 'NCOPERAWEWCD4A34NP5UQCCKEX44MW4SL3QYJYS5',
-			'message': {
-				'payload': '48656C6C6F',
-				'type': MessageType.PLAIN.value
-			}
+			'message': message
 		}
+		return TransactionHandler().map[TransactionType.TRANSFER.value](tx_json)
 
-		# Act:
-		mapped_args = TransactionHandler._map_transfer_args(tx_json)
+	def test_maps_plain_message_type_to_is_plain_true(self):
+		# Arrange + Act:
+		mapped_args = self._map_transfer({'payload': '48656C6C6F', 'type': MessageType.PLAIN.value})
 
 		# Assert:
 		self.assertEqual(Message('48656C6C6F', True), mapped_args['message'])
 
-	def test_map_transfer_args_sets_is_plain_false_for_non_plain_type(self):
-		# Arrange:
-		tx_json = {
-			'amount': 1,
-			'recipient': 'NCOPERAWEWCD4A34NP5UQCCKEX44MW4SL3QYJYS5',
-			'message': {
-				'payload': 'ABCD',
-				'type': MessageType.ENCRYPTED.value
-			}
-		}
-
-		# Act:
-		mapped_args = TransactionHandler._map_transfer_args(tx_json)
+	def test_maps_encrypted_message_type_to_is_plain_false(self):
+		# Arrange + Act:
+		mapped_args = self._map_transfer({'payload': 'ABCD', 'type': MessageType.ENCRYPTED.value})
 
 		# Assert:
 		self.assertEqual(Message('ABCD', False), mapped_args['message'])
+
+	def test_maps_missing_message_to_none(self):
+		# Arrange + Act:
+		mapped_args = self._map_transfer(None)
+
+		# Assert:
+		self.assertIsNone(mapped_args['message'])


### PR DESCRIPTION
## Summary
- Keep NEM transfer message semantics in lightapi by exposing the original message type in Message objects instead of a derived boolean.
- Rename the transfer message field from is_plain to type in lightapi mapping (1 = plain, 2 = encrypted).
- Update lightapi tests to validate message type mapping for plain and encrypted transfer messages.
- Use `MessageType.PLAIN` instead of forwarding the raw NEM message type integer (`1` / `2`).

## Motivation
A boolean is_plain loses message-type information and makes downstream handling brittle if new NEM message types appear in the future. Keeping the raw type in lightapi preserves protocol semantics and centralizes interpretation in Explorer/UI logic while maintaining a clear migration path for already persisted data.

Issue: https://github.com/symbol/product/issues/2352