### PR TITLE
[explorer/puller] fix: keep linked remote address across account refreshes

### DIFF
--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -453,7 +453,7 @@ class NemDatabase(DatabaseConnection):
 			VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 			ON CONFLICT (address)
 			DO UPDATE SET
-				remote_address = EXCLUDED.remote_address,
+				-- remote_address is owned exclusively by update_account_remote_address;
 				importance = EXCLUDED.importance,
 				balance = EXCLUDED.balance,
 				vested_balance = EXCLUDED.vested_balance,
@@ -478,6 +478,23 @@ class NemDatabase(DatabaseConnection):
 				account_info.min_cosignatories,
 				[address.bytes for address in account_info.cosignatory_of] if len(account_info.cosignatory_of) > 0 else None,
 				[address.bytes for address in account_info.cosignatories] if len(account_info.cosignatories) > 0 else None,
+			)
+		)
+
+	@staticmethod
+	def update_account_remote_address(cursor, address, remote_address):
+		"""Sets or clears the remote (linked) address on a main account."""
+
+		cursor.execute(
+			'''
+			UPDATE accounts
+			SET remote_address = %s,
+				updated_at = CURRENT_TIMESTAMP
+			WHERE address = %s
+			''',
+			(
+				remote_address.bytes if remote_address else None,
+				address.bytes
 			)
 		)
 

--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -453,7 +453,6 @@ class NemDatabase(DatabaseConnection):
 			VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 			ON CONFLICT (address)
 			DO UPDATE SET
-				-- remote_address is owned exclusively by update_account_remote_address;
 				importance = EXCLUDED.importance,
 				balance = EXCLUDED.balance,
 				vested_balance = EXCLUDED.vested_balance,

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -15,6 +15,8 @@ from zenlog import log
 
 from puller.db.NemDatabase import NemDatabase
 
