### PR TITLE
[explorer/frontend] fix: header too wide css issue

### DIFF
--- a/explorer/frontend/styles/components/Header.module.scss
+++ b/explorer/frontend/styles/components/Header.module.scss
@@ -72,7 +72,7 @@
 	user-select: none;
 }
 
-.modal {
+.header .modal {
 	position: absolute;
 	top: $spacing-header-height + $spacing-base;
 	right: $spacing-base * 3;
@@ -178,7 +178,7 @@
 		transform: translate(-50%, -50%);
 	}
 
-	.modal {
+	.header .modal {
 		top: $spacing-header-height + $spacing-base;
 		right: 0;
 		width: 100%;


### PR DESCRIPTION
Problem: The search modal is too wide because the reusable Card width overrides the header modal width. https://github.com/symbol/product/issues/2407
Solution: Increase the header modal selector specificity so its dimensions are independent of CSS loading order.