### PR TITLE
[explorer/puller] fix: process account updates when a transferred mosaic has levy receipient.

### DIFF
--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -408,6 +408,26 @@ class NemDatabase(DatabaseConnection):
 		return [AccountRefreshRecord(record[0], Address(record[1])) for record in results]
 
 	@staticmethod
+	def get_mosaic_levy_recipients(cursor, namespace_names):
+		"""Gets levy recipient addresses for mosaics."""
+
+		if not namespace_names:
+			return []
+
+		cursor.execute(
+			'''
+			SELECT levy_recipient
+			FROM mosaics
+			WHERE namespace_name = ANY(%s)
+				AND levy_recipient IS NOT NULL
+			''',
+			(list(namespace_names),)
+		)
+		results = cursor.fetchall()
+
+		return [Address(record[0]) for record in results]
+
+	@staticmethod
 	def upsert_account(cursor, account_info):
 		"""Insert or update account information."""
 

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -165,10 +165,11 @@ class NemPuller:
 
 		return self.nem_facade.network.public_key_to_address(PublicKey(public_key))
 
-	def _extract_addresses_from_block(self, block):
+	def _extract_addresses_from_block(self, cursor, block):
 		"""Extract address and public key from block and transactions."""
 
 		addresses = set()
+		transferred_mosaic_names = set()  # track transferred mosaic names for levy recipient lookup
 
 		public_key_fields = ['sender', 'remote_account', 'creator']
 		address_fields = ['recipient', 'rental_fee_sink', 'creation_fee_sink']
@@ -191,6 +192,11 @@ class NemPuller:
 			if levy:
 				addresses.add(str(Address(levy.recipient)))
 
+			if transaction.transaction_type == TransactionType.TRANSFER.value and transaction.mosaics:
+				for mosaic in transaction.mosaics:
+					if mosaic.namespace_name != 'nem.xem':
+						transferred_mosaic_names.add(mosaic.namespace_name)
+
 			# Handle multisig signatures
 			if hasattr(transaction, 'signatures'):
 				for signature in transaction.signatures:
@@ -211,6 +217,9 @@ class NemPuller:
 
 			if hasattr(transaction, 'other_transaction'):
 				_extract_from_transaction(transaction.other_transaction)
+
+		for recipient in self.nem_db.get_mosaic_levy_recipients(cursor, transferred_mosaic_names):
+			addresses.add(str(recipient))
 
 		return addresses
 
@@ -572,7 +581,7 @@ class NemPuller:
 
 		self._process_block(cursor, nemesis_block)
 
-		addresses = self._extract_addresses_from_block(nemesis_block)
+		addresses = self._extract_addresses_from_block(cursor, nemesis_block)
 		await self._process_account_batch(cursor, {address: nemesis_block.height for address in addresses})
 
 		self._process_transactions(cursor, nemesis_block.transactions, nemesis_block.height)
@@ -611,7 +620,7 @@ class NemPuller:
 			processed += 1
 
 			# Extract addresses for account processing
-			addresses = self._extract_addresses_from_block(block)
+			addresses = self._extract_addresses_from_block(cursor, block)
 			self._add_pending_addresses(pending_addresses, addresses, block.height)
 
 			# Track beneficiary harvested fees

--- a/explorer/puller/tests/db/test_NemDatabase.py
+++ b/explorer/puller/tests/db/test_NemDatabase.py
@@ -592,6 +592,41 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			'TALICE6XEEEOBFJVY3ZCENZ7WBG6LB4KB7P7KMQX'
 		])
 
+	def test_can_get_mosaic_levy_recipients(self):
+		# Arrange:
+		levy_recipient = Address('TBRYCNWZINEVNITUESKUMFIENWKYCRUGNE63PMQQ')
+		mosaics = [
+			MOSAICS[0]._replace(
+				root_namespace='namespace',
+				namespace_name='namespace.test',
+				levy_type=1,
+				levy_namespace_name='nem.xem',
+				levy_fee=500,
+				levy_recipient=levy_recipient
+			),
+			MOSAICS[0]._replace(
+				root_namespace='namespace',
+				namespace_name='namespace.no_levy'
+			)
+		]
+
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+
+			cursor = nem_database.connection.cursor()
+			for mosaic in mosaics:
+				nem_database.upsert_mosaic(cursor, mosaic)
+
+			nem_database.connection.commit()
+
+			# Act:
+			empty_results = nem_database.get_mosaic_levy_recipients(cursor, set())
+			results = nem_database.get_mosaic_levy_recipients(cursor, set(['namespace.test', 'namespace.no_levy', 'namespace.missing']))
+
+		# Assert:
+		self.assertEqual(empty_results, [])
+		self.assertEqual([str(result) for result in results], [str(levy_recipient)])
+
 	def test_can_update_vested_balance_and_importance(self):
 		# Arrange:
 		with NemDatabase(self.db_config) as nem_database:

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -727,6 +727,8 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			83397,
 			'e0cc7f71e353ca0aaf2f009d74aeac5f97d4796b0f08c009058fb33d93c2e8ca'
 			'68c0b63e46ff125f43314014d324ac032d2c82996a6e47068b251f1d71fdd001',