+ACCOUNT_KEY_LINK_MODE_ACTIVATE = 1
+
 BlockRecord = namedtuple('BlockRecord', [
 	'height',
 	'timestamp',
@@ -137,11 +139,11 @@ class NemPuller:
 			delay
 		)
 
-	async def _retry_get_account_info(self, address, forwarded=False, retries=3, delay=2):
+	async def _retry_get_account_info(self, address, retries=3, delay=2):
 		"""Retries fetching account info with exponential backoff."""
 
 		return await self._retry_operation(
-			lambda: self.nem_connector.account_info(address, forwarded),
+			lambda: self.nem_connector.account_info(address),
 			f'fetching account {address[:16]}...',
 			retries,
 			delay
@@ -269,7 +271,6 @@ class NemPuller:
 	def _create_account_record(account_info, mosaics_json, height):
 		"""Create AccountRecord from account info and mosaics."""
 
-		# remote_address is linked separately after the upsert, see _process_account_batch
 		return AccountRecord(
 			account_info.address,
 			height,
@@ -304,10 +305,6 @@ class NemPuller:
 
 		log.info(f'Processing batch of {len(address_heights)} addresses')
 
-		# Remote links are applied after every account in the batch has been upserted, so the main
-		# account row is guaranteed to exist regardless of processing order within the batch.
-		remote_links = []
-
 		# Fetch account info for all addresses (both new and existing)
 		for address, height in address_heights.items():
 			account_info = await self._retry_get_account_info(address)
@@ -317,15 +314,6 @@ class NemPuller:
 			account = self._create_account_record(account_info, mosaics_json, height)
 
 			self.nem_db.upsert_account(cursor, account)
-
-			if 'REMOTE' == account_info.remote_status:
-				main_account_info = await self._retry_get_account_info(address, forwarded=True)
-				if main_account_info.address != account.address:
-					remote_address = None if 'DEACTIVATING' == main_account_info.remote_status else account.address
-					remote_links.append((main_account_info.address, remote_address))
-
-		for main_address, remote_address in remote_links:
-			self.nem_db.update_account_remote_address(cursor, main_address, remote_address)
 
 	@staticmethod
 	def _add_pending_addresses(pending_addresses, addresses, height):
@@ -425,6 +413,17 @@ class NemPuller:
 		)
 
 		self.nem_db.upsert_mosaic(cursor, mosaic)
+
+	def _process_account_key_link(self, cursor, transaction):
+		"""Apply a remote link change announced by an account key link transaction."""
+
+		main_address = self._convert_public_key_to_address(transaction.sender)
+		remote_address = (
+			self._convert_public_key_to_address(transaction.remote_account)
+			if ACCOUNT_KEY_LINK_MODE_ACTIVATE == transaction.mode else None
+		)
+
+		self.nem_db.update_account_remote_address(cursor, main_address, remote_address)
 
 	def _process_mosaic_supply_change(self, cursor, transaction):
 		"""Process mosaic supply change in a block."""
@@ -557,6 +556,8 @@ class NemPuller:
 			self._process_mosaic_definition(cursor, transaction, block_height)
 		elif transaction.transaction_type == TransactionType.MOSAIC_SUPPLY_CHANGE.value:
 			self._process_mosaic_supply_change(cursor, transaction)
+		elif transaction.transaction_type == TransactionType.ACCOUNT_KEY_LINK.value:
+			self._process_account_key_link(cursor, transaction)
 
 		return transaction_id
 

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -212,6 +212,7 @@ class NemPuller:
 
 		# Block signer
 		addresses.add(str(self._convert_public_key_to_address(block.signer)))
+		addresses.add(str(block.beneficiary))
 
 		# Block transactions
 		for transaction in block.transactions:
@@ -302,6 +303,10 @@ class NemPuller:
 
 		log.info(f'Processing batch of {len(address_heights)} addresses')
 
+		# Remote links are applied after every account in the batch has been upserted, so the main
+		# account row is guaranteed to exist regardless of processing order within the batch.
+		remote_links = []
+
 		# Fetch account info for all addresses (both new and existing)
 		for address, height in address_heights.items():
 			account_info = await self._retry_get_account_info(address)
@@ -313,14 +318,13 @@ class NemPuller:
 			self.nem_db.upsert_account(cursor, account)
 
 			if 'REMOTE' == account_info.remote_status:
-				# Try fetching forwarded account info if remote status is REMOTE
 				main_account_info = await self._retry_get_account_info(address, forwarded=True)
-				main_account_mosaics = await self._retry_get_account_mosaics(str(main_account_info.address))
+				if main_account_info.address != account.address:
+					remote_address = None if 'DEACTIVATING' == main_account_info.remote_status else account.address
+					remote_links.append((main_account_info.address, remote_address))
 
-				main_mosaics_json = self._convert_mosaics_to_json(main_account_mosaics)
-				main_account = self._create_account_record(main_account_info, main_mosaics_json, height, remote_address=account.address)
-
-				self.nem_db.upsert_account(cursor, main_account)
+		for main_address, remote_address in remote_links:
+			self.nem_db.update_account_remote_address(cursor, main_address, remote_address)
 
 	@staticmethod
 	def _add_pending_addresses(pending_addresses, addresses, height):

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -266,14 +266,15 @@ class NemPuller:
 		]
 
 	@staticmethod
-	def _create_account_record(account_info, mosaics_json, height, remote_address=None):
+	def _create_account_record(account_info, mosaics_json, height):
 		"""Create AccountRecord from account info and mosaics."""
 
+		# remote_address is linked separately after the upsert, see _process_account_batch
 		return AccountRecord(
 			account_info.address,
 			height,
 			account_info.public_key,
-			remote_address,
+			None,
 			account_info.importance,
 			_format_xem_absolute(account_info.balance),
 			_format_xem_absolute(account_info.vested_balance),

--- a/explorer/puller/tests/db/test_NemDatabase.py
+++ b/explorer/puller/tests/db/test_NemDatabase.py
@@ -543,6 +543,72 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 		# Assert:
 		self.assertEqual(result[1], 1)
 
+	def test_upsert_account_does_not_overwrite_remote_address(self):
+		# Arrange:
+		remote_address = Address('TBKQWJJGPOHL462DBVMTYOAERXGG2BOS5XRFO2P6')
+
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+
+			cursor = nem_database.connection.cursor()
+
+			# insert an account that already carries a remote link
+			nem_database.upsert_account(
+				cursor,
+				ACCOUNTS[0]._replace(remote_address=remote_address)
+			)
+
+			# Act:
+			nem_database.upsert_account(
+				cursor,
+				ACCOUNTS[0]._replace(remote_address=None, balance=2000000)
+			)
+
+			nem_database.connection.commit()
+			result = self._fetch_account_from_db(cursor, ACCOUNTS[0].address)
+
+		# Assert:
+		self.assertEqual(result[3], remote_address.bytes.hex())
+		self.assertEqual(result[5], 2000000)
+
+	def test_can_set_account_remote_address(self):
+		# Arrange:
+		remote_address = Address('TBKQWJJGPOHL462DBVMTYOAERXGG2BOS5XRFO2P6')
+
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+
+			cursor = nem_database.connection.cursor()
+
+			nem_database.upsert_account(cursor, ACCOUNTS[0])
+
+			# Act:
+			nem_database.update_account_remote_address(cursor, ACCOUNTS[0].address, remote_address)
+			nem_database.connection.commit()
+			result = self._fetch_account_from_db(cursor, ACCOUNTS[0].address)
+
+		# Assert:
+		self.assertEqual(result[3], remote_address.bytes.hex())
+
+	def test_can_clear_account_remote_address(self):
+		# Arrange:
+		remote_address = Address('TBKQWJJGPOHL462DBVMTYOAERXGG2BOS5XRFO2P6')
+
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+
+			cursor = nem_database.connection.cursor()
+
+			nem_database.upsert_account(cursor, ACCOUNTS[0]._replace(remote_address=remote_address))
+
+			# Act:
+			nem_database.update_account_remote_address(cursor, ACCOUNTS[0].address, None)
+			nem_database.connection.commit()
+			result = self._fetch_account_from_db(cursor, ACCOUNTS[0].address)
+
+		# Assert:
+		self.assertIsNone(result[3])
+
 	def test_can_get_accounts_for_refresh(self):
 		# Arrange:
 		accounts = [

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -342,12 +342,14 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		sender_address = Address('TALICE6XEEEOBFJVY3ZCENZ7WBG6LB4KB7P7KMQX')
 		recipient_address = Address('NCOPERAWEWCD4A34NP5UQCCKEX44MW4SL3QYJYS5')
 		signer_address = Address('TBEM6SFOHU5PORIGAVG3NNJIMCG73R2TWH35O2VF')
+		beneficiary_address = Address('TBZWVEKB2XMTO4F3RAOEIBWRBMPQ5N23G56ZJM4I')
 
 		mock_get_block.return_value = NEM_CONNECTOR_RESPONSE_BLOCKS[0]
 		mock_account_info.side_effect = [
 			NemAccountInfo(sender_address),
 			NemAccountInfo(recipient_address),
-			NemAccountInfo(signer_address)
+			NemAccountInfo(signer_address),
+			NemAccountInfo(beneficiary_address)
 		]
 		mock_account_mosaics.return_value = [AccountMosaic(('nem', 'xem'), 0), ]
 
@@ -376,7 +378,12 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 
 			account_results = self._query_fetch_accounts(self.puller)
 			self.assertCountEqual(
-				[sender_address.bytes.hex(), recipient_address.bytes.hex(), signer_address.bytes.hex()],
+				[
+					sender_address.bytes.hex(),
+					recipient_address.bytes.hex(),
+					signer_address.bytes.hex(),
+					beneficiary_address.bytes.hex()
+				],
 				[row[0] for row in account_results],
 			)
 			mock_seed_network_currency.assert_called_once()
@@ -449,7 +456,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 
 			call_args = mock_process_account_batch.call_args_list[0]
 			address_heights = call_args[0][1]
-			self.assertEqual(len(address_heights), 19)
+			self.assertEqual(len(address_heights), 21)
 			self.assertIn(1, address_heights.values())
 			self.assertIn(2, address_heights.values())
 			self.assertIn(3, address_heights.values())
@@ -667,7 +674,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		mock_account_mosaics.assert_called_once_with(address)
 
 	@patch('puller.facade.NemPuller.NemDatabase.get_mosaic_levy_recipients')
-	def test_can_extract_addresses_from_block_with_only_signer(self, mock_get_mosaic_levy_recipients):
+	def test_can_extract_addresses_from_block_signer_and_beneficiary(self, mock_get_mosaic_levy_recipients):
 		# Arrange:
 		block = NEM_CONNECTOR_RESPONSE_BLOCKS[1]
 		cursor = Mock()
@@ -677,7 +684,26 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		addresses = self.puller._extract_addresses_from_block(cursor, block)  # pylint: disable=protected-access
 
 		# Assert:
-		self.assertEqual(addresses, {'TALICE6XEEEOBFJVY3ZCENZ7WBG6LB4KB7P7KMQX'})
+		self.assertEqual(addresses, {
+			'TALICE6XEEEOBFJVY3ZCENZ7WBG6LB4KB7P7KMQX',
+			'TCJLCZSOQ6RGWHTPSV2DW467WZSHK4NBSITND4OF'
+		})
+		mock_get_mosaic_levy_recipients.assert_called_once_with(cursor, set())
+
+	@patch('puller.facade.NemPuller.NemDatabase.get_mosaic_levy_recipients')
+	def test_extract_addresses_does_not_duplicate_beneficiary_equal_to_signer(self, mock_get_mosaic_levy_recipients):
+		# Arrange:
+		signer = PublicKey('f9bd190dd0c364261f5c8a74870cc7f7374e631352293c62ecc437657e5de2cd')
+		signer_address = self.puller._convert_public_key_to_address(signer)  # pylint: disable=protected-access
+		block = Block(9, 78976, [], 100, 'a' * 64, 1000000, signer_address, signer, 'd' * 128, 200)
+		cursor = Mock()
+		mock_get_mosaic_levy_recipients.return_value = []
+
+		# Act:
+		addresses = self.puller._extract_addresses_from_block(cursor, block)  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual(addresses, {str(signer_address)})
 		mock_get_mosaic_levy_recipients.assert_called_once_with(cursor, set())
 
 	@patch('puller.facade.NemPuller.NemDatabase.get_mosaic_levy_recipients')
@@ -709,7 +735,8 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			'NBRYCNWZINEVNITUESKUMFIENWKYCRUGNFZV25AV',
 			'TANIBAXPVLBP37YXSGREVD77NXIFZML5FANIVEXX',
 			'TBEM6SFOHU5PORIGAVG3NNJIMCG73R2TWH35O2VF',
-			'TADMEHCFJD45GPTDL4HZP2LJLZVAZRLYWY2K4OOH'
+			'TADMEHCFJD45GPTDL4HZP2LJLZVAZRLYWY2K4OOH',
+			'TCJLCZSOQ6RGWHTPSV2DW467WZSHK4NBSITND4OF'
 		})
 		mock_get_mosaic_levy_recipients.assert_called_once_with(cursor, set())
 
@@ -807,25 +834,27 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			)
 		)
 
