### PR TITLE
[explorer/puller] feat: throttle Symbol node requests to a configurable rate

### DIFF
--- a/explorer/puller/puller/facade/RequestRateLimiter.py
+++ b/explorer/puller/puller/facade/RequestRateLimiter.py
@@ -1,0 +1,30 @@
+import asyncio
+import time
+
+
+class RequestRateLimiter:
+	"""Paces async operations to a maximum requests-per-second budget."""
+
+	def __init__(self, max_requests_per_second, time_source=time.monotonic, sleep=asyncio.sleep):
+		"""Creates a request rate limiter with injectable timing dependencies."""
+
+		self._min_interval_seconds = 1 / max_requests_per_second
+		self._time_source = time_source
+		self._sleep = sleep
+		self._lock = asyncio.Lock()
+		self._next_allowed_time = None
+
+	async def wait_for_turn(self):
+		"""Blocks until this caller's turn to dispatch a request, per the configured rate."""
+
+		async with self._lock:
+			now = self._time_source()
+			if self._next_allowed_time is None:
+				self._next_allowed_time = now
+
+			wait_seconds = self._next_allowed_time - now
+			if wait_seconds > 0:
+				await self._sleep(wait_seconds)
+				now = self._time_source()
+
+			self._next_allowed_time = now + self._min_interval_seconds

--- a/explorer/puller/puller/facade/SymbolPuller.py
+++ b/explorer/puller/puller/facade/SymbolPuller.py
@@ -11,6 +11,7 @@ from symbollightapi.model.Exceptions import NodeException
 from zenlog import log
 
 from puller.db.SymbolDatabase import SymbolDatabase
+from puller.facade.RequestRateLimiter import RequestRateLimiter
 from puller.model.symbol.Block import create_block_row
 from puller.model.symbol.Receipt import INFLATION_RECEIPT_TYPE, create_receipt_rows
 from puller.model.symbol.Transaction import create_transaction_row
@@ -18,6 +19,7 @@ from puller.model.symbol.Transaction import create_transaction_row
 DatabaseConfiguration = namedtuple('DatabaseConfiguration', ['database', 'user', 'password', 'host', 'port'])
 MAX_PAGE_SIZE = 100
 BLOCK_PAGE_FETCH_CONCURRENCY = 10
+DEFAULT_MAX_REQUESTS_PER_SECOND = 20
 
 
 def _get_symbol_network(network_type):
@@ -47,7 +49,9 @@ class SymbolPuller:
 		config_file,
 		network_type='mainnet',
 		node_config=None,
-		connector=None
+		connector=None,
+		max_requests_per_second=DEFAULT_MAX_REQUESTS_PER_SECOND,
+		rate_limiter=None
 	):
 		"""Creates a Symbol puller facade object."""
 
@@ -65,6 +69,7 @@ class SymbolPuller:
 		self._symbol_connector.timeout_seconds = self.node_config.timeout_seconds
 		self.symbol_facade = SymbolFacade(network)
 		self._retry_delay = 2
+		self._rate_limiter = rate_limiter or RequestRateLimiter(max_requests_per_second)
 
 	def __enter__(self):
 		self.symbol_db.__enter__()
@@ -108,6 +113,7 @@ class SymbolPuller:
 		"""Validates and dispatches a Symbol node GET request."""
 
 		normalized_path = self._validate_symbol_node_path(url_path)
