### PR TITLE
[explorer/puller] feat: add Symbol accounts core current-state persistence

### DIFF
--- a/explorer/common/tests/PostgresTestUtils.py
+++ b/explorer/common/tests/PostgresTestUtils.py
@@ -41,11 +41,15 @@ def drop_symbol_block_tables_if_present(database):
 	cursor.execute('DROP TABLE IF EXISTS symbol_transaction_addresses')
 	cursor.execute('DROP TABLE IF EXISTS symbol_transactions')
 	cursor.execute('DROP TABLE IF EXISTS symbol_receipts')
+	cursor.execute('DROP TABLE IF EXISTS symbol_multisig')
+	cursor.execute('DROP TABLE IF EXISTS symbol_account_mosaics')
+	cursor.execute('DROP TABLE IF EXISTS symbol_accounts')
 	cursor.execute('DROP TABLE IF EXISTS symbol_blocks')
 	cursor.execute('DROP TABLE IF EXISTS symbol_sync_state')
 	cursor.execute('DROP SEQUENCE IF EXISTS symbol_transaction_list_sequence_seq')
 	cursor.execute('DROP TYPE IF EXISTS symbol_sync_state_status')
 	cursor.execute('DROP TYPE IF EXISTS symbol_block_type')
+	cursor.execute('DROP TYPE IF EXISTS symbol_account_type')
 	database.connection.commit()
 
 

--- a/explorer/puller/puller/db/SymbolDatabase.py
+++ b/explorer/puller/puller/db/SymbolDatabase.py
@@ -334,11 +334,10 @@ class SymbolDatabase(DatabaseConnection):
 				sync_state['last_synced_block_hash']
 			])
 
-	def upsert_account_current_state(  # pylint: disable=too-many-arguments
+	def upsert_account_current_state(
 		self,
 		account_row,
 		mosaic_rows,
-		overwrite_importance_percentage=False,
 		overwrite_is_harvesting_active=True
 	):
 		"""Upserts one Symbol account current-state row and replaces its current mosaic rows."""
@@ -348,16 +347,14 @@ class SymbolDatabase(DatabaseConnection):
 			cursor,
 			account_row,
 			mosaic_rows,
-			overwrite_importance_percentage,
 			overwrite_is_harvesting_active)
 		self.connection.commit()
 
 	@staticmethod
-	def _execute_upsert_account_current_state(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+	def _execute_upsert_account_current_state(
 		cursor,
 		account_row,
 		mosaic_rows,
-		overwrite_importance_percentage=False,
 		overwrite_is_harvesting_active=True
 	):
 		update_columns = [
@@ -375,8 +372,6 @@ class SymbolDatabase(DatabaseConnection):
 			'raw_payload',
 			'last_seen_height'
 		]
-		if overwrite_importance_percentage:
-			update_columns.append('importance_percentage')
 		if overwrite_is_harvesting_active:
 			update_columns.append('is_harvesting_active')
 

--- a/explorer/puller/puller/db/SymbolDatabase.py
+++ b/explorer/puller/puller/db/SymbolDatabase.py
@@ -338,7 +338,7 @@ class SymbolDatabase(DatabaseConnection):
 		self,
 		account_row,
 		mosaic_rows,
-		overwrite_importance_percentage=True,
+		overwrite_importance_percentage=False,
 		overwrite_is_harvesting_active=True
 	):
 		"""Upserts one Symbol account current-state row and replaces its current mosaic rows."""
@@ -357,8 +357,8 @@ class SymbolDatabase(DatabaseConnection):
 		cursor,
 		account_row,
 		mosaic_rows,