+			202,
+			2,
 			1999999,
 			recipient,
 			None,

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -665,22 +665,29 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		self.assertEqual(result, mosaics)
 		mock_account_mosaics.assert_called_once_with(address)
 
-	def test_can_extract_addresses_from_block_with_only_signer(self):
+	@patch('puller.facade.NemPuller.NemDatabase.get_mosaic_levy_recipients')
+	def test_can_extract_addresses_from_block_with_only_signer(self, mock_get_mosaic_levy_recipients):
 		# Arrange:
 		block = NEM_CONNECTOR_RESPONSE_BLOCKS[1]
+		cursor = Mock()
+		mock_get_mosaic_levy_recipients.return_value = []
 
 		# Act:
-		addresses = self.puller._extract_addresses_from_block(block)  # pylint: disable=protected-access
+		addresses = self.puller._extract_addresses_from_block(cursor, block)  # pylint: disable=protected-access
 
 		# Assert:
 		self.assertEqual(addresses, {'TALICE6XEEEOBFJVY3ZCENZ7WBG6LB4KB7P7KMQX'})
+		mock_get_mosaic_levy_recipients.assert_called_once_with(cursor, set())
 
-	def test_can_extract_addresses_from_block(self):
+	@patch('puller.facade.NemPuller.NemDatabase.get_mosaic_levy_recipients')
+	def test_can_extract_addresses_from_block(self, mock_get_mosaic_levy_recipients):
 		# Arrange:
 		block = NEM_CONNECTOR_RESPONSE_BLOCKS[2]
+		cursor = Mock()
+		mock_get_mosaic_levy_recipients.return_value = []
 
 		# Act:
-		addresses = self.puller._extract_addresses_from_block(block)  # pylint: disable=protected-access
+		addresses = self.puller._extract_addresses_from_block(cursor, block)  # pylint: disable=protected-access
 
 		# Assert:
 		self.assertEqual(addresses, {
@@ -703,6 +710,57 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			'TBEM6SFOHU5PORIGAVG3NNJIMCG73R2TWH35O2VF',
 			'TADMEHCFJD45GPTDL4HZP2LJLZVAZRLYWY2K4OOH'
 		})
+		mock_get_mosaic_levy_recipients.assert_called_once_with(cursor, set())
+
+	@patch('puller.facade.NemPuller.NemDatabase.get_mosaic_levy_recipients')
+	def test_can_extract_levy_recipient_addresses_from_transfer_mosaics(self, mock_get_mosaic_levy_recipients):
+		# Arrange:
+		sender = PublicKey('8d07f90fb4bbe7715fa327c926770166a11be2e494a970605f2e12557f66c9b9')
+		recipient = Address('NCOPERAWEWCD4A34NP5UQCCKEX44MW4SL3QYJYS5')
+		levy_recipient = Address('TBRYCNWZINEVNITUESKUMFIENWKYCRUGNE63PMQQ')
+		transaction = TransferTransaction(
+			'd6c9902cfa23dbbdd212d720f86391dd91d215bf77d806f03a6c2dd2e730628a',
+			3,
+			sender,
+			9000000,
+			73397,
+			83397,
+			'e0cc7f71e353ca0aaf2f009d74aeac5f97d4796b0f08c009058fb33d93c2e8ca'
+			'68c0b63e46ff125f43314014d324ac032d2c82996a6e47068b251f1d71fdd001',
+			1999999,
+			recipient,
+			None,
+			[
+				Mosaic('namespace.test', 20),
+				Mosaic('nem.xem', 8000000)
+			]
+		)
+		block = Block(
+			3,
+			73976,
+			[transaction],
+			300,
+			'1dd9d4d7b6af603d29c082f9aa4e123f07d18154ddbcd7ddc6702491b854c5e4',
+			9000000,
+			recipient,
+			sender,
+			'fdf6a9830e9320af79123f467fcb03d6beab735575ff50eab363d812c5581436'
+			'2ad7be0503db2ee70e60ac3408d83cdbcbd941067a6df703e0c21c7bf389f105',
+			345
+		)
+		cursor = Mock()
+		mock_get_mosaic_levy_recipients.return_value = [levy_recipient]
+
+		# Act:
+		addresses = self.puller._extract_addresses_from_block(cursor, block)  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual(addresses, {
+			str(self.puller.nem_facade.network.public_key_to_address(sender)),
+			str(recipient),
+			str(levy_recipient)
+		})
+		mock_get_mosaic_levy_recipients.assert_called_once_with(cursor, {'namespace.test'})
 
 	@staticmethod
 	def _exclude_account_status(account):


### PR DESCRIPTION
Problem: Currently, the levy recipient is missed when mosaics are transferred. https://github.com/symbol/product/issues/2354
Solution: Added logic to check the levy recipient of each transferred mosaic and extract the recipient’s address for account processing.