+		await self._rate_limiter.wait_for_turn()
 		return await self._retry_operation(
 			lambda: self._symbol_connector.get(normalized_path, property_name, not_found_as_error),
 			f'fetching Symbol node path {normalized_path}',
@@ -118,6 +124,7 @@ class SymbolPuller:
 		"""Validates and dispatches a Symbol node POST request."""
 
 		normalized_path = self._validate_symbol_node_path(url_path)
+		await self._rate_limiter.wait_for_turn()
 		return await self._retry_operation(
 			lambda: self._symbol_connector.post(normalized_path, request_payload, property_name, not_found_as_error),
 			f'posting Symbol node path {normalized_path}',

--- a/explorer/puller/puller/facade/SymbolPuller.py
+++ b/explorer/puller/puller/facade/SymbolPuller.py
@@ -90,12 +90,12 @@ class SymbolPuller:
 
 		return normalized_path
 
-	@staticmethod
-	async def _retry_operation(operation, description, retries=3, delay=2):
+	async def _retry_operation(self, operation, description, retries=3):
 		"""Retries a Symbol node operation with exponential backoff."""
 
 		for attempt_index in range(retries):
 			try:
+				await self._rate_limiter.wait_for_turn()
 				response = await operation()
 				_raise_if_node_error(response)
 				return response
@@ -105,7 +105,7 @@ class SymbolPuller:
 					log.error(f'Failed {description} after {retries} attempts: {error}')
 					raise
 
-				wait_time = delay * (2 ** attempt_index)
+				wait_time = self._retry_delay * (2 ** attempt_index)
 				log.warning(f'Error {description} (attempt {attempt}/{retries}): {error}. Retrying in {wait_time}s...')
 				await asyncio.sleep(wait_time)
 
@@ -113,22 +113,18 @@ class SymbolPuller:
 		"""Validates and dispatches a Symbol node GET request."""
 
 		normalized_path = self._validate_symbol_node_path(url_path)
-		await self._rate_limiter.wait_for_turn()
 		return await self._retry_operation(
 			lambda: self._symbol_connector.get(normalized_path, property_name, not_found_as_error),
-			f'fetching Symbol node path {normalized_path}',
-			delay=self._retry_delay
+			f'fetching Symbol node path {normalized_path}'
 		)
 
 	async def post_symbol_node(self, url_path, request_payload, property_name=None, not_found_as_error=True):
 		"""Validates and dispatches a Symbol node POST request."""
 
 		normalized_path = self._validate_symbol_node_path(url_path)
-		await self._rate_limiter.wait_for_turn()
 		return await self._retry_operation(
 			lambda: self._symbol_connector.post(normalized_path, request_payload, property_name, not_found_as_error),
-			f'posting Symbol node path {normalized_path}',
-			delay=self._retry_delay
+			f'posting Symbol node path {normalized_path}'
 		)
 
 	async def sync_block_headers(self, max_height=None):

--- a/explorer/puller/puller/workflows/sync_symbol_block.py
+++ b/explorer/puller/puller/workflows/sync_symbol_block.py
@@ -23,6 +23,7 @@ def parse_args():
 	parser.add_argument('--network', choices=['mainnet', 'testnet'], required=True)
 	parser.add_argument('--db-config', required=True)
 	parser.add_argument('--max-height', type=_positive_int, help='maximum block height to sync for manual validation')
+	parser.add_argument('--max-requests-per-second', type=_positive_int, help='maximum Symbol node requests per second')
 
 	return parser.parse_args()
 
@@ -37,12 +38,16 @@ def _create_node_config(symbol_node):
 	})
 
 
-async def main():
+async def main(symbol_puller_factory=SymbolPuller):
 	"""Synchronizes Symbol block headers."""
 
 	args = parse_args()
 	node_config = _create_node_config(args.symbol_node)
-	puller = SymbolPuller(args.symbol_node, args.db_config, args.network, node_config)
+	puller_kwargs = {}
+	if args.max_requests_per_second is not None:
+		puller_kwargs['max_requests_per_second'] = args.max_requests_per_second
+
+	puller = symbol_puller_factory(args.symbol_node, args.db_config, args.network, node_config, **puller_kwargs)
 
 	with puller:
 		puller.symbol_db.create_tables()

--- a/explorer/puller/tests/facade/symbol/puller_test_utils.py
+++ b/explorer/puller/tests/facade/symbol/puller_test_utils.py
@@ -43,12 +43,13 @@ def create_db_config(config_dir, db_config=None, include_symbol_db=True):
 	return db_config_path
 
 
