### PR TITLE
[wallet/symbol/mobile] fix: Multisig Account Modification confirmation dialog text

### DIFF
--- a/wallet/symbol/mobile/__tests__/screens/multisig/CreateMultisigAccount.test.js
+++ b/wallet/symbol/mobile/__tests__/screens/multisig/CreateMultisigAccount.test.js
@@ -50,6 +50,7 @@ const SCREEN_TEXT = {
 	// Dialog
 	textDialogAddCosignatoryTitle: 's_multisig_create_dialog_addCosignatory_title',
 	textDialogConfirmTitle: 's_multisig_create_dialog_confirm_title',
+	textDialogConfirmText: 's_multisig_create_dialog_confirm_text',
 
 	// Default name
 	textDefaultAccountName: 's_multisig_defaultAccountName'
@@ -520,6 +521,24 @@ describe('screens/multisig/CreateMultisigAccount', () => {
 	});
 
 	describe('send transaction flow', () => {
+		it('shows creation wording in the confirmation dialog', async () => {
+			// Arrange:
+			setupMocks();
+			const screenTester = new ScreenTester(CreateMultisigAccount, routeProps);
+			await screenTester.waitForTimer(); // account generation
+			await screenTester.waitForTimer(); // fee calculation
+
+			// Act:
+			screenTester.pressButton(SCREEN_TEXT.buttonSend);
+			await screenTester.waitForTimer(); // dialog
+
+			// Assert:
+			screenTester.expectText([
+				SCREEN_TEXT.textDialogConfirmTitle,
+				SCREEN_TEXT.textDialogConfirmText
+			]);
+		});
+
 		it('sends transaction when send button is pressed and confirmed', async () => {
 			// Arrange:
 			const { walletControllerMock } = setupMocks();

--- a/wallet/symbol/mobile/__tests__/screens/multisig/ModifyMultisigAccount.test.js
+++ b/wallet/symbol/mobile/__tests__/screens/multisig/ModifyMultisigAccount.test.js
@@ -53,7 +53,8 @@ const SCREEN_TEXT = {
 
 	// Dialog
 	textDialogAddCosignatoryTitle: 's_multisig_create_dialog_addCosignatory_title',
-	textDialogConfirmTitle: 's_multisig_create_dialog_confirm_title',
+	textDialogConfirmTitle: 's_multisig_modify_dialog_confirm_title',
+	textDialogConfirmText: 's_multisig_modify_dialog_confirm_text',
 
 	// Default name
 	textDefaultAccountName: 's_multisig_defaultAccountName'
@@ -537,6 +538,25 @@ describe('screens/multisig/ModifyMultisigAccount', () => {
 	});
 
 	describe('send transaction flow', () => {
+		it('shows modification wording in the confirmation dialog', async () => {
+			// Arrange:
+			setupMocks();
+			const props = createRouteProps(multisigAccountInfo.address);
+			const screenTester = new ScreenTester(ModifyMultisigAccount, props);
+			await screenTester.waitForTimer(); // fetch account info
+			await screenTester.waitForTimer(); // fee calculation
+
+			// Act:
+			screenTester.pressButton(SCREEN_TEXT.buttonSend);
+			await screenTester.waitForTimer(); // dialog
+
+			// Assert:
+			screenTester.expectText([
+				SCREEN_TEXT.textDialogConfirmTitle,
+				SCREEN_TEXT.textDialogConfirmText
+			]);
+		});
+
 		it('sends transaction when send button is pressed and confirmed', async () => {
 			// Arrange:
 			const { walletControllerMock } = setupMocks();

--- a/wallet/symbol/mobile/src/localization/locales/en.json
+++ b/wallet/symbol/mobile/src/localization/locales/en.json
@@ -688,6 +688,8 @@
     "s_multisig_approvals_description": "Set the number of cosigner approvals required for account actions. Minimum approval defines how many approvals are needed to authorize transactions or add a cosigner. Minimum removal defines how many approvals are required to remove a cosigner.",
     "s_multisig_create_dialog_confirm_title": "Confirm Multisig Creation",
     "s_multisig_create_dialog_confirm_text": "You are about to create a multisig account at %{address} with %{cosignatoriesCount} cosignatories.",
+    "s_multisig_modify_dialog_confirm_title": "Confirm Multisig Modification",
+    "s_multisig_modify_dialog_confirm_text": "You are about to update the multisig account at %{address}. It will have %{cosignatoriesCount} cosignatories.",
     "s_multisig_create_dialog_addCosignatory_title": "Add Cosignatory",
     "s_multisig_cosignatoryAlert_currentAccount_text": "The current account is not included in the cosigner list. As a result, it will lose control over the multisig account and will not be able to approve its transactions.",
     "s_multisig_accountList_title": "My Multisig Accounts",

--- a/wallet/symbol/mobile/src/screens/multisig/ModifyMultisigAccount.jsx
+++ b/wallet/symbol/mobile/src/screens/multisig/ModifyMultisigAccount.jsx
@@ -140,8 +140,8 @@ export const ModifyMultisigAccount = props => {
 			walletController={walletController}
 			workflow={workflow}
 			isCustomSendButtonUsed={true}
-			confirmDialogTitle={$t('s_multisig_create_dialog_confirm_title')}
-			confirmDialogText={$t('s_multisig_create_dialog_confirm_text', {
+			confirmDialogTitle={$t('s_multisig_modify_dialog_confirm_title')}
+			confirmDialogText={$t('s_multisig_modify_dialog_confirm_text', {
 				address: accountAddress,
 				cosignatoriesCount
 			})}


### PR DESCRIPTION
## Problem:
- The multisig confirmation dialog always shows the title "Confirm Multisig Creation", even when the user is modifying an existing multisig account — this doesn't match the "Modify Multisig Account" screen and is misleading.
- The dialog body also reuses the create-specific text ("You are about to create a multisig account at %{address}...") during the modify flow, which is inaccurate since no new account is being created.
- Root cause: both the create and modify flows reuse the same localization key (`s_multisig_create_dialog_confirm_title`), which is only correct for the create flow.

## Solution:
- Added a separate modify-flow string for the confirmation dialog title and body, distinct from the create-flow strings.
- Updated the confirmation dialog to select the create vs. modify copy based on which flow triggered it.

Resolved: #2397