+	@patch('puller.facade.NemPuller.NemDatabase.update_account_remote_address')
 	@patch('puller.facade.NemPuller.NemConnector.account_info')
 	@patch('puller.facade.NemPuller.NemConnector.account_mosaics')
 	@patch('puller.facade.NemPuller.NemDatabase.upsert_account')
-	def test_can_process_account_batch_with_remote_status(self, mock_upsert_account, mock_account_mosaics, mock_account_info):
+	def test_can_process_account_batch_with_remote_status(
+		self,
+		mock_upsert_account,
+		mock_account_mosaics,
+		mock_account_info,
+		mock_update_remote_address
+	):
+		# pylint: disable=too-many-arguments,too-many-positional-arguments
 		# Arrange:
 		account = NEM_CONNECTOR_RESPONSE_ACCOUNT_INFO
 		account.remote_status = 'REMOTE'
 
-		remote_account = NemAccountInfo(Address('TBKQWJJGPOHL462DBVMTYOAERXGG2BOS5XRFO2P6'))
+		main_account = NemAccountInfo(Address('TBKQWJJGPOHL462DBVMTYOAERXGG2BOS5XRFO2P6'))
+		main_account.remote_status = 'ACTIVE'
 
-		mock_account_info.side_effect = [
-			account,
-			remote_account
-		]
-
-		mock_account_mosaics.side_effect = [
-			[AccountMosaic(('nem', 'xem'), 0)],
-			[AccountMosaic(('nem', 'xem'), 1000000)]  # for remote account
-		]
+		mock_account_info.side_effect = [account, main_account]
+		mock_account_mosaics.side_effect = [[AccountMosaic(('nem', 'xem'), 0)]]
 
 		cursor = Mock()
 		address_heights = {
@@ -842,13 +871,11 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		self.assertEqual(account_info_calls[1][0], (str(account.address), True))
 
 		account_mosaics_calls = mock_account_mosaics.call_args_list
-		self.assertEqual(len(account_mosaics_calls), 2)
+		self.assertEqual(len(account_mosaics_calls), 1)
 		self.assertEqual(account_mosaics_calls[0][0], (str(account.address),))
-		self.assertEqual(account_mosaics_calls[1][0], (str(remote_account.address),))
 
-		upsert_account_calls = mock_upsert_account.call_args_list
-		self.assertEqual(len(upsert_account_calls), 2)
-		self.assertEqual(upsert_account_calls[0][0], (
+		self.assertEqual(mock_upsert_account.call_count, 1)
+		self.assertEqual(mock_upsert_account.call_args_list[0][0], (
 			cursor,
 			AccountRecord(
 				height=3,
@@ -860,18 +887,62 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 				**self._exclude_account_status(account)
 			),
 		))
-		self.assertEqual(upsert_account_calls[1][0], (
-			cursor,
-			AccountRecord(
-				height=3,
-				mosaics=[{
-					'namespace_name': 'nem.xem',
-					'quantity': 1000000
-				}],
-				remote_address=account.address,
-				**self._exclude_account_status(remote_account)
-			),
-		))
+
+		mock_update_remote_address.assert_called_once_with(cursor, main_account.address, account.address)
+
+	@patch('puller.facade.NemPuller.NemConnector.account_info')
+	@patch('puller.facade.NemPuller.NemConnector.account_mosaics')
+	@patch('puller.facade.NemPuller.NemDatabase.update_account_remote_address')
+	def test_process_account_batch_clears_remote_link_when_deactivating(
+		self,
+		mock_update_remote_address,
+		mock_account_mosaics,
+		mock_account_info
+	):
+		# Arrange: a link being torn down (main account is DEACTIVATING)
+		account = NEM_CONNECTOR_RESPONSE_ACCOUNT_INFO
+		account.remote_status = 'REMOTE'
+
+		main_account = NemAccountInfo(Address('TBKQWJJGPOHL462DBVMTYOAERXGG2BOS5XRFO2P6'))
+		main_account.remote_status = 'DEACTIVATING'
+
+		mock_account_info.side_effect = [account, main_account]
+		mock_account_mosaics.side_effect = [[AccountMosaic(('nem', 'xem'), 0)]]
+
+		cursor = Mock()
+
+		# Act:
+		asyncio.run(self.puller._process_account_batch(cursor, {str(account.address): 3}))  # pylint: disable=protected-access
+
+		# Assert:
+		mock_update_remote_address.assert_called_once_with(cursor, main_account.address, None)
+
+	@patch('puller.facade.NemPuller.NemConnector.account_info')
+	@patch('puller.facade.NemPuller.NemConnector.account_mosaics')
+	@patch('puller.facade.NemPuller.NemDatabase.update_account_remote_address')
+	def test_process_account_batch_skips_remote_link_when_forwarded_returns_self(
+		self,
+		mock_update_remote_address,
+		mock_account_mosaics,
+		mock_account_info
+	):
+		# Arrange: forwarded lookup returns the account itself (link not active yet)
+		account = NEM_CONNECTOR_RESPONSE_ACCOUNT_INFO
+		account.remote_status = 'REMOTE'
+
+		main_account = NemAccountInfo(account.address)
+		main_account.remote_status = 'REMOTE'
+
+		mock_account_info.side_effect = [account, main_account]
+		mock_account_mosaics.side_effect = [[AccountMosaic(('nem', 'xem'), 0)]]
+
+		cursor = Mock()
+
+		# Act:
+		asyncio.run(self.puller._process_account_batch(cursor, {str(account.address): 3}))  # pylint: disable=protected-access
+
+		# Assert:
+		mock_update_remote_address.assert_not_called()
 
 	@patch('puller.facade.NemPuller.NemDatabase.update_account_harvested_fees')
 	def test_can_process_harvested_fees(self, mock_update_account_harvested_fees):

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -654,7 +654,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 
 		# Assert:
 		self.assertEqual(result, NEM_CONNECTOR_RESPONSE_ACCOUNT_INFO)
-		mock_account_info.assert_called_once_with(address, False)
+		mock_account_info.assert_called_once_with(address)
 
 	@patch('puller.facade.NemPuller.NemConnector.account_mosaics')
 	def test_retry_get_account_mosaics(self, mock_account_mosaics):
@@ -819,7 +819,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		asyncio.run(self.puller._process_account_batch(cursor, address_heights))  # pylint: disable=protected-access
 
 		# Assert:
-		mock_account_info.assert_called_once_with(str(NEM_CONNECTOR_RESPONSE_ACCOUNT_INFO.address), False)
+		mock_account_info.assert_called_once_with(str(NEM_CONNECTOR_RESPONSE_ACCOUNT_INFO.address))
 		mock_account_mosaics.assert_called_once_with(str(NEM_CONNECTOR_RESPONSE_ACCOUNT_INFO.address))
 		mock_upsert_account.assert_called_once_with(
 			cursor,
@@ -833,116 +833,6 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 				**self._exclude_account_status(NEM_CONNECTOR_RESPONSE_ACCOUNT_INFO)
 			)
 		)
-
-	@patch('puller.facade.NemPuller.NemDatabase.update_account_remote_address')
-	@patch('puller.facade.NemPuller.NemConnector.account_info')
-	@patch('puller.facade.NemPuller.NemConnector.account_mosaics')
-	@patch('puller.facade.NemPuller.NemDatabase.upsert_account')
-	def test_can_process_account_batch_with_remote_status(
-		self,
-		mock_upsert_account,
-		mock_account_mosaics,
-		mock_account_info,
-		mock_update_remote_address
-	):
-		# pylint: disable=too-many-arguments,too-many-positional-arguments
-		# Arrange:
-		account = NEM_CONNECTOR_RESPONSE_ACCOUNT_INFO
-		account.remote_status = 'REMOTE'
-
-		main_account = NemAccountInfo(Address('TBKQWJJGPOHL462DBVMTYOAERXGG2BOS5XRFO2P6'))
-		main_account.remote_status = 'ACTIVE'
-
-		mock_account_info.side_effect = [account, main_account]
-		mock_account_mosaics.side_effect = [[AccountMosaic(('nem', 'xem'), 0)]]
-
-		cursor = Mock()
-		address_heights = {
-			str(account.address): 3,
-		}
-
-		# Act:
-		asyncio.run(self.puller._process_account_batch(cursor, address_heights))  # pylint: disable=protected-access
-
-		# Assert:
-		account_info_calls = mock_account_info.call_args_list
-		self.assertEqual(len(account_info_calls), 2)
-		self.assertEqual(account_info_calls[0][0], (str(account.address), False))
-		self.assertEqual(account_info_calls[1][0], (str(account.address), True))
-
-		account_mosaics_calls = mock_account_mosaics.call_args_list
-		self.assertEqual(len(account_mosaics_calls), 1)
-		self.assertEqual(account_mosaics_calls[0][0], (str(account.address),))
-
-		self.assertEqual(mock_upsert_account.call_count, 1)
-		self.assertEqual(mock_upsert_account.call_args_list[0][0], (
-			cursor,
-			AccountRecord(
-				height=3,
-				mosaics=[{
-					'namespace_name': 'nem.xem',
-					'quantity': 0
-				}],
-				remote_address=None,
-				**self._exclude_account_status(account)
-			),
-		))
-
-		mock_update_remote_address.assert_called_once_with(cursor, main_account.address, account.address)
-
-	@patch('puller.facade.NemPuller.NemConnector.account_info')
-	@patch('puller.facade.NemPuller.NemConnector.account_mosaics')
-	@patch('puller.facade.NemPuller.NemDatabase.update_account_remote_address')
-	def test_process_account_batch_clears_remote_link_when_deactivating(
-		self,
-		mock_update_remote_address,
-		mock_account_mosaics,
-		mock_account_info
-	):
-		# Arrange: a link being torn down (main account is DEACTIVATING)
-		account = NEM_CONNECTOR_RESPONSE_ACCOUNT_INFO
-		account.remote_status = 'REMOTE'
-
-		main_account = NemAccountInfo(Address('TBKQWJJGPOHL462DBVMTYOAERXGG2BOS5XRFO2P6'))
-		main_account.remote_status = 'DEACTIVATING'
-
-		mock_account_info.side_effect = [account, main_account]
-		mock_account_mosaics.side_effect = [[AccountMosaic(('nem', 'xem'), 0)]]
-
-		cursor = Mock()
-
-		# Act:
-		asyncio.run(self.puller._process_account_batch(cursor, {str(account.address): 3}))  # pylint: disable=protected-access
-
-		# Assert:
-		mock_update_remote_address.assert_called_once_with(cursor, main_account.address, None)
-
-	@patch('puller.facade.NemPuller.NemConnector.account_info')
-	@patch('puller.facade.NemPuller.NemConnector.account_mosaics')
-	@patch('puller.facade.NemPuller.NemDatabase.update_account_remote_address')
-	def test_process_account_batch_skips_remote_link_when_forwarded_returns_self(
-		self,
-		mock_update_remote_address,
-		mock_account_mosaics,
-		mock_account_info
-	):
-		# Arrange: forwarded lookup returns the account itself (link not active yet)
-		account = NEM_CONNECTOR_RESPONSE_ACCOUNT_INFO
-		account.remote_status = 'REMOTE'
-
-		main_account = NemAccountInfo(account.address)
-		main_account.remote_status = 'REMOTE'
-
-		mock_account_info.side_effect = [account, main_account]
-		mock_account_mosaics.side_effect = [[AccountMosaic(('nem', 'xem'), 0)]]
-
-		cursor = Mock()
-
-		# Act:
-		asyncio.run(self.puller._process_account_batch(cursor, {str(account.address): 3}))  # pylint: disable=protected-access
-
-		# Assert:
-		mock_update_remote_address.assert_not_called()
 
 	@patch('puller.facade.NemPuller.NemDatabase.update_account_harvested_fees')
 	def test_can_process_harvested_fees(self, mock_update_account_harvested_fees):
@@ -1181,6 +1071,89 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			mock_update_mosaic_total_supply,
 			supply_type=1,
 			expected_supply_change=500000
+		)
+
+	def _assert_account_key_link(self, mock_update_account_remote_address, mode, expects_remote_address):
+		# Arrange:
+		transaction = AccountKeyLinkTransaction(
+			'a1cd7bc6d3b13d5eb0e1b6a4c40b1e0c2ea6d6f9f3e0c1a7b2d5e8f0a3c6d9e2',
+			3,
+			PublicKey('da04b4a1d64add6c70958d383f9d247af1aaa957cb89f15b2d059b278e0594d5'),
+			150000,
+			73397,
+			83397,
+			'7fef5a89a1c6c98347b8d488a8dd28902e8422680f917c28f3ef0100d394b91c'
+			'd85f7cdfd7bdcd6f0cb8089ae9d4e6ef24a8caca35d1cfec7e33c9ccab5e1503',
+			165,
+			1,
+			mode,
+			PublicKey('7195f4d7a40ad7e31958ae96c4afed002962229675a4cae8dc8a18e290618981')
+		)
+
+		cursor = Mock()
+		network = self.puller.nem_facade.network
+
+		# Act:
+		self.puller._process_account_key_link(cursor, transaction)  # pylint: disable=protected-access
+
+		# Assert:
+		mock_update_account_remote_address.assert_called_once_with(
+			cursor,
+			network.public_key_to_address(transaction.sender),
+			network.public_key_to_address(transaction.remote_account) if expects_remote_address else None
+		)
+
+	@patch('puller.facade.NemPuller.NemDatabase.update_account_remote_address')
+	def test_can_process_account_key_link_activate(self, mock_update_account_remote_address):
+		self._assert_account_key_link(mock_update_account_remote_address, mode=1, expects_remote_address=True)
+
+	@patch('puller.facade.NemPuller.NemDatabase.update_account_remote_address')
+	def test_can_process_account_key_link_deactivate(self, mock_update_account_remote_address):
+		self._assert_account_key_link(mock_update_account_remote_address, mode=2, expects_remote_address=False)
+
+	@patch('puller.facade.NemPuller.NemDatabase.insert_transaction')
+	@patch('puller.facade.NemPuller.NemDatabase.update_account_remote_address')
+	def test_can_process_multisig_account_key_link_links_multisig_account(
+		self,
+		mock_update_account_remote_address,
+		mock_insert_transaction
+	):
+		# Arrange:
+		multisig_account = PublicKey('fbae41931de6a0cc25153781321f3de0806c7ba9a191474bb9a838118c8de4d3')
+		cosignatory = PublicKey('aa455d831430872feb0c6ae14265209182546c985a321c501be7fdc96ed04757')
+		remote_account = PublicKey('7195f4d7a40ad7e31958ae96c4afed002962229675a4cae8dc8a18e290618981')
+
+		inner_transaction = AccountKeyLinkTransaction(
+			None, None, multisig_account, 750000, 73397, 83397, None, 184, 1, 1, remote_account
+		)
+		multisig_transaction = MultisigTransaction(
+			'3375969dbc2aaae1cad0d89854d4f41b4fef553dbe9c7d39bdf72e3c538f98fe',
+			3,
+			cosignatory,
+			500000,
+			73397,
+			83397,
+			'0e7112b029e030d2d1c7dff79c88a29812f7254422d80e37a7aac5228fff5706'
+			'133500b0119a1327cab8787416b5873cc873e3181066c46cb2b108c5da10d90f',
+			468,
+			1,
+			[],
+			inner_transaction,
+			'edcc8d1c48165f5b771087fbe3c4b4d41f5f8f6c4ce715e050b86fb4e7fdeb64'
+		)
+
+		mock_insert_transaction.return_value = 1
+		cursor = Mock()
+		network = self.puller.nem_facade.network
+
+		# Act:
+		self.puller._process_transactions(cursor, [multisig_transaction], 3)  # pylint: disable=protected-access
+
+		# Assert:
+		mock_update_account_remote_address.assert_called_once_with(
+			cursor,
+			network.public_key_to_address(multisig_account),
+			network.public_key_to_address(remote_account)
 		)
 
 	def _assert_transaction_record(self, transaction, payload, recipient_address=None):


### PR DESCRIPTION
## Summary

Closes #2408

After an account key link, the explorer showed the linked remote account correctly, but the `remote_address` was wiped as soon as the main account did anything else (e.g. sent a transfer), even though the link was still active on-chain. The link also sometimes failed to appear right after the key link transaction.

## Root cause

The puller does not reconstruct account state per block - for every address touched by a block it fetches the node's **current** account snapshot and upserts it. `remote_address`, however, is only known when the *remote* account is processed (via a forwarded lookup), so a normal refresh of the main account always carried `remote_address = NULL`. Because `upsert_account` unconditionally wrote `remote_address = EXCLUDED.remote_address` on conflict, any plain refresh of the main account cleared the link. Address extraction also relies on a `set`, so within a batch the main and remote accounts were processed in a non-deterministic order - which is why the link occasionally failed to
appear immediately after linking.

## Why clear on `DEACTIVATING`

`remoteStatus` is a NIS `AccountMetaData` field with values `REMOTE / ACTIVATING / ACTIVE / DEACTIVATING / INACTIVE`. During `DEACTIVATING` the link is still active and the remote still harvests, so it still appears in blocks and forwards to the main account - this is the last reliable window to observe the teardown. Once `INACTIVE` the remote stops harvesting and may never appear in a block again, so clearing only on `INACTIVE` could leave a stale link.

### Additional benefit of refreshing the block beneficiary

The forwarded lookup always resolves the remote to its **current** main account, but a remote can be re-linked to a different main account over time. When processing a historical block we would resolve the *current* main and miss refreshing the account that was actually harvesting back then. The block `beneficiary`, by contrast, is block-accurate - it is the main account for that specific block - so adding it to the refresh set keeps previously-linked main accounts up to date as well.