-def create_symbol_puller(
+def create_symbol_puller(  # pylint: disable=too-many-arguments,too-many-positional-arguments
 	db_config_path,
 	network_type='mainnet',
 	request_timeout_seconds=10,
 	node_url=NODE_URL,
-	connector=None
+	connector=None,
+	rate_limiter=None
 ):
 	node_config = SymbolNodeConfiguration.from_url(
 		node_url,
@@ -61,7 +62,9 @@ def create_symbol_puller(
 		db_config_path,
 		network_type,
 		node_config,
-		connector
+		connector,
+		max_requests_per_second=1_000_000,
+		rate_limiter=rate_limiter
 	)
 	puller._retry_delay = 0  # pylint: disable=protected-access
 
@@ -72,7 +75,8 @@ def create_symbol_puller(
 def temporary_symbol_puller(
 	network_type='mainnet',
 	request_timeout_seconds=10,
-	connector=None
+	connector=None,
+	rate_limiter=None
 ):
 	with tempfile.TemporaryDirectory() as temp_directory:
 		db_config_path = create_db_config(temp_directory)
@@ -81,7 +85,8 @@ def temporary_symbol_puller(
 			db_config_path,
 			network_type,
 			request_timeout_seconds,
-			connector=connector
+			connector=connector,
+			rate_limiter=rate_limiter
 		)
 
 

--- a/explorer/puller/tests/facade/symbol/test_Puller.py
+++ b/explorer/puller/tests/facade/symbol/test_Puller.py
@@ -10,6 +10,14 @@ from puller.facade.SymbolPuller import SymbolPuller
 from .puller_test_utils import NODE_URL, ResponseConnector, create_db_config, create_symbol_puller, temporary_symbol_puller
 
 
+class CountingRateLimiter:
+	def __init__(self):
+		self.call_count = 0
+
+	async def wait_for_turn(self):
+		self.call_count += 1
+
+
 class SymbolPullerTest(TestCase):
 
 	def test_create_default_puller_instance(self):
@@ -130,6 +138,29 @@ class SymbolPullerTest(TestCase):
 		# Assert:
 		self.assertEqual({'ok': True}, result)
 		connector.post.assert_awaited_once_with('path', {'payload': 1}, 'data', False)
+
+	def test_get_symbol_node_waits_for_rate_limiter_turn(self):
+		# Arrange:
+		connector = ResponseConnector({'chain/info': {'ok': True}})
+		rate_limiter = CountingRateLimiter()
+		with temporary_symbol_puller(connector=connector, rate_limiter=rate_limiter) as puller:
+			# Act:
+			asyncio.run(puller.get_symbol_node('/chain/info'))
+
+		# Assert:
+		self.assertEqual(1, rate_limiter.call_count)
+
+	def test_post_symbol_node_waits_for_rate_limiter_turn(self):
+		# Arrange:
+		connector = MagicMock()
+		connector.post = AsyncMock(return_value={'ok': True})
+		rate_limiter = CountingRateLimiter()
+		with temporary_symbol_puller(connector=connector, rate_limiter=rate_limiter) as puller:
+			# Act:
+			asyncio.run(puller.post_symbol_node('/transactions', {'payload': 'ABCD'}))
+
+		# Assert:
+		self.assertEqual(1, rate_limiter.call_count)
 
 	def test_post_symbol_node_retries_api_error_response(self):
 		# Arrange:

--- a/explorer/puller/tests/facade/symbol/test_Puller.py
+++ b/explorer/puller/tests/facade/symbol/test_Puller.py
@@ -162,6 +162,22 @@ class SymbolPullerTest(TestCase):
 		# Assert:
 		self.assertEqual(1, rate_limiter.call_count)
 
+	def test_get_symbol_node_waits_for_rate_limiter_turn_on_each_retry(self):
+		# Arrange:
+		connector = MagicMock()
+		connector.get = AsyncMock(side_effect=[
+			NodeException('Connection refused'),
+			{'ok': True}
+		])
+		rate_limiter = CountingRateLimiter()
+		with temporary_symbol_puller(connector=connector, rate_limiter=rate_limiter) as puller:
+			# Act:
+			result = asyncio.run(puller.get_symbol_node('/chain/info'))
+
+		# Assert:
+		self.assertEqual({'ok': True}, result)
+		self.assertEqual(2, rate_limiter.call_count)
+
 	def test_post_symbol_node_retries_api_error_response(self):
 		# Arrange:
 		connector = MagicMock()

--- a/explorer/puller/tests/facade/test_RequestRateLimiter.py
+++ b/explorer/puller/tests/facade/test_RequestRateLimiter.py
@@ -1,0 +1,84 @@
+import asyncio
+from unittest import TestCase
+
+from puller.facade.RequestRateLimiter import RequestRateLimiter
+
+
+class FakeClock:
+	def __init__(self):
+		self.value = 0
+
+	def __call__(self):
+		return self.value
+
+
+class RecordingSleep:
+	def __init__(self, clock):
+		self.wait_seconds = []
+		self._clock = clock
+
+	async def __call__(self, wait_seconds):
+		self.wait_seconds.append(wait_seconds)
+		self._clock.value += wait_seconds
+
+
+class RequestRateLimiterTest(TestCase):
+	def test_wait_for_turn_does_not_sleep_on_first_call(self):
+		# Arrange:
+		clock = FakeClock()
+		sleep = RecordingSleep(clock)
+		limiter = RequestRateLimiter(10, clock, sleep)
+
+		# Act:
+		asyncio.run(limiter.wait_for_turn())
+
+		# Assert:
+		self.assertEqual([], sleep.wait_seconds)
+
+	def test_wait_for_turn_sleeps_for_remaining_interval_on_immediate_second_call(self):
+		# Arrange:
+		clock = FakeClock()
+		sleep = RecordingSleep(clock)
+		limiter = RequestRateLimiter(10, clock, sleep)
+
+		# Act:
+		async def wait_twice():
+			await limiter.wait_for_turn()
+			await limiter.wait_for_turn()
+
+		asyncio.run(wait_twice())
+
+		# Assert:
+		self.assertEqual([0.1], sleep.wait_seconds)
+
+	def test_wait_for_turn_does_not_sleep_when_enough_time_already_elapsed(self):
+		# Arrange:
+		clock = FakeClock()
+		sleep = RecordingSleep(clock)
+		limiter = RequestRateLimiter(10, clock, sleep)
+
+		async def wait_with_elapsed_time():
+			await limiter.wait_for_turn()
+			clock.value += 0.2
+			await limiter.wait_for_turn()
+
+		# Act:
+		asyncio.run(wait_with_elapsed_time())
+
+		# Assert:
+		self.assertEqual([], sleep.wait_seconds)
+
+	def test_wait_for_turn_serializes_concurrent_callers(self):
+		# Arrange:
+		clock = FakeClock()
+		sleep = RecordingSleep(clock)
+		limiter = RequestRateLimiter(10, clock, sleep)
+
+		# Act:
+		async def wait_concurrently():
+			await asyncio.gather(*[limiter.wait_for_turn() for _ in range(4)])
+
+		asyncio.run(wait_concurrently())
+
+		# Assert:
+		self.assertEqual(3, len(sleep.wait_seconds))

--- a/explorer/puller/tests/workflows/test_sync_symbol_block.py
+++ b/explorer/puller/tests/workflows/test_sync_symbol_block.py
@@ -1,11 +1,45 @@
 import asyncio
 import unittest
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 from common.symbol.NodeConfiguration import SymbolNodeConfigurationError
-from workflow_test_utils import create_symbol_facade_with_mock_db, parse_args_with_argv
+from workflow_test_utils import parse_args_with_argv
 
 from puller.workflows.sync_symbol_block import _create_node_config, main, parse_args
+
+
+class RecordingSymbolDatabase:
+	def __init__(self):
+		self.create_tables_call_count = 0
+
+	def create_tables(self):
+		self.create_tables_call_count += 1
+
+
+class RecordingSymbolPuller:
+	def __init__(self, *args, **kwargs):
+		self.constructor_args = args
+		self.constructor_kwargs = kwargs
+		self.symbol_db = RecordingSymbolDatabase()
+		self.synced_max_heights = []
+
+	def __enter__(self):
+		return self
+
+	def __exit__(self, *_):
+		return None
+
+	async def sync_block_headers(self, max_height):
+		self.synced_max_heights.append(max_height)
+
+
+class RecordingSymbolPullerFactory:
+	def __init__(self):
+		self.puller = None
+
+	def __call__(self, *args, **kwargs):
+		self.puller = RecordingSymbolPuller(*args, **kwargs)
+		return self.puller
 
 
 class SyncSymbolBlockTest(unittest.TestCase):
@@ -28,6 +62,7 @@ class SyncSymbolBlockTest(unittest.TestCase):
 		self.assertEqual(args.network, 'mainnet')
 		self.assertEqual(args.db_config, 'config.ini')
 		self.assertIsNone(args.max_height)
+		self.assertIsNone(args.max_requests_per_second)
 
 	def test_parse_args_with_custom_values(self):
 		# Act:
@@ -37,13 +72,15 @@ class SyncSymbolBlockTest(unittest.TestCase):
 			'--symbol-node', 'http://localhost:3000',
 			'--network', 'testnet',
 			'--db-config', 'test_config.ini',
-			'--max-height', '1000')
+			'--max-height', '1000',
+			'--max-requests-per-second', '25')
 
 		# Assert:
 		self.assertEqual(args.symbol_node, 'http://localhost:3000')
 		self.assertEqual(args.network, 'testnet')
 		self.assertEqual(args.db_config, 'test_config.ini')
 		self.assertEqual(args.max_height, 1000)
+		self.assertEqual(args.max_requests_per_second, 25)
 
 	def test_parse_args_rejects_invalid_network(self):
 		# Act + Assert:
@@ -65,6 +102,17 @@ class SyncSymbolBlockTest(unittest.TestCase):
 				'--network', 'testnet',
 				'--db-config', 'test_config.ini',
 				'--max-height', '0')