-		overwrite_importance_percentage,
-		overwrite_is_harvesting_active
+		overwrite_importance_percentage=False,
+		overwrite_is_harvesting_active=True
 	):
 		update_columns = [
 			'address_text',

--- a/explorer/puller/puller/db/SymbolDatabase.py
+++ b/explorer/puller/puller/db/SymbolDatabase.py
@@ -508,24 +508,27 @@ class SymbolDatabase(DatabaseConnection):
 		"""Deletes blocks from the supplied height for rollback repair."""
 
 		cursor = self.connection.cursor()
-		self._delete_blocks_and_transactions_from_height(cursor, height)
+		self._delete_rollback_affected_rows_from_height(cursor, height)
 		self.connection.commit()
 
 	def repair_rollback_from_height(self, height, sync_state):
 		"""Deletes rollbacked blocks and updates sync state in one transaction."""
 
 		cursor = self.connection.cursor()
-		self._delete_blocks_and_transactions_from_height(cursor, height)
+		self._delete_rollback_affected_rows_from_height(cursor, height)
 		self._execute_upsert_sync_state(cursor, sync_state)
 		self.connection.commit()
 
 	@staticmethod
-	def _delete_blocks_and_transactions_from_height(cursor, height):
+	def _delete_rollback_affected_rows_from_height(cursor, height):
 		cursor.execute('DELETE FROM symbol_transaction_mosaics WHERE height >= %s', (height,))
 		cursor.execute('DELETE FROM symbol_transaction_addresses WHERE height >= %s', (height,))
 		cursor.execute('DELETE FROM symbol_transactions WHERE height >= %s', (height,))
 		cursor.execute('DELETE FROM symbol_receipts WHERE height >= %s', (height,))
 		cursor.execute('DELETE FROM symbol_blocks WHERE height >= %s', (height,))
+		cursor.execute('DELETE FROM symbol_multisig WHERE updated_at_height >= %s', (height,))
+		cursor.execute('DELETE FROM symbol_account_mosaics WHERE updated_at_height >= %s', (height,))
+		cursor.execute('DELETE FROM symbol_accounts WHERE last_seen_height >= %s', (height,))
 
 	def upsert_transactions_for_height(self, height, transaction_entries):
 		"""Replaces persisted Symbol transactions and child index rows for one height."""

--- a/explorer/puller/puller/db/SymbolDatabase.py
+++ b/explorer/puller/puller/db/SymbolDatabase.py
@@ -1,5 +1,6 @@
 from psycopg2.extras import Json
 
+from puller.model.symbol.Account import ACCOUNT_TYPE_VALUES
 from puller.model.symbol.Block import BLOCK_TYPE_VALUES
 from puller.model.symbol.Receipt import RECEIPT_TYPE_LABELS
 from puller.model.symbol.Transaction import MESSAGE_TYPE_LABELS, TRANSACTION_TYPE_LABELS
@@ -70,6 +71,41 @@ SYMBOL_BLOCK_DEFINITIONS = [
 	'raw_payload jsonb NOT NULL',
 	'created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP',
 	'updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP'
+]
+SYMBOL_ACCOUNT_DEFINITIONS = [
+	'address bytea PRIMARY KEY',
+	'address_text varchar(39) UNIQUE NOT NULL',
+	'public_key bytea UNIQUE',
+	'account_type symbol_account_type',
+	'address_height bigint',
+	'importance bigint NOT NULL DEFAULT 0',
+	'importance_percentage numeric NOT NULL DEFAULT 0',
+	'is_harvesting_active boolean',
+	'is_eligible_for_harvesting boolean',
+	'linked_public_key bytea',
+	'node_public_key bytea',
+	'vrf_public_key bytea',
+	"voting_public_keys jsonb NOT NULL DEFAULT '[]'::jsonb",
+	"activity_buckets jsonb NOT NULL DEFAULT '[]'::jsonb",
+	'raw_payload jsonb NOT NULL',
+	'first_seen_height bigint',
+	'last_seen_height bigint NOT NULL',
+	'updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP'
+]
+SYMBOL_ACCOUNT_MOSAIC_DEFINITIONS = [
+	'address bytea NOT NULL REFERENCES symbol_accounts(address)',
+	'mosaic_id varchar(16) NOT NULL',
+	'amount bigint NOT NULL',
+	'updated_at_height bigint NOT NULL',
+	'PRIMARY KEY (address, mosaic_id)'
+]
+SYMBOL_MULTISIG_DEFINITIONS = [
+	'address bytea PRIMARY KEY REFERENCES symbol_accounts(address)',
+	'min_approval int NOT NULL',
+	'min_removal int NOT NULL',
+	"cosignatory_addresses bytea[] NOT NULL DEFAULT '{}'",
+	"multisig_addresses bytea[] NOT NULL DEFAULT '{}'",
+	'updated_at_height bigint NOT NULL'
 ]
 SYMBOL_TRANSACTION_DEFINITIONS = [
 	'id bigserial PRIMARY KEY',
@@ -169,6 +205,7 @@ class SymbolDatabase(DatabaseConnection):
 		"""Creates Symbol block synchronization tables."""
 
 		cursor = self.connection.cursor()
+		_create_enum_type(cursor, 'symbol_account_type', ACCOUNT_TYPE_VALUES)
 		_create_enum_type(cursor, 'symbol_block_type', BLOCK_TYPE_VALUES)
 		_create_enum_type(cursor, 'symbol_receipt_type', SYMBOL_RECEIPT_TYPE_VALUES)
 		_create_enum_type(cursor, 'symbol_receipt_group', SYMBOL_RECEIPT_GROUP_VALUES)
@@ -179,6 +216,9 @@ class SymbolDatabase(DatabaseConnection):
 		_create_enum_type(cursor, 'symbol_transaction_message_type', SYMBOL_TRANSACTION_MESSAGE_TYPE_VALUES)
 		_create_table(cursor, 'symbol_sync_state', SYMBOL_SYNC_STATE_DEFINITIONS)
 		_create_table(cursor, 'symbol_blocks', SYMBOL_BLOCK_DEFINITIONS)
+		_create_table(cursor, 'symbol_accounts', SYMBOL_ACCOUNT_DEFINITIONS)
+		_create_table(cursor, 'symbol_account_mosaics', SYMBOL_ACCOUNT_MOSAIC_DEFINITIONS)
+		_create_table(cursor, 'symbol_multisig', SYMBOL_MULTISIG_DEFINITIONS)
 		cursor.execute('CREATE SEQUENCE IF NOT EXISTS symbol_transaction_list_sequence_seq')
 		_create_table(cursor, 'symbol_transactions', SYMBOL_TRANSACTION_DEFINITIONS)
 		_create_table(cursor, 'symbol_transaction_mosaics', SYMBOL_TRANSACTION_MOSAIC_DEFINITIONS)
@@ -187,6 +227,12 @@ class SymbolDatabase(DatabaseConnection):
 		cursor.execute('CREATE INDEX IF NOT EXISTS idx_symbol_blocks_height_desc ON symbol_blocks(height DESC)')
 		cursor.execute('CREATE INDEX IF NOT EXISTS idx_symbol_blocks_timestamp ON symbol_blocks(timestamp)')
 		cursor.execute('CREATE INDEX IF NOT EXISTS idx_symbol_blocks_signer_address ON symbol_blocks(signer_address)')
+		cursor.execute('CREATE INDEX IF NOT EXISTS idx_symbol_accounts_importance_desc ON symbol_accounts(importance DESC)')
+		cursor.execute('CREATE INDEX IF NOT EXISTS idx_symbol_accounts_address_height ON symbol_accounts(address_height)')
+		cursor.execute('CREATE INDEX IF NOT EXISTS idx_symbol_accounts_harvesting ON symbol_accounts(is_harvesting_active)')
+		cursor.execute('CREATE INDEX IF NOT EXISTS idx_symbol_accounts_eligible ON symbol_accounts(is_eligible_for_harvesting)')
+		cursor.execute('CREATE INDEX IF NOT EXISTS idx_symbol_account_mosaics_address ON symbol_account_mosaics(address)')
+		cursor.execute('CREATE INDEX IF NOT EXISTS idx_symbol_account_mosaics_mosaic ON symbol_account_mosaics(mosaic_id)')
 		cursor.execute('''
 			CREATE INDEX IF NOT EXISTS idx_symbol_transactions_height_desc
 			ON symbol_transactions(height DESC, id DESC)
@@ -287,6 +333,157 @@ class SymbolDatabase(DatabaseConnection):
 				sync_state['last_synced_height'],
 				sync_state['last_synced_block_hash']
 			])
+
+	def upsert_account_current_state(  # pylint: disable=too-many-arguments
+		self,
+		account_row,
+		mosaic_rows,
+		overwrite_importance_percentage=True,
+		overwrite_is_harvesting_active=True
+	):
+		"""Upserts one Symbol account current-state row and replaces its current mosaic rows."""
+
+		cursor = self.connection.cursor()
+		self._execute_upsert_account_current_state(
+			cursor,
+			account_row,
+			mosaic_rows,
+			overwrite_importance_percentage,
+			overwrite_is_harvesting_active)
+		self.connection.commit()
+
+	@staticmethod
+	def _execute_upsert_account_current_state(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+		cursor,
+		account_row,
+		mosaic_rows,
+		overwrite_importance_percentage,
+		overwrite_is_harvesting_active
+	):
+		update_columns = [
+			'address_text',
+			'public_key',
+			'account_type',
+			'address_height',
+			'importance',
+			'is_eligible_for_harvesting',
+			'linked_public_key',
+			'node_public_key',
+			'vrf_public_key',
+			'voting_public_keys',
+			'activity_buckets',
+			'raw_payload',
+			'last_seen_height'
+		]
+		if overwrite_importance_percentage:
+			update_columns.append('importance_percentage')
+		if overwrite_is_harvesting_active:
+			update_columns.append('is_harvesting_active')
+
+		update_assignments = ', '.join([f'{column} = EXCLUDED.{column}' for column in update_columns])
+		cursor.execute(
+			f'''
+			INSERT INTO symbol_accounts (
+				address,
+				address_text,
+				public_key,
+				account_type,
+				address_height,
+				importance,
+				importance_percentage,
+				is_harvesting_active,
+				is_eligible_for_harvesting,
+				linked_public_key,
+				node_public_key,
+				vrf_public_key,
+				voting_public_keys,
+				activity_buckets,
+				raw_payload,
+				first_seen_height,
+				last_seen_height,
+				updated_at
+			)
+			VALUES (
+				%(address)s,
+				%(address_text)s,
+				%(public_key)s,
+				%(account_type)s,
+				%(address_height)s,
+				%(importance)s,
+				%(importance_percentage)s,
+				%(is_harvesting_active)s,
+				%(is_eligible_for_harvesting)s,
+				%(linked_public_key)s,
+				%(node_public_key)s,
+				%(vrf_public_key)s,
+				%(voting_public_keys)s,
+				%(activity_buckets)s,
+				%(raw_payload)s,
+				%(first_seen_height)s,
+				%(last_seen_height)s,
+				CURRENT_TIMESTAMP
+			)
+			ON CONFLICT (address) DO UPDATE SET
+				{update_assignments},
+				first_seen_height = COALESCE(symbol_accounts.first_seen_height, EXCLUDED.first_seen_height),
+				updated_at = CURRENT_TIMESTAMP
+			''',
+			account_row)
+		cursor.execute('DELETE FROM symbol_account_mosaics WHERE address = %s', (account_row['address'],))
+		for mosaic_row in mosaic_rows:
+			cursor.execute(
+				'''
+				INSERT INTO symbol_account_mosaics (
+					address,
+					mosaic_id,
+					amount,
+					updated_at_height
+				)
+				VALUES (
+					%(address)s,
+					%(mosaic_id)s,
+					%(amount)s,
+					%(updated_at_height)s
+				)
+				''',
+				mosaic_row)
+
+	def upsert_multisig(self, address, multisig_row_or_none):
+		"""Upserts or deletes one Symbol multisig current-state row."""
+
+		cursor = self.connection.cursor()
+		if multisig_row_or_none is None:
+			cursor.execute('DELETE FROM symbol_multisig WHERE address = %s', (address,))
+			self.connection.commit()
+			return
+
+		cursor.execute(
+			'''
+			INSERT INTO symbol_multisig (
+				address,
+				min_approval,
+				min_removal,
+				cosignatory_addresses,
+				multisig_addresses,
+				updated_at_height
+			)
+			VALUES (
+				%(address)s,
+				%(min_approval)s,
+				%(min_removal)s,
+				%(cosignatory_addresses)s,
+				%(multisig_addresses)s,
+				%(updated_at_height)s
+			)
+			ON CONFLICT (address) DO UPDATE SET
+				min_approval = EXCLUDED.min_approval,
+				min_removal = EXCLUDED.min_removal,
+				cosignatory_addresses = EXCLUDED.cosignatory_addresses,
+				multisig_addresses = EXCLUDED.multisig_addresses,
+				updated_at_height = EXCLUDED.updated_at_height
+			''',
+			multisig_row_or_none)
+		self.connection.commit()
 
 	def get_block_hash(self, height):
 		"""Gets a block hash by height."""

--- a/explorer/puller/puller/facade/SymbolPuller.py
+++ b/explorer/puller/puller/facade/SymbolPuller.py
@@ -307,25 +307,32 @@ class SymbolPuller:
 				last_synced_block_hash = last_row['hash']
 
 				if len(blocks) < MAX_PAGE_SIZE:
-					await self._sync_block_batch(batch_rows, epoch_adjustment_seconds)
-					await self._refresh_dirty_accounts_for_batch(batch_rows, native_mosaic_id, native_mosaic_divisibility)
+					await self._sync_block_batch(batch_rows, epoch_adjustment_seconds, native_mosaic_id, native_mosaic_divisibility)
 					return last_synced_height, last_synced_block_hash
 
-			await self._sync_block_batch(batch_rows, epoch_adjustment_seconds)
-			await self._refresh_dirty_accounts_for_batch(batch_rows, native_mosaic_id, native_mosaic_divisibility)
+			await self._sync_block_batch(batch_rows, epoch_adjustment_seconds, native_mosaic_id, native_mosaic_divisibility)
 
 		return last_synced_height, last_synced_block_hash
 
-	async def _sync_block_batch(self, batch_rows, epoch_adjustment_seconds):
+	async def _sync_block_batch(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+		self,
+		batch_rows,
+		epoch_adjustment_seconds,
+		native_mosaic_id,
+		native_mosaic_divisibility
+	):
 		transaction_rows_by_height = await self._get_transaction_rows_by_height(
 			batch_rows[0]['height'],
 			batch_rows[-1]['height'],
 			epoch_adjustment_seconds
 		)
 		receipt_rows_by_height = await self._get_receipt_rows_by_height(batch_rows[0]['height'], batch_rows[-1]['height'])
+		dirty_account_rows = await self._fetch_dirty_accounts_for_batch(batch_rows, native_mosaic_id, native_mosaic_divisibility)
+
 		self.symbol_db.upsert_blocks(batch_rows)
 		self._upsert_transactions_for_batch(batch_rows, transaction_rows_by_height)
 		self._upsert_receipts_for_batch(batch_rows, receipt_rows_by_height)
+		self._write_dirty_accounts_for_batch(dirty_account_rows)
 
 	def _upsert_transactions_for_batch(self, block_rows, rows_by_height):
 		for row in block_rows:
@@ -413,8 +420,8 @@ class SymbolPuller:
 
 		return self._native_mosaic_info
 
-	async def _refresh_dirty_accounts_for_batch(self, block_rows, native_mosaic_id, native_mosaic_divisibility):
-		"""Refreshes beneficiary current-state account rows touched by a synced block batch."""
+	async def _fetch_dirty_accounts_for_batch(self, block_rows, native_mosaic_id, native_mosaic_divisibility):
+		"""Fetches beneficiary current-state account rows touched by a synced block batch."""
 
 		latest_block_by_beneficiary = {}
 		for row in block_rows:
@@ -423,15 +430,31 @@ class SymbolPuller:
 				latest_block_by_beneficiary[row['beneficiary_address']] = row
 
 		observed_height = max(row['height'] for row in block_rows)
+		dirty_account_rows = []
 		for address, block_row in sorted(latest_block_by_beneficiary.items()):
-			await self._refresh_account_current_state(
+			dirty_account_rows.append(await self._fetch_account_current_state(
 				address,
 				observed_height=observed_height,
 				native_mosaic_id=native_mosaic_id,
 				native_mosaic_divisibility=native_mosaic_divisibility,
-				harvested_block_timestamp=block_row['timestamp'])
+				harvested_block_timestamp=block_row['timestamp']))
 
-	async def _refresh_account_current_state(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+		return dirty_account_rows
+
+	def _write_dirty_accounts_for_batch(self, dirty_account_rows):
+		"""Writes fetched dirty account current-state rows after block rows are persisted."""
+
+		for dirty_account_row in dirty_account_rows:
+			self.symbol_db.upsert_account_current_state(
+				dirty_account_row['account_row'],
+				dirty_account_row['mosaic_rows'],
+				overwrite_importance_percentage=False,
+				overwrite_is_harvesting_active=dirty_account_row['overwrite_is_harvesting_active'])
+			self.symbol_db.upsert_multisig(
+				dirty_account_row['address'],
+				dirty_account_row['multisig_row'])
+
+	async def _fetch_account_current_state(  # pylint: disable=too-many-arguments,too-many-positional-arguments
 		self,
 		address,
 		observed_height,
@@ -439,7 +462,7 @@ class SymbolPuller:
 		native_mosaic_divisibility,
 		harvested_block_timestamp
 	):
-		"""Refreshes one Symbol account current-state row and its multisig row from the configured node."""
+		"""Fetches one Symbol account current-state row and its multisig row from the configured node."""
 
 		address_text = str(self.symbol_facade.network.address_class(address))
 		item = await self.get_symbol_node(f'/accounts/{address_text}')
@@ -455,14 +478,16 @@ class SymbolPuller:
 		if overwrite_is_harvesting_active:
 			account_row['is_harvesting_active'] = True
 
-		self.symbol_db.upsert_account_current_state(
-			account_row,
-			mosaic_rows,
-			overwrite_importance_percentage=False,
-			overwrite_is_harvesting_active=overwrite_is_harvesting_active)
-		self.symbol_db.upsert_multisig(
-			address,
-			None if _is_not_found_response(multisig_response) else create_multisig_row(address, multisig_response['multisig'], observed_height))
+		return {
+			'address': address,
+			'account_row': account_row,
+			'mosaic_rows': mosaic_rows,
+			'overwrite_is_harvesting_active': overwrite_is_harvesting_active,
+			'multisig_row': None if _is_not_found_response(multisig_response) else create_multisig_row(
+				address,
+				multisig_response['multisig'],
+				observed_height)
+		}
 
 	@staticmethod
 	def _is_harvested_block_within_active_window(harvested_block_timestamp):

--- a/explorer/puller/puller/facade/SymbolPuller.py
+++ b/explorer/puller/puller/facade/SymbolPuller.py
@@ -1,6 +1,7 @@
 import asyncio
 import configparser
 from collections import defaultdict, namedtuple
+from datetime import datetime, timedelta, timezone
 from urllib.parse import urlparse
 
 from common.symbol.NodeConfiguration import SymbolNodeConfiguration
@@ -12,6 +13,7 @@ from zenlog import log
 
 from puller.db.SymbolDatabase import SymbolDatabase
 from puller.facade.RequestRateLimiter import RequestRateLimiter
+from puller.model.symbol.Account import HARVESTING_ACTIVE_WINDOW_DAYS, create_account_row, create_multisig_row
 from puller.model.symbol.Block import create_block_row
 from puller.model.symbol.Receipt import INFLATION_RECEIPT_TYPE, create_receipt_rows
 from puller.model.symbol.Transaction import create_transaction_row
@@ -35,9 +37,16 @@ class SymbolRollbackError(RuntimeError):
 	"""Raised when Symbol rollback repair is outside the safe Backend2 scope."""
 
 
-def _raise_if_node_error(response):
+def _raise_if_node_error(response, allow_not_found=False):
 	if isinstance(response, dict) and 'code' in response and 'message' in response:
+		if allow_not_found and 'ResourceNotFound' == response.get('code'):
+			return
+
 		raise NodeException(f'{response["code"]}: {response["message"]}')
+
+
+def _is_not_found_response(response):
+	return isinstance(response, dict) and 'ResourceNotFound' == response.get('code')
 
 
 class SymbolPuller:
@@ -70,6 +79,7 @@ class SymbolPuller:
 		self.symbol_facade = SymbolFacade(network)
 		self._retry_delay = 2
 		self._rate_limiter = rate_limiter or RequestRateLimiter(max_requests_per_second)
+		self._native_mosaic_info = None
 
 	def __enter__(self):
 		self.symbol_db.__enter__()
@@ -90,14 +100,14 @@ class SymbolPuller:
 
 		return normalized_path
 
-	async def _retry_operation(self, operation, description, retries=3):
+	async def _retry_operation(self, operation, description, retries=3, not_found_as_error=True):
 		"""Retries a Symbol node operation with exponential backoff."""
 
 		for attempt_index in range(retries):
 			try:
 				await self._rate_limiter.wait_for_turn()
 				response = await operation()
-				_raise_if_node_error(response)
+				_raise_if_node_error(response, allow_not_found=not not_found_as_error)
 				return response
 			except NodeException as error:
 				attempt = attempt_index + 1
@@ -115,7 +125,8 @@ class SymbolPuller:
 		normalized_path = self._validate_symbol_node_path(url_path)
 		return await self._retry_operation(
 			lambda: self._symbol_connector.get(normalized_path, property_name, not_found_as_error),
-			f'fetching Symbol node path {normalized_path}'
+			f'fetching Symbol node path {normalized_path}',
+			not_found_as_error=not_found_as_error
 		)
 
 	async def post_symbol_node(self, url_path, request_payload, property_name=None, not_found_as_error=True):
@@ -124,10 +135,11 @@ class SymbolPuller:
 		normalized_path = self._validate_symbol_node_path(url_path)
 		return await self._retry_operation(
 			lambda: self._symbol_connector.post(normalized_path, request_payload, property_name, not_found_as_error),
-			f'posting Symbol node path {normalized_path}'
+			f'posting Symbol node path {normalized_path}',
+			not_found_as_error=not_found_as_error
 		)
 
-	async def sync_block_headers(self, max_height=None):
+	async def sync_block_headers(self, max_height=None):  # pylint: disable=too-many-locals
 		"""Synchronizes Symbol block headers from the configured node."""
 
 		chain_info = await self.get_symbol_node('/chain/info')
@@ -137,6 +149,7 @@ class SymbolPuller:
 			self._get_finalized_watermark(chain_info, chain_height)
 		)
 		epoch_adjustment_seconds = self._parse_epoch_adjustment(network_properties)
+		native_mosaic_id, native_mosaic_divisibility = await self._get_native_mosaic_info(network_properties)
 		sync_state = self._get_bounded_sync_state(self.symbol_db.get_sync_state(), chain_height)
 		if is_finalization_capped and sync_state and sync_state['last_synced_height'] >= finalized_height:
 			finalized_hash = self.symbol_db.get_block_hash(finalized_height)
@@ -145,7 +158,12 @@ class SymbolPuller:
 		if not start_height:
 			start_height = (sync_state['last_synced_height'] + 1) if sync_state and sync_state['last_synced_height'] else 1
 
-		last_synced_height, last_synced_block_hash = await self._sync_block_pages(start_height, chain_height, epoch_adjustment_seconds)
+		last_synced_height, last_synced_block_hash = await self._sync_block_pages(
+			start_height,
+			chain_height,
+			epoch_adjustment_seconds,
+			native_mosaic_id,
+			native_mosaic_divisibility)
 		if last_synced_height is None and sync_state:
 			last_synced_height = sync_state['last_synced_height']
 			last_synced_block_hash = sync_state['last_synced_block_hash']
@@ -250,7 +268,14 @@ class SymbolPuller:
 		})
 		return height
 
-	async def _sync_block_pages(self, start_height, chain_height, epoch_adjustment_seconds):
+	async def _sync_block_pages(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
+		self,
+		start_height,
+		chain_height,
+		epoch_adjustment_seconds,
+		native_mosaic_id,
+		native_mosaic_divisibility
+	):
 		last_synced_height = None
 		last_synced_block_hash = None
 		all_offsets = range(start_height - 1, chain_height, MAX_PAGE_SIZE)
@@ -283,9 +308,11 @@ class SymbolPuller:
 
 				if len(blocks) < MAX_PAGE_SIZE:
 					await self._sync_block_batch(batch_rows, epoch_adjustment_seconds)
+					await self._refresh_dirty_accounts_for_batch(batch_rows, native_mosaic_id, native_mosaic_divisibility)
 					return last_synced_height, last_synced_block_hash
 
 			await self._sync_block_batch(batch_rows, epoch_adjustment_seconds)
+			await self._refresh_dirty_accounts_for_batch(batch_rows, native_mosaic_id, native_mosaic_divisibility)
 
 		return last_synced_height, last_synced_block_hash
 
@@ -372,6 +399,76 @@ class SymbolPuller:
 		raw_epoch_adjustment = network_properties['network']['epochAdjustment']
 		raw_epoch_adjustment = str(raw_epoch_adjustment)
 		return int(raw_epoch_adjustment[:-1] if raw_epoch_adjustment.endswith('s') else raw_epoch_adjustment)
+
+	async def _get_native_mosaic_info(self, network_properties=None):
+		"""Gets and memoizes the native mosaic id and divisibility for this puller instance."""
+
+		if self._native_mosaic_info:
+			return self._native_mosaic_info
+
+		network_properties = network_properties or await self.get_symbol_node('/network/properties')
+		native_mosaic_id = network_properties['chain']['currencyMosaicId'].replace('0x', '').replace("'", '').upper()
+		mosaic_definition = await self.get_symbol_node(f'/mosaics/{native_mosaic_id}')
+		self._native_mosaic_info = (native_mosaic_id, int(mosaic_definition['mosaic']['divisibility']))
+
+		return self._native_mosaic_info
+
+	async def _refresh_dirty_accounts_for_batch(self, block_rows, native_mosaic_id, native_mosaic_divisibility):
+		"""Refreshes beneficiary current-state account rows touched by a synced block batch."""
+
+		latest_block_by_beneficiary = {}
+		for row in block_rows:
+			current_row = latest_block_by_beneficiary.get(row['beneficiary_address'])
+			if not current_row or (row['timestamp'], row['height']) > (current_row['timestamp'], current_row['height']):
+				latest_block_by_beneficiary[row['beneficiary_address']] = row
+
+		observed_height = max(row['height'] for row in block_rows)
+		for address, block_row in sorted(latest_block_by_beneficiary.items()):
+			await self._refresh_account_current_state(
+				address,
+				observed_height=observed_height,
+				native_mosaic_id=native_mosaic_id,
+				native_mosaic_divisibility=native_mosaic_divisibility,
+				harvested_block_timestamp=block_row['timestamp'])
+
+	async def _refresh_account_current_state(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+		self,
+		address,
+		observed_height,
+		native_mosaic_id,
+		native_mosaic_divisibility,
+		harvested_block_timestamp
+	):
+		"""Refreshes one Symbol account current-state row and its multisig row from the configured node."""
+
+		address_text = str(self.symbol_facade.network.address_class(address))
+		item = await self.get_symbol_node(f'/accounts/{address_text}')
+		account_row, mosaic_rows = create_account_row(
+			item,
+			self.symbol_facade.network,
+			observed_height,
+			native_mosaic_id,
+			native_mosaic_divisibility)
+
+		overwrite_is_harvesting_active = self._is_harvested_block_within_active_window(harvested_block_timestamp)
+		if overwrite_is_harvesting_active:
+			account_row['is_harvesting_active'] = True
+
+		self.symbol_db.upsert_account_current_state(
+			account_row,
+			mosaic_rows,
+			overwrite_importance_percentage=False,
+			overwrite_is_harvesting_active=overwrite_is_harvesting_active)
+
+		response = await self.get_symbol_node(f'/account/{address_text}/multisig', not_found_as_error=False)
+		self.symbol_db.upsert_multisig(
+			address,
+			None if _is_not_found_response(response) else create_multisig_row(address, response['multisig'], observed_height))
+
+	@staticmethod
+	def _is_harvested_block_within_active_window(harvested_block_timestamp):
+		cutoff_timestamp = datetime.now(timezone.utc) - timedelta(days=HARVESTING_ACTIVE_WINDOW_DAYS)
+		return harvested_block_timestamp >= cutoff_timestamp
 
 	@staticmethod
 	def _validate_block_page(rows, expected_start_height):

--- a/explorer/puller/puller/facade/SymbolPuller.py
+++ b/explorer/puller/puller/facade/SymbolPuller.py
@@ -443,6 +443,7 @@ class SymbolPuller:
 
 		address_text = str(self.symbol_facade.network.address_class(address))
 		item = await self.get_symbol_node(f'/accounts/{address_text}')
+		multisig_response = await self.get_symbol_node(f'/account/{address_text}/multisig', not_found_as_error=False)
 		account_row, mosaic_rows = create_account_row(
 			item,
 			self.symbol_facade.network,
@@ -459,11 +460,9 @@ class SymbolPuller:
 			mosaic_rows,
 			overwrite_importance_percentage=False,
 			overwrite_is_harvesting_active=overwrite_is_harvesting_active)
-
-		response = await self.get_symbol_node(f'/account/{address_text}/multisig', not_found_as_error=False)
 		self.symbol_db.upsert_multisig(
 			address,
-			None if _is_not_found_response(response) else create_multisig_row(address, response['multisig'], observed_height))
+			None if _is_not_found_response(multisig_response) else create_multisig_row(address, multisig_response['multisig'], observed_height))
 
 	@staticmethod
 	def _is_harvested_block_within_active_window(harvested_block_timestamp):

--- a/explorer/puller/puller/facade/SymbolPuller.py
+++ b/explorer/puller/puller/facade/SymbolPuller.py
@@ -330,7 +330,10 @@ class SymbolPuller:
 			epoch_adjustment_seconds
 		)
 		receipt_rows_by_height = await self._get_receipt_rows_by_height(batch_rows[0]['height'], batch_rows[-1]['height'])
-		dirty_addresses = self._collect_dirty_addresses_for_batch(batch_rows, transaction_rows_by_height)
+		dirty_addresses = self._collect_dirty_addresses_for_batch(
+			batch_rows,
+			transaction_rows_by_height,
+			receipt_rows_by_height)
 		observed_height = max(row['height'] for row in batch_rows)
 		dirty_account_rows = await self._fetch_dirty_accounts_for_batch(
 			dirty_addresses,
@@ -434,8 +437,12 @@ class SymbolPuller:
 		return self._native_mosaic_info
 
 	@staticmethod
-	def _collect_dirty_addresses_for_batch(block_rows, transaction_rows_by_height):
-		"""Collects unique dirty addresses touched by synced block beneficiaries and transaction participants."""
+	def _collect_dirty_addresses_for_batch(  # pylint: disable=too-many-branches
+		block_rows,
+		transaction_rows_by_height,
+		receipt_rows_by_height
+	):
+		"""Collects unique dirty addresses touched by synced block, transaction, and receipt rows."""
 
 		dirty_addresses = {}
 		latest_block_by_beneficiary = {}
@@ -455,6 +462,22 @@ class SymbolPuller:
 				for address_row in transaction_row['address_rows']:
 					address = address_row['address']
 					if address not in dirty_addresses and not Address(address).is_alias():
+						dirty_addresses[address] = {
+							'is_beneficiary': False,
+							'harvested_block_timestamp': None
+						}
+
+		for receipt_rows in receipt_rows_by_height.values():
+			for receipt_row in receipt_rows:
+				if 'balanceChange' == receipt_row['receipt_group']:
+					receipt_addresses = [receipt_row['target_address']]
+				elif 'balanceTransfer' == receipt_row['receipt_group']:
+					receipt_addresses = [receipt_row['sender_address'], receipt_row['recipient_address']]
+				else:
+					continue
+
+				for address in receipt_addresses:
+					if address is not None and address not in dirty_addresses:
 						dirty_addresses[address] = {
 							'is_beneficiary': False,
 							'harvested_block_timestamp': None

--- a/explorer/puller/puller/facade/SymbolPuller.py
+++ b/explorer/puller/puller/facade/SymbolPuller.py
@@ -307,32 +307,37 @@ class SymbolPuller:
 				last_synced_block_hash = last_row['hash']
 
 				if len(blocks) < MAX_PAGE_SIZE:
-					await self._sync_block_batch(batch_rows, epoch_adjustment_seconds, native_mosaic_id, native_mosaic_divisibility)
+					await self._sync_block_batch_with_dirty_accounts(
+						batch_rows, epoch_adjustment_seconds, native_mosaic_id, native_mosaic_divisibility)
 					return last_synced_height, last_synced_block_hash
 
-			await self._sync_block_batch(batch_rows, epoch_adjustment_seconds, native_mosaic_id, native_mosaic_divisibility)
+			await self._sync_block_batch_with_dirty_accounts(
+				batch_rows, epoch_adjustment_seconds, native_mosaic_id, native_mosaic_divisibility)
 
 		return last_synced_height, last_synced_block_hash
 
-	async def _sync_block_batch(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+	async def _sync_block_batch_with_dirty_accounts(  # pylint: disable=too-many-arguments,too-many-positional-arguments
 		self,
 		batch_rows,
 		epoch_adjustment_seconds,
 		native_mosaic_id,
 		native_mosaic_divisibility
 	):
+		dirty_account_rows = await self._fetch_dirty_accounts_for_batch(batch_rows, native_mosaic_id, native_mosaic_divisibility)
+		await self._sync_block_batch(batch_rows, epoch_adjustment_seconds)
+		self._write_dirty_accounts_for_batch(dirty_account_rows)
+
+	async def _sync_block_batch(self, batch_rows, epoch_adjustment_seconds):
 		transaction_rows_by_height = await self._get_transaction_rows_by_height(
 			batch_rows[0]['height'],
 			batch_rows[-1]['height'],
 			epoch_adjustment_seconds
 		)
 		receipt_rows_by_height = await self._get_receipt_rows_by_height(batch_rows[0]['height'], batch_rows[-1]['height'])
-		dirty_account_rows = await self._fetch_dirty_accounts_for_batch(batch_rows, native_mosaic_id, native_mosaic_divisibility)
 
 		self.symbol_db.upsert_blocks(batch_rows)
 		self._upsert_transactions_for_batch(batch_rows, transaction_rows_by_height)
 		self._upsert_receipts_for_batch(batch_rows, receipt_rows_by_height)
-		self._write_dirty_accounts_for_batch(dirty_account_rows)
 
 	def _upsert_transactions_for_batch(self, block_rows, rows_by_height):
 		for row in block_rows:

--- a/explorer/puller/puller/facade/SymbolPuller.py
+++ b/explorer/puller/puller/facade/SymbolPuller.py
@@ -503,54 +503,52 @@ class SymbolPuller:
 	):
 		"""Fetches current-state account and multisig rows touched by a synced block batch."""
 
-		addresses = list(dirty_addresses.keys())
-		address_text_by_address = {
-			address: str(self.symbol_facade.network.address_class(address))
-			for address in addresses
-		}
-
-		account_items_by_address = {}
-		for chunk_start in range(0, len(addresses), ACCOUNT_BATCH_FETCH_SIZE):
-			chunk = addresses[chunk_start:chunk_start + ACCOUNT_BATCH_FETCH_SIZE]
-			response = await self.post_symbol_node('/accounts', {
-				'addresses': [address_text_by_address[address] for address in chunk]
-			})
-			if not isinstance(response, list):
-				raise ValueError('Malformed Symbol accounts batch response')
-			for item in response:
-				account_items_by_address[bytes.fromhex(item['account']['address'])] = item
+		addresses = [self.symbol_facade.network.address_class(address) for address in dirty_addresses.keys()]
 
 		dirty_account_rows = []
-		for address in addresses:
-			address_text = address_text_by_address[address]
-			if address not in account_items_by_address:
-				raise ValueError(f'Missing Symbol accounts batch item for address {address_text}')
-
-			item = account_items_by_address[address]
-			multisig_response = await self.get_symbol_node(f'/account/{address_text}/multisig', not_found_as_error=False)
-			account_row, mosaic_rows = create_account_row(
-				item,
-				self.symbol_facade.network,
-				observed_height,
-				native_mosaic_info.id,
-				native_mosaic_info.divisibility)
-
-			dirty_info = dirty_addresses[address]
-			overwrite_is_harvesting_active = dirty_info['is_beneficiary'] and self._is_harvested_block_within_active_window(
-				dirty_info['harvested_block_timestamp'])
-			if overwrite_is_harvesting_active:
-				account_row['is_harvesting_active'] = True
-
-			dirty_account_rows.append({
-				'address': address,
-				'account_row': account_row,
-				'mosaic_rows': mosaic_rows,
-				'overwrite_is_harvesting_active': overwrite_is_harvesting_active,
-				'multisig_row': None if _is_not_found_response(multisig_response) else create_multisig_row(
-					address,
-					multisig_response['multisig'],
-					observed_height)
+		for chunk_start in range(0, len(addresses), ACCOUNT_BATCH_FETCH_SIZE):
+			chunk = addresses[chunk_start:chunk_start + ACCOUNT_BATCH_FETCH_SIZE]
+			accounts_response = await self.post_symbol_node('/accounts', {
+				'addresses': [str(address) for address in chunk]
 			})
+			if not isinstance(accounts_response, list):
+				raise ValueError('Malformed Symbol accounts batch response')
+			account_items_by_address = {bytes.fromhex(item['account']['address']): item for item in accounts_response}
+
+			multisig_responses = await asyncio.gather(*(
+				self.get_symbol_node(f'/account/{address}/multisig', not_found_as_error=False)
+				for address in chunk
+			))
+
+			for address, multisig_response in zip(chunk, multisig_responses):
+				address_bytes = address.bytes
+				if address_bytes not in account_items_by_address:
+					raise ValueError(f'Missing Symbol accounts batch item for address {address}')
+
+				item = account_items_by_address[address_bytes]
+				account_row, mosaic_rows = create_account_row(
+					item,
+					self.symbol_facade.network,
+					observed_height,
+					native_mosaic_info.id,
+					native_mosaic_info.divisibility)
+
+				dirty_info = dirty_addresses[address_bytes]
+				overwrite_is_harvesting_active = dirty_info['is_beneficiary'] and self._is_harvested_block_within_active_window(
+					dirty_info['harvested_block_timestamp'])
+				if overwrite_is_harvesting_active:
+					account_row['is_harvesting_active'] = True
+
+				dirty_account_rows.append({
+					'address': address_bytes,
+					'account_row': account_row,
+					'mosaic_rows': mosaic_rows,
+					'overwrite_is_harvesting_active': overwrite_is_harvesting_active,
+					'multisig_row': None if _is_not_found_response(multisig_response) else create_multisig_row(
+						address_bytes,
+						multisig_response['multisig'],
+						observed_height)
+				})
 
 		return dirty_account_rows
 

--- a/explorer/puller/puller/facade/SymbolPuller.py
+++ b/explorer/puller/puller/facade/SymbolPuller.py
@@ -19,6 +19,7 @@ from puller.model.symbol.Receipt import INFLATION_RECEIPT_TYPE, create_receipt_r
 from puller.model.symbol.Transaction import create_transaction_row
 
 DatabaseConfiguration = namedtuple('DatabaseConfiguration', ['database', 'user', 'password', 'host', 'port'])
+NativeMosaicInfo = namedtuple('NativeMosaicInfo', ['id', 'divisibility'])
 MAX_PAGE_SIZE = 100
 ACCOUNT_BATCH_FETCH_SIZE = MAX_PAGE_SIZE
 BLOCK_PAGE_FETCH_CONCURRENCY = 10
@@ -151,7 +152,7 @@ class SymbolPuller:
 			self._get_finalized_watermark(chain_info, chain_height)
 		)
 		epoch_adjustment_seconds = self._parse_epoch_adjustment(network_properties)
-		native_mosaic_id, native_mosaic_divisibility = await self._get_native_mosaic_info()
+		native_mosaic_info = await self._get_native_mosaic_info()
 		sync_state = self._get_bounded_sync_state(self.symbol_db.get_sync_state(), chain_height)
 		if is_finalization_capped and sync_state and sync_state['last_synced_height'] >= finalized_height:
 			finalized_hash = self.symbol_db.get_block_hash(finalized_height)
@@ -164,8 +165,7 @@ class SymbolPuller:
 			start_height,
 			chain_height,
 			epoch_adjustment_seconds,
-			native_mosaic_id,
-			native_mosaic_divisibility)
+			native_mosaic_info)
 		if last_synced_height is None and sync_state:
 			last_synced_height = sync_state['last_synced_height']
 			last_synced_block_hash = sync_state['last_synced_block_hash']
@@ -270,13 +270,12 @@ class SymbolPuller:
 		})
 		return height
 
-	async def _sync_block_pages(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
+	async def _sync_block_pages(  # pylint: disable=too-many-locals
 		self,
 		start_height,
 		chain_height,
 		epoch_adjustment_seconds,
-		native_mosaic_id,
-		native_mosaic_divisibility
+		native_mosaic_info
 	):
 		last_synced_height = None
 		last_synced_block_hash = None
@@ -310,20 +309,19 @@ class SymbolPuller:
 
 				if len(blocks) < MAX_PAGE_SIZE:
 					await self._sync_block_batch_with_dirty_accounts(
-						batch_rows, epoch_adjustment_seconds, native_mosaic_id, native_mosaic_divisibility)
+						batch_rows, epoch_adjustment_seconds, native_mosaic_info)
 					return last_synced_height, last_synced_block_hash
 
 			await self._sync_block_batch_with_dirty_accounts(
-				batch_rows, epoch_adjustment_seconds, native_mosaic_id, native_mosaic_divisibility)
+				batch_rows, epoch_adjustment_seconds, native_mosaic_info)
 
 		return last_synced_height, last_synced_block_hash
 
-	async def _sync_block_batch_with_dirty_accounts(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+	async def _sync_block_batch_with_dirty_accounts(
 		self,
 		batch_rows,
 		epoch_adjustment_seconds,
-		native_mosaic_id,
-		native_mosaic_divisibility
+		native_mosaic_info
 	):
 		transaction_rows_by_height = await self._get_transaction_rows_by_height(
 			batch_rows[0]['height'],
@@ -339,8 +337,7 @@ class SymbolPuller:
 		dirty_account_rows = await self._fetch_dirty_accounts_for_batch(
 			dirty_addresses,
 			observed_height,
-			native_mosaic_id,
-			native_mosaic_divisibility)
+			native_mosaic_info)
 		self._sync_block_batch(batch_rows, transaction_rows_by_height, receipt_rows_by_height)
 		self._write_dirty_accounts_for_batch(dirty_account_rows)
 
@@ -445,7 +442,7 @@ class SymbolPuller:
 		network_properties = await self._get_network_properties()
 		native_mosaic_id = network_properties['chain']['currencyMosaicId'].replace('0x', '').replace("'", '').upper()
 		mosaic_definition = await self.get_symbol_node(f'/mosaics/{native_mosaic_id}')
-		self._native_mosaic_info = (native_mosaic_id, int(mosaic_definition['mosaic']['divisibility']))
+		self._native_mosaic_info = NativeMosaicInfo(native_mosaic_id, int(mosaic_definition['mosaic']['divisibility']))
 
 		return self._native_mosaic_info
 
@@ -498,12 +495,11 @@ class SymbolPuller:
 
 		return dirty_addresses
 
-	async def _fetch_dirty_accounts_for_batch(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
+	async def _fetch_dirty_accounts_for_batch(  # pylint: disable=too-many-locals
 		self,
 		dirty_addresses,
 		observed_height,
-		native_mosaic_id,
-		native_mosaic_divisibility
+		native_mosaic_info
 	):
 		"""Fetches current-state account and multisig rows touched by a synced block batch."""
 
@@ -536,8 +532,8 @@ class SymbolPuller:
 				item,
 				self.symbol_facade.network,
 				observed_height,
-				native_mosaic_id,
-				native_mosaic_divisibility)
+				native_mosaic_info.id,
+				native_mosaic_info.divisibility)
 
 			dirty_info = dirty_addresses[address]
 			overwrite_is_harvesting_active = dirty_info['is_beneficiary'] and self._is_harvested_block_within_active_window(

--- a/explorer/puller/puller/facade/SymbolPuller.py
+++ b/explorer/puller/puller/facade/SymbolPuller.py
@@ -81,6 +81,7 @@ class SymbolPuller:
 		self._retry_delay = 2
 		self._rate_limiter = rate_limiter or RequestRateLimiter(max_requests_per_second)
 		self._native_mosaic_info = None
+		self._network_properties = None
 
 	def __enter__(self):
 		self.symbol_db.__enter__()
@@ -144,7 +145,7 @@ class SymbolPuller:
 		"""Synchronizes Symbol block headers from the configured node."""
 
 		chain_info = await self.get_symbol_node('/chain/info')
-		network_properties = await self.get_symbol_node('/network/properties')
+		network_properties = await self._get_network_properties()
 		chain_height = self._get_sync_chain_height(int(chain_info['height']), max_height)
 		finalized_height, finalized_hash, finalized_epoch, finalized_point, is_finalization_capped = (
 			self._get_finalized_watermark(chain_info, chain_height)
@@ -344,7 +345,11 @@ class SymbolPuller:
 		self._write_dirty_accounts_for_batch(dirty_account_rows)
 
 	def _sync_block_batch(self, batch_rows, transaction_rows_by_height, receipt_rows_by_height):
-		"""Writes previously-fetched block, transaction, and receipt rows for one batch."""
+		"""Writes previously-fetched block, transaction, and receipt rows for one batch.
+
+		Takes already-fetched rows rather than fetching them itself so all of a batch's network
+		fetches complete before any of its writes begin — a mid-batch failure leaves no partial writes.
+		"""
 
 		self.symbol_db.upsert_blocks(batch_rows)
 		self._upsert_transactions_for_batch(batch_rows, transaction_rows_by_height)
@@ -423,13 +428,21 @@ class SymbolPuller:
 		raw_epoch_adjustment = str(raw_epoch_adjustment)
 		return int(raw_epoch_adjustment[:-1] if raw_epoch_adjustment.endswith('s') else raw_epoch_adjustment)
 
+	async def _get_network_properties(self):
+		"""Gets and memoizes Symbol network properties for this puller instance."""
+
+		if self._network_properties is None:
+			self._network_properties = await self.get_symbol_node('/network/properties')
+
+		return self._network_properties
+
 	async def _get_native_mosaic_info(self, network_properties=None):
 		"""Gets and memoizes the native mosaic id and divisibility for this puller instance."""
 
 		if self._native_mosaic_info:
 			return self._native_mosaic_info
 
-		network_properties = network_properties or await self.get_symbol_node('/network/properties')
+		network_properties = network_properties or await self._get_network_properties()
 		native_mosaic_id = network_properties['chain']['currencyMosaicId'].replace('0x', '').replace("'", '').upper()
 		mosaic_definition = await self.get_symbol_node(f'/mosaics/{native_mosaic_id}')
 		self._native_mosaic_info = (native_mosaic_id, int(mosaic_definition['mosaic']['divisibility']))

--- a/explorer/puller/puller/facade/SymbolPuller.py
+++ b/explorer/puller/puller/facade/SymbolPuller.py
@@ -565,7 +565,6 @@ class SymbolPuller:
 			self.symbol_db.upsert_account_current_state(
 				dirty_account_row['account_row'],
 				dirty_account_row['mosaic_rows'],
-				overwrite_importance_percentage=False,
 				overwrite_is_harvesting_active=dirty_account_row['overwrite_is_harvesting_active'])
 			self.symbol_db.upsert_multisig(
 				dirty_account_row['address'],

--- a/explorer/puller/puller/facade/SymbolPuller.py
+++ b/explorer/puller/puller/facade/SymbolPuller.py
@@ -151,7 +151,7 @@ class SymbolPuller:
 			self._get_finalized_watermark(chain_info, chain_height)
 		)
 		epoch_adjustment_seconds = self._parse_epoch_adjustment(network_properties)
-		native_mosaic_id, native_mosaic_divisibility = await self._get_native_mosaic_info(network_properties)
+		native_mosaic_id, native_mosaic_divisibility = await self._get_native_mosaic_info()
 		sync_state = self._get_bounded_sync_state(self.symbol_db.get_sync_state(), chain_height)
 		if is_finalization_capped and sync_state and sync_state['last_synced_height'] >= finalized_height:
 			finalized_hash = self.symbol_db.get_block_hash(finalized_height)
@@ -436,13 +436,13 @@ class SymbolPuller:
 
 		return self._network_properties
 
-	async def _get_native_mosaic_info(self, network_properties=None):
+	async def _get_native_mosaic_info(self):
 		"""Gets and memoizes the native mosaic id and divisibility for this puller instance."""
 
 		if self._native_mosaic_info:
 			return self._native_mosaic_info
 
-		network_properties = network_properties or await self._get_network_properties()
+		network_properties = await self._get_network_properties()
 		native_mosaic_id = network_properties['chain']['currencyMosaicId'].replace('0x', '').replace("'", '').upper()
 		mosaic_definition = await self.get_symbol_node(f'/mosaics/{native_mosaic_id}')
 		self._native_mosaic_info = (native_mosaic_id, int(mosaic_definition['mosaic']['divisibility']))

--- a/explorer/puller/puller/facade/SymbolPuller.py
+++ b/explorer/puller/puller/facade/SymbolPuller.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 
 from common.symbol.NodeConfiguration import SymbolNodeConfiguration
 from symbolchain.facade.SymbolFacade import SymbolFacade
-from symbolchain.symbol.Network import Network
+from symbolchain.symbol.Network import Address, Network
 from symbollightapi.connector.SymbolConnector import SymbolConnector
 from symbollightapi.model.Exceptions import NodeException
 from zenlog import log
@@ -454,7 +454,7 @@ class SymbolPuller:
 			for transaction_row in transaction_rows:
 				for address_row in transaction_row['address_rows']:
 					address = address_row['address']
-					if address not in dirty_addresses:
+					if address not in dirty_addresses and not Address(address).is_alias():
 						dirty_addresses[address] = {
 							'is_beneficiary': False,
 							'harvested_block_timestamp': None

--- a/explorer/puller/puller/facade/SymbolPuller.py
+++ b/explorer/puller/puller/facade/SymbolPuller.py
@@ -20,6 +20,7 @@ from puller.model.symbol.Transaction import create_transaction_row
 
 DatabaseConfiguration = namedtuple('DatabaseConfiguration', ['database', 'user', 'password', 'host', 'port'])
 MAX_PAGE_SIZE = 100
+ACCOUNT_BATCH_FETCH_SIZE = MAX_PAGE_SIZE
 BLOCK_PAGE_FETCH_CONCURRENCY = 10
 DEFAULT_MAX_REQUESTS_PER_SECOND = 20
 
@@ -323,17 +324,24 @@ class SymbolPuller:
 		native_mosaic_id,
 		native_mosaic_divisibility
 	):
-		dirty_account_rows = await self._fetch_dirty_accounts_for_batch(batch_rows, native_mosaic_id, native_mosaic_divisibility)
-		await self._sync_block_batch(batch_rows, epoch_adjustment_seconds)
-		self._write_dirty_accounts_for_batch(dirty_account_rows)
-
-	async def _sync_block_batch(self, batch_rows, epoch_adjustment_seconds):
 		transaction_rows_by_height = await self._get_transaction_rows_by_height(
 			batch_rows[0]['height'],
 			batch_rows[-1]['height'],
 			epoch_adjustment_seconds
 		)
 		receipt_rows_by_height = await self._get_receipt_rows_by_height(batch_rows[0]['height'], batch_rows[-1]['height'])
+		dirty_addresses = self._collect_dirty_addresses_for_batch(batch_rows, transaction_rows_by_height)
+		observed_height = max(row['height'] for row in batch_rows)
+		dirty_account_rows = await self._fetch_dirty_accounts_for_batch(
+			dirty_addresses,
+			observed_height,
+			native_mosaic_id,
+			native_mosaic_divisibility)
+		self._sync_block_batch(batch_rows, transaction_rows_by_height, receipt_rows_by_height)
+		self._write_dirty_accounts_for_batch(dirty_account_rows)
+
+	def _sync_block_batch(self, batch_rows, transaction_rows_by_height, receipt_rows_by_height):
+		"""Writes previously-fetched block, transaction, and receipt rows for one batch."""
 
 		self.symbol_db.upsert_blocks(batch_rows)
 		self._upsert_transactions_for_batch(batch_rows, transaction_rows_by_height)
@@ -425,24 +433,92 @@ class SymbolPuller:
 
 		return self._native_mosaic_info
 
-	async def _fetch_dirty_accounts_for_batch(self, block_rows, native_mosaic_id, native_mosaic_divisibility):
-		"""Fetches beneficiary current-state account rows touched by a synced block batch."""
+	@staticmethod
+	def _collect_dirty_addresses_for_batch(block_rows, transaction_rows_by_height):
+		"""Collects unique dirty addresses touched by synced block beneficiaries and transaction participants."""
 
+		dirty_addresses = {}
 		latest_block_by_beneficiary = {}
 		for row in block_rows:
 			current_row = latest_block_by_beneficiary.get(row['beneficiary_address'])
 			if not current_row or (row['timestamp'], row['height']) > (current_row['timestamp'], current_row['height']):
 				latest_block_by_beneficiary[row['beneficiary_address']] = row
 
-		observed_height = max(row['height'] for row in block_rows)
+		for address, block_row in latest_block_by_beneficiary.items():
+			dirty_addresses[address] = {
+				'is_beneficiary': True,
+				'harvested_block_timestamp': block_row['timestamp']
+			}
+
+		for transaction_rows in transaction_rows_by_height.values():
+			for transaction_row in transaction_rows:
+				for address_row in transaction_row['address_rows']:
+					address = address_row['address']
+					if address not in dirty_addresses:
+						dirty_addresses[address] = {
+							'is_beneficiary': False,
+							'harvested_block_timestamp': None
+						}
+
+		return dirty_addresses
+
+	async def _fetch_dirty_accounts_for_batch(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
+		self,
+		dirty_addresses,
+		observed_height,
+		native_mosaic_id,
+		native_mosaic_divisibility
+	):
+		"""Fetches current-state account and multisig rows touched by a synced block batch."""
+
+		sorted_addresses = sorted(dirty_addresses.keys())
+		address_text_by_address = {
+			address: str(self.symbol_facade.network.address_class(address))
+			for address in sorted_addresses
+		}
+
+		account_items_by_address = {}
+		for chunk_start in range(0, len(sorted_addresses), ACCOUNT_BATCH_FETCH_SIZE):
+			chunk = sorted_addresses[chunk_start:chunk_start + ACCOUNT_BATCH_FETCH_SIZE]
+			response = await self.post_symbol_node('/accounts', {
+				'addresses': [address_text_by_address[address] for address in chunk]
+			})
+			if not isinstance(response, list):
+				raise ValueError('Malformed Symbol accounts batch response')
+			for item in response:
+				account_items_by_address[bytes.fromhex(item['account']['address'])] = item
+
 		dirty_account_rows = []
-		for address, block_row in sorted(latest_block_by_beneficiary.items()):
-			dirty_account_rows.append(await self._fetch_account_current_state(
-				address,
-				observed_height=observed_height,
-				native_mosaic_id=native_mosaic_id,
-				native_mosaic_divisibility=native_mosaic_divisibility,
-				harvested_block_timestamp=block_row['timestamp']))
+		for address in sorted_addresses:
+			address_text = address_text_by_address[address]
+			if address not in account_items_by_address:
+				raise ValueError(f'Missing Symbol accounts batch item for address {address_text}')
+
+			item = account_items_by_address[address]
+			multisig_response = await self.get_symbol_node(f'/account/{address_text}/multisig', not_found_as_error=False)
+			account_row, mosaic_rows = create_account_row(
+				item,
+				self.symbol_facade.network,
+				observed_height,
+				native_mosaic_id,
+				native_mosaic_divisibility)
+
+			dirty_info = dirty_addresses[address]
+			overwrite_is_harvesting_active = dirty_info['is_beneficiary'] and self._is_harvested_block_within_active_window(
+				dirty_info['harvested_block_timestamp'])
+			if overwrite_is_harvesting_active:
+				account_row['is_harvesting_active'] = True
+
+			dirty_account_rows.append({
+				'address': address,
+				'account_row': account_row,
+				'mosaic_rows': mosaic_rows,
+				'overwrite_is_harvesting_active': overwrite_is_harvesting_active,
+				'multisig_row': None if _is_not_found_response(multisig_response) else create_multisig_row(
+					address,
+					multisig_response['multisig'],
+					observed_height)
+			})
 
 		return dirty_account_rows
 
@@ -458,41 +534,6 @@ class SymbolPuller:
 			self.symbol_db.upsert_multisig(
 				dirty_account_row['address'],
 				dirty_account_row['multisig_row'])
-
-	async def _fetch_account_current_state(  # pylint: disable=too-many-arguments,too-many-positional-arguments
-		self,
-		address,
-		observed_height,
-		native_mosaic_id,
-		native_mosaic_divisibility,
-		harvested_block_timestamp
-	):
-		"""Fetches one Symbol account current-state row and its multisig row from the configured node."""
-
-		address_text = str(self.symbol_facade.network.address_class(address))
-		item = await self.get_symbol_node(f'/accounts/{address_text}')
-		multisig_response = await self.get_symbol_node(f'/account/{address_text}/multisig', not_found_as_error=False)
-		account_row, mosaic_rows = create_account_row(
-			item,
-			self.symbol_facade.network,
-			observed_height,
-			native_mosaic_id,
-			native_mosaic_divisibility)
-
-		overwrite_is_harvesting_active = self._is_harvested_block_within_active_window(harvested_block_timestamp)
-		if overwrite_is_harvesting_active:
-			account_row['is_harvesting_active'] = True
-
-		return {
-			'address': address,
-			'account_row': account_row,
-			'mosaic_rows': mosaic_rows,
-			'overwrite_is_harvesting_active': overwrite_is_harvesting_active,
-			'multisig_row': None if _is_not_found_response(multisig_response) else create_multisig_row(
-				address,
-				multisig_response['multisig'],
-				observed_height)
-		}
 
 	@staticmethod
 	def _is_harvested_block_within_active_window(harvested_block_timestamp):

--- a/explorer/puller/puller/facade/SymbolPuller.py
+++ b/explorer/puller/puller/facade/SymbolPuller.py
@@ -507,15 +507,15 @@ class SymbolPuller:
 	):
 		"""Fetches current-state account and multisig rows touched by a synced block batch."""
 
-		sorted_addresses = sorted(dirty_addresses.keys())
+		addresses = list(dirty_addresses.keys())
 		address_text_by_address = {
 			address: str(self.symbol_facade.network.address_class(address))
-			for address in sorted_addresses
+			for address in addresses
 		}
 
 		account_items_by_address = {}
-		for chunk_start in range(0, len(sorted_addresses), ACCOUNT_BATCH_FETCH_SIZE):
-			chunk = sorted_addresses[chunk_start:chunk_start + ACCOUNT_BATCH_FETCH_SIZE]
+		for chunk_start in range(0, len(addresses), ACCOUNT_BATCH_FETCH_SIZE):
+			chunk = addresses[chunk_start:chunk_start + ACCOUNT_BATCH_FETCH_SIZE]
 			response = await self.post_symbol_node('/accounts', {
 				'addresses': [address_text_by_address[address] for address in chunk]
 			})
@@ -525,7 +525,7 @@ class SymbolPuller:
 				account_items_by_address[bytes.fromhex(item['account']['address'])] = item
 
 		dirty_account_rows = []
-		for address in sorted_addresses:
+		for address in addresses:
 			address_text = address_text_by_address[address]
 			if address not in account_items_by_address:
 				raise ValueError(f'Missing Symbol accounts batch item for address {address_text}')

--- a/explorer/puller/puller/facade/SymbolPuller.py
+++ b/explorer/puller/puller/facade/SymbolPuller.py
@@ -462,7 +462,7 @@ class SymbolPuller:
 				latest_block_by_beneficiary[row['beneficiary_address']] = row
 
 		for address, block_row in latest_block_by_beneficiary.items():
-			dirty_addresses[address] = {
+			dirty_addresses[Address(address)] = {
 				'is_beneficiary': True,
 				'harvested_block_timestamp': block_row['timestamp']
 			}
@@ -470,8 +470,8 @@ class SymbolPuller:
 		for transaction_rows in transaction_rows_by_height.values():
 			for transaction_row in transaction_rows:
 				for address_row in transaction_row['address_rows']:
-					address = address_row['address']
-					if address not in dirty_addresses and not Address(address).is_alias():
+					address = Address(address_row['address'])
+					if address not in dirty_addresses and not address.is_alias():
 						dirty_addresses[address] = {
 							'is_beneficiary': False,
 							'harvested_block_timestamp': None
@@ -487,11 +487,13 @@ class SymbolPuller:
 					continue
 
 				for address in receipt_addresses:
-					if address is not None and address not in dirty_addresses:
-						dirty_addresses[address] = {
-							'is_beneficiary': False,
-							'harvested_block_timestamp': None
-						}
+					if address is not None:
+						address = Address(address)
+						if address not in dirty_addresses:
+							dirty_addresses[address] = {
+								'is_beneficiary': False,
+								'harvested_block_timestamp': None
+							}
 
 		return dirty_addresses
 
@@ -503,7 +505,7 @@ class SymbolPuller:
 	):
 		"""Fetches current-state account and multisig rows touched by a synced block batch."""
 
-		addresses = [self.symbol_facade.network.address_class(address) for address in dirty_addresses.keys()]
+		addresses = list(dirty_addresses.keys())
 
 		dirty_account_rows = []
 		for chunk_start in range(0, len(addresses), ACCOUNT_BATCH_FETCH_SIZE):
@@ -513,7 +515,10 @@ class SymbolPuller:
 			})
 			if not isinstance(accounts_response, list):
 				raise ValueError('Malformed Symbol accounts batch response')
-			account_items_by_address = {bytes.fromhex(item['account']['address']): item for item in accounts_response}
+			account_items_by_address = {
+				Address(bytes.fromhex(item['account']['address'])): item
+				for item in accounts_response
+			}
 
 			multisig_responses = await asyncio.gather(*(
 				self.get_symbol_node(f'/account/{address}/multisig', not_found_as_error=False)
@@ -521,11 +526,10 @@ class SymbolPuller:
 			))
 
 			for address, multisig_response in zip(chunk, multisig_responses):
-				address_bytes = address.bytes
-				if address_bytes not in account_items_by_address:
+				if address not in account_items_by_address:
 					raise ValueError(f'Missing Symbol accounts batch item for address {address}')
 
-				item = account_items_by_address[address_bytes]
+				item = account_items_by_address[address]
 				account_row, mosaic_rows = create_account_row(
 					item,
 					self.symbol_facade.network,
@@ -533,12 +537,13 @@ class SymbolPuller:
 					native_mosaic_info.id,
 					native_mosaic_info.divisibility)
 
-				dirty_info = dirty_addresses[address_bytes]
+				dirty_info = dirty_addresses[address]
 				overwrite_is_harvesting_active = dirty_info['is_beneficiary'] and self._is_harvested_block_within_active_window(
 					dirty_info['harvested_block_timestamp'])
 				if overwrite_is_harvesting_active:
 					account_row['is_harvesting_active'] = True
 
+				address_bytes = address.bytes
 				dirty_account_rows.append({
 					'address': address_bytes,
 					'account_row': account_row,

--- a/explorer/puller/puller/model/symbol/Account.py
+++ b/explorer/puller/puller/model/symbol/Account.py
@@ -1,6 +1,6 @@
 from psycopg2.extras import Json
 
-from puller.model.symbol.format import bytes_from_hex_or_none
+from puller.model.symbol.format import bytes_from_hex_or_none, label_for_type
 
 ACCOUNT_TYPE_LABELS = {
 	0: 'unlinked',
@@ -42,7 +42,7 @@ def create_account_row(item, network, observed_height, native_mosaic_id, native_
 		'address': address,
 		'address_text': str(network.address_class(address)),
 		'public_key': _public_key_from_hex(account['publicKey']),
-		'account_type': ACCOUNT_TYPE_LABELS[int(account['accountType'])],
+		'account_type': label_for_type(ACCOUNT_TYPE_LABELS, account['accountType'], 'account'),
 		'address_height': int(account['addressHeight']),
 		'importance': int(account['importance']),
 		'importance_percentage': 0,

--- a/explorer/puller/puller/model/symbol/Account.py
+++ b/explorer/puller/puller/model/symbol/Account.py
@@ -1,0 +1,87 @@
+from psycopg2.extras import Json
+
+from puller.model.symbol.format import bytes_from_hex_or_none
+
+ACCOUNT_TYPE_LABELS = {
+	0: 'unlinked',
+	1: 'main',
+	2: 'remote',
+	3: 'remoteUnlinked'
+}
+ACCOUNT_TYPE_VALUES = tuple(ACCOUNT_TYPE_LABELS.values())
+
+HARVESTING_ELIGIBLE_MIN_NATIVE_BALANCE = 10_000
+HARVESTING_ELIGIBLE_MAX_NATIVE_BALANCE = 50_000_000
+HARVESTING_ACTIVE_WINDOW_DAYS = 7
+
+
+def _public_key_from_hex(public_key_hex):
+	public_key = bytes.fromhex(public_key_hex)
+	return None if all(0 == byte for byte in public_key) else public_key
+
+
+def _is_eligible_for_harvesting(account, native_mosaic_id, native_mosaic_divisibility):
+	native_balance_raw = next(
+		(int(mosaic['amount']) for mosaic in account.get('mosaics', []) if mosaic['id'] == native_mosaic_id),
+		0)
+	scale = 10 ** native_mosaic_divisibility
+	minimum_raw_balance = HARVESTING_ELIGIBLE_MIN_NATIVE_BALANCE * scale
+	maximum_raw_balance = HARVESTING_ELIGIBLE_MAX_NATIVE_BALANCE * scale
+
+	return minimum_raw_balance <= native_balance_raw < maximum_raw_balance
+
+
+def create_account_row(item, network, observed_height, native_mosaic_id, native_mosaic_divisibility):
+	"""Creates a persisted Symbol account current-state row and mosaic rows from one node account DTO."""
+
+	account = item['account']
+	address = bytes.fromhex(account['address'])
+	supplemental_public_keys = account.get('supplementalPublicKeys', {})
+
+	account_row = {
+		'address': address,
+		'address_text': str(network.address_class(address)),
+		'public_key': _public_key_from_hex(account['publicKey']),
+		'account_type': ACCOUNT_TYPE_LABELS[int(account['accountType'])],
+		'address_height': int(account['addressHeight']),
+		'importance': int(account['importance']),
+		'importance_percentage': 0,
+		'is_harvesting_active': None,
+		'is_eligible_for_harvesting': _is_eligible_for_harvesting(account, native_mosaic_id, native_mosaic_divisibility),
+		'linked_public_key': bytes_from_hex_or_none(supplemental_public_keys.get('linked', {}).get('publicKey')),
+		'node_public_key': bytes_from_hex_or_none(supplemental_public_keys.get('node', {}).get('publicKey')),
+		'vrf_public_key': bytes_from_hex_or_none(supplemental_public_keys.get('vrf', {}).get('publicKey')),
+		'voting_public_keys': Json(supplemental_public_keys.get('voting', {}).get('publicKeys', [])),
+		'activity_buckets': Json(account.get('activityBuckets', [])),
+		'raw_payload': Json(item),
+		'first_seen_height': observed_height,
+		'last_seen_height': observed_height
+	}
+
+	mosaic_rows = [
+		{
+			'address': address,
+			'mosaic_id': mosaic['id'],
+			'amount': int(mosaic['amount']),
+			'updated_at_height': observed_height
+		}
+		for mosaic in account.get('mosaics', [])
+	]
+
+	return account_row, mosaic_rows
+
+
+def create_multisig_row(address, multisig_json_or_none, observed_height):
+	"""Creates a persisted Symbol multisig row from one node multisig DTO, or None for absent multisig state."""
+
+	if multisig_json_or_none is None:
+		return None
+
+	return {
+		'address': address,
+		'min_approval': int(multisig_json_or_none['minApproval']),
+		'min_removal': int(multisig_json_or_none['minRemoval']),
+		'cosignatory_addresses': [bytes.fromhex(address_hex) for address_hex in multisig_json_or_none['cosignatoryAddresses']],
+		'multisig_addresses': [bytes.fromhex(address_hex) for address_hex in multisig_json_or_none['multisigAddresses']],
+		'updated_at_height': observed_height
+	}

--- a/explorer/puller/tests/__init__.py
+++ b/explorer/puller/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Puller test package."""

--- a/explorer/puller/tests/db/test_SymbolDatabase.py
+++ b/explorer/puller/tests/db/test_SymbolDatabase.py
@@ -2,20 +2,25 @@
 import datetime
 from collections import namedtuple
 from contextlib import ExitStack
+from decimal import Decimal
 from unittest import TestCase
 
 from common.tests.PostgresTestUtils import PostgresTestDatabase, drop_symbol_block_tables_if_present
 from psycopg2 import Error as PsycopgError
 from psycopg2.extras import Json
 from symbolchain.sc import ReceiptType
+from symbolchain.symbol.Network import Network
 
 from puller.db.SymbolDatabase import SymbolDatabase
+from puller.model.symbol.Account import create_account_row
 
 from ..test.SymbolTransactionTestUtils import create_transaction_entry
 
 DatabaseConfig = namedtuple(
 	'DatabaseConfig',
 	['database', 'user', 'password', 'host', 'port'])
+ADDRESS1 = '9889432DE263BB8FE88444A4DA28D3609BD8BB8FAE18AE95'
+NATIVE_MOSAIC_ID = '72C0212E67A08BCE'
 
 
 def _create_block(height, block_hash=None, **overrides):
@@ -104,6 +109,32 @@ def _create_receipt(height, receipt_type='inflation', **overrides):
 	return receipt
 
 
+def _create_account_item(address_hex=ADDRESS1, item_id='account-id', importance='100', native_amount='20000000000', **account_overrides):
+	account = {
+		'address': address_hex,
+		'addressHeight': '7',
+		'publicKey': '0' * 64,
+		'accountType': 0,
+		'supplementalPublicKeys': {},
+		'activityBuckets': [],
+		'mosaics': [{'id': NATIVE_MOSAIC_ID, 'amount': native_amount}],
+		'importance': importance,
+		'importanceHeight': '6'
+	}
+	account.update(account_overrides)
+
+	return {'account': account, 'id': item_id}
+
+
+def _create_account_row(address_hex=ADDRESS1, observed_height=10, **item_overrides):
+	return create_account_row(
+		_create_account_item(address_hex, **item_overrides),
+		Network.TESTNET,
+		observed_height,
+		NATIVE_MOSAIC_ID,
+		6)
+
+
 class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 	def setUp(self):
 		self.exit_stack = ExitStack()
@@ -153,13 +184,109 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		tables = [result[0] for result in cursor.fetchall()]
 
 		self.assertEqual([
+			'symbol_account_mosaics',
+			'symbol_accounts',
 			'symbol_blocks',
+			'symbol_multisig',
 			'symbol_receipts',
 			'symbol_sync_state',
 			'symbol_transaction_addresses',
 			'symbol_transaction_mosaics',
 			'symbol_transactions'
 		], tables)
+
+	def test_create_tables_creates_symbol_account_enum_types(self):
+		# Arrange:
+		database = self._create_uninitialized_database()
+		cursor = database.connection.cursor()
+
+		# Act:
+		database.create_tables()
+
+		# Assert:
+		cursor.execute(
+			'''
+			SELECT pg_type.typname, enumlabel
+			FROM pg_enum
+			JOIN pg_type ON pg_type.oid = pg_enum.enumtypid
+			WHERE pg_type.typname = 'symbol_account_type'
+			ORDER BY pg_type.typname, enumsortorder
+			'''
+		)
+
+		self.assertEqual([
+			('symbol_account_type', 'unlinked'),
+			('symbol_account_type', 'main'),
+			('symbol_account_type', 'remote'),
+			('symbol_account_type', 'remoteUnlinked')
+		], cursor.fetchall())
+
+	def test_create_tables_creates_symbol_account_current_state_columns(self):
+		# Arrange:
+		database = self._create_uninitialized_database()
+		cursor = database.connection.cursor()
+
+		# Act:
+		database.create_tables()
+
+		# Assert:
+		cursor.execute(
+			'''
+			SELECT column_name, udt_name, is_nullable
+			FROM information_schema.columns
+			WHERE table_name = 'symbol_accounts'
+			ORDER BY ordinal_position
+			'''
+		)
+
+		self.assertEqual([
+			('address', 'bytea', 'NO'),
+			('address_text', 'varchar', 'NO'),
+			('public_key', 'bytea', 'YES'),
+			('account_type', 'symbol_account_type', 'YES'),
+			('address_height', 'int8', 'YES'),
+			('importance', 'int8', 'NO'),
+			('importance_percentage', 'numeric', 'NO'),
+			('is_harvesting_active', 'bool', 'YES'),
+			('is_eligible_for_harvesting', 'bool', 'YES'),
+			('linked_public_key', 'bytea', 'YES'),
+			('node_public_key', 'bytea', 'YES'),
+			('vrf_public_key', 'bytea', 'YES'),
+			('voting_public_keys', 'jsonb', 'NO'),
+			('activity_buckets', 'jsonb', 'NO'),
+			('raw_payload', 'jsonb', 'NO'),
+			('first_seen_height', 'int8', 'YES'),
+			('last_seen_height', 'int8', 'NO'),
+			('updated_at', 'timestamp', 'NO')
+		], cursor.fetchall())
+
+	def test_create_tables_creates_symbol_account_indexes(self):
+		# Arrange:
+		database = self._create_uninitialized_database()
+		cursor = database.connection.cursor()
+
+		# Act:
+		database.create_tables()
+
+		# Assert:
+		cursor.execute(
+			'''
+			SELECT indexname
+			FROM pg_indexes
+			WHERE schemaname = 'public'
+				AND indexname LIKE 'idx_symbol_account%'
+			ORDER BY indexname
+			'''
+		)
+
+		self.assertEqual([
+			'idx_symbol_account_mosaics_address',
+			'idx_symbol_account_mosaics_mosaic',
+			'idx_symbol_accounts_address_height',
+			'idx_symbol_accounts_eligible',
+			'idx_symbol_accounts_harvesting',
+			'idx_symbol_accounts_importance_desc'
+		], [row[0] for row in cursor.fetchall()])
 
 	def test_create_tables_creates_symbol_sync_state_schema(self):
 		# Arrange:
@@ -819,6 +946,149 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 				'INSERT INTO symbol_sync_state (id, status) '
 				'VALUES (2, \'initialized\')'
 			)
+
+	def test_can_upsert_account_current_state_and_replace_mosaics(self):
+		# Arrange:
+		database = self._create_database()
+		account_row, mosaic_rows = _create_account_row()
+		updated_account_row, updated_mosaic_rows = _create_account_row(
+			observed_height=20,
+			native_amount='30000000000',
+			importance='200')
+
+		# Act:
+		database.upsert_account_current_state(account_row, mosaic_rows)
+		database.upsert_account_current_state(updated_account_row, updated_mosaic_rows)
+
+		# Assert:
+		cursor = database.connection.cursor()
+		cursor.execute(
+			'''
+			SELECT importance, first_seen_height, last_seen_height
+			FROM symbol_accounts
+			WHERE address = %s
+			''',
+			(bytes.fromhex(ADDRESS1),))
+		account_result = cursor.fetchone()
+		cursor.execute(
+			'''
+			SELECT mosaic_id, amount, updated_at_height
+			FROM symbol_account_mosaics
+			WHERE address = %s
+			''',
+			(bytes.fromhex(ADDRESS1),))
+		mosaic_results = cursor.fetchall()
+
+		self.assertEqual((200, 10, 20), account_result)
+		self.assertEqual([(NATIVE_MOSAIC_ID, 30000000000, 20)], mosaic_results)
+
+	def test_upsert_account_current_state_preserves_importance_percentage_when_not_overwriting(self):
+		# Arrange:
+		database = self._create_database()
+		account_row, mosaic_rows = _create_account_row()
+		account_row['importance_percentage'] = Decimal('0.75')
+		updated_account_row, updated_mosaic_rows = _create_account_row(importance='200')
+
+		# Act:
+		database.upsert_account_current_state(account_row, mosaic_rows)
+		database.upsert_account_current_state(
+			updated_account_row,
+			updated_mosaic_rows,
+			overwrite_importance_percentage=False)
+
+		# Assert:
+		cursor = database.connection.cursor()
+		cursor.execute('SELECT importance, importance_percentage FROM symbol_accounts WHERE address = %s', (bytes.fromhex(ADDRESS1),))
+
+		self.assertEqual((200, Decimal('0.75')), cursor.fetchone())
+
+	def test_upsert_account_current_state_preserves_harvesting_active_when_not_overwriting(self):
+		# Arrange:
+		database = self._create_database()
+		account_row, mosaic_rows = _create_account_row()
+		account_row['is_harvesting_active'] = False
+		updated_account_row, updated_mosaic_rows = _create_account_row()
+		updated_account_row['is_harvesting_active'] = True
+
+		# Act:
+		database.upsert_account_current_state(account_row, mosaic_rows)
+		database.upsert_account_current_state(
+			updated_account_row,
+			updated_mosaic_rows,
+			overwrite_is_harvesting_active=False)
+
+		# Assert:
+		cursor = database.connection.cursor()
+		cursor.execute('SELECT is_harvesting_active FROM symbol_accounts WHERE address = %s', (bytes.fromhex(ADDRESS1),))
+
+		self.assertEqual((False,), cursor.fetchone())
+
+	def test_can_upsert_and_delete_multisig(self):
+		# Arrange:
+		database = self._create_database()
+		account_row, mosaic_rows = _create_account_row()
+		database.upsert_account_current_state(account_row, mosaic_rows)
+		multisig_row = {
+			'address': bytes.fromhex(ADDRESS1),
+			'min_approval': 2,
+			'min_removal': 1,
+			'cosignatory_addresses': [bytes.fromhex('AA' * 24)],
+			'multisig_addresses': [bytes.fromhex('BB' * 24)],
+			'updated_at_height': 50
+		}
+
+		# Act:
+		database.upsert_multisig(bytes.fromhex(ADDRESS1), multisig_row)
+		database.upsert_multisig(bytes.fromhex(ADDRESS1), None)
+
+		# Assert:
+		cursor = database.connection.cursor()
+		cursor.execute('SELECT COUNT(*) FROM symbol_multisig WHERE address = %s', (bytes.fromhex(ADDRESS1),))
+
+		self.assertEqual((0,), cursor.fetchone())
+
+	def test_can_update_existing_multisig(self):
+		# Arrange:
+		database = self._create_database()
+		account_row, mosaic_rows = _create_account_row()
+		database.upsert_account_current_state(account_row, mosaic_rows)
+		first_multisig_row = {
+			'address': bytes.fromhex(ADDRESS1),
+			'min_approval': 2,
+			'min_removal': 1,
+			'cosignatory_addresses': [bytes.fromhex('AA' * 24)],
+			'multisig_addresses': [bytes.fromhex('BB' * 24)],
+			'updated_at_height': 50
+		}
+		second_multisig_row = {
+			'address': bytes.fromhex(ADDRESS1),
+			'min_approval': 3,
+			'min_removal': 2,
+			'cosignatory_addresses': [bytes.fromhex('CC' * 24)],
+			'multisig_addresses': [bytes.fromhex('DD' * 24)],
+			'updated_at_height': 60
+		}
+
+		# Act:
+		database.upsert_multisig(bytes.fromhex(ADDRESS1), first_multisig_row)
+		database.upsert_multisig(bytes.fromhex(ADDRESS1), second_multisig_row)
+
+		# Assert:
+		cursor = database.connection.cursor()
+		cursor.execute(
+			'''
+			SELECT min_approval, min_removal, cosignatory_addresses, multisig_addresses, updated_at_height
+			FROM symbol_multisig
+			WHERE address = %s
+			''',
+			(bytes.fromhex(ADDRESS1),))
+		result = cursor.fetchone()
+
+		self.assertEqual(3, result[0])
+		self.assertEqual(2, result[1])
+		self.assertEqual([bytes.fromhex('CC' * 24)], [bytes(value) for value in result[2]])
+		self.assertEqual([bytes.fromhex('DD' * 24)], [bytes(value) for value in result[3]])
+		self.assertEqual(60, result[4])
 
 	def test_rejects_invalid_block_type(self):
 		# Arrange:

--- a/explorer/puller/tests/db/test_SymbolDatabase.py
+++ b/explorer/puller/tests/db/test_SymbolDatabase.py
@@ -14,6 +14,7 @@ from symbolchain.symbol.Network import Network
 from puller.db.SymbolDatabase import SymbolDatabase
 from puller.model.symbol.Account import create_account_row
 from tests.facade.symbol.puller_test_utils import NATIVE_MOSAIC_ID, create_account_item
+from tests.test.SymbolTestConstants import RECIPIENT_ADDRESS
 
 from ..test.SymbolTransactionTestUtils import create_transaction_entry
 
@@ -21,6 +22,7 @@ DatabaseConfig = namedtuple(
 	'DatabaseConfig',
 	['database', 'user', 'password', 'host', 'port'])
 ADDRESS1 = '9889432DE263BB8FE88444A4DA28D3609BD8BB8FAE18AE95'
+ADDRESS3 = '98' + '11' * 23
 
 
 def _create_block(height, block_hash=None, **overrides):
@@ -116,6 +118,17 @@ def _create_account_row(address_hex=ADDRESS1, observed_height=10, **item_overrid
 		observed_height,
 		NATIVE_MOSAIC_ID,
 		6)
+
+
+def _create_multisig_row(address_hex, updated_at_height):
+	return {
+		'address': bytes.fromhex(address_hex),
+		'min_approval': 1,
+		'min_removal': 1,
+		'cosignatory_addresses': [],
+		'multisig_addresses': [],
+		'updated_at_height': updated_at_height
+	}
 
 
 class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
@@ -1605,6 +1618,40 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		self.assertEqual(0, address_count)
 		self.assertEqual([(1,)], block_results)
 
+	def test_delete_blocks_from_height_deletes_account_family_rows(self):
+		# Arrange:
+		database = self._create_database()
+		cursor = database.connection.cursor()
+		database.upsert_blocks([_create_block(1), _create_block(2), _create_block(3)])
+		kept_account_row, kept_mosaic_rows = _create_account_row(ADDRESS1, observed_height=1)
+		rollbacked_account_row, rollbacked_mosaic_rows = _create_account_row(RECIPIENT_ADDRESS, observed_height=2)
+		after_fork_account_row, after_fork_mosaic_rows = _create_account_row(ADDRESS3, observed_height=3)
+		database.upsert_account_current_state(kept_account_row, kept_mosaic_rows)
+		database.upsert_account_current_state(rollbacked_account_row, rollbacked_mosaic_rows)
+		database.upsert_account_current_state(after_fork_account_row, after_fork_mosaic_rows)
+		kept_multisig_row = _create_multisig_row(ADDRESS1, 1)
+		rollbacked_multisig_row = _create_multisig_row(RECIPIENT_ADDRESS, 2)
+		after_fork_multisig_row = _create_multisig_row(ADDRESS3, 3)
+		database.upsert_multisig(kept_multisig_row['address'], kept_multisig_row)
+		database.upsert_multisig(rollbacked_multisig_row['address'], rollbacked_multisig_row)
+		database.upsert_multisig(after_fork_multisig_row['address'], after_fork_multisig_row)
+
+		# Act:
+		database.delete_blocks_from_height(2)
+
+		# Assert:
+		cursor.execute('SELECT encode(address, \'hex\'), last_seen_height FROM symbol_accounts ORDER BY address')
+		account_results = cursor.fetchall()
+		cursor.execute(
+			'SELECT encode(address, \'hex\'), mosaic_id, updated_at_height FROM symbol_account_mosaics ORDER BY address, mosaic_id')
+		mosaic_results = cursor.fetchall()
+		cursor.execute('SELECT encode(address, \'hex\'), updated_at_height FROM symbol_multisig ORDER BY address')
+		multisig_results = cursor.fetchall()
+
+		self.assertEqual([(ADDRESS1.lower(), 1)], account_results)
+		self.assertEqual([(ADDRESS1.lower(), NATIVE_MOSAIC_ID, 1)], mosaic_results)
+		self.assertEqual([(ADDRESS1.lower(), 1)], multisig_results)
+
 	def test_can_repair_rollback_from_height_in_one_transaction(self):
 		# Arrange:
 		database = self._create_database()
@@ -1628,6 +1675,10 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		database.upsert_receipts_for_height(1, [_create_receipt(1)], 100)
 		database.upsert_receipts_for_height(2, [_create_receipt(2)], 100)
 		database.upsert_receipts_for_height(3, [_create_receipt(3)], 100)
+		database.upsert_account_current_state(*_create_account_row(ADDRESS1, observed_height=1))
+		database.upsert_account_current_state(*_create_account_row(RECIPIENT_ADDRESS, observed_height=2))
+		database.upsert_multisig(bytes.fromhex(ADDRESS1), _create_multisig_row(ADDRESS1, 1))
+		database.upsert_multisig(bytes.fromhex(RECIPIENT_ADDRESS), _create_multisig_row(RECIPIENT_ADDRESS, 2))
 
 		# Act:
 		database.repair_rollback_from_height(2, _create_sync_state(
@@ -1650,6 +1701,13 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		receipt_results = cursor.fetchall()
 		cursor.execute('SELECT height, block_reward FROM symbol_blocks ORDER BY height')
 		block_reward_results = cursor.fetchall()
+		cursor.execute('SELECT encode(address, \'hex\'), last_seen_height FROM symbol_accounts ORDER BY address')
+		account_results = cursor.fetchall()
+		cursor.execute(
+			'SELECT encode(address, \'hex\'), mosaic_id, updated_at_height FROM symbol_account_mosaics ORDER BY address, mosaic_id')
+		account_mosaic_results = cursor.fetchall()
+		cursor.execute('SELECT encode(address, \'hex\'), updated_at_height FROM symbol_multisig ORDER BY address')
+		multisig_results = cursor.fetchall()
 		sync_state = database.get_sync_state()
 
 		self.assertEqual([(1,)], block_results)
@@ -1658,6 +1716,9 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		self.assertEqual([(1, 'kept address', 'signer')], address_results)
 		self.assertEqual([(1,)], receipt_results)
 		self.assertEqual([(1, 100)], block_reward_results)
+		self.assertEqual([(ADDRESS1.lower(), 1)], account_results)
+		self.assertEqual([(ADDRESS1.lower(), NATIVE_MOSAIC_ID, 1)], account_mosaic_results)
+		self.assertEqual([(ADDRESS1.lower(), 1)], multisig_results)
 		self.assertEqual('repairing', sync_state['status'])
 		self.assertEqual(1, sync_state['last_synced_height'])
 		self.assertEqual(

--- a/explorer/puller/tests/db/test_SymbolDatabase.py
+++ b/explorer/puller/tests/db/test_SymbolDatabase.py
@@ -1048,7 +1048,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 
 		self.assertEqual((200, Decimal('0.9'), True), cursor.fetchone())
 
-	def test_can_upsert_and_delete_multisig(self):
+	def test_can_upsert_multisig(self):
 		# Arrange:
 		database = self._create_database()
 		account_row, mosaic_rows = _create_account_row()
@@ -1088,10 +1088,26 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 			[bytes(value) for value in result[3]]
 		))
 
+	def test_upsert_multisig_deletes_when_none(self):
+		# Arrange:
+		database = self._create_database()
+		account_row, mosaic_rows = _create_account_row()
+		database.upsert_account_current_state(account_row, mosaic_rows)
+		multisig_row = {
+			'address': bytes.fromhex(ADDRESS1),
+			'min_approval': 2,
+			'min_removal': 1,
+			'cosignatory_addresses': [bytes.fromhex('AA' * 24)],
+			'multisig_addresses': [bytes.fromhex('BB' * 24)],
+			'updated_at_height': 50
+		}
+		database.upsert_multisig(bytes.fromhex(ADDRESS1), multisig_row)
+
 		# Act:
 		database.upsert_multisig(bytes.fromhex(ADDRESS1), None)
 
 		# Assert:
+		cursor = database.connection.cursor()
 		cursor.execute('SELECT COUNT(*) FROM symbol_multisig WHERE address = %s', (bytes.fromhex(ADDRESS1),))
 
 		self.assertEqual((0,), cursor.fetchone())

--- a/explorer/puller/tests/db/test_SymbolDatabase.py
+++ b/explorer/puller/tests/db/test_SymbolDatabase.py
@@ -109,7 +109,6 @@ def _create_receipt(height, receipt_type='inflation', **overrides):
 	return receipt
 
 
-
 def _create_account_row(address_hex=ADDRESS1, observed_height=10, **item_overrides):
 	return create_account_row(
 		create_account_item(address_hex, **item_overrides),

--- a/explorer/puller/tests/db/test_SymbolDatabase.py
+++ b/explorer/puller/tests/db/test_SymbolDatabase.py
@@ -982,6 +982,26 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		self.assertEqual((200, 10, 20), account_result)
 		self.assertEqual([(NATIVE_MOSAIC_ID, 30000000000, 20)], mosaic_results)
 
+	def test_upsert_account_current_state_clears_existing_mosaics_when_replaced_with_empty_list(self):
+		# Arrange:
+		database = self._create_database()
+		account_row, mosaic_rows = _create_account_row()
+		updated_account_row, updated_mosaic_rows = _create_account_row(
+			observed_height=20,
+			mosaics=[])
+
+		# Act:
+		database.upsert_account_current_state(account_row, mosaic_rows)
+		database.upsert_account_current_state(updated_account_row, updated_mosaic_rows)
+
+		# Assert:
+		cursor = database.connection.cursor()
+		cursor.execute(
+			'SELECT COUNT(*) FROM symbol_account_mosaics WHERE address = %s',
+			(bytes.fromhex(ADDRESS1),))
+
+		self.assertEqual((0,), cursor.fetchone())
+
 	def test_upsert_account_current_state_preserves_importance_percentage_when_not_overwriting(self):
 		# Arrange:
 		database = self._create_database()

--- a/explorer/puller/tests/db/test_SymbolDatabase.py
+++ b/explorer/puller/tests/db/test_SymbolDatabase.py
@@ -13,6 +13,7 @@ from symbolchain.symbol.Network import Network
 
 from puller.db.SymbolDatabase import SymbolDatabase
 from puller.model.symbol.Account import create_account_row
+from tests.facade.symbol.puller_test_utils import NATIVE_MOSAIC_ID, create_account_item
 
 from ..test.SymbolTransactionTestUtils import create_transaction_entry
 
@@ -20,7 +21,6 @@ DatabaseConfig = namedtuple(
 	'DatabaseConfig',
 	['database', 'user', 'password', 'host', 'port'])
 ADDRESS1 = '9889432DE263BB8FE88444A4DA28D3609BD8BB8FAE18AE95'
-NATIVE_MOSAIC_ID = '72C0212E67A08BCE'
 
 
 def _create_block(height, block_hash=None, **overrides):
@@ -109,26 +109,10 @@ def _create_receipt(height, receipt_type='inflation', **overrides):
 	return receipt
 
 
-def _create_account_item(address_hex=ADDRESS1, item_id='account-id', importance='100', native_amount='20000000000', **account_overrides):
-	account = {
-		'address': address_hex,
-		'addressHeight': '7',
-		'publicKey': '0' * 64,
-		'accountType': 0,
-		'supplementalPublicKeys': {},
-		'activityBuckets': [],
-		'mosaics': [{'id': NATIVE_MOSAIC_ID, 'amount': native_amount}],
-		'importance': importance,
-		'importanceHeight': '6'
-	}
-	account.update(account_overrides)
-
-	return {'account': account, 'id': item_id}
-
 
 def _create_account_row(address_hex=ADDRESS1, observed_height=10, **item_overrides):
 	return create_account_row(
-		_create_account_item(address_hex, **item_overrides),
+		create_account_item(address_hex, **item_overrides),
 		Network.TESTNET,
 		observed_height,
 		NATIVE_MOSAIC_ID,
@@ -953,7 +937,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		account_row, mosaic_rows = _create_account_row()
 		updated_account_row, updated_mosaic_rows = _create_account_row(
 			observed_height=20,
-			native_amount='30000000000',
+			mosaics=[{'id': NATIVE_MOSAIC_ID, 'amount': '30000000000'}],
 			importance='200')
 
 		# Act:
@@ -1043,6 +1027,28 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 
 		self.assertEqual((False,), cursor.fetchone())
 
+	def test_can_upsert_account_current_state_and_overwrite_importance_percentage_and_harvesting_active(self):
+		# Arrange:
+		database = self._create_database()
+		account_row, mosaic_rows = _create_account_row()
+		account_row['importance_percentage'] = Decimal('0.5')
+		account_row['is_harvesting_active'] = False
+		updated_account_row, updated_mosaic_rows = _create_account_row(importance='200')
+		updated_account_row['importance_percentage'] = Decimal('0.9')
+		updated_account_row['is_harvesting_active'] = True
+
+		# Act:
+		database.upsert_account_current_state(account_row, mosaic_rows)
+		database.upsert_account_current_state(updated_account_row, updated_mosaic_rows)
+
+		# Assert:
+		cursor = database.connection.cursor()
+		cursor.execute(
+			'SELECT importance, importance_percentage, is_harvesting_active FROM symbol_accounts WHERE address = %s',
+			(bytes.fromhex(ADDRESS1),))
+
+		self.assertEqual((200, Decimal('0.9'), True), cursor.fetchone())
+
 	def test_can_upsert_and_delete_multisig(self):
 		# Arrange:
 		database = self._create_database()
@@ -1059,10 +1065,34 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 
 		# Act:
 		database.upsert_multisig(bytes.fromhex(ADDRESS1), multisig_row)
-		database.upsert_multisig(bytes.fromhex(ADDRESS1), None)
 
 		# Assert:
 		cursor = database.connection.cursor()
+		cursor.execute(
+			'''
+			SELECT min_approval, min_removal, cosignatory_addresses, multisig_addresses
+			FROM symbol_multisig
+			WHERE address = %s
+			''',
+			(bytes.fromhex(ADDRESS1),))
+		result = cursor.fetchone()
+
+		self.assertEqual((
+			multisig_row['min_approval'],
+			multisig_row['min_removal'],
+			multisig_row['cosignatory_addresses'],
+			multisig_row['multisig_addresses']
+		), (
+			result[0],
+			result[1],
+			[bytes(value) for value in result[2]],
+			[bytes(value) for value in result[3]]
+		))
+
+		# Act:
+		database.upsert_multisig(bytes.fromhex(ADDRESS1), None)
+
+		# Assert:
 		cursor.execute('SELECT COUNT(*) FROM symbol_multisig WHERE address = %s', (bytes.fromhex(ADDRESS1),))
 
 		self.assertEqual((0,), cursor.fetchone())

--- a/explorer/puller/tests/db/test_SymbolDatabase.py
+++ b/explorer/puller/tests/db/test_SymbolDatabase.py
@@ -1038,7 +1038,10 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 
 		# Act:
 		database.upsert_account_current_state(account_row, mosaic_rows)
-		database.upsert_account_current_state(updated_account_row, updated_mosaic_rows)
+		database.upsert_account_current_state(
+			updated_account_row,
+			updated_mosaic_rows,
+			overwrite_importance_percentage=True)
 
 		# Assert:
 		cursor = database.connection.cursor()
@@ -1069,7 +1072,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		cursor = database.connection.cursor()
 		cursor.execute(
 			'''
-			SELECT min_approval, min_removal, cosignatory_addresses, multisig_addresses
+			SELECT min_approval, min_removal, cosignatory_addresses, multisig_addresses, updated_at_height
 			FROM symbol_multisig
 			WHERE address = %s
 			''',
@@ -1080,12 +1083,14 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 			multisig_row['min_approval'],
 			multisig_row['min_removal'],
 			multisig_row['cosignatory_addresses'],
-			multisig_row['multisig_addresses']
+			multisig_row['multisig_addresses'],
+			multisig_row['updated_at_height']
 		), (
 			result[0],
 			result[1],
 			[bytes(value) for value in result[2]],
-			[bytes(value) for value in result[3]]
+			[bytes(value) for value in result[3]],
+			result[4]
 		))
 
 	def test_upsert_multisig_deletes_when_none(self):

--- a/explorer/puller/tests/db/test_SymbolDatabase.py
+++ b/explorer/puller/tests/db/test_SymbolDatabase.py
@@ -985,7 +985,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 
 		self.assertEqual((0,), cursor.fetchone())
 
-	def test_upsert_account_current_state_preserves_importance_percentage_when_not_overwriting(self):
+	def test_upsert_account_current_state_never_overwrites_importance_percentage(self):
 		# Arrange:
 		database = self._create_database()
 		account_row, mosaic_rows = _create_account_row()
@@ -994,10 +994,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 
 		# Act:
 		database.upsert_account_current_state(account_row, mosaic_rows)
-		database.upsert_account_current_state(
-			updated_account_row,
-			updated_mosaic_rows,
-			overwrite_importance_percentage=False)
+		database.upsert_account_current_state(updated_account_row, updated_mosaic_rows)
 
 		# Assert:
 		cursor = database.connection.cursor()
@@ -1026,30 +1023,25 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 
 		self.assertEqual((False,), cursor.fetchone())
 
-	def test_can_upsert_account_current_state_and_overwrite_importance_percentage_and_harvesting_active(self):
+	def test_can_upsert_account_current_state_and_overwrite_harvesting_active_by_default(self):
 		# Arrange:
 		database = self._create_database()
 		account_row, mosaic_rows = _create_account_row()
-		account_row['importance_percentage'] = Decimal('0.5')
 		account_row['is_harvesting_active'] = False
 		updated_account_row, updated_mosaic_rows = _create_account_row(importance='200')
-		updated_account_row['importance_percentage'] = Decimal('0.9')
 		updated_account_row['is_harvesting_active'] = True
 
 		# Act:
 		database.upsert_account_current_state(account_row, mosaic_rows)
-		database.upsert_account_current_state(
-			updated_account_row,
-			updated_mosaic_rows,
-			overwrite_importance_percentage=True)
+		database.upsert_account_current_state(updated_account_row, updated_mosaic_rows)
 
 		# Assert:
 		cursor = database.connection.cursor()
 		cursor.execute(
-			'SELECT importance, importance_percentage, is_harvesting_active FROM symbol_accounts WHERE address = %s',
+			'SELECT importance, is_harvesting_active FROM symbol_accounts WHERE address = %s',
 			(bytes.fromhex(ADDRESS1),))
 
-		self.assertEqual((200, Decimal('0.9'), True), cursor.fetchone())
+		self.assertEqual((200, True), cursor.fetchone())
 
 	def test_can_upsert_multisig(self):
 		# Arrange:

--- a/explorer/puller/tests/facade/symbol/puller_test_utils.py
+++ b/explorer/puller/tests/facade/symbol/puller_test_utils.py
@@ -7,6 +7,7 @@ from unittest import TestCase
 from common.symbol.NodeConfiguration import SymbolNodeConfiguration
 from common.tests.PostgresTestUtils import PostgresTestDatabase, drop_symbol_block_tables_if_present
 from symbolchain.sc import ReceiptType, TransactionType
+from symbolchain.symbol.Network import Network
 
 from puller.facade.SymbolPuller import MAX_PAGE_SIZE, DatabaseConfiguration, SymbolPuller
 from puller.model.symbol.Block import create_block_row
@@ -292,6 +293,15 @@ def create_account_item(address_hex=BENEFICIARY_ADDRESS, item_id='account-id', *
 	return {'account': account, 'id': item_id}
 
 
+class PostPath(str):
+	"""A str subclass that also carries the POST request payload, so connector.paths stays a flat path list."""
+
+	def __new__(cls, url_path, request_payload):
+		path = super().__new__(cls, url_path)
+		path.request_payload = request_payload
+		return path
+
+
 class FakeConnector:
 	def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
 		self,
@@ -313,6 +323,14 @@ class FakeConnector:
 		self.account_by_address = account_by_address or {}
 		self.multisig_by_address = multisig_by_address or {}
 		self.paths = []
+
+	@property
+	def post_payloads(self):
+		return [
+			path.request_payload
+			for path in self.paths
+			if hasattr(path, 'request_payload')
+		]
 
 	async def get(self, url_path, *_):  # pylint: disable=too-many-return-statements
 		self.paths.append(url_path)
@@ -351,6 +369,18 @@ class FakeConnector:
 				'code': 'ResourceNotFound',
 				'message': f'no resource exists with id {address_text}'
 			})
+
+		raise KeyError(url_path)
+
+	async def post(self, url_path, request_payload, *_):
+		self.paths.append(PostPath(url_path, request_payload))
+		if 'accounts' == url_path:
+			return [
+				self.account_by_address.get(
+					address_text,
+					create_account_item(address_hex=Network.TESTNET.address_class(address_text).bytes.hex().upper()))
+				for address_text in request_payload['addresses']
+			]
 
 		raise KeyError(url_path)
 

--- a/explorer/puller/tests/facade/symbol/puller_test_utils.py
+++ b/explorer/puller/tests/facade/symbol/puller_test_utils.py
@@ -13,6 +13,8 @@ from puller.model.symbol.Block import create_block_row
 from tests.test.SymbolTestConstants import BENEFICIARY_ADDRESS, RECIPIENT_ADDRESS, SIGNER_PUBLIC_KEY
 
 NODE_URL = 'http://127.0.0.1:3000'
+NATIVE_MOSAIC_ID = '72C0212E67A08BCE'
+NATIVE_MOSAIC_DIVISIBILITY = 6
 
 
 def create_db_config(config_dir, db_config=None, include_symbol_db=True):
@@ -261,7 +263,33 @@ def create_chain_info(chain_height=1, finalized_height=1):
 
 
 def create_network_properties(epoch_adjustment='100s'):
-	return {'network': {'epochAdjustment': epoch_adjustment}}
+	return {
+		'network': {'epochAdjustment': epoch_adjustment},
+		'chain': {'currencyMosaicId': "0x72C0'212E'67A0'8BCE"}
+	}
+
+
+def create_mosaic_definition(divisibility=NATIVE_MOSAIC_DIVISIBILITY):
+	return {'mosaic': {'divisibility': divisibility}}
+
+
+def create_account_item(address_hex=BENEFICIARY_ADDRESS, item_id='account-id', **account_overrides):
+	account = {
+		'version': 1,
+		'address': address_hex,
+		'addressHeight': '7',
+		'publicKey': '0' * 64,
+		'publicKeyHeight': '0',
+		'accountType': 0,
+		'supplementalPublicKeys': {},
+		'activityBuckets': [],
+		'mosaics': [{'id': NATIVE_MOSAIC_ID, 'amount': str(20_000 * 10 ** NATIVE_MOSAIC_DIVISIBILITY)}],
+		'importance': '100',
+		'importanceHeight': '6'
+	}
+	account.update(account_overrides)
+
+	return {'account': account, 'id': item_id}
 
 
 class FakeConnector:
@@ -272,7 +300,9 @@ class FakeConnector:
 		block_by_height=None,
 		finalized_height=1,
 		transactions_by_path=None,
-		statement_pages=None
+		statement_pages=None,
+		account_by_address=None,
+		multisig_by_address=None
 	):  # pylint: disable=too-many-arguments,too-many-positional-arguments
 		self.chain_height = chain_height
 		self.pages = pages
@@ -280,14 +310,18 @@ class FakeConnector:
 		self.finalized_height = finalized_height
 		self.transactions_by_path = transactions_by_path or {}
 		self.statement_pages = statement_pages or {}
+		self.account_by_address = account_by_address or {}
+		self.multisig_by_address = multisig_by_address or {}
 		self.paths = []
 
-	async def get(self, url_path, *_):
+	async def get(self, url_path, *_):  # pylint: disable=too-many-return-statements
 		self.paths.append(url_path)
 		if 'chain/info' == url_path:
 			return create_chain_info(self.chain_height, self.finalized_height)
 		if 'network/properties' == url_path:
 			return create_network_properties()
+		if f'mosaics/{NATIVE_MOSAIC_ID}' == url_path:
+			return create_mosaic_definition()
 		if url_path.startswith('blocks/'):
 			height = int(url_path.removeprefix('blocks/'))
 			return self.block_by_height[height]
@@ -308,6 +342,15 @@ class FakeConnector:
 			return response
 		if url_path.startswith('statements/transaction?'):
 			return self.statement_pages.get(url_path, {'data': []})
+		if url_path.startswith('accounts/'):
+			address_text = url_path.removeprefix('accounts/')
+			return self.account_by_address.get(address_text, create_account_item())
+		if url_path.startswith('account/') and url_path.endswith('/multisig'):
+			address_text = url_path.removeprefix('account/').removesuffix('/multisig')
+			return self.multisig_by_address.get(address_text, {
+				'code': 'ResourceNotFound',
+				'message': f'no resource exists with id {address_text}'
+			})
 
 		raise KeyError(url_path)
 
@@ -319,6 +362,9 @@ class ResponseConnector:
 
 	async def get(self, url_path, *_):
 		self.paths.append(url_path)
+		if f'mosaics/{NATIVE_MOSAIC_ID}' == url_path and url_path not in self.responses:
+			return create_mosaic_definition()
+
 		return self.responses[url_path]
 
 
@@ -396,6 +442,9 @@ class SymbolPullerTestBase(TestCase):
 		)
 
 		return cursor.fetchall()
+
+	def _beneficiary_address_text(self):
+		return str(self.puller.symbol_facade.network.address_class(bytes.fromhex(BENEFICIARY_ADDRESS)))
 
 	def _seed_blocks(self, database, heights, block_hashes=None):
 		block_hashes = block_hashes or {}

--- a/explorer/puller/tests/facade/symbol/puller_test_utils.py
+++ b/explorer/puller/tests/facade/symbol/puller_test_utils.py
@@ -302,7 +302,7 @@ class PostPath(str):
 		return path
 
 
-class FakeConnector:
+class FakeConnector:  # pylint: disable=too-many-instance-attributes
 	def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
 		self,
 		chain_height,

--- a/explorer/puller/tests/facade/symbol/puller_test_utils.py
+++ b/explorer/puller/tests/facade/symbol/puller_test_utils.py
@@ -360,9 +360,6 @@ class FakeConnector:  # pylint: disable=too-many-instance-attributes
 			return response
 		if url_path.startswith('statements/transaction?'):
 			return self.statement_pages.get(url_path, {'data': []})
-		if url_path.startswith('accounts/'):
-			address_text = url_path.removeprefix('accounts/')
-			return self.account_by_address.get(address_text, create_account_item())
 		if url_path.startswith('account/') and url_path.endswith('/multisig'):
 			address_text = url_path.removeprefix('account/').removesuffix('/multisig')
 			return self.multisig_by_address.get(address_text, {

--- a/explorer/puller/tests/facade/symbol/puller_test_utils.py
+++ b/explorer/puller/tests/facade/symbol/puller_test_utils.py
@@ -7,7 +7,7 @@ from unittest import TestCase
 from common.symbol.NodeConfiguration import SymbolNodeConfiguration
 from common.tests.PostgresTestUtils import PostgresTestDatabase, drop_symbol_block_tables_if_present
 from symbolchain.sc import ReceiptType, TransactionType
-from symbolchain.symbol.Network import Network
+from symbolchain.symbol.Network import Address, Network
 
 from puller.facade.SymbolPuller import MAX_PAGE_SIZE, DatabaseConfiguration, SymbolPuller
 from puller.model.symbol.Block import create_block_row
@@ -296,15 +296,6 @@ def create_account_item(address_hex=BENEFICIARY_ADDRESS, item_id='account-id', *
 	return {'account': account, 'id': item_id}
 
 
-class PostPath(str):
-	"""A str subclass that also carries the POST request payload, so connector.paths stays a flat path list."""
-
-	def __new__(cls, url_path, request_payload):
-		path = super().__new__(cls, url_path)
-		path.request_payload = request_payload
-		return path
-
-
 class FakeConnector:  # pylint: disable=too-many-instance-attributes
 	def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
 		self,
@@ -326,14 +317,11 @@ class FakeConnector:  # pylint: disable=too-many-instance-attributes
 		self.account_by_address = account_by_address or {}
 		self.multisig_by_address = multisig_by_address or {}
 		self.paths = []
+		self.post_payloads_list = []
 
 	@property
 	def post_payloads(self):
-		return [
-			path.request_payload
-			for path in self.paths
-			if hasattr(path, 'request_payload')
-		]
+		return self.post_payloads_list
 
 	async def get(self, url_path, *_):  # pylint: disable=too-many-return-statements
 		self.paths.append(url_path)
@@ -373,7 +361,8 @@ class FakeConnector:  # pylint: disable=too-many-instance-attributes
 		raise KeyError(url_path)
 
 	async def post(self, url_path, request_payload, *_):
-		self.paths.append(PostPath(url_path, request_payload))
+		self.paths.append(url_path)
+		self.post_payloads_list.append(request_payload)
 		if 'accounts' == url_path:
 			return [
 				self.account_by_address.get(
@@ -473,8 +462,9 @@ class SymbolPullerTestBase(TestCase):
 
 		return cursor.fetchall()
 
-	def _beneficiary_address_text(self):
-		return str(self.puller.symbol_facade.network.address_class(bytes.fromhex(BENEFICIARY_ADDRESS)))
+	@staticmethod
+	def _beneficiary_address_text():
+		return str(Address.from_decoded_address_hex_string(BENEFICIARY_ADDRESS))
 
 	def _seed_blocks(self, database, heights, block_hashes=None):
 		block_hashes = block_hashes or {}

--- a/explorer/puller/tests/facade/symbol/puller_test_utils.py
+++ b/explorer/puller/tests/facade/symbol/puller_test_utils.py
@@ -218,17 +218,20 @@ def statement_path(start_height, end_height, page_number=1):
 	)
 
 
-def create_statement_item(height, amount, receipt_type=ReceiptType.INFLATION.value):
+def create_statement_item(height, amount, receipt_type=ReceiptType.INFLATION.value, **receipt_overrides):
+	receipt = {
+		'version': 1,
+		'type': receipt_type,
+		'mosaicId': '72C0212E67A08BCE',
+		'amount': str(amount)
+	}
+	receipt.update(receipt_overrides)
+
 	return {
 		'statement': {
 			'height': str(height),
 			'source': {'primaryId': height, 'secondaryId': 0},
-			'receipts': [{
-				'version': 1,
-				'type': receipt_type,
-				'mosaicId': '72C0212E67A08BCE',
-				'amount': str(amount)
-			}]
+			'receipts': [receipt]
 		},
 		'id': f'statement-{height}-{amount}',
 		'meta': {'timestamp': '0'}

--- a/explorer/puller/tests/facade/symbol/test_Puller.py
+++ b/explorer/puller/tests/facade/symbol/test_Puller.py
@@ -251,6 +251,27 @@ class SymbolPullerTest(TestCase):
 		)
 		self.assertEqual(2, connector.get.await_count)
 
+	def test_get_symbol_node_retries_non_not_found_api_error_when_not_found_is_allowed(self):
+		# Arrange:
+		connector = MagicMock()
+		connector.get = AsyncMock(side_effect=[
+			{
+				'code': 'InvalidArgument',
+				'message': 'offset has an invalid format'
+			},
+			{'data': []}
+		])
+		with temporary_symbol_puller(connector=connector) as puller:
+			# Act:
+			result = asyncio.run(puller.get_symbol_node(
+				'/blocks?pageSize=100&offset=bad&orderBy=height',
+				not_found_as_error=False
+			))
+
+		# Assert:
+		self.assertEqual({'data': []}, result)
+		self.assertEqual(2, connector.get.await_count)
+
 	def test_symbol_node_path_must_be_relative(self):
 		# Arrange:
 		connector = MagicMock()

--- a/explorer/puller/tests/facade/symbol/test_Puller.py
+++ b/explorer/puller/tests/facade/symbol/test_Puller.py
@@ -272,6 +272,21 @@ class SymbolPullerTest(TestCase):
 		self.assertEqual({'data': []}, result)
 		self.assertEqual(2, connector.get.await_count)
 
+	def test_get_symbol_node_does_not_retry_resource_not_found_when_not_found_is_allowed(self):
+		# Arrange:
+		connector = MagicMock()
+		connector.get = AsyncMock(return_value={
+			'code': 'ResourceNotFound',
+			'message': 'no resource exists with id foo'
+		})
+		with temporary_symbol_puller(connector=connector) as puller:
+			# Act:
+			result = asyncio.run(puller.get_symbol_node('/account/foo/multisig', not_found_as_error=False))
+
+		# Assert:
+		self.assertEqual({'code': 'ResourceNotFound', 'message': 'no resource exists with id foo'}, result)
+		self.assertEqual(1, connector.get.await_count)
+
 	def test_symbol_node_path_must_be_relative(self):
 		# Arrange:
 		connector = MagicMock()

--- a/explorer/puller/tests/facade/symbol/test_PullerAccounts.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerAccounts.py
@@ -1,6 +1,8 @@
 import asyncio
 from datetime import datetime, timedelta, timezone
 
+from symbollightapi.model.Exceptions import NodeException
+
 from puller.model.symbol.Account import create_account_row
 
 from .puller_test_utils import (
@@ -9,6 +11,7 @@ from .puller_test_utils import (
 	FakeConnector,
 	SymbolPullerTestBase,
 	create_account_item,
+	create_node_block,
 	set_symbol_connector
 )
 
@@ -29,83 +32,67 @@ class SymbolPullerAccountsTest(SymbolPullerTestBase):
 
 		return cursor.fetchone()
 
+	def _fetch_account_count(self, address_hex=BENEFICIARY_ADDRESS):
+		cursor = self.puller.symbol_db.connection.cursor()
+		cursor.execute(
+			'SELECT COUNT(*) FROM symbol_accounts WHERE address = %s',
+			(bytes.fromhex(address_hex),))
+
+		return cursor.fetchone()[0]
+
+	@staticmethod
+	def _raw_network_timestamp(days_ago=0):
+		return str(int(((datetime.now(timezone.utc) - timedelta(days=days_ago)).timestamp() - 100) * 1000))
+
+	def _create_block(self, height, days_ago=0):
+		return create_node_block(height, timestamp=self._raw_network_timestamp(days_ago))
+
+	def _sync_blocks(self, blocks, account_item=None, multisig_by_address=None):
+		address_text = self._address_text()
+		connector = FakeConnector(
+			max(int(block['block']['height']) for block in blocks),
+			{0: blocks},
+			account_by_address={address_text: account_item or create_account_item()},
+			multisig_by_address=multisig_by_address)
+
+		self._sync_with_connector(connector)
+
+		return connector
+
 	def test_refresh_dirty_accounts_for_batch_upserts_beneficiary_account_once_per_batch(self):
 		# Arrange:
 		address_text = self._address_text()
-		connector = FakeConnector(
-			1,
-			{},
-			account_by_address={address_text: create_account_item(importance='321')}
-		)
-		set_symbol_connector(self.puller, connector)
-		block_rows = [
-			{
-				'height': 1,
-				'beneficiary_address': bytes.fromhex(BENEFICIARY_ADDRESS),
-				'timestamp': datetime.now(timezone.utc) - timedelta(days=8)
-			},
-			{
-				'height': 2,
-				'beneficiary_address': bytes.fromhex(BENEFICIARY_ADDRESS),
-				'timestamp': datetime.now(timezone.utc)
-			}
-		]
+		blocks = [self._create_block(1), self._create_block(2)]
 
 		# Act:
-		asyncio.run(self.puller._refresh_dirty_accounts_for_batch(block_rows, NATIVE_MOSAIC_ID, 6))  # pylint: disable=protected-access
+		connector = self._sync_blocks(blocks, create_account_item(importance='321'))
 
 		# Assert:
 		self.assertEqual(1, connector.paths.count(f'accounts/{address_text}'))
 		self.assertEqual((321, 0, True, True, 2), self._fetch_account_current_state())
 
-	def test_refresh_dirty_accounts_for_batch_uses_latest_beneficiary_block_when_recent_block_is_first(self):
+	def test_refresh_dirty_accounts_for_batch_uses_latest_beneficiary_block_when_recent_block_is_second(self):
 		# Arrange:
-		address_text = self._address_text()
-		connector = FakeConnector(
-			1,
-			{},
-			account_by_address={address_text: create_account_item(importance='321')}
-		)
-		set_symbol_connector(self.puller, connector)
-		block_rows = [
-			{
-				'height': 2,
-				'beneficiary_address': bytes.fromhex(BENEFICIARY_ADDRESS),
-				'timestamp': datetime.now(timezone.utc)
-			},
-			{
-				'height': 1,
-				'beneficiary_address': bytes.fromhex(BENEFICIARY_ADDRESS),
-				'timestamp': datetime.now(timezone.utc) - timedelta(days=8)
-			}
-		]
+		account_row, mosaic_rows = self._create_current_account_row()
+		account_row['is_harvesting_active'] = False
+		self.puller.symbol_db.upsert_account_current_state(account_row, mosaic_rows)
+		blocks = [self._create_block(1, days_ago=8), self._create_block(2)]
 
 		# Act:
-		asyncio.run(self.puller._refresh_dirty_accounts_for_batch(block_rows, NATIVE_MOSAIC_ID, 6))  # pylint: disable=protected-access
+		self._sync_blocks(blocks, create_account_item(importance='321'))
 
 		# Assert:
-		self.assertEqual(1, connector.paths.count(f'accounts/{address_text}'))
 		self.assertEqual((321, 0, True, True, 2), self._fetch_account_current_state())
 
 	def test_refresh_dirty_accounts_for_batch_preserves_importance_percentage(self):
 		# Arrange:
-		address_text = self._address_text()
 		account_row, mosaic_rows = self._create_current_account_row(importance='100')
 		account_row['importance_percentage'] = 0.5
 		self.puller.symbol_db.upsert_account_current_state(account_row, mosaic_rows)
-		connector = FakeConnector(
-			1,
-			{},
-			account_by_address={address_text: create_account_item(importance='200')}
-		)
-		set_symbol_connector(self.puller, connector)
+		blocks = [self._create_block(1)]
 
 		# Act:
-		asyncio.run(self.puller._refresh_dirty_accounts_for_batch([{  # pylint: disable=protected-access
-			'height': 3,
-			'beneficiary_address': bytes.fromhex(BENEFICIARY_ADDRESS),
-			'timestamp': datetime.now(timezone.utc)
-		}], NATIVE_MOSAIC_ID, 6))
+		self._sync_blocks(blocks, create_account_item(importance='200'))
 
 		# Assert:
 		self.assertEqual(200, self._fetch_account_current_state()[0])
@@ -113,23 +100,13 @@ class SymbolPullerAccountsTest(SymbolPullerTestBase):
 
 	def test_refresh_dirty_accounts_for_batch_leaves_old_harvesting_active_value_unchanged(self):
 		# Arrange:
-		address_text = self._address_text()
 		account_row, mosaic_rows = self._create_current_account_row()
 		account_row['is_harvesting_active'] = False
 		self.puller.symbol_db.upsert_account_current_state(account_row, mosaic_rows)
-		connector = FakeConnector(
-			1,
-			{},
-			account_by_address={address_text: create_account_item(importance='200')}
-		)
-		set_symbol_connector(self.puller, connector)
+		blocks = [self._create_block(1, days_ago=8)]
 
 		# Act:
-		asyncio.run(self.puller._refresh_dirty_accounts_for_batch([{  # pylint: disable=protected-access
-			'height': 3,
-			'beneficiary_address': bytes.fromhex(BENEFICIARY_ADDRESS),
-			'timestamp': datetime.now(timezone.utc) - timedelta(days=8)
-		}], NATIVE_MOSAIC_ID, 6))
+		self._sync_blocks(blocks, create_account_item(importance='200'))
 
 		# Assert:
 		self.assertEqual(False, self._fetch_account_current_state()[2])
@@ -137,27 +114,20 @@ class SymbolPullerAccountsTest(SymbolPullerTestBase):
 	def test_refresh_dirty_accounts_for_batch_upserts_multisig(self):
 		# Arrange:
 		address_text = self._address_text()
-		connector = FakeConnector(
-			1,
-			{},
-			account_by_address={address_text: create_account_item()},
-			multisig_by_address={address_text: {
+		blocks = [self._create_block(1)]
+		multisig_by_address = {
+			address_text: {
 				'multisig': {
 					'minApproval': 2,
 					'minRemoval': 1,
 					'cosignatoryAddresses': ['AA' * 24],
 					'multisigAddresses': ['BB' * 24]
 				}
-			}}
-		)
-		set_symbol_connector(self.puller, connector)
+			}
+		}
 
 		# Act:
-		asyncio.run(self.puller._refresh_dirty_accounts_for_batch([{  # pylint: disable=protected-access
-			'height': 3,
-			'beneficiary_address': bytes.fromhex(BENEFICIARY_ADDRESS),
-			'timestamp': datetime.now(timezone.utc)
-		}], NATIVE_MOSAIC_ID, 6))
+		self._sync_blocks(blocks, multisig_by_address=multisig_by_address)
 
 		# Assert:
 		cursor = self.puller.symbol_db.connection.cursor()
@@ -171,7 +141,6 @@ class SymbolPullerAccountsTest(SymbolPullerTestBase):
 
 	def test_refresh_dirty_accounts_for_batch_deletes_multisig_when_node_returns_not_found(self):
 		# Arrange:
-		address_text = self._address_text()
 		account_row, mosaic_rows = self._create_current_account_row()
 		self.puller.symbol_db.upsert_account_current_state(account_row, mosaic_rows)
 		self.puller.symbol_db.upsert_multisig(bytes.fromhex(BENEFICIARY_ADDRESS), {
@@ -182,19 +151,10 @@ class SymbolPullerAccountsTest(SymbolPullerTestBase):
 			'multisig_addresses': [],
 			'updated_at_height': 2
 		})
-		connector = FakeConnector(
-			1,
-			{},
-			account_by_address={address_text: create_account_item()}
-		)
-		set_symbol_connector(self.puller, connector)
+		blocks = [self._create_block(1)]
 
 		# Act:
-		asyncio.run(self.puller._refresh_dirty_accounts_for_batch([{  # pylint: disable=protected-access
-			'height': 3,
-			'beneficiary_address': bytes.fromhex(BENEFICIARY_ADDRESS),
-			'timestamp': datetime.now(timezone.utc)
-		}], NATIVE_MOSAIC_ID, 6))
+		self._sync_blocks(blocks)
 
 		# Assert:
 		cursor = self.puller.symbol_db.connection.cursor()
@@ -202,19 +162,34 @@ class SymbolPullerAccountsTest(SymbolPullerTestBase):
 
 		self.assertEqual((0,), cursor.fetchone())
 
-	def test_get_native_mosaic_info_is_memoized(self):
+	def test_refresh_dirty_accounts_for_batch_does_not_upsert_account_when_multisig_fetch_fails(self):
 		# Arrange:
-		connector = FakeConnector(1, {})
+		address_text = self._address_text()
+		connector = FakeConnector(
+			1,
+			{0: [self._create_block(1)]},
+			account_by_address={address_text: create_account_item()},
+			multisig_by_address={address_text: {'code': 'InternalError', 'message': 'boom'}})
 		set_symbol_connector(self.puller, connector)
 
-		# Act:
-		first_result = asyncio.run(self.puller._get_native_mosaic_info())  # pylint: disable=protected-access
-		second_result = asyncio.run(self.puller._get_native_mosaic_info())  # pylint: disable=protected-access
+		# Act / Assert:
+		with self.assertRaisesRegex(NodeException, 'InternalError: boom'):
+			asyncio.run(self.puller.sync_block_headers())
 
 		# Assert:
-		self.assertEqual((NATIVE_MOSAIC_ID, 6), first_result)
-		self.assertEqual(first_result, second_result)
-		self.assertEqual(['network/properties', f'mosaics/{NATIVE_MOSAIC_ID}'], connector.paths)
+		self.assertEqual(0, self._fetch_account_count())
+
+	def test_get_native_mosaic_info_is_memoized(self):
+		# Arrange:
+		connector = FakeConnector(1, {0: [self._create_block(1)]})
+
+		# Act:
+		self._sync_with_connector(connector)
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual(2, connector.paths.count('network/properties'))
+		self.assertEqual(1, connector.paths.count(f'mosaics/{NATIVE_MOSAIC_ID}'))
 
 	def _create_current_account_row(self, address_hex=BENEFICIARY_ADDRESS, **overrides):
 		return create_account_row(

--- a/explorer/puller/tests/facade/symbol/test_PullerAccounts.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerAccounts.py
@@ -1,0 +1,225 @@
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+from puller.model.symbol.Account import create_account_row
+
+from .puller_test_utils import (
+	BENEFICIARY_ADDRESS,
+	NATIVE_MOSAIC_ID,
+	FakeConnector,
+	SymbolPullerTestBase,
+	create_account_item,
+	set_symbol_connector
+)
+
+
+class SymbolPullerAccountsTest(SymbolPullerTestBase):
+	def _address_text(self, address_hex=BENEFICIARY_ADDRESS):
+		return str(self.puller.symbol_facade.network.address_class(bytes.fromhex(address_hex)))
+
+	def _fetch_account_current_state(self, address_hex=BENEFICIARY_ADDRESS):
+		cursor = self.puller.symbol_db.connection.cursor()
+		cursor.execute(
+			'''
+			SELECT importance, importance_percentage, is_harvesting_active, is_eligible_for_harvesting, last_seen_height
+			FROM symbol_accounts
+			WHERE address = %s
+			''',
+			(bytes.fromhex(address_hex),))
+
+		return cursor.fetchone()
+
+	def test_refresh_dirty_accounts_for_batch_upserts_beneficiary_account_once_per_batch(self):
+		# Arrange:
+		address_text = self._address_text()
+		connector = FakeConnector(
+			1,
+			{},
+			account_by_address={address_text: create_account_item(importance='321')}
+		)
+		set_symbol_connector(self.puller, connector)
+		block_rows = [
+			{
+				'height': 1,
+				'beneficiary_address': bytes.fromhex(BENEFICIARY_ADDRESS),
+				'timestamp': datetime.now(timezone.utc) - timedelta(days=8)
+			},
+			{
+				'height': 2,
+				'beneficiary_address': bytes.fromhex(BENEFICIARY_ADDRESS),
+				'timestamp': datetime.now(timezone.utc)
+			}
+		]
+
+		# Act:
+		asyncio.run(self.puller._refresh_dirty_accounts_for_batch(block_rows, NATIVE_MOSAIC_ID, 6))  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual(1, connector.paths.count(f'accounts/{address_text}'))
+		self.assertEqual((321, 0, True, True, 2), self._fetch_account_current_state())
+
+	def test_refresh_dirty_accounts_for_batch_uses_latest_beneficiary_block_when_recent_block_is_first(self):
+		# Arrange:
+		address_text = self._address_text()
+		connector = FakeConnector(
+			1,
+			{},
+			account_by_address={address_text: create_account_item(importance='321')}
+		)
+		set_symbol_connector(self.puller, connector)
+		block_rows = [
+			{
+				'height': 2,
+				'beneficiary_address': bytes.fromhex(BENEFICIARY_ADDRESS),
+				'timestamp': datetime.now(timezone.utc)
+			},
+			{
+				'height': 1,
+				'beneficiary_address': bytes.fromhex(BENEFICIARY_ADDRESS),
+				'timestamp': datetime.now(timezone.utc) - timedelta(days=8)
+			}
+		]
+
+		# Act:
+		asyncio.run(self.puller._refresh_dirty_accounts_for_batch(block_rows, NATIVE_MOSAIC_ID, 6))  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual(1, connector.paths.count(f'accounts/{address_text}'))
+		self.assertEqual((321, 0, True, True, 2), self._fetch_account_current_state())
+
+	def test_refresh_dirty_accounts_for_batch_preserves_importance_percentage(self):
+		# Arrange:
+		address_text = self._address_text()
+		account_row, mosaic_rows = self._create_current_account_row(importance='100')
+		account_row['importance_percentage'] = 0.5
+		self.puller.symbol_db.upsert_account_current_state(account_row, mosaic_rows)
+		connector = FakeConnector(
+			1,
+			{},
+			account_by_address={address_text: create_account_item(importance='200')}
+		)
+		set_symbol_connector(self.puller, connector)
+
+		# Act:
+		asyncio.run(self.puller._refresh_dirty_accounts_for_batch([{  # pylint: disable=protected-access
+			'height': 3,
+			'beneficiary_address': bytes.fromhex(BENEFICIARY_ADDRESS),
+			'timestamp': datetime.now(timezone.utc)
+		}], NATIVE_MOSAIC_ID, 6))
+
+		# Assert:
+		self.assertEqual(200, self._fetch_account_current_state()[0])
+		self.assertEqual(0.5, float(self._fetch_account_current_state()[1]))
+
+	def test_refresh_dirty_accounts_for_batch_leaves_old_harvesting_active_value_unchanged(self):
+		# Arrange:
+		address_text = self._address_text()
+		account_row, mosaic_rows = self._create_current_account_row()
+		account_row['is_harvesting_active'] = False
+		self.puller.symbol_db.upsert_account_current_state(account_row, mosaic_rows)
+		connector = FakeConnector(
+			1,
+			{},
+			account_by_address={address_text: create_account_item(importance='200')}
+		)
+		set_symbol_connector(self.puller, connector)
+
+		# Act:
+		asyncio.run(self.puller._refresh_dirty_accounts_for_batch([{  # pylint: disable=protected-access
+			'height': 3,
+			'beneficiary_address': bytes.fromhex(BENEFICIARY_ADDRESS),
+			'timestamp': datetime.now(timezone.utc) - timedelta(days=8)
+		}], NATIVE_MOSAIC_ID, 6))
+
+		# Assert:
+		self.assertEqual(False, self._fetch_account_current_state()[2])
+
+	def test_refresh_dirty_accounts_for_batch_upserts_multisig(self):
+		# Arrange:
+		address_text = self._address_text()
+		connector = FakeConnector(
+			1,
+			{},
+			account_by_address={address_text: create_account_item()},
+			multisig_by_address={address_text: {
+				'multisig': {
+					'minApproval': 2,
+					'minRemoval': 1,
+					'cosignatoryAddresses': ['AA' * 24],
+					'multisigAddresses': ['BB' * 24]
+				}
+			}}
+		)
+		set_symbol_connector(self.puller, connector)
+
+		# Act:
+		asyncio.run(self.puller._refresh_dirty_accounts_for_batch([{  # pylint: disable=protected-access
+			'height': 3,
+			'beneficiary_address': bytes.fromhex(BENEFICIARY_ADDRESS),
+			'timestamp': datetime.now(timezone.utc)
+		}], NATIVE_MOSAIC_ID, 6))
+
+		# Assert:
+		cursor = self.puller.symbol_db.connection.cursor()
+		cursor.execute('SELECT min_approval, min_removal, cosignatory_addresses, multisig_addresses FROM symbol_multisig')
+
+		result = cursor.fetchone()
+		self.assertEqual(2, result[0])
+		self.assertEqual(1, result[1])
+		self.assertEqual([bytes.fromhex('AA' * 24)], [bytes(value) for value in result[2]])
+		self.assertEqual([bytes.fromhex('BB' * 24)], [bytes(value) for value in result[3]])
+
+	def test_refresh_dirty_accounts_for_batch_deletes_multisig_when_node_returns_not_found(self):
+		# Arrange:
+		address_text = self._address_text()
+		account_row, mosaic_rows = self._create_current_account_row()
+		self.puller.symbol_db.upsert_account_current_state(account_row, mosaic_rows)
+		self.puller.symbol_db.upsert_multisig(bytes.fromhex(BENEFICIARY_ADDRESS), {
+			'address': bytes.fromhex(BENEFICIARY_ADDRESS),
+			'min_approval': 1,
+			'min_removal': 1,
+			'cosignatory_addresses': [],
+			'multisig_addresses': [],
+			'updated_at_height': 2
+		})
+		connector = FakeConnector(
+			1,
+			{},
+			account_by_address={address_text: create_account_item()}
+		)
+		set_symbol_connector(self.puller, connector)
+
+		# Act:
+		asyncio.run(self.puller._refresh_dirty_accounts_for_batch([{  # pylint: disable=protected-access
+			'height': 3,
+			'beneficiary_address': bytes.fromhex(BENEFICIARY_ADDRESS),
+			'timestamp': datetime.now(timezone.utc)
+		}], NATIVE_MOSAIC_ID, 6))
+
+		# Assert:
+		cursor = self.puller.symbol_db.connection.cursor()
+		cursor.execute('SELECT COUNT(*) FROM symbol_multisig')
+
+		self.assertEqual((0,), cursor.fetchone())
+
+	def test_get_native_mosaic_info_is_memoized(self):
+		# Arrange:
+		connector = FakeConnector(1, {})
+		set_symbol_connector(self.puller, connector)
+
+		# Act:
+		first_result = asyncio.run(self.puller._get_native_mosaic_info())  # pylint: disable=protected-access
+		second_result = asyncio.run(self.puller._get_native_mosaic_info())  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual((NATIVE_MOSAIC_ID, 6), first_result)
+		self.assertEqual(first_result, second_result)
+		self.assertEqual(['network/properties', f'mosaics/{NATIVE_MOSAIC_ID}'], connector.paths)
+
+	def _create_current_account_row(self, address_hex=BENEFICIARY_ADDRESS, **overrides):
+		return create_account_row(
+			create_account_item(address_hex, **overrides),
+			self.puller.symbol_facade.network,
+			1,
+			NATIVE_MOSAIC_ID,
+			6)

--- a/explorer/puller/tests/facade/symbol/test_PullerAccounts.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerAccounts.py
@@ -113,6 +113,26 @@ class SymbolPullerAccountsTest(SymbolPullerTestBase):
 			(100, 0, False, True, 1),
 			self._fetch_account_current_state(RECIPIENT_ADDRESS))
 
+	def test_refresh_dirty_accounts_for_batch_ignores_namespace_alias_transaction_participant(self):
+		# Arrange:
+		alias_address = '99065A28385EB5AE88000000000000000000000000000000'
+		beneficiary_address_text = self._address_text()
+		connector = FakeConnector(
+			1,
+			{0: [self._create_block(1)]},
+			transactions_by_path={
+				transaction_path(1, 1): {
+					'data': [create_node_transaction(1, recipientAddress=alias_address)]
+				}
+			},
+			account_by_address=self._account_by_address_text(BENEFICIARY_ADDRESS))
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual([{'addresses': [beneficiary_address_text]}], connector.post_payloads)
+
 	def test_refresh_dirty_accounts_for_batch_prefers_beneficiary_timestamp_when_address_is_also_transaction_participant(self):
 		# Arrange:
 		connector = FakeConnector(

--- a/explorer/puller/tests/facade/symbol/test_PullerAccounts.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerAccounts.py
@@ -97,7 +97,7 @@ class SymbolPullerAccountsTest(SymbolPullerTestBase):
 		self.assertEqual([{'addresses': [address_text]}], connector.post_payloads)
 		self.assertEqual((321, 0, True, True, 2), self._fetch_account_current_state())
 
-	def test_refresh_dirty_accounts_for_batch_does_not_mark_transaction_participant_as_active_harvester(self):
+	def test_refresh_dirty_accounts_for_batch_does_not_mark_transaction_participant_as_inactive_harvester(self):
 		# Arrange:
 		account_row, mosaic_rows = self._create_current_account_row(address_hex=RECIPIENT_ADDRESS, importance='100')
 		account_row['is_harvesting_active'] = True
@@ -139,12 +139,14 @@ class SymbolPullerAccountsTest(SymbolPullerTestBase):
 		self.assertEqual([{'addresses': [beneficiary_address_text]}], connector.post_payloads)
 
 	def test_refresh_dirty_accounts_for_batch_prefers_beneficiary_timestamp_when_address_is_also_transaction_participant(self):
-		# Arrange:
+		# Arrange: BENEFICIARY_ADDRESS is only a transaction participant at height 1 (old block, outside the
+		# harvesting-active window) and the block beneficiary at height 2 (recent block, inside the window) —
+		# if the wrong source's timestamp were used, is_harvesting_active would come out False.
 		connector = FakeConnector(
-			1,
-			{0: [self._create_block(1)]},
+			2,
+			{0: [self._create_block(1, days_ago=8), self._create_block(2)]},
 			transactions_by_path={
-				transaction_path(1, 1): {'data': [create_node_transaction(1, recipientAddress=BENEFICIARY_ADDRESS)]}
+				transaction_path(1, 2): {'data': [create_node_transaction(1, recipientAddress=BENEFICIARY_ADDRESS)]}
 			},
 			account_by_address=self._account_by_address_text(BENEFICIARY_ADDRESS))
 
@@ -158,24 +160,23 @@ class SymbolPullerAccountsTest(SymbolPullerTestBase):
 
 	def test_refresh_dirty_accounts_for_batch_deduplicates_repeated_transaction_participant_addresses(self):
 		# Arrange:
-		beneficiary_address_text = self._address_text(RECIPIENT_ADDRESS)
-		participant_address_text = self._address_text(BENEFICIARY_ADDRESS)
+		beneficiary_address_text = self._address_text(BENEFICIARY_ADDRESS)
+		participant_address_text = self._address_text(RECIPIENT_ADDRESS)
 		connector = FakeConnector(
 			1,
-			{0: [self._create_block(1, beneficiaryAddress=RECIPIENT_ADDRESS)]},
+			{0: [self._create_block(1)]},
 			transactions_by_path={
 				transaction_path(1, 1): {
 					'data': [
 						create_node_transaction(
 							1,
 							transaction_hash=f'{index:064X}',
-							transaction_id=f'transaction-{index}',
-							recipientAddress=BENEFICIARY_ADDRESS)
+							transaction_id=f'transaction-{index}')
 						for index in range(2)
 					]
 				}
 			},
-			account_by_address=self._account_by_address_text(RECIPIENT_ADDRESS, BENEFICIARY_ADDRESS))
+			account_by_address=self._account_by_address_text(BENEFICIARY_ADDRESS, RECIPIENT_ADDRESS))
 
 		# Act:
 		self._sync_with_connector(connector)

--- a/explorer/puller/tests/facade/symbol/test_PullerAccounts.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerAccounts.py
@@ -4,22 +4,41 @@ from decimal import Decimal
 
 from symbollightapi.model.Exceptions import NodeException
 
+from puller.facade.SymbolPuller import ACCOUNT_BATCH_FETCH_SIZE
 from puller.model.symbol.Account import create_account_row
 
 from .puller_test_utils import (
 	BENEFICIARY_ADDRESS,
 	NATIVE_MOSAIC_ID,
+	RECIPIENT_ADDRESS,
 	FakeConnector,
 	SymbolPullerTestBase,
 	create_account_item,
 	create_node_block,
-	set_symbol_connector
+	create_node_transaction,
+	set_symbol_connector,
+	transaction_path
 )
+
+
+class MalformedAccountsConnector(FakeConnector):
+	async def post(self, url_path, request_payload, *_):
+		self.paths.append(url_path)
+		if 'accounts' == url_path:
+			return {'data': []}
+
+		raise KeyError(url_path)
 
 
 class SymbolPullerAccountsTest(SymbolPullerTestBase):
 	def _address_text(self, address_hex=BENEFICIARY_ADDRESS):
 		return str(self.puller.symbol_facade.network.address_class(bytes.fromhex(address_hex)))
+
+	def _account_by_address_text(self, *address_hex_values):
+		return {
+			self._address_text(address_hex): create_account_item(address_hex=address_hex)
+			for address_hex in address_hex_values
+		}
 
 	def _fetch_account_current_state(self, address_hex=BENEFICIARY_ADDRESS):
 		cursor = self.puller.symbol_db.connection.cursor()
@@ -45,8 +64,8 @@ class SymbolPullerAccountsTest(SymbolPullerTestBase):
 	def _raw_network_timestamp(days_ago=0):
 		return str(int(((datetime.now(timezone.utc) - timedelta(days=days_ago)).timestamp() - 100) * 1000))
 
-	def _create_block(self, height, days_ago=0):
-		return create_node_block(height, timestamp=self._raw_network_timestamp(days_ago))
+	def _create_block(self, height, days_ago=0, **block_overrides):
+		return create_node_block(height, timestamp=self._raw_network_timestamp(days_ago), **block_overrides)
 
 	def _sync_blocks(self, blocks, account_item=None, multisig_by_address=None):
 		address_text = self._address_text()
@@ -69,8 +88,121 @@ class SymbolPullerAccountsTest(SymbolPullerTestBase):
 		connector = self._sync_blocks(blocks, create_account_item(importance='321'))
 
 		# Assert:
-		self.assertEqual(1, connector.paths.count(f'accounts/{address_text}'))
+		self.assertEqual(1, connector.paths.count('accounts'))
+		self.assertEqual([{'addresses': [address_text]}], connector.post_payloads)
 		self.assertEqual((321, 0, True, True, 2), self._fetch_account_current_state())
+
+	def test_refresh_dirty_accounts_for_batch_updates_transaction_participant_without_overwriting_harvesting_active(self):
+		# Arrange:
+		account_row, mosaic_rows = self._create_current_account_row(address_hex=RECIPIENT_ADDRESS, importance='100')
+		account_row['is_harvesting_active'] = False
+		self.puller.symbol_db.upsert_account_current_state(account_row, mosaic_rows)
+		connector = FakeConnector(
+			1,
+			{0: [self._create_block(1, days_ago=8)]},
+			transactions_by_path={
+				transaction_path(1, 1): {'data': [create_node_transaction(1)]}
+			},
+			account_by_address=self._account_by_address_text(BENEFICIARY_ADDRESS, RECIPIENT_ADDRESS))
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual(
+			(100, 0, False, True, 1),
+			self._fetch_account_current_state(RECIPIENT_ADDRESS))
+
+	def test_refresh_dirty_accounts_for_batch_prefers_beneficiary_timestamp_when_address_is_also_transaction_participant(self):
+		# Arrange:
+		connector = FakeConnector(
+			1,
+			{0: [self._create_block(1)]},
+			transactions_by_path={
+				transaction_path(1, 1): {'data': [create_node_transaction(1)]}
+			},
+			account_by_address=self._account_by_address_text(BENEFICIARY_ADDRESS, RECIPIENT_ADDRESS))
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual(True, self._fetch_account_current_state()[2])
+
+	def test_refresh_dirty_accounts_for_batch_deduplicates_repeated_transaction_participant_addresses(self):
+		# Arrange:
+		participant_address_text = self._address_text(BENEFICIARY_ADDRESS)
+		beneficiary_address = '980101010101010101010101010101010101010101010101'
+		connector = FakeConnector(
+			1,
+			{0: [self._create_block(1, beneficiaryAddress=beneficiary_address)]},
+			transactions_by_path={
+				transaction_path(1, 1): {
+					'data': [
+						create_node_transaction(
+							1,
+							transaction_hash=f'{index:064X}',
+							transaction_id=f'transaction-{index}',
+							recipientAddress=BENEFICIARY_ADDRESS)
+						for index in range(2)
+					]
+				}
+			},
+			account_by_address=self._account_by_address_text(beneficiary_address, BENEFICIARY_ADDRESS))
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual(1, connector.paths.count('accounts'))
+		self.assertEqual(1, connector.post_payloads[0]['addresses'].count(participant_address_text))
+
+	def test_refresh_dirty_accounts_for_batch_chunks_account_fetches(self):
+		# Arrange:
+		participant_addresses = [
+			f'98{index:046X}'
+			for index in range(1, ACCOUNT_BATCH_FETCH_SIZE + 2)
+		]
+		transactions = [
+			create_node_transaction(
+				1,
+				transaction_hash=f'{index:064X}',
+				transaction_id=f'transaction-{index}',
+				recipientAddress=address)
+			for index, address in enumerate(participant_addresses)
+		]
+		connector = FakeConnector(
+			1,
+			{0: [self._create_block(1)]},
+			transactions_by_path={
+				transaction_path(1, 1): {'data': transactions[:ACCOUNT_BATCH_FETCH_SIZE]},
+				transaction_path(1, 1, 2): {'data': transactions[ACCOUNT_BATCH_FETCH_SIZE:]}
+			})
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual(2, connector.paths.count('accounts'))
+		self.assertEqual([ACCOUNT_BATCH_FETCH_SIZE, 2], [len(payload['addresses']) for payload in connector.post_payloads])
+
+	def test_refresh_dirty_accounts_for_batch_rejects_malformed_accounts_batch_response(self):
+		# Arrange:
+		connector = MalformedAccountsConnector(1, {0: [self._create_block(1)]})
+
+		# Act / Assert:
+		self._assert_sync_rejects_node_response(connector, ValueError, 'Malformed Symbol accounts batch response')
+
+	def test_refresh_dirty_accounts_for_batch_rejects_missing_accounts_batch_item(self):
+		# Arrange:
+		address_text = self._address_text()
+		connector = FakeConnector(
+			1,
+			{0: [self._create_block(1)]},
+			account_by_address={address_text: create_account_item(address_hex=RECIPIENT_ADDRESS)})
+
+		# Act / Assert:
+		self._assert_sync_rejects_node_response(connector, ValueError, 'Missing Symbol accounts batch item for address')
 
 	def test_refresh_dirty_accounts_for_batch_uses_latest_beneficiary_block_when_recent_block_is_second(self):
 		# Arrange:

--- a/explorer/puller/tests/facade/symbol/test_PullerAccounts.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerAccounts.py
@@ -2,6 +2,7 @@ import asyncio
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 
+from symbolchain.sc import ReceiptType
 from symbollightapi.model.Exceptions import NodeException
 
 from puller.facade.SymbolPuller import ACCOUNT_BATCH_FETCH_SIZE
@@ -16,7 +17,9 @@ from .puller_test_utils import (
 	create_account_item,
 	create_node_block,
 	create_node_transaction,
+	create_statement_item,
 	set_symbol_connector,
+	statement_path,
 	transaction_path
 )
 
@@ -179,6 +182,96 @@ class SymbolPullerAccountsTest(SymbolPullerTestBase):
 		self.assertEqual(
 			sorted([beneficiary_address_text, participant_address_text]),
 			sorted(connector.post_payloads[0]['addresses']))
+
+	def test_refresh_dirty_accounts_for_batch_includes_balance_change_receipt_target_address_without_matching_transaction(self):
+		# Arrange:
+		connector = FakeConnector(
+			1,
+			{0: [self._create_block(1)]},
+			statement_pages={
+				statement_path(1, 1): {
+					'data': [create_statement_item(
+						1,
+						100,
+						ReceiptType.LOCK_HASH_EXPIRED.value,
+						targetAddress=RECIPIENT_ADDRESS)]
+				}
+			})
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual(1, self._fetch_account_count(RECIPIENT_ADDRESS))
+
+	def test_refresh_dirty_accounts_for_batch_includes_balance_transfer_receipt_sender_and_recipient_addresses(self):
+		# Arrange:
+		recipient_address = '980202020202020202020202020202020202020202020202'
+		connector = FakeConnector(
+			1,
+			{0: [self._create_block(1)]},
+			statement_pages={
+				statement_path(1, 1): {
+					'data': [create_statement_item(
+						1,
+						100,
+						ReceiptType.MOSAIC_RENTAL_FEE.value,
+						senderAddress=RECIPIENT_ADDRESS,
+						recipientAddress=recipient_address)]
+				}
+			})
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual(
+			sorted([
+				self._address_text(BENEFICIARY_ADDRESS),
+				self._address_text(RECIPIENT_ADDRESS),
+				self._address_text(recipient_address)
+			]),
+			sorted(connector.post_payloads[0]['addresses']))
+
+	def test_refresh_dirty_accounts_for_batch_deduplicates_receipt_target_address_already_dirty_from_beneficiary(self):
+		# Arrange:
+		beneficiary_address_text = self._address_text()
+		connector = FakeConnector(
+			1,
+			{0: [self._create_block(1)]},
+			statement_pages={
+				statement_path(1, 1): {
+					'data': [create_statement_item(
+						1,
+						100,
+						ReceiptType.HARVEST_FEE.value,
+						targetAddress=BENEFICIARY_ADDRESS)]
+				}
+			})
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual(1, connector.paths.count('accounts'))
+		self.assertEqual([{'addresses': [beneficiary_address_text]}], connector.post_payloads)
+
+	def test_refresh_dirty_accounts_for_batch_ignores_receipts_without_address_fields(self):
+		# Arrange:
+		beneficiary_address_text = self._address_text()
+		connector = FakeConnector(
+			1,
+			{0: [self._create_block(1)]},
+			statement_pages={
+				statement_path(1, 1): {'data': [create_statement_item(1, 100)]}
+			})
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual(1, connector.paths.count('accounts'))
+		self.assertEqual([{'addresses': [beneficiary_address_text]}], connector.post_payloads)
 
 	def test_refresh_dirty_accounts_for_batch_chunks_account_fetches(self):
 		# Arrange:

--- a/explorer/puller/tests/facade/symbol/test_PullerAccounts.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerAccounts.py
@@ -175,7 +175,10 @@ class SymbolPullerAccountsTest(SymbolPullerTestBase):
 
 		# Assert:
 		self.assertEqual(1, connector.paths.count('accounts'))
-		self.assertEqual(1, connector.post_payloads[0]['addresses'].count(participant_address_text))
+		beneficiary_address_text = self._address_text(beneficiary_address)
+		self.assertEqual(
+			sorted([beneficiary_address_text, participant_address_text]),
+			sorted(connector.post_payloads[0]['addresses']))
 
 	def test_refresh_dirty_accounts_for_batch_chunks_account_fetches(self):
 		# Arrange:

--- a/explorer/puller/tests/facade/symbol/test_PullerAccounts.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerAccounts.py
@@ -1,5 +1,6 @@
 import asyncio
 from datetime import datetime, timedelta, timezone
+from decimal import Decimal
 
 from symbollightapi.model.Exceptions import NodeException
 
@@ -95,8 +96,7 @@ class SymbolPullerAccountsTest(SymbolPullerTestBase):
 		self._sync_blocks(blocks, create_account_item(importance='200'))
 
 		# Assert:
-		self.assertEqual(200, self._fetch_account_current_state()[0])
-		self.assertEqual(0.5, float(self._fetch_account_current_state()[1]))
+		self.assertEqual((200, Decimal('0.5'), True, True, 1), self._fetch_account_current_state())
 
 	def test_refresh_dirty_accounts_for_batch_leaves_old_harvesting_active_value_unchanged(self):
 		# Arrange:
@@ -177,6 +177,7 @@ class SymbolPullerAccountsTest(SymbolPullerTestBase):
 			asyncio.run(self.puller.sync_block_headers())
 
 		# Assert:
+		self.assertEqual([], self._fetch_block_heights(self.puller.symbol_db))
 		self.assertEqual(0, self._fetch_account_count())
 
 	def test_get_native_mosaic_info_is_memoized(self):

--- a/explorer/puller/tests/facade/symbol/test_PullerAccounts.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerAccounts.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 
 from symbolchain.sc import ReceiptType
+from symbolchain.symbol.Network import Address
 from symbollightapi.model.Exceptions import NodeException
 
 from puller.facade.SymbolPuller import ACCOUNT_BATCH_FETCH_SIZE
@@ -34,8 +35,9 @@ class MalformedAccountsConnector(FakeConnector):
 
 
 class SymbolPullerAccountsTest(SymbolPullerTestBase):
-	def _address_text(self, address_hex=BENEFICIARY_ADDRESS):
-		return str(self.puller.symbol_facade.network.address_class(bytes.fromhex(address_hex)))
+	@staticmethod
+	def _address_text(address_hex=BENEFICIARY_ADDRESS):
+		return str(Address.from_decoded_address_hex_string(address_hex))
 
 	def _account_by_address_text(self, *address_hex_values):
 		return {
@@ -95,10 +97,10 @@ class SymbolPullerAccountsTest(SymbolPullerTestBase):
 		self.assertEqual([{'addresses': [address_text]}], connector.post_payloads)
 		self.assertEqual((321, 0, True, True, 2), self._fetch_account_current_state())
 
-	def test_refresh_dirty_accounts_for_batch_updates_transaction_participant_without_overwriting_harvesting_active(self):
+	def test_refresh_dirty_accounts_for_batch_does_not_mark_transaction_participant_as_active_harvester(self):
 		# Arrange:
 		account_row, mosaic_rows = self._create_current_account_row(address_hex=RECIPIENT_ADDRESS, importance='100')
-		account_row['is_harvesting_active'] = False
+		account_row['is_harvesting_active'] = True
 		self.puller.symbol_db.upsert_account_current_state(account_row, mosaic_rows)
 		connector = FakeConnector(
 			1,
@@ -113,7 +115,7 @@ class SymbolPullerAccountsTest(SymbolPullerTestBase):
 
 		# Assert:
 		self.assertEqual(
-			(100, 0, False, True, 1),
+			(100, 0, True, True, 1),
 			self._fetch_account_current_state(RECIPIENT_ADDRESS))
 
 	def test_refresh_dirty_accounts_for_batch_ignores_namespace_alias_transaction_participant(self):
@@ -142,23 +144,25 @@ class SymbolPullerAccountsTest(SymbolPullerTestBase):
 			1,
 			{0: [self._create_block(1)]},
 			transactions_by_path={
-				transaction_path(1, 1): {'data': [create_node_transaction(1)]}
+				transaction_path(1, 1): {'data': [create_node_transaction(1, recipientAddress=BENEFICIARY_ADDRESS)]}
 			},
-			account_by_address=self._account_by_address_text(BENEFICIARY_ADDRESS, RECIPIENT_ADDRESS))
+			account_by_address=self._account_by_address_text(BENEFICIARY_ADDRESS))
 
 		# Act:
 		self._sync_with_connector(connector)
 
 		# Assert:
+		self.assertEqual(1, connector.paths.count('accounts'))
+		self.assertEqual([{'addresses': [self._address_text()]}], connector.post_payloads)
 		self.assertEqual(True, self._fetch_account_current_state()[2])
 
 	def test_refresh_dirty_accounts_for_batch_deduplicates_repeated_transaction_participant_addresses(self):
 		# Arrange:
+		beneficiary_address_text = self._address_text(RECIPIENT_ADDRESS)
 		participant_address_text = self._address_text(BENEFICIARY_ADDRESS)
-		beneficiary_address = '980101010101010101010101010101010101010101010101'
 		connector = FakeConnector(
 			1,
-			{0: [self._create_block(1, beneficiaryAddress=beneficiary_address)]},
+			{0: [self._create_block(1, beneficiaryAddress=RECIPIENT_ADDRESS)]},
 			transactions_by_path={
 				transaction_path(1, 1): {
 					'data': [
@@ -171,14 +175,13 @@ class SymbolPullerAccountsTest(SymbolPullerTestBase):
 					]
 				}
 			},
-			account_by_address=self._account_by_address_text(beneficiary_address, BENEFICIARY_ADDRESS))
+			account_by_address=self._account_by_address_text(RECIPIENT_ADDRESS, BENEFICIARY_ADDRESS))
 
 		# Act:
 		self._sync_with_connector(connector)
 
 		# Assert:
 		self.assertEqual(1, connector.paths.count('accounts'))
-		beneficiary_address_text = self._address_text(beneficiary_address)
 		self.assertEqual(
 			sorted([beneficiary_address_text, participant_address_text]),
 			sorted(connector.post_payloads[0]['addresses']))
@@ -437,7 +440,7 @@ class SymbolPullerAccountsTest(SymbolPullerTestBase):
 		self._sync_with_connector(connector)
 
 		# Assert:
-		self.assertEqual(2, connector.paths.count('network/properties'))
+		self.assertEqual(1, connector.paths.count('network/properties'))
 		self.assertEqual(1, connector.paths.count(f'mosaics/{NATIVE_MOSAIC_ID}'))
 
 	def _create_current_account_row(self, address_hex=BENEFICIARY_ADDRESS, **overrides):

--- a/explorer/puller/tests/facade/symbol/test_PullerRollback.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerRollback.py
@@ -6,6 +6,7 @@ from puller.facade.SymbolPuller import SymbolRollbackError
 from ...test.SymbolTestConstants import RECIPIENT_ADDRESS, SIGNER_ADDRESS
 from ...test.SymbolTransactionTestUtils import create_transaction_entry
 from .puller_test_utils import (
+	NATIVE_MOSAIC_ID,
 	FakeConnector,
 	SymbolPullerTestBase,
 	create_node_block,
@@ -314,7 +315,7 @@ class SymbolPullerRollbackTest(SymbolPullerTestBase):
 		self.assertEqual([1, 2, 3], block_heights)
 		self.assertEqual(3, sync_state['last_synced_height'])
 		self.assertEqual(
-			['chain/info', 'network/properties', 'blocks/2', 'blocks/3'],
+			['chain/info', 'network/properties', f'mosaics/{NATIVE_MOSAIC_ID}', 'blocks/2', 'blocks/3'],
 			connector.paths
 		)
 

--- a/explorer/puller/tests/facade/symbol/test_PullerSync.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerSync.py
@@ -6,12 +6,14 @@ from symbollightapi.model.Exceptions import NodeException
 
 from puller.facade.SymbolPuller import BLOCK_PAGE_FETCH_CONCURRENCY, MAX_PAGE_SIZE
 from puller.model.symbol.Block import create_block_row
+from puller.model.symbol.Receipt import create_receipt_rows
 
 from .puller_test_utils import (
 	NATIVE_MOSAIC_ID,
 	FakeConnector,
 	ResponseConnector,
 	SymbolPullerTestBase,
+	create_network_properties,
 	create_node_block,
 	create_statement_item,
 	create_sync_state,
@@ -365,24 +367,19 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 		self.assertEqual([10], [row['amount'] for row in rows_by_height[1]])
 		self.assertEqual([20, 30], [row['amount'] for row in rows_by_height[2]])
 
-	def test_sync_block_batch_upserts_empty_heights_and_queries_batch_range(self):
+	def test_sync_block_batch_upserts_empty_heights_and_writes_previously_fetched_receipts(self):
 		# Arrange:
-		connector = ResponseConnector({
-			transaction_path(5, 7): {'data': []},
-			statement_path(5, 7): {'data': [create_statement_item(6, 600)]}
-		})
 		self._seed_blocks(self.puller.symbol_db, [5, 6, 7])
-		set_symbol_connector(self.puller, connector)
 		block_rows = [
 			create_block_row(create_node_block(height), 100, self.puller.symbol_facade.network)
 			for height in [5, 6, 7]
 		]
+		receipt_rows_by_height = {6: create_receipt_rows(create_statement_item(6, 600))}
 
 		# Act:
-		asyncio.run(self.puller._sync_block_batch(block_rows, 100))  # pylint: disable=protected-access
+		self.puller._sync_block_batch(block_rows, {}, receipt_rows_by_height)  # pylint: disable=protected-access
 
 		# Assert:
-		self.assertEqual([transaction_path(5, 7), statement_path(5, 7)], connector.paths)
 		self.assertEqual([
 			(6, 'inflation', 'inflation', 6, 0, '72C0212E67A08BCE', 600)
 		], self._fetch_receipts(self.puller.symbol_db))
@@ -402,7 +399,7 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 					'hash': f'{1:064X}'
 				}
 			},
-			'network/properties': {'network': {'epochAdjustment': '100s'}},
+			'network/properties': create_network_properties(),
 			'blocks?pageSize=100&offset=0&orderBy=height': {'data': [create_node_block(1)]},
 			transaction_path(1, 1): {'data': []},
 			statement_path(1, 1): {'pagination': {'pageNumber': 1}}
@@ -453,7 +450,7 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 					'hash': f'{1:064X}'
 				}
 			},
-			'network/properties': {'network': {'epochAdjustment': '100s'}},
+			'network/properties': create_network_properties(),
 			'blocks?pageSize=100&offset=0&orderBy=height': {'data': [create_node_block(1)]},
 			transaction_path(1, 1): {'data': []},
 			statement_path(1, 1): {

--- a/explorer/puller/tests/facade/symbol/test_PullerSync.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerSync.py
@@ -39,7 +39,7 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 		]
 		account_paths = [
 			path for path in connector.paths
-			if path.startswith('accounts/')
+			if 'accounts' == path
 		]
 		multisig_paths = [
 			path for path in connector.paths
@@ -75,10 +75,10 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 			'network/properties',
 			f'mosaics/{NATIVE_MOSAIC_ID}',
 			'blocks?pageSize=100&offset=0&orderBy=height',
-			f'accounts/{beneficiary_address_text}',
-			f'account/{beneficiary_address_text}/multisig',
 			transaction_path(1, 2),
-			statement_path(1, 2)
+			statement_path(1, 2),
+			'accounts',
+			f'account/{beneficiary_address_text}/multisig'
 		], connector.paths)
 
 	def test_sync_block_headers_persists_synced_block_watermark(self):
@@ -208,10 +208,10 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 			'network/properties',
 			f'mosaics/{NATIVE_MOSAIC_ID}',
 			'blocks?pageSize=100&offset=0&orderBy=height',
-			f'accounts/{beneficiary_address_text}',
-			f'account/{beneficiary_address_text}/multisig',
 			transaction_path(1, 2),
-			statement_path(1, 2)
+			statement_path(1, 2),
+			'accounts',
+			f'account/{beneficiary_address_text}/multisig'
 		], connector.paths)
 		self.assertEqual([1, 2], block_heights)
 		self.assertEqual('healthy', sync_state['status'])
@@ -268,10 +268,10 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 			f'mosaics/{NATIVE_MOSAIC_ID}',
 			'blocks/2',
 			'blocks?pageSize=100&offset=2&orderBy=height',
-			f'accounts/{beneficiary_address_text}',
-			f'account/{beneficiary_address_text}/multisig',
 			transaction_path(3, 4),
-			statement_path(3, 4)
+			statement_path(3, 4),
+			'accounts',
+			f'account/{beneficiary_address_text}/multisig'
 		], connector.paths)
 		self.assertEqual([1, 2, 3, 4], block_heights)
 		self.assertEqual('healthy', sync_state['status'])

--- a/explorer/puller/tests/facade/symbol/test_PullerSync.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerSync.py
@@ -23,6 +23,38 @@ from .puller_test_utils import (
 
 
 class SymbolPullerSyncTest(SymbolPullerTestBase):
+	def _assert_sync_request_counts(self, connector, block_page_count, batch_count):
+		# Assert:
+		block_paths = [
+			path for path in connector.paths
+			if path.startswith('blocks?pageSize=100&offset=')
+		]
+		transaction_paths = [
+			path for path in connector.paths
+			if path.startswith('transactions/confirmed?')
+		]
+		statement_paths = [
+			path for path in connector.paths
+			if path.startswith('statements/transaction?')
+		]
+		account_paths = [
+			path for path in connector.paths
+			if path.startswith('accounts/')
+		]
+		multisig_paths = [
+			path for path in connector.paths
+			if path.startswith('account/') and path.endswith('/multisig')
+		]
+
+		self.assertEqual(1, connector.paths.count('chain/info'))
+		self.assertEqual(1, connector.paths.count('network/properties'))
+		self.assertEqual(1, connector.paths.count(f'mosaics/{NATIVE_MOSAIC_ID}'))
+		self.assertEqual(block_page_count, len(block_paths))
+		self.assertEqual(batch_count, len(transaction_paths))
+		self.assertEqual(batch_count, len(statement_paths))
+		self.assertEqual(batch_count, len(account_paths))
+		self.assertEqual(batch_count, len(multisig_paths))
+		self.assertEqual(3 + block_page_count + 4 * batch_count, len(connector.paths))
 
 	def test_sync_block_headers_pulls_chain_info_network_properties_and_blocks(
 		self
@@ -126,20 +158,7 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 		block_heights, sync_state = self._sync_with_connector(connector)
 
 		# Assert:
-		block_paths = [path for path in connector.paths if path.startswith('blocks?')]
-		transaction_paths = [path for path in connector.paths if path.startswith('transactions/confirmed?')]
-		statement_paths = [path for path in connector.paths if path.startswith('statements/transaction?')]
-		account_paths = [path for path in connector.paths if path.startswith('accounts/')]
-		multisig_paths = [path for path in connector.paths if path.startswith('account/') and path.endswith('/multisig')]
-		self.assertEqual([
-			'blocks?pageSize=100&offset=0&orderBy=height',
-			'blocks?pageSize=100&offset=100&orderBy=height',
-			'blocks?pageSize=100&offset=200&orderBy=height'
-		], block_paths)
-		self.assertEqual([transaction_path(1, 201)], transaction_paths)
-		self.assertEqual([statement_path(1, 201)], statement_paths)
-		self.assertEqual(1, len(account_paths))
-		self.assertEqual(1, len(multisig_paths))
+		self._assert_sync_request_counts(connector, block_page_count=3, batch_count=1)
 		self.assertEqual(list(range(1, 202)), block_heights)
 		self.assertEqual(201, sync_state['last_synced_height'])
 
@@ -164,16 +183,7 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 		block_heights, sync_state = self._sync_with_connector(connector)
 
 		# Assert:
-		block_paths = [path for path in connector.paths if path.startswith('blocks?')]
-		transaction_paths = [path for path in connector.paths if path.startswith('transactions/confirmed?')]
-		statement_paths = [path for path in connector.paths if path.startswith('statements/transaction?')]
-		account_paths = [path for path in connector.paths if path.startswith('accounts/')]
-		multisig_paths = [path for path in connector.paths if path.startswith('account/') and path.endswith('/multisig')]
-		self.assertEqual(11, len(block_paths))
-		self.assertEqual(2, len(transaction_paths))
-		self.assertEqual([statement_path(1, 1000), statement_path(1001, chain_height)], statement_paths)
-		self.assertEqual(2, len(account_paths))
-		self.assertEqual(2, len(multisig_paths))
+		self._assert_sync_request_counts(connector, block_page_count=11, batch_count=2)
 		self.assertEqual(list(range(1, chain_height + 1)), block_heights)
 		self.assertEqual(chain_height, sync_state['last_synced_height'])
 		self.assertEqual('healthy', sync_state['status'])

--- a/explorer/puller/tests/facade/symbol/test_PullerSync.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerSync.py
@@ -8,6 +8,7 @@ from puller.facade.SymbolPuller import BLOCK_PAGE_FETCH_CONCURRENCY, MAX_PAGE_SI
 from puller.model.symbol.Block import create_block_row
 
 from .puller_test_utils import (
+	NATIVE_MOSAIC_ID,
 	FakeConnector,
 	ResponseConnector,
 	SymbolPullerTestBase,
@@ -36,12 +37,16 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 		self._sync_with_connector(connector)
 
 		# Assert:
+		beneficiary_address_text = self._beneficiary_address_text()
 		self.assertEqual([
 			'chain/info',
 			'network/properties',
+			f'mosaics/{NATIVE_MOSAIC_ID}',
 			'blocks?pageSize=100&offset=0&orderBy=height',
 			transaction_path(1, 2),
-			statement_path(1, 2)
+			statement_path(1, 2),
+			f'accounts/{beneficiary_address_text}',
+			f'account/{beneficiary_address_text}/multisig'
 		], connector.paths)
 
 	def test_sync_block_headers_persists_synced_block_watermark(self):
@@ -124,6 +129,8 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 		block_paths = [path for path in connector.paths if path.startswith('blocks?')]
 		transaction_paths = [path for path in connector.paths if path.startswith('transactions/confirmed?')]
 		statement_paths = [path for path in connector.paths if path.startswith('statements/transaction?')]
+		account_paths = [path for path in connector.paths if path.startswith('accounts/')]
+		multisig_paths = [path for path in connector.paths if path.startswith('account/') and path.endswith('/multisig')]
 		self.assertEqual([
 			'blocks?pageSize=100&offset=0&orderBy=height',
 			'blocks?pageSize=100&offset=100&orderBy=height',
@@ -131,6 +138,8 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 		], block_paths)
 		self.assertEqual([transaction_path(1, 201)], transaction_paths)
 		self.assertEqual([statement_path(1, 201)], statement_paths)
+		self.assertEqual(1, len(account_paths))
+		self.assertEqual(1, len(multisig_paths))
 		self.assertEqual(list(range(1, 202)), block_heights)
 		self.assertEqual(201, sync_state['last_synced_height'])
 
@@ -158,9 +167,13 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 		block_paths = [path for path in connector.paths if path.startswith('blocks?')]
 		transaction_paths = [path for path in connector.paths if path.startswith('transactions/confirmed?')]
 		statement_paths = [path for path in connector.paths if path.startswith('statements/transaction?')]
+		account_paths = [path for path in connector.paths if path.startswith('accounts/')]
+		multisig_paths = [path for path in connector.paths if path.startswith('account/') and path.endswith('/multisig')]
 		self.assertEqual(11, len(block_paths))
 		self.assertEqual(2, len(transaction_paths))
 		self.assertEqual([statement_path(1, 1000), statement_path(1001, chain_height)], statement_paths)
+		self.assertEqual(2, len(account_paths))
+		self.assertEqual(2, len(multisig_paths))
 		self.assertEqual(list(range(1, chain_height + 1)), block_heights)
 		self.assertEqual(chain_height, sync_state['last_synced_height'])
 		self.assertEqual('healthy', sync_state['status'])
@@ -179,12 +192,16 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 		)
 
 		# Assert:
+		beneficiary_address_text = self._beneficiary_address_text()
 		self.assertEqual([
 			'chain/info',
 			'network/properties',
+			f'mosaics/{NATIVE_MOSAIC_ID}',
 			'blocks?pageSize=100&offset=0&orderBy=height',
 			transaction_path(1, 2),
-			statement_path(1, 2)
+			statement_path(1, 2),
+			f'accounts/{beneficiary_address_text}',
+			f'account/{beneficiary_address_text}/multisig'
 		], connector.paths)
 		self.assertEqual([1, 2], block_heights)
 		self.assertEqual('healthy', sync_state['status'])
@@ -234,13 +251,17 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 		block_heights = self._fetch_block_heights(self.puller.symbol_db)
 		sync_state = self.puller.symbol_db.get_sync_state()
 
+		beneficiary_address_text = self._beneficiary_address_text()
 		self.assertEqual([
 			'chain/info',
 			'network/properties',
+			f'mosaics/{NATIVE_MOSAIC_ID}',
 			'blocks/2',
 			'blocks?pageSize=100&offset=2&orderBy=height',
 			transaction_path(3, 4),
-			statement_path(3, 4)
+			statement_path(3, 4),
+			f'accounts/{beneficiary_address_text}',
+			f'account/{beneficiary_address_text}/multisig'
 		], connector.paths)
 		self.assertEqual([1, 2, 3, 4], block_heights)
 		self.assertEqual('healthy', sync_state['status'])
@@ -272,7 +293,8 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 
 		self.assertEqual([
 			'chain/info',
-			'network/properties'
+			'network/properties',
+			f'mosaics/{NATIVE_MOSAIC_ID}'
 		], connector.paths)
 		self.assertEqual(2, sync_state['chain_height'])
 		self.assertEqual(2, sync_state['finalized_height'])

--- a/explorer/puller/tests/facade/symbol/test_PullerSync.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerSync.py
@@ -75,10 +75,10 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 			'network/properties',
 			f'mosaics/{NATIVE_MOSAIC_ID}',
 			'blocks?pageSize=100&offset=0&orderBy=height',
-			transaction_path(1, 2),
-			statement_path(1, 2),
 			f'accounts/{beneficiary_address_text}',
-			f'account/{beneficiary_address_text}/multisig'
+			f'account/{beneficiary_address_text}/multisig',
+			transaction_path(1, 2),
+			statement_path(1, 2)
 		], connector.paths)
 
 	def test_sync_block_headers_persists_synced_block_watermark(self):
@@ -208,10 +208,10 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 			'network/properties',
 			f'mosaics/{NATIVE_MOSAIC_ID}',
 			'blocks?pageSize=100&offset=0&orderBy=height',
-			transaction_path(1, 2),
-			statement_path(1, 2),
 			f'accounts/{beneficiary_address_text}',
-			f'account/{beneficiary_address_text}/multisig'
+			f'account/{beneficiary_address_text}/multisig',
+			transaction_path(1, 2),
+			statement_path(1, 2)
 		], connector.paths)
 		self.assertEqual([1, 2], block_heights)
 		self.assertEqual('healthy', sync_state['status'])
@@ -268,10 +268,10 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):
 			f'mosaics/{NATIVE_MOSAIC_ID}',
 			'blocks/2',
 			'blocks?pageSize=100&offset=2&orderBy=height',
-			transaction_path(3, 4),
-			statement_path(3, 4),
 			f'accounts/{beneficiary_address_text}',
-			f'account/{beneficiary_address_text}/multisig'
+			f'account/{beneficiary_address_text}/multisig',
+			transaction_path(3, 4),
+			statement_path(3, 4)
 		], connector.paths)
 		self.assertEqual([1, 2, 3, 4], block_heights)
 		self.assertEqual('healthy', sync_state['status'])

--- a/explorer/puller/tests/facade/symbol/test_PullerTransactionSync.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerTransactionSync.py
@@ -10,7 +10,6 @@ from .puller_test_utils import (
 	create_node_transaction,
 	create_sync_state,
 	set_symbol_connector,
-	statement_path,
 	transaction_path
 )
 

--- a/explorer/puller/tests/facade/symbol/test_PullerTransactionSync.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerTransactionSync.py
@@ -128,18 +128,16 @@ class SymbolPullerTransactionSyncTest(SymbolPullerTestBase):
 		# Arrange: height 2 has no transactions, but must still be passed to upsert_transactions_for_height
 		# so that any stale data from a previously-synced (since-replaced) block at that height is cleared.
 		# See test_upsert_transactions_for_height_clears_existing_rows_when_replaced_with_empty_list.
-		connector = FakeConnector(3, {}, transactions_by_path={
-			transaction_path(1, 3): {
-				'data': [create_node_transaction(1), create_node_transaction(3, transaction_hash='C' * 64, transaction_id='height-3')]
-			}
-		})
 		transaction_database = FakeTransactionDatabase()
 		self.puller.symbol_db = transaction_database
-		set_symbol_connector(self.puller, connector)
 		block_rows = [{'height': 1}, {'height': 2}, {'height': 3}]
+		transaction_rows_by_height = {
+			1: [{'hash': bytes.fromhex(f'{1:064X}')}],
+			3: [{'hash': bytes.fromhex('C' * 64)}]
+		}
 
 		# Act:
-		asyncio.run(self.puller._sync_block_batch(block_rows, 100))  # pylint: disable=protected-access
+		self.puller._sync_block_batch(block_rows, transaction_rows_by_height, {})  # pylint: disable=protected-access
 
 		# Assert:
 		self.assertEqual([
@@ -151,20 +149,29 @@ class SymbolPullerTransactionSyncTest(SymbolPullerTestBase):
 			for height, transaction_rows in transaction_database.calls
 		])
 
-	def test_sync_block_batch_queries_exact_batch_range(self):
+	def test_sync_block_batch_writes_previously_fetched_transactions_for_exact_batch_rows(self):
 		# Arrange:
-		connector = FakeConnector(12, {}, transactions_by_path={
-			transaction_path(10, 12): {'data': []}
-		})
-		self.puller.symbol_db = FakeTransactionDatabase()
-		set_symbol_connector(self.puller, connector)
+		transaction_database = FakeTransactionDatabase()
+		self.puller.symbol_db = transaction_database
 		block_rows = [{'height': 10}, {'height': 11}, {'height': 12}]
+		transaction_rows_by_height = {
+			10: [{'hash': bytes.fromhex('A' * 64)}],
+			12: [{'hash': bytes.fromhex('C' * 64)}]
+		}
 
 		# Act:
-		asyncio.run(self.puller._sync_block_batch(block_rows, 100))  # pylint: disable=protected-access
+		self.puller._sync_block_batch(block_rows, transaction_rows_by_height, {})  # pylint: disable=protected-access
 
 		# Assert:
-		self.assertEqual([transaction_path(10, 12), statement_path(10, 12)], connector.paths)
+		self.assertEqual([block_rows], transaction_database.block_calls)
+		self.assertEqual([
+			(10, [bytes.fromhex('A' * 64)]),
+			(11, []),
+			(12, [bytes.fromhex('C' * 64)])
+		], [
+			(height, [row['hash'] for row in transaction_rows])
+			for height, transaction_rows in transaction_database.calls
+		])
 
 	def test_sync_block_headers_keeps_existing_watermark_when_transaction_fetch_fails(self):
 		# Arrange:

--- a/explorer/puller/tests/model/symbol/test_Account.py
+++ b/explorer/puller/tests/model/symbol/test_Account.py
@@ -4,7 +4,6 @@ from psycopg2.extras import Json
 from symbolchain.symbol.Network import Network
 
 from puller.model.symbol.Account import (
-	ACCOUNT_TYPE_LABELS,
 	HARVESTING_ELIGIBLE_MAX_NATIVE_BALANCE,
 	HARVESTING_ELIGIBLE_MIN_NATIVE_BALANCE,
 	create_account_row,
@@ -55,7 +54,7 @@ class AccountTest(TestCase):
 			'address': bytes.fromhex(ADDRESS),
 			'address_text': str(Network.TESTNET.address_class(bytes.fromhex(ADDRESS))),
 			'public_key': bytes.fromhex('1' * 64),
-			'account_type': ACCOUNT_TYPE_LABELS[0],
+			'account_type': 'unlinked',
 			'address_height': 11,
 			'importance': 123,
 			'importance_percentage': 0,
@@ -101,7 +100,7 @@ class AccountTest(TestCase):
 		# Assert:
 		self.assertEqual(1234, account_row['address_height'])
 
-	def _assert_account_type_maps_to_label(self, account_type):
+	def _assert_account_type_maps_to_label(self, account_type, expected_label):
 		# Arrange:
 		item = _create_account_item(accountType=account_type)
 
@@ -109,19 +108,19 @@ class AccountTest(TestCase):
 		account_row, _ = create_account_row(item, Network.TESTNET, 99, NATIVE_MOSAIC_ID, DIVISIBILITY)
 
 		# Assert:
-		self.assertEqual(ACCOUNT_TYPE_LABELS[account_type], account_row['account_type'])
+		self.assertEqual(expected_label, account_row['account_type'])
 
 	def test_create_account_row_maps_account_type_unlinked(self):
-		self._assert_account_type_maps_to_label(0)
+		self._assert_account_type_maps_to_label(0, 'unlinked')
 
 	def test_create_account_row_maps_account_type_main(self):
-		self._assert_account_type_maps_to_label(1)
+		self._assert_account_type_maps_to_label(1, 'main')
 
 	def test_create_account_row_maps_account_type_remote(self):
-		self._assert_account_type_maps_to_label(2)
+		self._assert_account_type_maps_to_label(2, 'remote')
 
 	def test_create_account_row_maps_account_type_remote_unlinked(self):
-		self._assert_account_type_maps_to_label(3)
+		self._assert_account_type_maps_to_label(3, 'remoteUnlinked')
 
 	def test_create_account_row_rejects_unknown_account_type(self):
 		# Arrange:

--- a/explorer/puller/tests/model/symbol/test_Account.py
+++ b/explorer/puller/tests/model/symbol/test_Account.py
@@ -127,7 +127,15 @@ class AccountTest(TestCase):
 		item = _create_account_item(accountType=4)
 
 		# Act / Assert:
-		with self.assertRaises(KeyError):
+		with self.assertRaisesRegex(ValueError, 'Unsupported Symbol account type 4'):
+			create_account_row(item, Network.TESTNET, 99, NATIVE_MOSAIC_ID, DIVISIBILITY)
+
+	def test_create_account_row_rejects_non_numeric_account_type(self):
+		# Arrange:
+		item = _create_account_item(accountType='invalid')
+
+		# Act / Assert:
+		with self.assertRaisesRegex(ValueError, 'Unsupported Symbol account type invalid'):
 			create_account_row(item, Network.TESTNET, 99, NATIVE_MOSAIC_ID, DIVISIBILITY)
 
 	def _assert_harvesting_eligibility(self, native_balance_raw, expected):

--- a/explorer/puller/tests/model/symbol/test_Account.py
+++ b/explorer/puller/tests/model/symbol/test_Account.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from psycopg2.extras import Json
-from symbolchain.symbol.Network import Network
+from symbolchain.symbol.Network import Address, Network
 
 from puller.model.symbol.Account import (
 	HARVESTING_ELIGIBLE_MAX_NATIVE_BALANCE,
@@ -52,7 +52,7 @@ class AccountTest(TestCase):
 		# Assert:
 		self.assertEqual({
 			'address': bytes.fromhex(ADDRESS),
-			'address_text': str(Network.TESTNET.address_class(bytes.fromhex(ADDRESS))),
+			'address_text': str(Address.from_decoded_address_hex_string(ADDRESS)),
 			'public_key': bytes.fromhex('1' * 64),
 			'account_type': 'unlinked',
 			'address_height': 11,
@@ -151,19 +151,19 @@ class AccountTest(TestCase):
 	def test_create_account_row_marks_lower_boundary_balance_as_eligible(self):
 		self._assert_harvesting_eligibility(HARVESTING_ELIGIBLE_MIN_NATIVE_BALANCE * 10 ** DIVISIBILITY, True)
 
-	def test_create_account_row_rejects_balance_one_raw_unit_below_lower_boundary(self):
+	def test_create_account_row_marks_balance_one_raw_unit_below_lower_boundary_as_not_eligible(self):
 		self._assert_harvesting_eligibility(HARVESTING_ELIGIBLE_MIN_NATIVE_BALANCE * 10 ** DIVISIBILITY - 1, False)
 
-	def test_create_account_row_rejects_upper_boundary_balance(self):
+	def test_create_account_row_marks_upper_boundary_balance_as_not_eligible(self):
 		self._assert_harvesting_eligibility(HARVESTING_ELIGIBLE_MAX_NATIVE_BALANCE * 10 ** DIVISIBILITY, False)
 
 	def test_create_account_row_marks_balance_one_raw_unit_below_upper_boundary_as_eligible(self):
 		self._assert_harvesting_eligibility(HARVESTING_ELIGIBLE_MAX_NATIVE_BALANCE * 10 ** DIVISIBILITY - 1, True)
 
-	def test_create_account_row_rejects_zero_balance(self):
+	def test_create_account_row_marks_zero_balance_as_not_eligible(self):
 		self._assert_harvesting_eligibility(0, False)
 
-	def test_create_account_row_rejects_missing_native_mosaic(self):
+	def test_create_account_row_marks_missing_native_mosaic_as_not_eligible(self):
 		# Arrange:
 		item = _create_account_item(mosaics=[{'id': '0000000000000001', 'amount': str(1_000_000 * 10 ** DIVISIBILITY)}])
 
@@ -171,6 +171,17 @@ class AccountTest(TestCase):
 		account_row, _ = create_account_row(item, Network.TESTNET, 99, NATIVE_MOSAIC_ID, DIVISIBILITY)
 
 		# Assert:
+		self.assertFalse(account_row['is_eligible_for_harvesting'])
+
+	def test_create_account_row_returns_empty_mosaic_rows_when_account_has_no_mosaics(self):
+		# Arrange:
+		item = _create_account_item(mosaics=[])
+
+		# Act:
+		account_row, mosaic_rows = create_account_row(item, Network.TESTNET, 99, NATIVE_MOSAIC_ID, DIVISIBILITY)
+
+		# Assert:
+		self.assertEqual([], mosaic_rows)
 		self.assertFalse(account_row['is_eligible_for_harvesting'])
 
 	def test_create_multisig_row_returns_none_for_absent_multisig(self):

--- a/explorer/puller/tests/model/symbol/test_Account.py
+++ b/explorer/puller/tests/model/symbol/test_Account.py
@@ -1,0 +1,196 @@
+from unittest import TestCase
+
+from psycopg2.extras import Json
+from symbolchain.symbol.Network import Network
+
+from puller.model.symbol.Account import (
+	ACCOUNT_TYPE_LABELS,
+	HARVESTING_ELIGIBLE_MAX_NATIVE_BALANCE,
+	HARVESTING_ELIGIBLE_MIN_NATIVE_BALANCE,
+	create_account_row,
+	create_multisig_row
+)
+
+ADDRESS = '9889432DE263BB8FE88444A4DA28D3609BD8BB8FAE18AE95'
+NATIVE_MOSAIC_ID = '72C0212E67A08BCE'
+DIVISIBILITY = 6
+
+
+def _create_account_item(**account_overrides):
+	account = {
+		'address': ADDRESS,
+		'addressHeight': '11',
+		'publicKey': '1' * 64,
+		'accountType': 0,
+		'supplementalPublicKeys': {
+			'linked': {'publicKey': '2' * 64},
+			'node': {'publicKey': '3' * 64},
+			'vrf': {'publicKey': '4' * 64},
+			'voting': {'publicKeys': [{'publicKey': '5' * 64, 'startEpoch': 1, 'endEpoch': 2}]}
+		},
+		'activityBuckets': [{'startHeight': '1', 'totalFeesPaid': '2'}],
+		'mosaics': [{'id': NATIVE_MOSAIC_ID, 'amount': str(20_000 * 10 ** DIVISIBILITY)}],
+		'importance': '123',
+		'importanceHeight': '10'
+	}
+	account.update(account_overrides)
+
+	return {'account': account, 'id': 'search-id'}
+
+
+def _plain_value(value):
+	return value.adapted if isinstance(value, Json) else value
+
+
+class AccountTest(TestCase):
+	def test_create_account_row_populates_account_and_mosaic_rows(self):
+		# Arrange:
+		item = _create_account_item()
+
+		# Act:
+		account_row, mosaic_rows = create_account_row(item, Network.TESTNET, 99, NATIVE_MOSAIC_ID, DIVISIBILITY)
+
+		# Assert:
+		self.assertEqual({
+			'address': bytes.fromhex(ADDRESS),
+			'address_text': str(Network.TESTNET.address_class(bytes.fromhex(ADDRESS))),
+			'public_key': bytes.fromhex('1' * 64),
+			'account_type': ACCOUNT_TYPE_LABELS[0],
+			'address_height': 11,
+			'importance': 123,
+			'importance_percentage': 0,
+			'is_harvesting_active': None,
+			'is_eligible_for_harvesting': True,
+			'linked_public_key': bytes.fromhex('2' * 64),
+			'node_public_key': bytes.fromhex('3' * 64),
+			'vrf_public_key': bytes.fromhex('4' * 64),
+			'voting_public_keys': [{'publicKey': '5' * 64, 'startEpoch': 1, 'endEpoch': 2}],
+			'activity_buckets': [{'startHeight': '1', 'totalFeesPaid': '2'}],
+			'raw_payload': item,
+			'first_seen_height': 99,
+			'last_seen_height': 99
+		}, {
+			key: _plain_value(value)
+			for key, value in account_row.items()
+		})
+		self.assertEqual([{
+			'address': bytes.fromhex(ADDRESS),
+			'mosaic_id': NATIVE_MOSAIC_ID,
+			'amount': 20_000 * 10 ** DIVISIBILITY,
+			'updated_at_height': 99
+		}], mosaic_rows)
+
+	def test_create_account_row_stores_zero_public_key_as_none(self):
+		# Arrange:
+		item = _create_account_item(publicKey='0' * 128)
+
+		# Act:
+		account_row, _ = create_account_row(item, Network.TESTNET, 99, NATIVE_MOSAIC_ID, DIVISIBILITY)
+
+		# Assert:
+		self.assertIsNone(account_row['public_key'])
+		self.assertEqual(11, account_row['address_height'])
+
+	def test_create_account_row_uses_address_height_not_observed_height(self):
+		# Arrange:
+		item = _create_account_item(addressHeight='1234')
+
+		# Act:
+		account_row, _ = create_account_row(item, Network.TESTNET, 99, NATIVE_MOSAIC_ID, DIVISIBILITY)
+
+		# Assert:
+		self.assertEqual(1234, account_row['address_height'])
+
+	def _assert_account_type_maps_to_label(self, account_type):
+		# Arrange:
+		item = _create_account_item(accountType=account_type)
+
+		# Act:
+		account_row, _ = create_account_row(item, Network.TESTNET, 99, NATIVE_MOSAIC_ID, DIVISIBILITY)
+
+		# Assert:
+		self.assertEqual(ACCOUNT_TYPE_LABELS[account_type], account_row['account_type'])
+
+	def test_create_account_row_maps_account_type_unlinked(self):
+		self._assert_account_type_maps_to_label(0)
+
+	def test_create_account_row_maps_account_type_main(self):
+		self._assert_account_type_maps_to_label(1)
+
+	def test_create_account_row_maps_account_type_remote(self):
+		self._assert_account_type_maps_to_label(2)
+
+	def test_create_account_row_maps_account_type_remote_unlinked(self):
+		self._assert_account_type_maps_to_label(3)
+
+	def test_create_account_row_rejects_unknown_account_type(self):
+		# Arrange:
+		item = _create_account_item(accountType=4)
+
+		# Act / Assert:
+		with self.assertRaises(KeyError):
+			create_account_row(item, Network.TESTNET, 99, NATIVE_MOSAIC_ID, DIVISIBILITY)
+
+	def _assert_harvesting_eligibility(self, native_balance_raw, expected):
+		# Arrange:
+		item = _create_account_item(mosaics=[{'id': NATIVE_MOSAIC_ID, 'amount': str(native_balance_raw)}])
+
+		# Act:
+		account_row, _ = create_account_row(item, Network.TESTNET, 99, NATIVE_MOSAIC_ID, DIVISIBILITY)
+
+		# Assert:
+		self.assertEqual(expected, account_row['is_eligible_for_harvesting'])
+
+	def test_create_account_row_marks_lower_boundary_balance_as_eligible(self):
+		self._assert_harvesting_eligibility(HARVESTING_ELIGIBLE_MIN_NATIVE_BALANCE * 10 ** DIVISIBILITY, True)
+
+	def test_create_account_row_rejects_balance_one_raw_unit_below_lower_boundary(self):
+		self._assert_harvesting_eligibility(HARVESTING_ELIGIBLE_MIN_NATIVE_BALANCE * 10 ** DIVISIBILITY - 1, False)
+
+	def test_create_account_row_rejects_upper_boundary_balance(self):
+		self._assert_harvesting_eligibility(HARVESTING_ELIGIBLE_MAX_NATIVE_BALANCE * 10 ** DIVISIBILITY, False)
+
+	def test_create_account_row_marks_balance_one_raw_unit_below_upper_boundary_as_eligible(self):
+		self._assert_harvesting_eligibility(HARVESTING_ELIGIBLE_MAX_NATIVE_BALANCE * 10 ** DIVISIBILITY - 1, True)
+
+	def test_create_account_row_rejects_zero_balance(self):
+		self._assert_harvesting_eligibility(0, False)
+
+	def test_create_account_row_rejects_missing_native_mosaic(self):
+		# Arrange:
+		item = _create_account_item(mosaics=[{'id': '0000000000000001', 'amount': str(1_000_000 * 10 ** DIVISIBILITY)}])
+
+		# Act:
+		account_row, _ = create_account_row(item, Network.TESTNET, 99, NATIVE_MOSAIC_ID, DIVISIBILITY)
+
+		# Assert:
+		self.assertFalse(account_row['is_eligible_for_harvesting'])
+
+	def test_create_multisig_row_returns_none_for_absent_multisig(self):
+		# Act:
+		row = create_multisig_row(bytes.fromhex(ADDRESS), None, 50)
+
+		# Assert:
+		self.assertIsNone(row)
+
+	def test_create_multisig_row_maps_fields(self):
+		# Arrange:
+		multisig_json = {
+			'minApproval': 2,
+			'minRemoval': 1,
+			'cosignatoryAddresses': ['AA' * 24, 'BB' * 24],
+			'multisigAddresses': ['CC' * 24]
+		}
+
+		# Act:
+		row = create_multisig_row(bytes.fromhex(ADDRESS), multisig_json, 50)
+
+		# Assert:
+		self.assertEqual({
+			'address': bytes.fromhex(ADDRESS),
+			'min_approval': 2,
+			'min_removal': 1,
+			'cosignatory_addresses': [bytes.fromhex('AA' * 24), bytes.fromhex('BB' * 24)],
+			'multisig_addresses': [bytes.fromhex('CC' * 24)],
+			'updated_at_height': 50
+		}, row)


### PR DESCRIPTION
## Summary

* Add `symbol_accounts` / `symbol_account_mosaics` / `symbol_multisig` tables and `puller/model/symbol/Account.py` to persist current-state account data (current balances, importance, supplemental keys, multisig) needed by account detail and current-state enrichment.
* Introduce a dirty-key current-state account refresh: after each block-sync batch, collect the set of addresses touched by that batch and refresh their current state via a batched `POST /accounts` (chunked at 100 addresses) plus a per-address `GET /account/{address}/multisig` (no batch endpoint exists for multisig). "Touched" covers three sources:
  * Block beneficiaries.
  * Every transaction participant address (signer, recipient, target, cosignatory, mosaic owner, etc.), excluding namespace-alias pseudo-addresses (`Address.is_alias()`), which aren't resolvable accounts.
  * Receipt addresses: `balanceChange` receipts' `target_address` and `balanceTransfer` receipts' `sender_address`/`recipient_address`. This is needed because some receipts change an account's balance with no correlated transaction in that block — `LOCK_HASH_EXPIRED`/`LOCK_SECRET_EXPIRED` fire automatically at a protocol-timeout height with no transaction at all, and rental-fee (`MOSAIC_RENTAL_FEE`/`NAMESPACE_RENTAL_FEE`) recipient addresses aren't signers of the triggering transaction. `HARVEST_FEE`'s target always equals the block beneficiary, so it's already covered by dedup with no special-casing.
* Like the existing block/transaction/receipt sync, all of this batch's network fetches (transactions, receipts, dirty accounts) complete before any DB writes begin, so a mid-batch failure leaves zero partial writes.
  * `is_harvesting_active`: an address that was a block's beneficiary gets `true` when that block's timestamp is within the last 7 days; dirty-key refresh never overwrites this back to `false` (no reliable negative signal from a single batch). When an address is both a beneficiary and a transaction participant in the same batch, the beneficiary result takes priority.

## Known limitation (out of scope for this PR)

When a transaction's address field (e.g. `recipientAddress`) encodes a namespace alias instead of a real address, dirty-key refresh currently excludes that alias pseudo-address entirely rather than resolving it to the real account via `/statements/resolutions/address`. This means an account reachable only through an alias reference in a block's transactions doesn't get a dirty-key refresh. Resolving this correctly requires per-height (not range) resolution-statement fetches and tracking each transaction's block-relative source id — including embedded transactions, which need their parent aggregate's index. It also affects `symbol_transaction_addresses` (Backend4, already merged), which persists the same unresolved alias bytes for participant rows. Both call sites should be fixed together in a future phase; deferring both is intentional, not an oversight.