### PR TITLE
[wallet/symbol/mobile] fix: add copy button to private key dialog on AccountDetails screen

### DIFF
--- a/wallet/symbol/mobile/src/screens/account/AccountDetails.jsx
+++ b/wallet/symbol/mobile/src/screens/account/AccountDetails.jsx
@@ -2,6 +2,7 @@ import {
 	AccountInfoCard, 
 	ButtonPlain, 
 	Card, 
+	CopyButtonContainer, 
 	DialogBox, 
 	Divider, 
 	PasscodeView, 
@@ -161,10 +162,15 @@ export const AccountDetails = () => {
 				<DialogBox
 					type="alert"
 					title={$t('dialog_sensitive')}
-					text={privateKey}
 					isVisible={isPrivateKeyDialogShown}
 					onSuccess={togglePrivateKeyDialog}
-				/>
+				>
+					<CopyButtonContainer value={privateKey}>
+						<StyledText>
+							{privateKey}
+						</StyledText>
+					</CopyButtonContainer>
+				</DialogBox>
 				<PasscodeView {...privateKeyPasscode.props} />
 			</Screen.Modals>
 		</Screen >


### PR DESCRIPTION
## Problem:
- Not possible to copy private key from the Account Details screen.

## Solution:
- Added copy button to the private key dialog box.

Resolved: #2449