+
+	def test_parse_args_rejects_invalid_max_requests_per_second(self):
+		# Act + Assert:
+		with self.assertRaises(SystemExit):
+			parse_args_with_argv(
+				'sync_symbol_block.py',
+				parse_args,
+				'--symbol-node', 'http://localhost:3000',
+				'--network', 'testnet',
+				'--db-config', 'test_config.ini',
+				'--max-requests-per-second', '0')
 
 	def test_create_node_config_rejects_missing_allowed_hosts(self):
 		# Arrange:
@@ -96,18 +144,16 @@ class SyncSymbolBlockTest(unittest.TestCase):
 		self.assertFalse(node_config.allow_private)
 		self.assertEqual(17, node_config.timeout_seconds)
 
-	@patch('puller.workflows.sync_symbol_block.SymbolPuller')
-	def test_main_creates_tables_and_syncs_block_headers(self, mock_symbol_puller):
+	def test_main_forwards_custom_max_requests_per_second_to_symbol_puller(self):
 		# Arrange:
-		mock_facade, mock_db = create_symbol_facade_with_mock_db(mock_symbol_puller)
-		mock_facade.sync_block_headers = AsyncMock()
-
+		puller_factory = RecordingSymbolPullerFactory()
 		with patch('sys.argv', [
 			'sync_symbol_block.py',
 			'--symbol-node', 'http://localhost:7890',
 			'--network', 'testnet',
 			'--db-config', 'test_config.ini',
-			'--max-height', '3000'
+			'--max-height', '3000',
+			'--max-requests-per-second', '25'
 		]), patch.dict('os.environ', {
 			'SYMBOL_NODE_ALLOWED_HOSTS': 'localhost:7890',
 			'SYMBOL_NODE_ALLOW_LOOPBACK': 'true',
@@ -115,8 +161,33 @@ class SyncSymbolBlockTest(unittest.TestCase):
 			'SYMBOL_NODE_REQUEST_TIMEOUT_SECONDS': '9'
 		}, clear=True):
 			# Act:
