### PR TITLE
[explorer/puller] fix: widen symbol_blocks.total_fee to bigint to avoid overflow

### DIFF
--- a/explorer/puller/puller/db/SymbolDatabase.py
+++ b/explorer/puller/puller/db/SymbolDatabase.py
@@ -43,7 +43,7 @@ SYMBOL_BLOCK_DEFINITIONS = [
 	'previous_hash bytea NOT NULL',
 	'timestamp timestamp NOT NULL',
 	'network_timestamp bigint NOT NULL',
-	'total_fee int NOT NULL',
+	'total_fee bigint NOT NULL',
 	'transactions_count int NOT NULL',
 	'total_transactions_count int NOT NULL',
 	'statements_count int NOT NULL',

--- a/explorer/puller/tests/db/test_SymbolDatabase.py
+++ b/explorer/puller/tests/db/test_SymbolDatabase.py
@@ -20,19 +20,22 @@ DatabaseConfig = namedtuple(
 
 def _create_block(height, block_hash=None, **overrides):
 	block_hash = block_hash or f'hash {height}'.encode('utf8')
-
-	block = {
-		'height': height,
-		'hash': block_hash,
-		'previous_hash': f'previous {height}'.encode('utf8'),
-		'timestamp': datetime.datetime(
+	timestamp = overrides.pop('timestamp', None)
+	if timestamp is None:
+		timestamp = datetime.datetime(
 			2026,
 			1,
 			1,
 			0,
 			height,
 			tzinfo=datetime.timezone.utc
-		),
+		)
+
+	block = {
+		'height': height,
+		'hash': block_hash,
+		'previous_hash': f'previous {height}'.encode('utf8'),
+		'timestamp': timestamp,
 		'network_timestamp': height * 1000,
 		'total_fee': height * 100,
 		'transactions_count': height,
@@ -383,7 +386,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 			('previous_hash', 'bytea', 'NO', None),
 			('timestamp', 'timestamp', 'NO', None),
 			('network_timestamp', 'int8', 'NO', None),
-			('total_fee', 'int4', 'NO', None),
+			('total_fee', 'int8', 'NO', None),
 			('transactions_count', 'int4', 'NO', None),
 			('total_transactions_count', 'int4', 'NO', None),
 			('statements_count', 'int4', 'NO', None),
@@ -891,6 +894,31 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		self.assertEqual(19000235663367, result[2])
 		self.assertEqual(bytes.fromhex('86' * 32), bytes(result[3]))
 		self.assertEqual('nemesis', result[4])
+
+	def test_can_upsert_block_when_total_fee_exceeds_int4(self):
+		# Arrange:
+		database = self._create_database()
+		large_total_fee = 13199992608
+
+		# Act:
+		database.upsert_blocks([_create_block(
+			6224,
+			timestamp=datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc),
+			total_fee=large_total_fee
+		)])
+
+		# Assert:
+		cursor = database.connection.cursor()
+		cursor.execute(
+			'''
+			SELECT total_fee
+			FROM symbol_blocks
+			WHERE height = 6224
+			'''
+		)
+		result = cursor.fetchone()
+
+		self.assertEqual((large_total_fee,), result)
 
 	def test_can_update_existing_block(self):
 		# Arrange:


### PR DESCRIPTION
## Problem

`symbol_blocks.total_fee` was defined as `int` (PostgreSQL `integer`, max ~2.1B). Live-node validation against testnet (`https://401-sai-dual.symboltest.net:3001`) found a real block (height 6224) with `totalFee = 13199992608`, which exceeds that range and made `upsert_blocks` fail with `psycopg2.errors.NumericValueOutOfRange`.

`total_fee` sums fees across every transaction in a block, so unlike per-transaction fee fields it can plausibly exceed `int4` on a block with many/large-fee transactions.

## Solution

Widen `total_fee` to `bigint`, matching the existing `difficulty`/`total_voting_balance` columns.

## Test plan

- [x] `test_create_tables_creates_symbol_block_columns_and_constraints` updated to expect `int8`
- [x] New regression test `test_can_upsert_block_when_total_fee_exceeds_int4`, using the real observed value (height 6224, `13199992608`)
- [x] `cd explorer/puller && PYTHONPATH=.:.. python -m pytest tests/ -v` — 231 passed
- [x] `bash scripts/ci/lint.sh` — 10.00/10
- [x] 100% patch coverage on changed lines