-			asyncio.run(main())
+			asyncio.run(main(puller_factory))
 
 		# Assert:
-		self.assertEqual(1, mock_db.create_tables.call_count)
-		mock_facade.sync_block_headers.assert_awaited_once_with(3000)
+		puller = puller_factory.puller
+		self.assertEqual(25, puller.constructor_kwargs['max_requests_per_second'])
+		self.assertEqual(1, puller.symbol_db.create_tables_call_count)
+		self.assertEqual([3000], puller.synced_max_heights)
+
+	def test_main_uses_symbol_puller_default_max_requests_per_second_when_omitted(self):
+		# Arrange:
+		puller_factory = RecordingSymbolPullerFactory()
+		with patch('sys.argv', [
+			'sync_symbol_block.py',
+			'--symbol-node', 'http://localhost:7890',
+			'--network', 'testnet',
+			'--db-config', 'test_config.ini'
+		]), patch.dict('os.environ', {
+			'SYMBOL_NODE_ALLOWED_HOSTS': 'localhost:7890',
+			'SYMBOL_NODE_ALLOW_LOOPBACK': 'true',
+			'SYMBOL_NODE_ALLOW_PRIVATE': 'false',
+			'SYMBOL_NODE_REQUEST_TIMEOUT_SECONDS': '9'
+		}, clear=True):
+			# Act:
+			asyncio.run(main(puller_factory))
+
+		# Assert:
+		puller = puller_factory.puller
+		self.assertEqual({}, puller.constructor_kwargs)
+		self.assertEqual(1, puller.symbol_db.create_tables_call_count)
+		self.assertEqual([None], puller.synced_max_heights)

--- a/explorer/puller/tests/workflows/workflow_test_utils.py
+++ b/explorer/puller/tests/workflows/workflow_test_utils.py
@@ -35,15 +35,3 @@ def create_facade_with_mock_db(mock_nem_puller):
 	mock_facade.nem_db.__exit__ = Mock(return_value=None)
 
 	return mock_facade, mock_db
-
-
-def create_symbol_facade_with_mock_db(mock_symbol_puller):
-	mock_facade = Mock()
-	mock_symbol_puller.return_value = mock_facade
-	mock_facade.__enter__ = Mock(return_value=mock_facade)
-	mock_facade.__exit__ = Mock(return_value=None)
-
-	mock_db = Mock()
-	mock_facade.symbol_db = mock_db
-
-	return mock_facade, mock_db


### PR DESCRIPTION
## Problem

Live-node validation against a public testnet node repeatedly hit `HTTP 429 TooManyRequests` ("You have exceeded your request rate of 60 r/s.") during both the dirty-key multisig fetch loop and the account refresh snapshot's `/accounts` pagination. The account refresh run failed outright after exhausting retries at page 2956 of ~3,159 needed pages (~315K accounts on that testnet).

## Solution

`SymbolPuller.get_symbol_node`/`post_symbol_node` are the only two places any Symbol node request is ever dispatched — every other method (block/transaction/receipt page fetches, the accounts batch `POST`, multisig `GET`, account refresh pagination) funnels through them. Add a `RequestRateLimiter` and call it from those two choke points, so every call site gets throttled by one change instead of needing per-loop pacing.

`RequestRateLimiter` paces callers to a `max_requests_per_second` budget via an `asyncio.Lock`-serialized "next allowed time" watermark; concurrent callers (e.g. the block-page fetches already running via `asyncio.gather` up to `BLOCK_PAGE_FETCH_CONCURRENCY`) queue on the lock and get spaced out rather than all firing at once. `time_source`/`sleep` are constructor-injected so it's unit-testable without waiting in real time.

Defaults to 20 req/s — well under the observed 60 r/s ceiling, leaving headroom for other clients sharing a public node. Exposed as `--max-requests-per-second` on `sync_symbol_block.py` so operators can tune it (raise it for a private node with no such limit, lower it further if still hitting 429s).

`SymbolPuller.__init__` also accepts an optional `rate_limiter` for DI (used by tests); `max_requests_per_second` is ignored when `rate_limiter` is explicitly supplied.