### PR TITLE
[explorer/puller] feat: add Symbol metadata state synchronization

### DIFF
--- a/explorer/common/tests/PostgresTestUtils.py
+++ b/explorer/common/tests/PostgresTestUtils.py
@@ -38,6 +38,7 @@ def drop_symbol_block_tables_if_present(database):
 	database.connection.rollback()
 	cursor = database.connection.cursor()
 	cursor.execute('DROP TABLE IF EXISTS symbol_mosaics')
+	cursor.execute('DROP TABLE IF EXISTS symbol_metadata')
 	cursor.execute('DROP TABLE IF EXISTS symbol_alias_names')
 	cursor.execute('DROP TABLE IF EXISTS symbol_namespaces')
 	cursor.execute('DROP TABLE IF EXISTS symbol_transaction_mosaics')
@@ -61,6 +62,7 @@ def drop_symbol_block_tables_if_present(database):
 	cursor.execute('DROP TYPE IF EXISTS symbol_namespace_registration_type')
 	cursor.execute('DROP TYPE IF EXISTS symbol_namespace_alias_type')
 	cursor.execute('DROP TYPE IF EXISTS symbol_alias_artifact_type')
+	cursor.execute('DROP TYPE IF EXISTS symbol_metadata_type')
 	database.connection.commit()
 
 

--- a/explorer/puller/puller/db/SymbolDatabase.py
+++ b/explorer/puller/puller/db/SymbolDatabase.py
@@ -14,7 +14,7 @@ from puller.model.symbol.Transaction import MESSAGE_TYPE_LABELS, TRANSACTION_TYP
 from .DatabaseConnection import DatabaseConnection
 
 RollbackRefreshEntries = namedtuple(
-	'RollbackRefreshEntries', ['namespace_entries', 'mosaic_entries', 'metadata_entries'])
+	'RollbackRefreshEntries', ['namespace_entries', 'mosaic_entries', 'metadata_entries'], defaults=((), (), ()))
 
 SYNC_STATE_COLUMNS = [
 	'status',

--- a/explorer/puller/puller/db/SymbolDatabase.py
+++ b/explorer/puller/puller/db/SymbolDatabase.py
@@ -1,15 +1,20 @@
 # pylint: disable=too-many-lines
+from collections import namedtuple
 from contextlib import contextmanager
 
 from psycopg2.extras import Json
 
 from puller.model.symbol.Account import ACCOUNT_TYPE_VALUES
 from puller.model.symbol.Block import BLOCK_TYPE_VALUES
+from puller.model.symbol.Metadata import METADATA_TYPE_LABELS
 from puller.model.symbol.Namespace import NAMESPACE_ALIAS_TYPE_LABELS, NAMESPACE_REGISTRATION_TYPE_LABELS
 from puller.model.symbol.Receipt import RECEIPT_TYPE_LABELS
 from puller.model.symbol.Transaction import MESSAGE_TYPE_LABELS, TRANSACTION_TYPE_LABELS
 
 from .DatabaseConnection import DatabaseConnection
+
+RollbackRefreshEntries = namedtuple(
+	'RollbackRefreshEntries', ['namespace_entries', 'mosaic_entries', 'metadata_entries'])
 
 SYNC_STATE_COLUMNS = [
 	'status',
@@ -32,6 +37,7 @@ SYMBOL_TRANSACTION_MESSAGE_TYPE_VALUES = tuple(MESSAGE_TYPE_LABELS.values())
 SYMBOL_NAMESPACE_REGISTRATION_TYPE_VALUES = tuple(NAMESPACE_REGISTRATION_TYPE_LABELS.values())
 SYMBOL_NAMESPACE_ALIAS_TYPE_VALUES = tuple(NAMESPACE_ALIAS_TYPE_LABELS.values())
 SYMBOL_ALIAS_ARTIFACT_TYPE_VALUES = ('mosaic', 'namespace', 'account')
+SYMBOL_METADATA_TYPE_VALUES = tuple(METADATA_TYPE_LABELS.values())
 ACCOUNT_REFRESH_STATE_STATUS_VALUES = ('healthy', 'refreshing', 'stale', 'unhealthy')
 ACCOUNT_REFRESH_STATE_COLUMNS = [
 	'last_successful_run_id',
@@ -257,6 +263,18 @@ SYMBOL_MOSAIC_DEFINITIONS = [
 	'raw_payload jsonb NOT NULL',
 	'updated_at_height bigint NOT NULL'
 ]
+SYMBOL_METADATA_DEFINITIONS = [
+	'composite_hash bytea PRIMARY KEY',
+	'metadata_type symbol_metadata_type NOT NULL',
+	'scoped_metadata_key varchar NOT NULL',
+	'source_address bytea NOT NULL',
+	'target_address bytea',
+	'target_id varchar(16)',
+	'value_hex text NOT NULL',
+	'value_utf8 text NOT NULL',
+	'raw_payload jsonb NOT NULL',
+	'updated_at_height bigint NOT NULL'
+]
 MOSAIC_ALIAS_NAMES_SUBQUERY = '''
 (
 	SELECT COALESCE(jsonb_agg(name ORDER BY name), '[]'::jsonb)
@@ -274,6 +292,15 @@ SYMBOL_MOSAIC_INDEXES = [
 	'CREATE INDEX IF NOT EXISTS idx_symbol_mosaics_restrictable ON symbol_mosaics(restrictable)',
 	'CREATE INDEX IF NOT EXISTS idx_symbol_mosaics_revokable ON symbol_mosaics(revokable)',
 	'CREATE INDEX IF NOT EXISTS idx_symbol_mosaics_updated_height ON symbol_mosaics(updated_at_height)'
+]
+SYMBOL_METADATA_INDEXES = [
+	'CREATE INDEX IF NOT EXISTS idx_symbol_metadata_target_address_height '
+	'ON symbol_metadata(target_address, updated_at_height DESC)',
+	'CREATE INDEX IF NOT EXISTS idx_symbol_metadata_type ON symbol_metadata(metadata_type)',
+	'CREATE INDEX IF NOT EXISTS idx_symbol_metadata_scoped_key ON symbol_metadata(scoped_metadata_key)',
+	'CREATE INDEX IF NOT EXISTS idx_symbol_metadata_source ON symbol_metadata(source_address)',
+	'CREATE INDEX IF NOT EXISTS idx_symbol_metadata_target_id ON symbol_metadata(target_id)',
+	'CREATE INDEX IF NOT EXISTS idx_symbol_metadata_updated_height ON symbol_metadata(updated_at_height)'
 ]
 SYMBOL_TRANSACTION_DEFINITIONS = [
 	'id bigserial PRIMARY KEY',
@@ -386,6 +413,7 @@ class SymbolDatabase(DatabaseConnection):  # pylint: disable=too-many-public-met
 		_create_enum_type(cursor, 'symbol_namespace_registration_type', SYMBOL_NAMESPACE_REGISTRATION_TYPE_VALUES)
 		_create_enum_type(cursor, 'symbol_namespace_alias_type', SYMBOL_NAMESPACE_ALIAS_TYPE_VALUES)
 		_create_enum_type(cursor, 'symbol_alias_artifact_type', SYMBOL_ALIAS_ARTIFACT_TYPE_VALUES)
+		_create_enum_type(cursor, 'symbol_metadata_type', SYMBOL_METADATA_TYPE_VALUES)
 		_create_table(cursor, 'symbol_sync_state', SYMBOL_SYNC_STATE_DEFINITIONS)
 		_create_table(cursor, 'symbol_blocks', SYMBOL_BLOCK_DEFINITIONS)
 		_create_table(cursor, 'symbol_account_refresh_state', SYMBOL_ACCOUNT_REFRESH_STATE_DEFINITIONS)
@@ -405,6 +433,9 @@ class SymbolDatabase(DatabaseConnection):  # pylint: disable=too-many-public-met
 			cursor.execute(index_sql)
 		_create_table(cursor, 'symbol_mosaics', SYMBOL_MOSAIC_DEFINITIONS)
 		for index_sql in SYMBOL_MOSAIC_INDEXES:
+			cursor.execute(index_sql)
+		_create_table(cursor, 'symbol_metadata', SYMBOL_METADATA_DEFINITIONS)
+		for index_sql in SYMBOL_METADATA_INDEXES:
 			cursor.execute(index_sql)
 		cursor.execute('CREATE SEQUENCE IF NOT EXISTS symbol_transaction_list_sequence_seq')
 		_create_table(cursor, 'symbol_transactions', SYMBOL_TRANSACTION_DEFINITIONS)
@@ -615,6 +646,14 @@ class SymbolDatabase(DatabaseConnection):  # pylint: disable=too-many-public-met
 				SymbolDatabase._execute_upsert_mosaic(cursor, entry['row'])
 
 	@staticmethod
+	def _execute_metadata_entries(cursor, metadata_entries):
+		for entry in metadata_entries:
+			if 'key' in entry:
+				SymbolDatabase._execute_delete_metadata_by_key(cursor, entry['key'])
+			else:
+				SymbolDatabase._execute_upsert_metadata(cursor, entry['row'])
+
+	@staticmethod
 	def _execute_refresh_mosaic_alias_names(cursor, mosaic_ids):
 		for mosaic_id in mosaic_ids:
 			cursor.execute(
@@ -709,6 +748,79 @@ class SymbolDatabase(DatabaseConnection):  # pylint: disable=too-many-public-met
 			(height,))
 
 		return [row[0] for row in cursor.fetchall()]
+
+	def upsert_metadata(self, metadata_row):
+		"""Upserts one Symbol metadata current-state row."""
+
+		with self._database_transaction() as cursor:
+			self._execute_upsert_metadata(cursor, metadata_row)
+
+	@staticmethod
+	def _execute_upsert_metadata(cursor, metadata_row):
+		cursor.execute(
+			'''
+			INSERT INTO symbol_metadata (
+				composite_hash, metadata_type, scoped_metadata_key, source_address, target_address, target_id,
+				value_hex, value_utf8, raw_payload, updated_at_height
+			)
+			VALUES (
+				%(composite_hash)s, %(metadata_type)s, %(scoped_metadata_key)s, %(source_address)s, %(target_address)s,
+				%(target_id)s, %(value_hex)s, %(value_utf8)s, %(raw_payload)s, %(updated_at_height)s
+			)
+			ON CONFLICT (composite_hash) DO UPDATE SET
+				metadata_type = EXCLUDED.metadata_type,
+				scoped_metadata_key = EXCLUDED.scoped_metadata_key,
+				source_address = EXCLUDED.source_address,
+				target_address = EXCLUDED.target_address,
+				target_id = EXCLUDED.target_id,
+				value_hex = EXCLUDED.value_hex,
+				value_utf8 = EXCLUDED.value_utf8,
+				raw_payload = EXCLUDED.raw_payload,
+				updated_at_height = EXCLUDED.updated_at_height
+			''',
+			{**metadata_row, 'raw_payload': Json(metadata_row['raw_payload'])})
+
+	def delete_metadata_by_key(self, metadata_key):
+		"""Deletes metadata matching its natural key when it exists."""
+
+		with self._database_transaction() as cursor:
+			self._execute_delete_metadata_by_key(cursor, metadata_key)
+
+	@staticmethod
+	def _execute_delete_metadata_by_key(cursor, metadata_key):
+		cursor.execute(
+			'''
+			DELETE FROM symbol_metadata
+			WHERE metadata_type = %(metadata_type)s
+				AND source_address = %(source_address)s
+				AND scoped_metadata_key = %(scoped_metadata_key)s
+				AND target_address IS NOT DISTINCT FROM %(target_address)s
+				AND target_id IS NOT DISTINCT FROM %(target_id)s
+			''',
+			metadata_key)
+
+	def get_metadata_keys_updated_from_height(self, height):  # pylint: disable=invalid-name
+		"""Gets natural metadata keys observed at or after a height."""
+
+		cursor = self.connection.cursor()
+		cursor.execute(
+			'''
+			SELECT metadata_type, source_address, target_address, scoped_metadata_key, target_id
+			FROM symbol_metadata
+			WHERE updated_at_height >= %s
+			ORDER BY composite_hash
+			''',
+			(height,))
+
+		columns = ('metadata_type', 'source_address', 'target_address', 'scoped_metadata_key', 'target_id')
+		return [
+			{
+				**dict(zip(columns, row)),
+				'source_address': bytes(row[1]),
+				'target_address': bytes(row[2]) if row[2] is not None else None
+			}
+			for row in cursor.fetchall()
+		]
 
 	def delete_namespace(self, namespace_id):
 		"""Deletes one namespace and its derived alias-name rows when it exists."""
@@ -1153,14 +1265,15 @@ class SymbolDatabase(DatabaseConnection):  # pylint: disable=too-many-public-met
 			self._delete_rollback_affected_rows_from_height(cursor, height)
 			self._stale_mark_account_refresh_state_if_needed(cursor, height)
 
-	def repair_rollback_from_height(self, height, sync_state, namespace_entries, mosaic_entries):
-		"""Repairs rollbacked chain, namespace state, and mosaic state in one transaction."""
+	def repair_rollback_from_height(self, height, sync_state, refresh_entries):
+		"""Repairs rollbacked chain and refreshed current state in one transaction."""
 
 		with self._database_transaction() as cursor:
 			self._delete_rollback_affected_rows_from_height(cursor, height)
 			self._stale_mark_account_refresh_state_if_needed(cursor, height)
-			self._execute_namespace_entries(cursor, namespace_entries)
-			self._execute_mosaic_entries(cursor, mosaic_entries)
+			self._execute_namespace_entries(cursor, refresh_entries.namespace_entries)
+			self._execute_mosaic_entries(cursor, refresh_entries.mosaic_entries)
+			self._execute_metadata_entries(cursor, refresh_entries.metadata_entries)
 			self._execute_upsert_sync_state(cursor, sync_state)
 
 	@staticmethod

--- a/explorer/puller/puller/facade/SymbolPuller.py
+++ b/explorer/puller/puller/facade/SymbolPuller.py
@@ -1,3 +1,5 @@
+# pylint: disable=too-many-lines
+
 import asyncio
 import configparser
 import uuid
@@ -13,10 +15,11 @@ from symbollightapi.connector.SymbolConnector import SymbolConnector
 from symbollightapi.model.Exceptions import NodeException
 from zenlog import log
 
-from puller.db.SymbolDatabase import SymbolDatabase
+from puller.db.SymbolDatabase import RollbackRefreshEntries, SymbolDatabase
 from puller.facade.RequestRateLimiter import RequestRateLimiter
 from puller.model.symbol.Account import HARVESTING_ACTIVE_WINDOW_DAYS, create_account_row, create_multisig_row
 from puller.model.symbol.Block import create_block_row
+from puller.model.symbol.Metadata import METADATA_TRANSACTION_TYPE_LABELS, METADATA_TYPE_NUMBERS, create_metadata_row
 from puller.model.symbol.Mosaic import create_mosaic_row
 from puller.model.symbol.Namespace import create_alias_name_rows, create_namespace_row
 from puller.model.symbol.Receipt import (
@@ -37,6 +40,7 @@ MAX_PAGE_SIZE = 100
 ACCOUNT_BATCH_FETCH_SIZE = MAX_PAGE_SIZE
 BLOCK_PAGE_FETCH_CONCURRENCY = 10
 RESOLUTION_FETCH_CONCURRENCY = 10
+METADATA_FETCH_CONCURRENCY = 10
 DEFAULT_MAX_REQUESTS_PER_SECOND = 20
 ACCOUNT_PAGE_SIZE = 100
 
@@ -278,20 +282,22 @@ class SymbolPuller:
 
 	async def _repair_from_height(self, height, sync_state):
 		# Unlike account/multisig rows (deleted by the repair and repopulated by the next dirty-key touch or
-		# refresh snapshot run), namespaces and mosaics have no broad re-dirty signal: only registration,
-		# alias, supply, or expiry events touch their ids, and none may recur after a fork. Re-fetch node state
-		# before the repair write and apply it in the same transaction, deleting an artifact only when the node
-		# confirms it is gone.
+		# refresh snapshot run), namespaces, mosaics, and metadata have no broad re-dirty signal: only
+		# registration, alias, supply, expiry, or metadata events touch their keys, and none may recur after a
+		# fork. Re-fetch node state before the repair write and apply it in the same transaction, deleting an
+		# artifact only when the node confirms it is gone.
 		namespace_ids = self.symbol_db.get_namespace_ids_updated_from_height(height)
 		namespace_entries = await self._fetch_dirty_namespaces(namespace_ids, height - 1)
 		mosaic_ids = self.symbol_db.get_mosaic_ids_updated_from_height(height)
 		mosaic_entries = await self._fetch_dirty_mosaics(mosaic_ids, height - 1)
+		metadata_keys = self.symbol_db.get_metadata_keys_updated_from_height(height)
+		metadata_entries = await self._fetch_dirty_metadata(metadata_keys, height - 1)
 		self.symbol_db.repair_rollback_from_height(height, {
 			**sync_state,
 			'status': 'repairing',
 			'last_synced_height': height - 1,
 			'last_synced_block_hash': self.symbol_db.get_block_hash(height - 1)
-		}, namespace_entries, mosaic_entries)
+		}, RollbackRefreshEntries(namespace_entries, mosaic_entries, metadata_entries))
 		return height
 
 	async def _sync_block_pages(  # pylint: disable=too-many-locals
@@ -363,17 +369,18 @@ class SymbolPuller:
 			dirty_addresses,
 			observed_height,
 			native_mosaic_info)
-		direct_dirty_namespace_ids = self._collect_dirty_namespace_ids_for_batch(
-			transaction_rows_by_height,
-			receipt_rows_by_height)
-		dirty_namespace_ids = self._expand_dirty_namespace_ids(direct_dirty_namespace_ids)
+		dirty_namespace_ids = self._expand_dirty_namespace_ids(
+			self._collect_dirty_namespace_ids_for_batch(transaction_rows_by_height, receipt_rows_by_height))
 		dirty_namespace_entries = await self._fetch_dirty_namespaces(dirty_namespace_ids, observed_height)
 		dirty_mosaic_ids = self._collect_dirty_mosaic_ids_for_batch(transaction_rows_by_height, receipt_rows_by_height)
 		dirty_mosaic_entries = await self._fetch_dirty_mosaics(dirty_mosaic_ids, observed_height)
+		dirty_metadata_keys = self._collect_dirty_metadata_keys_for_batch(transaction_rows_by_height)
+		dirty_metadata_entries = await self._fetch_dirty_metadata(dirty_metadata_keys, observed_height)
 		self._sync_block_batch(batch_rows, transaction_rows_by_height, receipt_rows_by_height)
 		self._write_dirty_accounts_for_batch(dirty_account_rows)
 		self.symbol_db.apply_namespace_entries(dirty_namespace_entries)
 		self._write_dirty_mosaics(dirty_mosaic_entries)
+		self._write_dirty_metadata(dirty_metadata_entries)
 
 	def _sync_block_batch(self, batch_rows, transaction_rows_by_height, receipt_rows_by_height):
 		"""Writes previously-fetched block, transaction, and receipt rows for one batch.
@@ -497,6 +504,9 @@ class SymbolPuller:
 			for mosaic_row in row['mosaic_rows']
 			if is_alias_mosaic_id(mosaic_row['mosaic_id'])
 		}
+		metadata_target_id = row['metadata_target_id']
+		if metadata_target_id is not None and is_alias_mosaic_id(metadata_target_id):
+			alias_mosaic_ids.add(metadata_target_id)
 		return alias_addresses, alias_mosaic_ids
 
 	@classmethod
@@ -547,6 +557,13 @@ class SymbolPuller:
 						source,
 						'mosaic',
 						height)
+			if row['metadata_target_id'] in alias_mosaic_ids:
+				row['metadata_target_id'] = self._resolve_transaction_alias(
+					resolution_statements.mosaic,
+					row['metadata_target_id'].upper(),
+					source,
+					'mosaic',
+					height)
 
 	async def _resolve_transaction_rows_for_batch(self, transaction_rows_by_height):  # pylint: disable=too-many-locals
 		resolution_requests = []
@@ -803,6 +820,88 @@ class SymbolPuller:
 				self.symbol_db.delete_mosaic(entry['mosaic_id'])
 			else:
 				self.symbol_db.upsert_mosaic(entry['row'])
+
+	@staticmethod
+	def _collect_dirty_metadata_keys_for_batch(transaction_rows_by_height):
+		"""Collects unique metadata natural keys touched by metadata transactions."""
+
+		dirty_metadata_keys = {}
+		for transaction_rows in transaction_rows_by_height.values():
+			for transaction_row in transaction_rows:
+				metadata_type = METADATA_TRANSACTION_TYPE_LABELS.get(transaction_row['type'])
+				if metadata_type is None:
+					continue
+
+				body = transaction_row['body']
+				if 'mosaic' == metadata_type:
+					target_id = transaction_row['metadata_target_id']
+				elif 'namespace' == metadata_type:
+					target_id = body['targetNamespaceId']
+				else:
+					target_id = None
+
+				key = {
+					'metadata_type': metadata_type,
+					'source_address': transaction_row['signer_address'],
+					'target_address': transaction_row['target_address'],
+					'scoped_metadata_key': body['scopedMetadataKey'],
+					'target_id': target_id
+				}
+				key_identity = (
+					key['metadata_type'],
+					key['source_address'],
+					key['target_address'],
+					key['scoped_metadata_key'],
+					key['target_id'])
+				dirty_metadata_keys[key_identity] = key
+
+		return list(dirty_metadata_keys.values())
+
+	async def _fetch_dirty_metadata(self, metadata_keys, observed_height):
+		"""Fetches metadata by exact natural key in bounded concurrent batches."""
+
+		if not metadata_keys:
+			return []
+
+		async def fetch_entry(metadata_key):
+			address = Address(metadata_key['source_address'])
+			target_address = Address(metadata_key['target_address'])
+			metadata_number = METADATA_TYPE_NUMBERS[metadata_key['metadata_type']]
+			path = (
+				f'/metadata?sourceAddress={address}&targetAddress={target_address}'
+				f'&scopedMetadataKey={metadata_key["scoped_metadata_key"]}&metadataType={metadata_number}'
+			)
+			if metadata_key['target_id'] is not None:
+				path += f'&targetId={metadata_key["target_id"]}'
+
+			response = await self.get_symbol_node(path)
+			if not isinstance(response, dict) or 'data' not in response:
+				raise ValueError('Malformed Symbol metadata search response')
+			items = response['data']
+			if not isinstance(items, list):
+				raise ValueError('Malformed Symbol metadata search data')
+			if len(items) > 1:
+				raise ValueError('Symbol metadata exact-key search returned multiple entries')
+			if not items:
+				return {'key': metadata_key}
+
+			return {'row': create_metadata_row(items[0], observed_height)}
+
+		entries = []
+		for chunk_start in range(0, len(metadata_keys), METADATA_FETCH_CONCURRENCY):
+			chunk = metadata_keys[chunk_start:chunk_start + METADATA_FETCH_CONCURRENCY]
+			entries.extend(await asyncio.gather(*(fetch_entry(metadata_key) for metadata_key in chunk)))
+
+		return entries
+
+	def _write_dirty_metadata(self, entries):
+		"""Writes fetched metadata current-state changes after all batch fetches complete."""
+
+		for entry in entries:
+			if 'key' in entry:
+				self.symbol_db.delete_metadata_by_key(entry['key'])
+			else:
+				self.symbol_db.upsert_metadata(entry['row'])
 
 	async def _fetch_dirty_accounts_for_batch(  # pylint: disable=too-many-locals
 		self,

--- a/explorer/puller/puller/facade/SymbolPuller.py
+++ b/explorer/puller/puller/facade/SymbolPuller.py
@@ -442,14 +442,14 @@ class SymbolPuller:
 
 		return dict(rows_by_height)
 
-	async def _get_resolution_statements(self, kind, height):
+	async def _get_resolution_statements(self, request):
 		resolution_entries_by_unresolved = {}
 		page_number = 1
 		while True:
 			response = await self.get_symbol_node(
-				f'/statements/resolutions/{kind}?height={height}&pageSize={MAX_PAGE_SIZE}&pageNumber={page_number}'
+				f'/statements/resolutions/{request.kind}?height={request.height}&pageSize={MAX_PAGE_SIZE}&pageNumber={page_number}'
 			)
-			items = self._get_node_page_data(response, f'Malformed Symbol {kind} resolution page response')
+			items = self._get_node_page_data(response, f'Malformed Symbol {request.kind} resolution page response')
 			for item in items:
 				statement = item['statement']
 				resolution_entries_by_unresolved[statement['unresolved'].upper()] = statement['resolutionEntries']
@@ -505,9 +505,9 @@ class SymbolPuller:
 			for mosaic_row in row['mosaic_rows']
 			if is_alias_mosaic_id(mosaic_row['mosaic_id'])
 		}
-		metadata_target_id = row['metadata_target_id']
-		if metadata_target_id is not None and is_alias_mosaic_id(metadata_target_id):
-			alias_mosaic_ids.add(metadata_target_id)
+		mosaic_metadata_target_id = row['mosaic_metadata_target_id']
+		if mosaic_metadata_target_id is not None and is_alias_mosaic_id(mosaic_metadata_target_id):
+			alias_mosaic_ids.add(mosaic_metadata_target_id)
 		return alias_addresses, alias_mosaic_ids
 
 	@classmethod
@@ -528,43 +528,38 @@ class SymbolPuller:
 
 		source = self._transaction_resolution_source(row, top_level_rows_by_hash)
 		if alias_addresses:
+			def _resolve_transaction_alias_address(address):
+				resolved_hex = self._resolve_transaction_alias(
+					resolution_statements.address,
+					address.hex().upper(),
+					source,
+					'address',
+					height)
+				return bytes.fromhex(resolved_hex)
+
 			for address_row in row['address_rows']:
 				if address_row['address'] in alias_addresses:
-					resolved = self._resolve_transaction_alias(
-						resolution_statements.address,
-						address_row['address'].hex().upper(),
-						source,
-						'address',
-						height)
-					address_row['address'] = bytes.fromhex(resolved)
+					address_row['address'] = _resolve_transaction_alias_address(address_row['address'])
 			row['address_rows'] = unique_address_rows(row['address_rows'])
 			for field_name in ('recipient_address', 'target_address'):
 				address = row[field_name]
 				if address in alias_addresses:
-					resolved = self._resolve_transaction_alias(
-						resolution_statements.address,
-						address.hex().upper(),
-						source,
-						'address',
-						height)
-					row[field_name] = bytes.fromhex(resolved)
+					row[field_name] = _resolve_transaction_alias_address(address)
 
 		if alias_mosaic_ids:
-			for mosaic_row in row['mosaic_rows']:
-				if mosaic_row['mosaic_id'] in alias_mosaic_ids:
-					mosaic_row['mosaic_id'] = self._resolve_transaction_alias(
-						resolution_statements.mosaic,
-						mosaic_row['mosaic_id'].upper(),
-						source,
-						'mosaic',
-						height)
-			if row['metadata_target_id'] in alias_mosaic_ids:
-				row['metadata_target_id'] = self._resolve_transaction_alias(
+			def _resolve_transaction_alias_mosaic(mosaic_id):
+				return self._resolve_transaction_alias(
 					resolution_statements.mosaic,
-					row['metadata_target_id'].upper(),
+					mosaic_id.upper(),
 					source,
 					'mosaic',
 					height)
+
+			for mosaic_row in row['mosaic_rows']:
+				if mosaic_row['mosaic_id'] in alias_mosaic_ids:
+					mosaic_row['mosaic_id'] = _resolve_transaction_alias_mosaic(mosaic_row['mosaic_id'])
+			if row['mosaic_metadata_target_id'] in alias_mosaic_ids:
+				row['mosaic_metadata_target_id'] = _resolve_transaction_alias_mosaic(row['mosaic_metadata_target_id'])
 
 	async def _resolve_transaction_rows_for_batch(self, transaction_rows_by_height):  # pylint: disable=too-many-locals
 		resolution_requests = []
@@ -583,7 +578,7 @@ class SymbolPuller:
 		for batch_start in range(0, len(resolution_requests), RESOLUTION_FETCH_CONCURRENCY):
 			batch_requests = resolution_requests[batch_start:batch_start + RESOLUTION_FETCH_CONCURRENCY]
 			batch_statements = await asyncio.gather(*(
-				self._get_resolution_statements(request.kind, request.height)
+				self._get_resolution_statements(request)
 				for request in batch_requests
 			))
 			for request, statements in zip(batch_requests, batch_statements):
@@ -838,7 +833,7 @@ class SymbolPuller:
 
 				body = transaction_row['body']
 				if 'mosaic' == metadata_type:
-					target_id = transaction_row['metadata_target_id']
+					target_id = transaction_row['mosaic_metadata_target_id']
 				elif 'namespace' == metadata_type:
 					target_id = body['targetNamespaceId']
 				else:

--- a/explorer/puller/puller/facade/SymbolPuller.py
+++ b/explorer/puller/puller/facade/SymbolPuller.py
@@ -36,6 +36,7 @@ DatabaseConfiguration = namedtuple('DatabaseConfiguration', ['database', 'user',
 NativeMosaicInfo = namedtuple('NativeMosaicInfo', ['id', 'divisibility'])
 TransactionSource = namedtuple('TransactionSource', ['primary_id', 'secondary_id'])
 ResolutionStatements = namedtuple('ResolutionStatements', ['address', 'mosaic'])
+ResolutionRequest = namedtuple('ResolutionRequest', ['height', 'kind'])
 MAX_PAGE_SIZE = 100
 ACCOUNT_BATCH_FETCH_SIZE = MAX_PAGE_SIZE
 BLOCK_PAGE_FETCH_CONCURRENCY = 10
@@ -575,19 +576,19 @@ class SymbolPuller:
 
 			resolution_statements_by_height[height] = ResolutionStatements({}, {})
 			if alias_addresses:
-				resolution_requests.append((height, 'address'))
+				resolution_requests.append(ResolutionRequest(height, 'address'))
 			if alias_mosaic_ids:
-				resolution_requests.append((height, 'mosaic'))
+				resolution_requests.append(ResolutionRequest(height, 'mosaic'))
 
 		for batch_start in range(0, len(resolution_requests), RESOLUTION_FETCH_CONCURRENCY):
 			batch_requests = resolution_requests[batch_start:batch_start + RESOLUTION_FETCH_CONCURRENCY]
 			batch_statements = await asyncio.gather(*(
-				self._get_resolution_statements(kind, height)
-				for height, kind in batch_requests
+				self._get_resolution_statements(request.kind, request.height)
+				for request in batch_requests
 			))
-			for (height, kind), statements in zip(batch_requests, batch_statements):
-				resolution_statements_by_height[height] = resolution_statements_by_height[height]._replace(
-					**{kind: statements})
+			for request, statements in zip(batch_requests, batch_statements):
+				resolution_statements_by_height[request.height] = resolution_statements_by_height[request.height]._replace(
+					**{request.kind: statements})
 
 		for height, transaction_rows in transaction_rows_by_height.items():
 			if height not in resolution_statements_by_height:
@@ -823,7 +824,10 @@ class SymbolPuller:
 
 	@staticmethod
 	def _collect_dirty_metadata_keys_for_batch(transaction_rows_by_height):
-		"""Collects unique metadata natural keys touched by metadata transactions."""
+		"""Collects natural keys for exact-key metadata searches and deduplication.
+
+		Empty exact-key searches must delete the local row, but supply no composite hash from the node.
+		"""
 
 		dirty_metadata_keys = {}
 		for transaction_rows in transaction_rows_by_height.values():
@@ -875,9 +879,7 @@ class SymbolPuller:
 				path += f'&targetId={metadata_key["target_id"]}'
 
 			response = await self.get_symbol_node(path)
-			if not isinstance(response, dict) or 'data' not in response:
-				raise ValueError('Malformed Symbol metadata search response')
-			items = response['data']
+			items = self._get_node_page_data(response, 'Malformed Symbol metadata search response')
 			if not isinstance(items, list):
 				raise ValueError('Malformed Symbol metadata search data')
 			if len(items) > 1:

--- a/explorer/puller/puller/model/symbol/Metadata.py
+++ b/explorer/puller/puller/model/symbol/Metadata.py
@@ -1,0 +1,34 @@
+"""Normalization helpers for Symbol metadata current state."""
+
+from symbolchain.sc import TransactionType
+
+from puller.model.symbol.format import label_for_type
+
+# Source: symbol/symbol catbuffer/schemas/symbol/metadata/{account,mosaic,namespace}_metadata.cats,
+# dev commit 3a509647a1a7fb20be0bdb5435d923cb073b2773 (verified 2026-07-28); no symbolchain.sc equivalent.
+METADATA_TYPE_LABELS = {0: 'account', 1: 'mosaic', 2: 'namespace'}
+METADATA_TYPE_NUMBERS = {label: number for number, label in METADATA_TYPE_LABELS.items()}
+METADATA_TRANSACTION_TYPE_LABELS = {
+	TransactionType.ACCOUNT_METADATA.value: 'account',
+	TransactionType.MOSAIC_METADATA.value: 'mosaic',
+	TransactionType.NAMESPACE_METADATA.value: 'namespace'
+}
+
+
+def create_metadata_row(metadata_item, observed_height):
+	"""Creates one persisted metadata row from a Symbol node metadata search item."""
+
+	entry = metadata_item['metadataEntry']
+	metadata_type = label_for_type(METADATA_TYPE_LABELS, entry['metadataType'], 'metadata')
+	return {
+		'composite_hash': bytes.fromhex(entry['compositeHash']),
+		'metadata_type': metadata_type,
+		'scoped_metadata_key': entry['scopedMetadataKey'],
+		'source_address': bytes.fromhex(entry['sourceAddress']),
+		'target_address': bytes.fromhex(entry['targetAddress']),
+		'target_id': None if 'account' == metadata_type else entry['targetId'],
+		'value_hex': entry['value'],
+		'value_utf8': bytes.fromhex(entry['value']).decode('utf-8', errors='replace'),
+		'raw_payload': metadata_item,
+		'updated_at_height': observed_height
+	}

--- a/explorer/puller/puller/model/symbol/Transaction.py
+++ b/explorer/puller/puller/model/symbol/Transaction.py
@@ -217,6 +217,11 @@ def create_transaction_row(item, network, epoch_adjustment_seconds):
 	transaction_type = int(transaction['type'])
 	signer_public_key = bytes.fromhex(transaction['signerPublicKey'])
 	signer_address = address_from_public_key(signer_public_key, network)
+	metadata_target_id = (
+		transaction['targetMosaicId']
+		if TransactionType.MOSAIC_METADATA.value == transaction_type
+		else None
+	)
 	message_type, message_payload = _parse_message(transaction)
 	variable_fields = _top_level_or_embedded_fields(meta, transaction, is_embedded, epoch_adjustment_seconds)
 
@@ -230,6 +235,7 @@ def create_transaction_row(item, network, epoch_adjustment_seconds):
 		'signer_address': signer_address,
 		'recipient_address': bytes.fromhex(transaction['recipientAddress']) if 'recipientAddress' in transaction else None,
 		'target_address': _target_address(transaction_type, transaction),
+		'metadata_target_id': metadata_target_id,
 		'message_type': message_type,
 		'message_payload': message_payload,
 		'body': {

--- a/explorer/puller/puller/model/symbol/Transaction.py
+++ b/explorer/puller/puller/model/symbol/Transaction.py
@@ -217,10 +217,11 @@ def create_transaction_row(item, network, epoch_adjustment_seconds):
 	transaction_type = int(transaction['type'])
 	signer_public_key = bytes.fromhex(transaction['signerPublicKey'])
 	signer_address = address_from_public_key(signer_public_key, network)
-	# Non-persisted: carries targetMosaicId through mosaic alias resolution so the metadata
-	# natural key uses the resolved id. Namespace metadata's targetNamespaceId is a NamespaceId
-	# and requires no mosaic alias resolution, so the collector reads it directly from body.
-	metadata_target_id = (
+	# Non-persisted: copies both direct and unresolved targetMosaicId values into one normalized field. SymbolPuller owns
+	# alias detection and resolution, replacing an alias here with its resolved mosaic id before the metadata collector uses
+	# it as a natural-key component; body and raw_payload retain the unresolved DTO. Namespace metadata's targetNamespaceId
+	# is a concrete NamespaceId, so the collector reads it directly from body instead of using this mosaic-only field.
+	mosaic_metadata_target_id = (
 		transaction['targetMosaicId']
 		if TransactionType.MOSAIC_METADATA.value == transaction_type
 		else None
@@ -238,7 +239,7 @@ def create_transaction_row(item, network, epoch_adjustment_seconds):
 		'signer_address': signer_address,
 		'recipient_address': bytes.fromhex(transaction['recipientAddress']) if 'recipientAddress' in transaction else None,
 		'target_address': _target_address(transaction_type, transaction),
-		'metadata_target_id': metadata_target_id,
+		'mosaic_metadata_target_id': mosaic_metadata_target_id,
 		'message_type': message_type,
 		'message_payload': message_payload,
 		'body': {

--- a/explorer/puller/puller/model/symbol/Transaction.py
+++ b/explorer/puller/puller/model/symbol/Transaction.py
@@ -217,6 +217,9 @@ def create_transaction_row(item, network, epoch_adjustment_seconds):
 	transaction_type = int(transaction['type'])
 	signer_public_key = bytes.fromhex(transaction['signerPublicKey'])
 	signer_address = address_from_public_key(signer_public_key, network)
+	# Non-persisted: carries targetMosaicId through mosaic alias resolution so the metadata
+	# natural key uses the resolved id. Namespace metadata's targetNamespaceId is a NamespaceId
+	# and requires no mosaic alias resolution, so the collector reads it directly from body.
 	metadata_target_id = (
 		transaction['targetMosaicId']
 		if TransactionType.MOSAIC_METADATA.value == transaction_type

--- a/explorer/puller/tests/db/test_SymbolDatabase.py
+++ b/explorer/puller/tests/db/test_SymbolDatabase.py
@@ -21,8 +21,8 @@ from tests.test.SymbolMetadataTestUtils import (
 	TARGET_ADDRESS,
 	create_expected_metadata_row,
 	create_metadata_item,
-	fetch_metadata_row,
-	fetch_metadata_rows
+	fetch_metadata_rows,
+	find_metadata_row
 )
 from tests.test.SymbolMosaicTestUtils import (
 	create_expected_mosaic_row,
@@ -1153,7 +1153,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		database.upsert_metadata(row)
 
 		# Assert:
-		self.assertEqual(row, fetch_metadata_row(database, row['composite_hash']))
+		self.assertEqual(row, find_metadata_row(database, row['composite_hash']))
 
 	def test_upsert_metadata_updates_all_non_key_columns_for_same_composite_hash(self):
 		# Arrange:
@@ -1181,7 +1181,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		database.upsert_metadata(updated_row)
 
 		# Assert:
-		self.assertEqual(updated_row, fetch_metadata_row(database, updated_row['composite_hash']))
+		self.assertEqual(updated_row, find_metadata_row(database, updated_row['composite_hash']))
 
 	def test_upsert_metadata_failed_update_preserves_existing_row(self):
 		# Arrange:
@@ -1198,7 +1198,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 			database.upsert_metadata(invalid_row)
 
 		# Assert:
-		self.assertEqual(original_row, fetch_metadata_row(database, original_row['composite_hash']))
+		self.assertEqual(original_row, find_metadata_row(database, original_row['composite_hash']))
 
 	def test_upsert_metadata_keeps_connection_usable_after_failed_update(self):
 		# Arrange:
@@ -1222,7 +1222,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		database.upsert_metadata(updated_row)
 
 		# Assert:
-		self.assertEqual(updated_row, fetch_metadata_row(database, original_row['composite_hash']))
+		self.assertEqual(updated_row, find_metadata_row(database, original_row['composite_hash']))
 
 	def test_delete_metadata_by_key_deletes_only_the_exact_null_target_id_key(self):
 		# Arrange:
@@ -1249,8 +1249,8 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		database.delete_metadata_by_key(metadata_key)
 
 		# Assert:
-		self.assertIsNone(fetch_metadata_row(database, null_target_row['composite_hash']))
-		self.assertEqual(value_target_row, fetch_metadata_row(database, value_target_row['composite_hash']))
+		self.assertIsNone(find_metadata_row(database, null_target_row['composite_hash']))
+		self.assertEqual(value_target_row, find_metadata_row(database, value_target_row['composite_hash']))
 
 	def test_delete_metadata_by_key_is_noop_for_missing_natural_key(self):
 		# Arrange:
@@ -1272,7 +1272,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		database.delete_metadata_by_key(missing_key)
 
 		# Assert:
-		self.assertEqual(row, fetch_metadata_row(database, row['composite_hash']))
+		self.assertEqual(row, find_metadata_row(database, row['composite_hash']))
 
 	def test_get_metadata_keys_updated_from_height_returns_exact_keys_in_composite_hash_order(self):
 		# Arrange:
@@ -1463,7 +1463,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		database.repair_rollback_from_height(2, _create_sync_state(
 			status='repairing',
 			last_synced_height=1,
-			last_synced_block_hash=b'hash 1'), RollbackRefreshEntries([], [], []))
+			last_synced_block_hash=b'hash 1'), RollbackRefreshEntries())
 
 		# Assert:
 		cursor = database.connection.cursor()
@@ -1489,7 +1489,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		database.repair_rollback_from_height(
 			fork_height,
 			_create_sync_state(status='repairing', last_synced_height=1, last_synced_block_hash=b'hash 1'),
-			RollbackRefreshEntries([], [], []))
+			RollbackRefreshEntries())
 
 		# Assert:
 		self.assertEqual(original_mosaic_state, fetch_mosaic_state(database))
@@ -1558,7 +1558,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 			status='repairing',
 			last_synced_height=1,
 			last_synced_block_hash=b'hash 1')
-		expected_mosaic_row = create_expected_mosaic_row(create_mosaic_item(mosaic_id=mosaic_id, supply='99'), 1)
+		expected_mosaic_row = refresh_entries.mosaic_entries[0]['row']
 		expected_mosaic_state = [create_persisted_mosaic_state(expected_mosaic_row, [])]
 		expected_namespace_state = (
 			[
@@ -1583,8 +1583,9 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		cursor.execute('SELECT height FROM symbol_blocks ORDER BY height')
 		self.assertEqual([(1,)], cursor.fetchall())
 
-	# pylint: disable=too-many-locals
 	def test_repair_rollback_rolls_back_namespace_mosaic_metadata_and_chain_state_after_metadata_failure(self):
+		# pylint: disable=too-many-locals
+
 		# Arrange:
 		database = self._create_database()
 		database.upsert_blocks([_create_block(1), _create_block(2)])
@@ -1614,6 +1615,9 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 			'mosaic': fetch_mosaic_state(database),
 			'metadata': fetch_metadata_rows(database)
 		}
+		self.assertEqual(2, len(original_state['namespace'][0]))
+		self.assertEqual(2, len(original_state['mosaic']))
+		self.assertEqual(2, len(original_state['metadata']))
 		updated_namespace_row = _create_namespace_row(
 			alias_type='none', alias_mosaic_id=None, end_height=100, observed_height=1,
 			raw_payload={'namespace': {'state': 'updated'}})
@@ -3309,7 +3313,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 
 		# Act:
 		database.repair_rollback_from_height(
-			10, _create_sync_state(status='repairing', last_synced_height=9), RollbackRefreshEntries([], [], []))
+			10, _create_sync_state(status='repairing', last_synced_height=9), RollbackRefreshEntries())
 
 		# Assert:
 		self.assertEqual('stale', database.get_account_refresh_state()['status'])
@@ -3325,7 +3329,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 
 		# Act:
 		database.repair_rollback_from_height(
-			10, _create_sync_state(status='repairing', last_synced_height=9), RollbackRefreshEntries([], [], []))
+			10, _create_sync_state(status='repairing', last_synced_height=9), RollbackRefreshEntries())
 
 		# Assert:
 		self.assertEqual('healthy', database.get_account_refresh_state()['status'])
@@ -3410,7 +3414,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 
 		# Act:
 		database.repair_rollback_from_height(
-			10, _create_sync_state(status='repairing', last_synced_height=9), RollbackRefreshEntries([], [], []))
+			10, _create_sync_state(status='repairing', last_synced_height=9), RollbackRefreshEntries())
 
 		# Assert:
 		expected_address = bytes.fromhex(ADDRESS1)
@@ -3963,7 +3967,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 			status='repairing',
 			last_synced_height=1,
 			last_synced_block_hash=b'hash 1'
-		), RollbackRefreshEntries([], [], []))
+		), RollbackRefreshEntries())
 
 		# Assert:
 		cursor = database.connection.cursor()

--- a/explorer/puller/tests/db/test_SymbolDatabase.py
+++ b/explorer/puller/tests/db/test_SymbolDatabase.py
@@ -11,10 +11,25 @@ from psycopg2.extras import Json
 from symbolchain.sc import ReceiptType
 from symbolchain.symbol.Network import Network
 
-from puller.db.SymbolDatabase import SymbolDatabase
+from puller.db.SymbolDatabase import RollbackRefreshEntries, SymbolDatabase
 from puller.model.symbol.Account import create_account_row
 from tests.facade.symbol.puller_test_utils import NATIVE_MOSAIC_ID, create_account_item
-from tests.test.SymbolMosaicTestUtils import create_expected_mosaic_row, create_mosaic_item, fetch_mosaic_state
+from tests.test.SymbolDatabaseTestUtils import fetch_full_block_state, fetch_normalized_sync_state
+from tests.test.SymbolMetadataTestUtils import (
+	SCOPED_METADATA_KEY,
+	SOURCE_ADDRESS,
+	TARGET_ADDRESS,
+	create_expected_metadata_row,
+	create_metadata_item,
+	fetch_metadata_row,
+	fetch_metadata_rows
+)
+from tests.test.SymbolMosaicTestUtils import (
+	create_expected_mosaic_row,
+	create_mosaic_item,
+	create_persisted_mosaic_state,
+	fetch_mosaic_state
+)
 from tests.test.SymbolNamespaceTestUtils import (
 	NAMESPACE_ROOT_ID,
 	NAMESPACE_SUB_ID,
@@ -180,12 +195,6 @@ def _create_alias_name_rows(namespace_row):
 		})
 
 	return rows
-
-
-def _fetch_block_state(database):
-	cursor = database.connection.cursor()
-	cursor.execute('SELECT * FROM symbol_blocks ORDER BY height')
-	return cursor.fetchall()
 
 
 class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
@@ -491,6 +500,103 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 			WHERE table_name = 'symbol_mosaics' AND column_name = 'alias_names'
 			''')
 		self.assertEqual([('NO', "'[]'::jsonb")], cursor.fetchall())
+
+	def test_create_tables_creates_symbol_metadata_columns(self):
+		# Arrange:
+		database = self._create_uninitialized_database()
+		cursor = database.connection.cursor()
+
+		# Act:
+		database.create_tables()
+
+		# Assert:
+		cursor.execute(
+			'''
+			SELECT column_name, udt_name, is_nullable, character_maximum_length
+			FROM information_schema.columns
+			WHERE table_name = 'symbol_metadata'
+			ORDER BY ordinal_position
+			''')
+		self.assertEqual([
+			('composite_hash', 'bytea', 'NO', None),
+			('metadata_type', 'symbol_metadata_type', 'NO', None),
+			('scoped_metadata_key', 'varchar', 'NO', None),
+			('source_address', 'bytea', 'NO', None),
+			('target_address', 'bytea', 'YES', None),
+			('target_id', 'varchar', 'YES', 16),
+			('value_hex', 'text', 'NO', None),
+			('value_utf8', 'text', 'NO', None),
+			('raw_payload', 'jsonb', 'NO', None),
+			('updated_at_height', 'int8', 'NO', None)
+		], cursor.fetchall())
+
+	def test_create_tables_creates_symbol_metadata_enum(self):
+		# Arrange:
+		database = self._create_uninitialized_database()
+		cursor = database.connection.cursor()
+
+		# Act:
+		database.create_tables()
+
+		# Assert:
+		cursor.execute(
+			'''
+			SELECT pg_type.typname, enumlabel
+			FROM pg_enum
+			JOIN pg_type ON pg_type.oid = pg_enum.enumtypid
+			WHERE pg_type.typname = 'symbol_metadata_type'
+			ORDER BY enumsortorder
+			''')
+		self.assertEqual([
+			('symbol_metadata_type', 'account'),
+			('symbol_metadata_type', 'mosaic'),
+			('symbol_metadata_type', 'namespace')
+		], cursor.fetchall())
+
+	def test_create_tables_creates_symbol_metadata_indexes(self):
+		# Arrange:
+		database = self._create_uninitialized_database()
+		cursor = database.connection.cursor()
+
+		# Act:
+		database.create_tables()
+
+		# Assert:
+		cursor.execute(
+			'''
+			SELECT indexname, indexdef
+			FROM pg_indexes
+			WHERE schemaname = 'public' AND tablename = 'symbol_metadata'
+			ORDER BY indexname
+			''')
+		self.assertEqual([
+			(
+				'idx_symbol_metadata_scoped_key',
+				'CREATE INDEX idx_symbol_metadata_scoped_key ON public.symbol_metadata USING btree (scoped_metadata_key)'
+			),
+			(
+				'idx_symbol_metadata_source',
+				'CREATE INDEX idx_symbol_metadata_source ON public.symbol_metadata USING btree (source_address)'
+			),
+			(
+				'idx_symbol_metadata_target_address_height',
+				'CREATE INDEX idx_symbol_metadata_target_address_height ON public.symbol_metadata '
+				'USING btree (target_address, updated_at_height DESC)'
+			),
+			(
+				'idx_symbol_metadata_target_id',
+				'CREATE INDEX idx_symbol_metadata_target_id ON public.symbol_metadata USING btree (target_id)'
+			),
+			(
+				'idx_symbol_metadata_type',
+				'CREATE INDEX idx_symbol_metadata_type ON public.symbol_metadata USING btree (metadata_type)'
+			),
+			(
+				'idx_symbol_metadata_updated_height',
+				'CREATE INDEX idx_symbol_metadata_updated_height ON public.symbol_metadata USING btree (updated_at_height)'
+			),
+			('symbol_metadata_pkey', 'CREATE UNIQUE INDEX symbol_metadata_pkey ON public.symbol_metadata USING btree (composite_hash)')
+		], cursor.fetchall())
 
 	def test_upsert_namespace_persists_fresh_namespace_and_full_alias_row_set(self):
 		# Arrange:
@@ -1035,6 +1141,181 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		# Assert:
 		self.assertEqual(valid_row['mosaic_id'], fetch_mosaic_state(database)[0].mosaic_id)
 
+	def test_upsert_metadata_persists_fresh_insert_as_a_full_row(self):
+		# Arrange:
+		database = self._create_database()
+		item = create_metadata_item(metadata_type=1, target_id='72C0212E67A08BCE')
+		row = create_expected_metadata_row(
+			item, 123, composite_hash=bytes.fromhex('11' * 32), metadata_type='mosaic',
+			target_id='72C0212E67A08BCE', value_utf8='hello')
+
+		# Act:
+		database.upsert_metadata(row)
+
+		# Assert:
+		self.assertEqual(row, fetch_metadata_row(database, row['composite_hash']))
+
+	def test_upsert_metadata_updates_all_non_key_columns_for_same_composite_hash(self):
+		# Arrange:
+		database = self._create_database()
+		original_item = create_metadata_item(metadata_type=1, target_id='72C0212E67A08BCE')
+		database.upsert_metadata(create_expected_metadata_row(
+			original_item, 123, composite_hash=bytes.fromhex('11' * 32), metadata_type='mosaic',
+			target_id='72C0212E67A08BCE', value_utf8='hello'))
+		updated_item = create_metadata_item(
+			metadata_type=2,
+			scoped_metadata_key='0102030405060708',
+			source_address='12' * 24,
+			target_address='13' * 24,
+			target_id='A95F1F8A96159516',
+			value='776F726C64',
+			composite_hash='11' * 32,
+			item_id='updated-metadata-item-id')
+		updated_row = create_expected_metadata_row(
+			updated_item, 456, composite_hash=bytes.fromhex('11' * 32), metadata_type='namespace',
+			scoped_metadata_key='0102030405060708', source_address=bytes.fromhex('12' * 24),
+			target_address=bytes.fromhex('13' * 24), target_id='A95F1F8A96159516', value_hex='776F726C64',
+			value_utf8='world')
+
+		# Act:
+		database.upsert_metadata(updated_row)
+
+		# Assert:
+		self.assertEqual(updated_row, fetch_metadata_row(database, updated_row['composite_hash']))
+
+	def test_upsert_metadata_failed_update_preserves_existing_row(self):
+		# Arrange:
+		database = self._create_database()
+		original_item = create_metadata_item(metadata_type=1, target_id='72C0212E67A08BCE')
+		original_row = create_expected_metadata_row(
+			original_item, 123, composite_hash=bytes.fromhex('11' * 32), metadata_type='mosaic',
+			target_id='72C0212E67A08BCE', value_utf8='hello')
+		database.upsert_metadata(original_row)
+		invalid_row = {**original_row, 'value_utf8': None}
+
+		# Act:
+		with self.assertRaises(PsycopgError):
+			database.upsert_metadata(invalid_row)
+
+		# Assert:
+		self.assertEqual(original_row, fetch_metadata_row(database, original_row['composite_hash']))
+
+	def test_upsert_metadata_keeps_connection_usable_after_failed_update(self):
+		# Arrange:
+		database = self._create_database()
+		original_item = create_metadata_item(metadata_type=1, target_id='72C0212E67A08BCE')
+		original_row = create_expected_metadata_row(
+			original_item, 123, composite_hash=bytes.fromhex('11' * 32), metadata_type='mosaic',
+			target_id='72C0212E67A08BCE', value_utf8='hello')
+		database.upsert_metadata(original_row)
+		invalid_row = {**original_row, 'value_utf8': None}
+		updated_row = {
+			**original_row,
+			'value_hex': '776F726C64',
+			'value_utf8': 'world',
+			'updated_at_height': 456
+		}
+
+		# Act:
+		with self.assertRaises(PsycopgError):
+			database.upsert_metadata(invalid_row)
+		database.upsert_metadata(updated_row)
+
+		# Assert:
+		self.assertEqual(updated_row, fetch_metadata_row(database, original_row['composite_hash']))
+
+	def test_delete_metadata_by_key_deletes_only_the_exact_null_target_id_key(self):
+		# Arrange:
+		database = self._create_database()
+		common_item = create_metadata_item(
+			metadata_type=0,
+			composite_hash='11' * 32,
+			target_id='0000000000000000')
+		null_target_row = create_expected_metadata_row(
+			common_item, 123, composite_hash=bytes.fromhex('11' * 32), metadata_type='account',
+			target_id=None, value_utf8='hello')
+		value_target_row = {**null_target_row, 'composite_hash': bytes.fromhex('22' * 32), 'target_id': '0000000000000001'}
+		database.upsert_metadata(null_target_row)
+		database.upsert_metadata(value_target_row)
+		metadata_key = {
+			'metadata_type': 'account',
+			'source_address': null_target_row['source_address'],
+			'target_address': null_target_row['target_address'],
+			'scoped_metadata_key': null_target_row['scoped_metadata_key'],
+			'target_id': None
+		}
+
+		# Act:
+		database.delete_metadata_by_key(metadata_key)
+
+		# Assert:
+		self.assertIsNone(fetch_metadata_row(database, null_target_row['composite_hash']))
+		self.assertEqual(value_target_row, fetch_metadata_row(database, value_target_row['composite_hash']))
+
+	def test_delete_metadata_by_key_is_noop_for_missing_natural_key(self):
+		# Arrange:
+		database = self._create_database()
+		item = create_metadata_item(metadata_type=1, target_id='72C0212E67A08BCE')
+		row = create_expected_metadata_row(
+			item, 123, composite_hash=bytes.fromhex('11' * 32), metadata_type='mosaic',
+			target_id='72C0212E67A08BCE', value_utf8='hello')
+		database.upsert_metadata(row)
+		missing_key = {
+			'metadata_type': row['metadata_type'],
+			'source_address': row['source_address'],
+			'target_address': row['target_address'],
+			'scoped_metadata_key': 'FFFFFFFFFFFFFFFF',
+			'target_id': row['target_id']
+		}
+
+		# Act:
+		database.delete_metadata_by_key(missing_key)
+
+		# Assert:
+		self.assertEqual(row, fetch_metadata_row(database, row['composite_hash']))
+
+	def test_get_metadata_keys_updated_from_height_returns_exact_keys_in_composite_hash_order(self):
+		# Arrange:
+		database = self._create_database()
+		rows = [
+			(create_metadata_item(
+				metadata_type=1, composite_hash='33' * 32, target_id='72C0212E67A08BCE',
+				scoped_metadata_key='0000000000000003'), 3, {
+				'composite_hash': bytes.fromhex('33' * 32), 'metadata_type': 'mosaic',
+				'scoped_metadata_key': '0000000000000003', 'source_address': bytes.fromhex(SOURCE_ADDRESS),
+				'target_address': bytes.fromhex(TARGET_ADDRESS), 'target_id': '72C0212E67A08BCE',
+				'value_hex': '68656C6C6F', 'value_utf8': 'hello'}),
+			(create_metadata_item(
+				metadata_type=2, composite_hash='11' * 32, target_id='A95F1F8A96159516',
+				scoped_metadata_key='0000000000000004'), 4, {
+				'composite_hash': bytes.fromhex('11' * 32), 'metadata_type': 'namespace',
+				'scoped_metadata_key': '0000000000000004', 'source_address': bytes.fromhex(SOURCE_ADDRESS),
+				'target_address': bytes.fromhex(TARGET_ADDRESS), 'target_id': 'A95F1F8A96159516',
+				'value_hex': '68656C6C6F', 'value_utf8': 'hello'}),
+			(create_metadata_item(metadata_type=0, composite_hash='22' * 32, scoped_metadata_key='0000000000000005'), 5, {
+				'composite_hash': bytes.fromhex('22' * 32), 'metadata_type': 'account',
+				'scoped_metadata_key': '0000000000000005', 'source_address': bytes.fromhex(SOURCE_ADDRESS),
+				'target_address': bytes.fromhex(TARGET_ADDRESS), 'target_id': None,
+				'value_hex': '68656C6C6F', 'value_utf8': 'hello'})
+		]
+		for item, height, normalized_row in rows:
+			database.upsert_metadata(create_expected_metadata_row(
+				item, height, **normalized_row))
+
+		# Act:
+		keys = database.get_metadata_keys_updated_from_height(4)
+
+		# Assert:
+		expected_keys = [
+			{'metadata_type': 'namespace', 'source_address': bytes.fromhex(SOURCE_ADDRESS),
+				'target_address': bytes.fromhex(TARGET_ADDRESS), 'scoped_metadata_key': '0000000000000004',
+				'target_id': 'A95F1F8A96159516'},
+			{'metadata_type': 'account', 'source_address': bytes.fromhex(SOURCE_ADDRESS),
+				'target_address': bytes.fromhex(TARGET_ADDRESS), 'scoped_metadata_key': '0000000000000005',
+				'target_id': None}
+		]
+		self.assertEqual(expected_keys, keys)
+
 	def test_upsert_namespace_refreshes_existing_mosaic_alias_names(self):
 		# Arrange:
 		database = self._create_database()
@@ -1182,7 +1463,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		database.repair_rollback_from_height(2, _create_sync_state(
 			status='repairing',
 			last_synced_height=1,
-			last_synced_block_hash=b'hash 1'), [], [])
+			last_synced_block_hash=b'hash 1'), RollbackRefreshEntries([], [], []))
 
 		# Assert:
 		cursor = database.connection.cursor()
@@ -1208,16 +1489,16 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		database.repair_rollback_from_height(
 			fork_height,
 			_create_sync_state(status='repairing', last_synced_height=1, last_synced_block_hash=b'hash 1'),
-			[],
-			[])
+			RollbackRefreshEntries([], [], []))
 
 		# Assert:
 		self.assertEqual(original_mosaic_state, fetch_mosaic_state(database))
 
-	def test_repair_rollback_from_height_applies_namespace_and_mosaic_changes_in_same_transaction(self):
+	def test_repair_rollback_from_height_applies_namespace_mosaic_and_metadata_changes_in_same_transaction(self):
 		# Arrange:
 		database = self._create_database()
 		database.upsert_blocks([_create_block(1), _create_block(2)])
+		database.upsert_sync_state(_create_sync_state())
 		refreshed_row = _create_namespace_row()
 		deleted_row = _create_namespace_row('B95F1F8A96159516', 'orphaned', 2)
 		database.upsert_namespace(refreshed_row, _create_alias_name_rows(refreshed_row))
@@ -1226,50 +1507,153 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		deleted_mosaic_id = '0000000000000002'
 		database.upsert_mosaic(create_expected_mosaic_row(create_mosaic_item(mosaic_id=mosaic_id), 2))
 		database.upsert_mosaic(create_expected_mosaic_row(create_mosaic_item(mosaic_id=deleted_mosaic_id), 2))
+		metadata_item = create_metadata_item(
+			metadata_type=1,
+			composite_hash='11' * 32,
+			target_id='72C0212E67A08BCE')
+		deleted_metadata_item = create_metadata_item(
+			metadata_type=2,
+			composite_hash='22' * 32,
+			target_id='A95F1F8A96159516')
+		database.upsert_metadata(create_expected_metadata_row(
+			metadata_item, 2, composite_hash=bytes.fromhex('11' * 32), metadata_type='mosaic',
+			target_id='72C0212E67A08BCE', value_utf8='hello'))
+		database.upsert_metadata(create_expected_metadata_row(
+			deleted_metadata_item, 2, composite_hash=bytes.fromhex('22' * 32), metadata_type='namespace',
+			target_id='A95F1F8A96159516', value_utf8='hello'))
 		refreshed_row = _create_namespace_row(
 			alias_type='none',
 			alias_mosaic_id=None,
 			end_height=100,
 			observed_height=1)
-
-		# Act:
-		database.repair_rollback_from_height(2, _create_sync_state(
+		refresh_entries = RollbackRefreshEntries(
+			[
+				{'row': refreshed_row, 'alias_rows': _create_alias_name_rows(refreshed_row)},
+				{'namespace_id': deleted_row['namespace_id']}
+			],
+			[
+				{'row': create_expected_mosaic_row(create_mosaic_item(mosaic_id=mosaic_id, supply='99'), 1)},
+				{'mosaic_id': deleted_mosaic_id}
+			],
+			[
+				{'row': create_expected_metadata_row(
+					create_metadata_item(
+						metadata_type=1,
+						composite_hash='11' * 32,
+						target_id='72C0212E67A08BCE',
+						value='776F726C64',
+						item_id='refreshed-metadata-item'),
+					1, composite_hash=bytes.fromhex('11' * 32), metadata_type='mosaic',
+					target_id='72C0212E67A08BCE', value_hex='776F726C64', value_utf8='world')},
+				{'key': {
+					'metadata_type': 'namespace',
+					'source_address': bytes.fromhex(SOURCE_ADDRESS),
+					'target_address': bytes.fromhex(TARGET_ADDRESS),
+					'scoped_metadata_key': SCOPED_METADATA_KEY,
+					'target_id': 'A95F1F8A96159516'
+				}}
+			])
+		refreshed_metadata_row = refresh_entries.metadata_entries[0]['row']
+		expected_sync_state = _create_sync_state(
 			status='repairing',
 			last_synced_height=1,
-			last_synced_block_hash=b'hash 1'), [
-			{'row': refreshed_row, 'alias_rows': _create_alias_name_rows(refreshed_row)},
-			{'namespace_id': deleted_row['namespace_id']}
-		], [
-			{'row': create_expected_mosaic_row(create_mosaic_item(mosaic_id=mosaic_id, supply='99'), 1)},
-			{'mosaic_id': deleted_mosaic_id}
-		])
+			last_synced_block_hash=b'hash 1')
+		expected_mosaic_row = create_expected_mosaic_row(create_mosaic_item(mosaic_id=mosaic_id, supply='99'), 1)
+		expected_mosaic_state = [create_persisted_mosaic_state(expected_mosaic_row, [])]
+		expected_namespace_state = (
+			[
+				(
+					NAMESPACE_ROOT_ID, None, NAMESPACE_ROOT_ID, 'root', 'root', 1, 'root',
+					ADDRESS1.lower(), 1, 100, 'none', None, None,
+					{'namespace': {'level0': NAMESPACE_ROOT_ID}}, 1
+				)
+			],
+			[('namespace', NAMESPACE_ROOT_ID, 'root', 1)]
+		)
+
+		# Act:
+		database.repair_rollback_from_height(2, expected_sync_state, refresh_entries)
 
 		# Assert:
+		self.assertEqual(expected_namespace_state, fetch_namespace_state(database.connection))
+		self.assertEqual(expected_mosaic_state, fetch_mosaic_state(database))
+		self.assertEqual([refreshed_metadata_row], fetch_metadata_rows(database))
+		self.assertEqual(expected_sync_state, fetch_normalized_sync_state(database))
 		cursor = database.connection.cursor()
-		cursor.execute(
-			'''
-			SELECT namespace_id, parent_id, root_id, name, full_name, depth, registration_type,
-				encode(owner_address, 'hex'), start_height, end_height, alias_type, alias_mosaic_id,
-				encode(alias_address, 'hex'), raw_payload, updated_at_height
-			FROM symbol_namespaces
-			ORDER BY namespace_id
-			''')
-		self.assertEqual([(
-			NAMESPACE_ROOT_ID, None, NAMESPACE_ROOT_ID, 'root', 'root', 1, 'root',
-			ADDRESS1.lower(), 1, 100, 'none', None, None,
-			{'namespace': {'level0': NAMESPACE_ROOT_ID}}, 1
-		)], cursor.fetchall())
-		cursor.execute(
-			'SELECT artifact_type, artifact_id, name, updated_at_height FROM symbol_alias_names ORDER BY artifact_type, artifact_id, name')
-		self.assertEqual([
-			('namespace', NAMESPACE_ROOT_ID, 'root', 1)
-		], cursor.fetchall())
-		cursor.execute('SELECT mosaic_id, supply, updated_at_height FROM symbol_mosaics ORDER BY mosaic_id')
-		self.assertEqual([(mosaic_id, 99, 1)], cursor.fetchall())
 		cursor.execute('SELECT height FROM symbol_blocks ORDER BY height')
 		self.assertEqual([(1,)], cursor.fetchall())
-		self.assertEqual('repairing', database.get_sync_state()['status'])
-		self.assertEqual(1, database.get_sync_state()['last_synced_height'])
+
+	# pylint: disable=too-many-locals
+	def test_repair_rollback_rolls_back_namespace_mosaic_metadata_and_chain_state_after_metadata_failure(self):
+		# Arrange:
+		database = self._create_database()
+		database.upsert_blocks([_create_block(1), _create_block(2)])
+		database.upsert_sync_state(_create_sync_state())
+		original_namespace_row = _create_namespace_row(observed_height=2)
+		deleted_namespace_row = _create_namespace_row('B95F1F8A96159516', 'gone', 2)
+		database.upsert_namespace(original_namespace_row, _create_alias_name_rows(original_namespace_row))
+		database.upsert_namespace(deleted_namespace_row, _create_alias_name_rows(deleted_namespace_row))
+		original_mosaic_row = create_expected_mosaic_row(create_mosaic_item(mosaic_id='0000000000000001'), 2)
+		deleted_mosaic_row = create_expected_mosaic_row(create_mosaic_item(mosaic_id='0000000000000002'), 2)
+		database.upsert_mosaic(original_mosaic_row)
+		database.upsert_mosaic(deleted_mosaic_row)
+		original_metadata_item = create_metadata_item(metadata_type=1, composite_hash='11' * 32, target_id='72C0212E67A08BCE')
+		deleted_metadata_item = create_metadata_item(metadata_type=2, composite_hash='22' * 32, target_id='A95F1F8A96159516')
+		original_metadata_row = create_expected_metadata_row(
+			original_metadata_item, 2, composite_hash=bytes.fromhex('11' * 32), metadata_type='mosaic',
+			target_id='72C0212E67A08BCE', value_utf8='hello')
+		deleted_metadata_row = create_expected_metadata_row(
+			deleted_metadata_item, 2, composite_hash=bytes.fromhex('22' * 32), metadata_type='namespace',
+			target_id='A95F1F8A96159516', value_utf8='hello')
+		database.upsert_metadata(original_metadata_row)
+		database.upsert_metadata(deleted_metadata_row)
+		original_state = {
+			'blocks': fetch_full_block_state(database),
+			'sync_state': fetch_normalized_sync_state(database),
+			'namespace': fetch_namespace_state(database.connection),
+			'mosaic': fetch_mosaic_state(database),
+			'metadata': fetch_metadata_rows(database)
+		}
+		updated_namespace_row = _create_namespace_row(
+			alias_type='none', alias_mosaic_id=None, end_height=100, observed_height=1,
+			raw_payload={'namespace': {'state': 'updated'}})
+		updated_mosaic_row = create_expected_mosaic_row(
+			create_mosaic_item(mosaic_id='0000000000000001', supply='99'), 1)
+		updated_metadata_item = create_metadata_item(
+			metadata_type=1,
+			composite_hash='11' * 32,
+			target_id='72C0212E67A08BCE',
+			value='776F726C64',
+			item_id='updated-metadata-item')
+		updated_metadata_row = create_expected_metadata_row(
+			updated_metadata_item, 1, composite_hash=bytes.fromhex('11' * 32), metadata_type='mosaic',
+			target_id='72C0212E67A08BCE', value_hex='776F726C64', value_utf8='world')
+		invalid_metadata_row = {**updated_metadata_row, 'composite_hash': bytes.fromhex('33' * 32), 'value_utf8': None}
+		refresh_entries = RollbackRefreshEntries(
+			[
+				{'row': updated_namespace_row, 'alias_rows': _create_alias_name_rows(updated_namespace_row)},
+				{'namespace_id': deleted_namespace_row['namespace_id']}
+			],
+			[
+				{'row': updated_mosaic_row},
+				{'mosaic_id': deleted_mosaic_row['mosaic_id']}
+			],
+			[
+				{'row': updated_metadata_row},
+				{'row': invalid_metadata_row}
+			])
+
+		# Act:
+		with self.assertRaises(PsycopgError):
+			database.repair_rollback_from_height(2, _create_sync_state(
+				status='repairing', last_synced_height=1, last_synced_block_hash=b'hash 1'), refresh_entries)
+
+		# Assert:
+		self.assertEqual(original_state['blocks'], fetch_full_block_state(database))
+		self.assertEqual(original_state['sync_state'], fetch_normalized_sync_state(database))
+		self.assertEqual(original_state['namespace'], fetch_namespace_state(database.connection))
+		self.assertEqual(original_state['mosaic'], fetch_mosaic_state(database))
+		self.assertEqual(original_state['metadata'], fetch_metadata_rows(database))
 
 	def test_repair_rollback_rolls_back_namespace_entries_and_chain_state_when_later_alias_insert_fails(self):
 		# Arrange:
@@ -1287,13 +1671,8 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 			raw_payload={'namespace': {'state': 'updated'}},
 			observed_height=1)
 		invalid_row = _create_namespace_row(NAMESPACE_SUB_ID, 'invalid', 1)
-
-		# Act:
-		with self.assertRaises(PsycopgError):
-			database.repair_rollback_from_height(2, _create_sync_state(
-				status='repairing',
-				last_synced_height=1,
-				last_synced_block_hash=b'hash 1'), [
+		refresh_entries = RollbackRefreshEntries(
+			[
 				{'row': updated_row, 'alias_rows': _create_alias_name_rows(updated_row)},
 				{'namespace_id': deleted_row['namespace_id']},
 				{'row': invalid_row, 'alias_rows': [{
@@ -1302,7 +1681,16 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 					'name': 'invalid',
 					'updated_at_height': 1
 				}]}
-			], [])
+			],
+			[],
+			[])
+
+		# Act:
+		with self.assertRaises(PsycopgError):
+			database.repair_rollback_from_height(2, _create_sync_state(
+				status='repairing',
+				last_synced_height=1,
+				last_synced_block_hash=b'hash 1'), refresh_entries)
 
 		# Assert:
 		cursor = database.connection.cursor()
@@ -1367,6 +1755,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 			'symbol_accounts',
 			'symbol_alias_names',
 			'symbol_blocks',
+			'symbol_metadata',
 			'symbol_mosaics',
 			'symbol_multisig',
 			'symbol_namespaces',
@@ -2919,7 +3308,8 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		})
 
 		# Act:
-		database.repair_rollback_from_height(10, _create_sync_state(status='repairing', last_synced_height=9), [], [])
+		database.repair_rollback_from_height(
+			10, _create_sync_state(status='repairing', last_synced_height=9), RollbackRefreshEntries([], [], []))
 
 		# Assert:
 		self.assertEqual('stale', database.get_account_refresh_state()['status'])
@@ -2934,7 +3324,8 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		})
 
 		# Act:
-		database.repair_rollback_from_height(10, _create_sync_state(status='repairing', last_synced_height=9), [], [])
+		database.repair_rollback_from_height(
+			10, _create_sync_state(status='repairing', last_synced_height=9), RollbackRefreshEntries([], [], []))
 
 		# Assert:
 		self.assertEqual('healthy', database.get_account_refresh_state()['status'])
@@ -2968,7 +3359,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 			10))
 		original_namespace_state = fetch_namespace_state(database.connection)
 		original_mosaic_state = fetch_mosaic_state(database)
-		original_block_state = _fetch_block_state(database)
+		original_block_state = fetch_full_block_state(database)
 		original_refresh_state = database.get_account_refresh_state()
 		refreshed_row = _create_namespace_row(
 			alias_mosaic_id='mosaic-refreshed',
@@ -2983,16 +3374,16 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 
 		# Act:
 		with self.assertRaises(PsycopgError):
-			database.repair_rollback_from_height(10, _create_sync_state(status='repairing', last_synced_height=9), [
+			database.repair_rollback_from_height(10, _create_sync_state(status='repairing', last_synced_height=9), RollbackRefreshEntries([
 				{'row': refreshed_row, 'alias_rows': _create_alias_name_rows(refreshed_row)},
 				{'namespace_id': deleted_row['namespace_id']}
 			], [
 				{'row': refreshed_mosaic_row},
 				{'mosaic_id': 'mosaic-gone'}
-			])
+			], []))
 
 		# Assert:
-		self.assertEqual(original_block_state, _fetch_block_state(database))
+		self.assertEqual(original_block_state, fetch_full_block_state(database))
 		self.assertEqual(original_refresh_state, database.get_account_refresh_state())
 		self.assertEqual(original_namespace_state, fetch_namespace_state(database.connection))
 		self.assertEqual(original_mosaic_state, fetch_mosaic_state(database))
@@ -3018,7 +3409,8 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		database.finalize_account_refresh('run-1', NATIVE_MOSAIC_ID, 10, datetime.datetime(2026, 1, 1))
 
 		# Act:
-		database.repair_rollback_from_height(10, _create_sync_state(status='repairing', last_synced_height=9), [], [])
+		database.repair_rollback_from_height(
+			10, _create_sync_state(status='repairing', last_synced_height=9), RollbackRefreshEntries([], [], []))
 
 		# Assert:
 		expected_address = bytes.fromhex(ADDRESS1)
@@ -3571,7 +3963,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 			status='repairing',
 			last_synced_height=1,
 			last_synced_block_hash=b'hash 1'
-		), [], [])
+		), RollbackRefreshEntries([], [], []))
 
 		# Assert:
 		cursor = database.connection.cursor()

--- a/explorer/puller/tests/facade/symbol/puller_test_utils.py
+++ b/explorer/puller/tests/facade/symbol/puller_test_utils.py
@@ -367,7 +367,8 @@ class FakeConnector:  # pylint: disable=too-many-instance-attributes
 		namespace_by_id=None,
 		namespace_names=None,
 		mosaics_by_id=None,
-		mosaics_response=None
+		mosaics_response=None,
+		metadata_by_query=None
 	):  # pylint: disable=too-many-arguments,too-many-positional-arguments
 		self.chain_height = chain_height
 		self.pages = pages
@@ -384,6 +385,7 @@ class FakeConnector:  # pylint: disable=too-many-instance-attributes
 		self.namespace_names = namespace_names or {}
 		self.mosaics_by_id = mosaics_by_id or {}
 		self.mosaics_response = mosaics_response
+		self.metadata_by_query = metadata_by_query or {}
 		self.paths = []
 		self.post_payloads_list = []
 		self.post_requests = []
@@ -460,6 +462,11 @@ class FakeConnector:  # pylint: disable=too-many-instance-attributes
 					'pageNumber': page_number
 				}
 			}
+		if url_path.startswith('metadata?'):
+			response = self.metadata_by_query.get(url_path, {'data': []})
+			if isinstance(response, Exception):
+				raise response
+			return response
 
 		raise KeyError(url_path)
 
@@ -495,6 +502,54 @@ class FakeConnector:  # pylint: disable=too-many-instance-attributes
 			return items
 
 		raise KeyError(url_path)
+
+
+class BoundedDetailConnector(FakeConnector):
+	"""Gates detail requests so tests can observe bounded concurrent access."""
+
+	DETAIL_PATH_PREFIX = None
+
+	def __init__(self, *args, **kwargs):
+		super().__init__(*args, **kwargs)
+		self.detail_paths = []
+		self.in_flight_detail_requests = 0
+		self.max_in_flight_detail_requests = 0
+		self._detail_requests_released = asyncio.Event()
+		self._release_scheduled = False
+
+	async def get(self, url_path, *args):
+		if not url_path.startswith(self.DETAIL_PATH_PREFIX):
+			return await super().get(url_path, *args)
+
+		self.paths.append(url_path)
+		self.detail_paths.append(url_path)
+		self.in_flight_detail_requests += 1
+		self.max_in_flight_detail_requests = max(
+			self.max_in_flight_detail_requests,
+			self.in_flight_detail_requests)
+		try:
+			if not self._release_scheduled:
+				self._release_scheduled = True
+				asyncio.get_running_loop().call_soon(self._detail_requests_released.set)
+			await self._detail_requests_released.wait()
+
+			return self._get_detail_response(url_path)
+		finally:
+			self.in_flight_detail_requests -= 1
+
+	def _get_detail_response(self, url_path):
+		raise NotImplementedError(url_path)
+
+
+class BoundedMetadataConnector(BoundedDetailConnector):
+	DETAIL_PATH_PREFIX = 'metadata?'
+
+	def _get_detail_response(self, url_path):
+		response = self.metadata_by_query.get(url_path, {'data': []})
+		if isinstance(response, Exception):
+			raise response
+
+		return response
 
 
 class ResponseConnector:
@@ -534,38 +589,15 @@ class NamespaceNamesResponseConnector(FakeConnector):
 		return await super().post(url_path, request_payload, *args)
 
 
-class BoundedNamespaceDetailConnector(FakeConnector):
-	def __init__(self, *args, **kwargs):
-		super().__init__(*args, **kwargs)
-		self.namespace_paths = []
-		self.in_flight_namespace_requests = 0
-		self.max_in_flight_namespace_requests = 0
-		self._namespace_requests_released = asyncio.Event()
-		self._release_scheduled = False
+class BoundedNamespaceDetailConnector(BoundedDetailConnector):
+	DETAIL_PATH_PREFIX = 'namespaces/'
 
-	async def get(self, url_path, *args):
-		if not url_path.startswith('namespaces/'):
-			return await super().get(url_path, *args)
+	def _get_detail_response(self, url_path):
+		response = self.namespace_by_id[url_path.removeprefix('namespaces/')]
+		if isinstance(response, Exception):
+			raise response
 
-		self.paths.append(url_path)
-		self.namespace_paths.append(url_path)
-		self.in_flight_namespace_requests += 1
-		self.max_in_flight_namespace_requests = max(
-			self.max_in_flight_namespace_requests,
-			self.in_flight_namespace_requests)
-		try:
-			if not self._release_scheduled:
-				self._release_scheduled = True
-				asyncio.get_running_loop().call_soon(self._namespace_requests_released.set)
-			await self._namespace_requests_released.wait()
-
-			response = self.namespace_by_id[url_path.removeprefix('namespaces/')]
-			if isinstance(response, Exception):
-				raise response
-
-			return response
-		finally:
-			self.in_flight_namespace_requests -= 1
+		return response
 
 
 class SymbolPullerTestBase(TestCase):

--- a/explorer/puller/tests/facade/symbol/puller_test_utils.py
+++ b/explorer/puller/tests/facade/symbol/puller_test_utils.py
@@ -533,7 +533,11 @@ class BoundedDetailConnector(FakeConnector):
 				asyncio.get_running_loop().call_soon(self._detail_requests_released.set)
 			await self._detail_requests_released.wait()
 
-			return self._get_detail_response(url_path)
+			response = self._get_detail_response(url_path)
+			if isinstance(response, Exception):
+				raise response
+
+			return response
 		finally:
 			self.in_flight_detail_requests -= 1
 
@@ -545,11 +549,7 @@ class BoundedMetadataConnector(BoundedDetailConnector):
 	DETAIL_PATH_PREFIX = 'metadata?'
 
 	def _get_detail_response(self, url_path):
-		response = self.metadata_by_query.get(url_path, {'data': []})
-		if isinstance(response, Exception):
-			raise response
-
-		return response
+		return self.metadata_by_query.get(url_path, {'data': []})
 
 
 class ResponseConnector:
@@ -593,11 +593,7 @@ class BoundedNamespaceDetailConnector(BoundedDetailConnector):
 	DETAIL_PATH_PREFIX = 'namespaces/'
 
 	def _get_detail_response(self, url_path):
-		response = self.namespace_by_id[url_path.removeprefix('namespaces/')]
-		if isinstance(response, Exception):
-			raise response
-
-		return response
+		return self.namespace_by_id[url_path.removeprefix('namespaces/')]
 
 
 class SymbolPullerTestBase(TestCase):

--- a/explorer/puller/tests/facade/symbol/test_PullerAccounts.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerAccounts.py
@@ -792,7 +792,7 @@ class SymbolPullerAccountsTest(SymbolPullerTestBase):  # pylint: disable=too-man
 			database.repair_rollback_from_height(
 				1,
 				sync_state,
-				RollbackRefreshEntries([], [], []))
+				RollbackRefreshEntries())
 
 	def test_refresh_accounts_can_restart_with_new_successful_run(self):  # pylint: disable=too-many-locals
 		# Arrange:

--- a/explorer/puller/tests/facade/symbol/test_PullerAccounts.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerAccounts.py
@@ -8,7 +8,7 @@ from symbolchain.sc import ReceiptType
 from symbolchain.symbol.Network import Address
 from symbollightapi.model.Exceptions import NodeException
 
-from puller.db.SymbolDatabase import SymbolDatabase
+from puller.db.SymbolDatabase import RollbackRefreshEntries, SymbolDatabase
 from puller.facade.SymbolPuller import ACCOUNT_BATCH_FETCH_SIZE
 from puller.model.symbol.Account import create_account_row
 from puller.model.symbol.Block import create_block_row
@@ -789,7 +789,10 @@ class SymbolPullerAccountsTest(SymbolPullerTestBase):  # pylint: disable=too-man
 
 		# Act:
 		with self.assertRaises(PsycopgError):
-			database.repair_rollback_from_height(1, sync_state, [], [])
+			database.repair_rollback_from_height(
+				1,
+				sync_state,
+				RollbackRefreshEntries([], [], []))
 
 	def test_refresh_accounts_can_restart_with_new_successful_run(self):  # pylint: disable=too-many-locals
 		# Arrange:

--- a/explorer/puller/tests/facade/symbol/test_PullerMetadata.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerMetadata.py
@@ -300,73 +300,74 @@ class SymbolPullerMetadataTest(SymbolPullerTestBase):  # pylint: disable=too-man
 		# Assert:
 		self.assertEqual([], keys)
 
-	def test_collect_dirty_metadata_keys_uses_resolved_target_address_for_account_metadata(self):
+	def _assert_collect_dirty_metadata_keys_prefers_row_target_address(self, transaction_row, expected_key):
 		# Arrange:
-		alias_address = '99065A28385EB5AE88000000000000000000000000000000'
-		row = {
-			'type': TransactionType.ACCOUNT_METADATA.value,
-			'signer_address': bytes.fromhex(SIGNER_ADDRESS),
-			'target_address': bytes.fromhex(TARGET_ADDRESS),
-			'metadata_target_id': None,
-			'body': {'targetAddress': alias_address, 'scopedMetadataKey': '0000000000000004'}
-		}
+		# body targetAddress is an unresolved alias; row target_address is the resolved address.
 
 		# Act:
-		keys = self.puller._collect_dirty_metadata_keys_for_batch({1: [row]})  # pylint: disable=protected-access
+		keys = self.puller._collect_dirty_metadata_keys_for_batch({1: [transaction_row]})  # pylint: disable=protected-access
 
 		# Assert:
-		self.assertEqual([{
-			'metadata_type': 'account', 'source_address': bytes.fromhex(SIGNER_ADDRESS),
-			'target_address': bytes.fromhex(TARGET_ADDRESS), 'scoped_metadata_key': '0000000000000004', 'target_id': None
-		}], keys)
+		self.assertEqual([expected_key], keys)
 
-	def test_collect_dirty_metadata_keys_uses_resolved_target_address_for_mosaic_metadata(self):
-		# Arrange:
-		alias_address = '99065A28385EB5AE88000000000000000000000000000000'
-		row = {
-			'type': TransactionType.MOSAIC_METADATA.value,
-			'signer_address': bytes.fromhex(SIGNER_ADDRESS),
-			'target_address': bytes.fromhex(TARGET_ADDRESS),
-			'metadata_target_id': MOSAIC_ID,
-			'body': {
-				'targetAddress': alias_address,
-				'targetMosaicId': MOSAIC_ID,
-				'scopedMetadataKey': '0000000000000005'
-			}
-		}
+	def test_collect_dirty_metadata_keys_prefers_row_target_address_over_body_target_address_for_account_metadata(self):
+		self._assert_collect_dirty_metadata_keys_prefers_row_target_address(
+			{
+				'type': TransactionType.ACCOUNT_METADATA.value,
+				'signer_address': bytes.fromhex(SIGNER_ADDRESS),
+				'target_address': bytes.fromhex(TARGET_ADDRESS),
+				'metadata_target_id': None,
+				'body': {'targetAddress': ALIAS_ADDRESS, 'scopedMetadataKey': '0000000000000004'}
+			},
+			{
+				'metadata_type': 'account',
+				'source_address': bytes.fromhex(SIGNER_ADDRESS),
+				'target_address': bytes.fromhex(TARGET_ADDRESS),
+				'scoped_metadata_key': '0000000000000004',
+				'target_id': None
+			})
 
-		# Act:
-		keys = self.puller._collect_dirty_metadata_keys_for_batch({1: [row]})  # pylint: disable=protected-access
+	def test_collect_dirty_metadata_keys_prefers_row_target_address_over_body_target_address_for_mosaic_metadata(self):
+		self._assert_collect_dirty_metadata_keys_prefers_row_target_address(
+			{
+				'type': TransactionType.MOSAIC_METADATA.value,
+				'signer_address': bytes.fromhex(SIGNER_ADDRESS),
+				'target_address': bytes.fromhex(TARGET_ADDRESS),
+				'metadata_target_id': MOSAIC_ID,
+				'body': {
+					'targetAddress': ALIAS_ADDRESS,
+					'targetMosaicId': MOSAIC_ID,
+					'scopedMetadataKey': '0000000000000005'
+				}
+			},
+			{
+				'metadata_type': 'mosaic',
+				'source_address': bytes.fromhex(SIGNER_ADDRESS),
+				'target_address': bytes.fromhex(TARGET_ADDRESS),
+				'scoped_metadata_key': '0000000000000005',
+				'target_id': MOSAIC_ID
+			})
 
-		# Assert:
-		self.assertEqual([{
-			'metadata_type': 'mosaic', 'source_address': bytes.fromhex(SIGNER_ADDRESS),
-			'target_address': bytes.fromhex(TARGET_ADDRESS), 'scoped_metadata_key': '0000000000000005', 'target_id': MOSAIC_ID
-		}], keys)
-
-	def test_collect_dirty_metadata_keys_uses_resolved_target_address_for_namespace_metadata(self):
-		# Arrange:
-		alias_address = '99065A28385EB5AE88000000000000000000000000000000'
-		row = {
-			'type': TransactionType.NAMESPACE_METADATA.value,
-			'signer_address': bytes.fromhex(SIGNER_ADDRESS),
-			'target_address': bytes.fromhex(TARGET_ADDRESS),
-			'metadata_target_id': None,
-			'body': {
-				'targetAddress': alias_address,
-				'targetNamespaceId': NAMESPACE_ID,
-				'scopedMetadataKey': '0000000000000006'
-			}
-		}
-
-		# Act:
-		keys = self.puller._collect_dirty_metadata_keys_for_batch({1: [row]})  # pylint: disable=protected-access
-
-		# Assert:
-		self.assertEqual([{
-			'metadata_type': 'namespace', 'source_address': bytes.fromhex(SIGNER_ADDRESS),
-			'target_address': bytes.fromhex(TARGET_ADDRESS), 'scoped_metadata_key': '0000000000000006', 'target_id': NAMESPACE_ID
-		}], keys)
+	def test_collect_dirty_metadata_keys_prefers_row_target_address_over_body_target_address_for_namespace_metadata(self):
+		self._assert_collect_dirty_metadata_keys_prefers_row_target_address(
+			{
+				'type': TransactionType.NAMESPACE_METADATA.value,
+				'signer_address': bytes.fromhex(SIGNER_ADDRESS),
+				'target_address': bytes.fromhex(TARGET_ADDRESS),
+				'metadata_target_id': None,
+				'body': {
+					'targetAddress': ALIAS_ADDRESS,
+					'targetNamespaceId': NAMESPACE_ID,
+					'scopedMetadataKey': '0000000000000006'
+				}
+			},
+			{
+				'metadata_type': 'namespace',
+				'source_address': bytes.fromhex(SIGNER_ADDRESS),
+				'target_address': bytes.fromhex(TARGET_ADDRESS),
+				'scoped_metadata_key': '0000000000000006',
+				'target_id': NAMESPACE_ID
+			})
 
 	def test_collect_dirty_metadata_keys_uses_resolved_mosaic_target_id_for_mosaic_alias(self):
 		# Arrange:
@@ -490,7 +491,7 @@ class SymbolPullerMetadataTest(SymbolPullerTestBase):  # pylint: disable=too-man
 		# Assert:
 		self.assertEqual([sibling_row], fetch_metadata_rows(self.puller.symbol_db))
 
-	def test_fetch_dirty_metadata_rejects_malformed_response(self):
+	def _assert_fetch_dirty_metadata_rejects_response(self, response, expected_message):
 		# Arrange:
 		key = {
 			'metadata_type': 'account',
@@ -499,74 +500,34 @@ class SymbolPullerMetadataTest(SymbolPullerTestBase):  # pylint: disable=too-man
 			'scoped_metadata_key': SCOPED_METADATA_KEY,
 			'target_id': None
 		}
-		connector = FakeConnector(1, {}, metadata_by_query={metadata_path(0): None})
+		connector = FakeConnector(1, {}, metadata_by_query={metadata_path(0): response})
 		set_symbol_connector(self.puller, connector)
 
 		# Act:
-		with self.assertRaisesRegex(ValueError, '^Malformed Symbol metadata search response$'):
+		with self.assertRaisesRegex(ValueError, expected_message):
 			asyncio.run(self.puller._fetch_dirty_metadata([key], 9))  # pylint: disable=protected-access
 
 		# Assert:
 		self.assertEqual([metadata_path(0)], connector.paths)
+
+	def test_fetch_dirty_metadata_rejects_malformed_response(self):
+		self._assert_fetch_dirty_metadata_rejects_response(None, '^Malformed Symbol metadata search response$')
 
 	def test_fetch_dirty_metadata_rejects_response_missing_data(self):
-		# Arrange:
-		key = {
-			'metadata_type': 'account',
-			'source_address': bytes.fromhex(SIGNER_ADDRESS),
-			'target_address': bytes.fromhex(RECIPIENT_ADDRESS),
-			'scoped_metadata_key': SCOPED_METADATA_KEY,
-			'target_id': None
-		}
-		connector = FakeConnector(1, {}, metadata_by_query={metadata_path(0): {}})
-		set_symbol_connector(self.puller, connector)
-
-		# Act:
-		with self.assertRaisesRegex(ValueError, '^Malformed Symbol metadata search response$'):
-			asyncio.run(self.puller._fetch_dirty_metadata([key], 9))  # pylint: disable=protected-access
-
-		# Assert:
-		self.assertEqual([metadata_path(0)], connector.paths)
+		self._assert_fetch_dirty_metadata_rejects_response({}, '^Malformed Symbol metadata search response$')
 
 	def test_fetch_dirty_metadata_rejects_non_list_data(self):
-		# Arrange:
-		key = {
-			'metadata_type': 'account',
-			'source_address': bytes.fromhex(SIGNER_ADDRESS),
-			'target_address': bytes.fromhex(RECIPIENT_ADDRESS),
-			'scoped_metadata_key': SCOPED_METADATA_KEY,
-			'target_id': None
-		}
-		connector = FakeConnector(1, {}, metadata_by_query={metadata_path(0): {'data': {}}})
-		set_symbol_connector(self.puller, connector)
-
-		# Act:
-		with self.assertRaisesRegex(ValueError, '^Malformed Symbol metadata search data$'):
-			asyncio.run(self.puller._fetch_dirty_metadata([key], 9))  # pylint: disable=protected-access
-
-		# Assert:
-		self.assertEqual([metadata_path(0)], connector.paths)
+		self._assert_fetch_dirty_metadata_rejects_response({'data': {}}, '^Malformed Symbol metadata search data$')
 
 	def test_fetch_dirty_metadata_rejects_multiple_entries(self):
-		# Arrange:
-		key = {
-			'metadata_type': 'account',
-			'source_address': bytes.fromhex(SIGNER_ADDRESS),
-			'target_address': bytes.fromhex(RECIPIENT_ADDRESS),
-			'scoped_metadata_key': SCOPED_METADATA_KEY,
-			'target_id': None
-		}
-		connector = FakeConnector(1, {}, metadata_by_query={metadata_path(0): {
-			'data': [create_metadata_item(), create_metadata_item(composite_hash='22' * 32)]
-		}})
-		set_symbol_connector(self.puller, connector)
-
-		# Act:
-		with self.assertRaisesRegex(ValueError, '^Symbol metadata exact-key search returned multiple entries$'):
-			asyncio.run(self.puller._fetch_dirty_metadata([key], 9))  # pylint: disable=protected-access
-
-		# Assert:
-		self.assertEqual([metadata_path(0)], connector.paths)
+		self._assert_fetch_dirty_metadata_rejects_response(
+			{
+				'data': [
+					create_metadata_item(),
+					create_metadata_item(composite_hash='22' * 32)
+				]
+			},
+			'^Symbol metadata exact-key search returned multiple entries$')
 
 	def test_fetch_dirty_metadata_returns_empty_for_no_keys(self):
 		# Arrange:
@@ -636,7 +597,7 @@ class SymbolPullerMetadataTest(SymbolPullerTestBase):  # pylint: disable=too-man
 				'value': '68656C6C6F'
 			})
 
-	def test_sync_block_headers_resolves_address_alias_for_embedded_metadata(self):
+	def test_sync_block_headers_resolves_address_alias_for_embedded_mosaic_metadata(self):
 		# Arrange:
 		connector, _, _, embedded_transaction, transactions, metadata_item = _create_embedded_metadata_fixture(
 			ALIAS_ADDRESS,
@@ -674,7 +635,7 @@ class SymbolPullerMetadataTest(SymbolPullerTestBase):  # pylint: disable=too-man
 				'value': '68656C6C6F'
 			})
 
-	def test_sync_block_headers_resolves_mosaic_target_id_alias_for_embedded_metadata(self):
+	def test_sync_block_headers_resolves_target_mosaic_id_alias_for_embedded_mosaic_metadata(self):
 		# Arrange:
 		connector, _, _, embedded_transaction, transactions, metadata_item = _create_embedded_metadata_fixture(
 			RECIPIENT_ADDRESS,
@@ -712,7 +673,7 @@ class SymbolPullerMetadataTest(SymbolPullerTestBase):  # pylint: disable=too-man
 				'value': '68656C6C6F'
 			})
 
-	def test_sync_block_headers_resolves_address_and_mosaic_aliases_for_embedded_metadata(self):
+	def test_sync_block_headers_resolves_address_and_target_mosaic_id_aliases_for_embedded_mosaic_metadata(self):
 		# Arrange:
 		connector, _, _, embedded_transaction, transactions, metadata_item = _create_embedded_metadata_fixture(
 			ALIAS_ADDRESS,
@@ -755,7 +716,7 @@ class SymbolPullerMetadataTest(SymbolPullerTestBase):  # pylint: disable=too-man
 				'value': '68656C6C6F'
 			})
 
-	def test_sync_block_headers_resolves_address_alias_and_persists_account_metadata(self):
+	def test_sync_block_headers_resolves_address_alias_for_embedded_account_metadata(self):
 		# Arrange:
 		_, _, embedded_transaction, transactions = _create_embedded_metadata_transactions(
 			TransactionType.ACCOUNT_METADATA.value,
@@ -812,7 +773,7 @@ class SymbolPullerMetadataTest(SymbolPullerTestBase):  # pylint: disable=too-man
 				'value': '68656C6C6F'
 			})
 
-	def test_sync_block_headers_resolves_address_alias_and_persists_namespace_metadata(self):
+	def test_sync_block_headers_resolves_address_alias_for_embedded_namespace_metadata(self):
 		# Arrange:
 		_, _, embedded_transaction, transactions = _create_embedded_metadata_transactions(
 			TransactionType.NAMESPACE_METADATA.value,
@@ -1134,17 +1095,19 @@ class SymbolPullerMetadataTest(SymbolPullerTestBase):  # pylint: disable=too-man
 			cursor.execute(f'SELECT COUNT(*) FROM {table}')
 			self.assertEqual(0, cursor.fetchone()[0])
 		self.assertIsNone(self.puller.symbol_db.get_sync_state())
-		self.assertEqual([f'namespaces/{NAMESPACE_ID}'], [
-			path for path in connector.paths if path.startswith('namespaces/') and path != 'namespaces/names'])
-		self.assertEqual(['mosaics'], [path for path in connector.paths if 'mosaics' == path])
-		self.assertEqual(['accounts'], [path for path in connector.paths if 'accounts' == path])
-		self.assertEqual([metadata_failure_path], [path for path in connector.paths if path.startswith('metadata?')])
+		self.assertEqual([
+			'accounts',
+			f'namespaces/{NAMESPACE_ID}',
+			'namespaces/names',
+			'mosaics',
+			metadata_failure_path
+		], [
+			path for path in connector.paths
+			if path in ('accounts', f'namespaces/{NAMESPACE_ID}', 'namespaces/names', 'mosaics') or path.startswith('metadata?')
+		])
 		self.assertEqual([{'addresses': account_addresses}], [
 			payload for path, payload in connector.post_requests if 'accounts' == path])
 		self.assertEqual([{'namespaceIds': [NAMESPACE_ID]}], [
 			payload for path, payload in connector.post_requests if 'namespaces/names' == path])
 		self.assertEqual([{'mosaicIds': [dirty_mosaic_id]}], [
 			payload for path, payload in connector.post_requests if 'mosaics' == path])
-		metadata_request_index = connector.paths.index(metadata_failure_path)
-		for request_path in ('accounts', f'namespaces/{NAMESPACE_ID}', 'mosaics'):
-			self.assertLess(connector.paths.index(request_path), metadata_request_index)

--- a/explorer/puller/tests/facade/symbol/test_PullerMetadata.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerMetadata.py
@@ -219,13 +219,13 @@ class SymbolPullerMetadataTest(SymbolPullerTestBase):  # pylint: disable=too-man
 		rows = {
 			1: [
 				{'type': TransactionType.ACCOUNT_METADATA.value, 'signer_address': bytes.fromhex(SIGNER_ADDRESS),
-					'target_address': bytes.fromhex(RECIPIENT_ADDRESS), 'metadata_target_id': None,
+					'target_address': bytes.fromhex(RECIPIENT_ADDRESS), 'mosaic_metadata_target_id': None,
 					'body': {'targetAddress': RECIPIENT_ADDRESS, 'scopedMetadataKey': '0000000000000001'}},
 				{'type': TransactionType.MOSAIC_METADATA.value, 'signer_address': bytes.fromhex(SIGNER_ADDRESS),
-					'target_address': bytes.fromhex(RECIPIENT_ADDRESS), 'metadata_target_id': MOSAIC_ID,
+					'target_address': bytes.fromhex(RECIPIENT_ADDRESS), 'mosaic_metadata_target_id': MOSAIC_ID,
 					'body': {'targetAddress': RECIPIENT_ADDRESS, 'targetMosaicId': MOSAIC_ID, 'scopedMetadataKey': '0000000000000002'}},
 				{'type': TransactionType.NAMESPACE_METADATA.value, 'signer_address': bytes.fromhex(SIGNER_ADDRESS),
-					'target_address': bytes.fromhex(RECIPIENT_ADDRESS), 'metadata_target_id': None,
+					'target_address': bytes.fromhex(RECIPIENT_ADDRESS), 'mosaic_metadata_target_id': None,
 					'body': {'targetAddress': RECIPIENT_ADDRESS, 'targetNamespaceId': NAMESPACE_ID, 'scopedMetadataKey': '0000000000000003'}}
 			]
 		}
@@ -248,19 +248,19 @@ class SymbolPullerMetadataTest(SymbolPullerTestBase):  # pylint: disable=too-man
 		rows = {
 			1: [
 				{'type': TransactionType.NAMESPACE_METADATA.value, 'signer_address': bytes.fromhex(SIGNER_ADDRESS),
-					'target_address': bytes.fromhex(RECIPIENT_ADDRESS), 'metadata_target_id': None,
+					'target_address': bytes.fromhex(RECIPIENT_ADDRESS), 'mosaic_metadata_target_id': None,
 					'body': {'targetAddress': RECIPIENT_ADDRESS, 'targetNamespaceId': NAMESPACE_ID, 'scopedMetadataKey': '0000000000000003'}},
 				{'type': TransactionType.ACCOUNT_METADATA.value, 'signer_address': bytes.fromhex(SIGNER_ADDRESS),
-					'target_address': bytes.fromhex(RECIPIENT_ADDRESS), 'metadata_target_id': None,
+					'target_address': bytes.fromhex(RECIPIENT_ADDRESS), 'mosaic_metadata_target_id': None,
 					'body': {'targetAddress': RECIPIENT_ADDRESS, 'scopedMetadataKey': '0000000000000001'}},
 				{'type': TransactionType.MOSAIC_METADATA.value, 'signer_address': bytes.fromhex(SIGNER_ADDRESS),
-					'target_address': bytes.fromhex(RECIPIENT_ADDRESS), 'metadata_target_id': MOSAIC_ID,
+					'target_address': bytes.fromhex(RECIPIENT_ADDRESS), 'mosaic_metadata_target_id': MOSAIC_ID,
 					'body': {'targetAddress': RECIPIENT_ADDRESS, 'targetMosaicId': MOSAIC_ID, 'scopedMetadataKey': '0000000000000002'}},
 				{'type': TransactionType.NAMESPACE_METADATA.value, 'signer_address': bytes.fromhex(SIGNER_ADDRESS),
-					'target_address': bytes.fromhex(RECIPIENT_ADDRESS), 'metadata_target_id': None,
+					'target_address': bytes.fromhex(RECIPIENT_ADDRESS), 'mosaic_metadata_target_id': None,
 					'body': {'targetAddress': RECIPIENT_ADDRESS, 'targetNamespaceId': NAMESPACE_ID, 'scopedMetadataKey': '0000000000000003'}},
 				{'type': TransactionType.ACCOUNT_METADATA.value, 'signer_address': bytes.fromhex(SIGNER_ADDRESS),
-					'target_address': bytes.fromhex(RECIPIENT_ADDRESS), 'metadata_target_id': None,
+					'target_address': bytes.fromhex(RECIPIENT_ADDRESS), 'mosaic_metadata_target_id': None,
 					'body': {'targetAddress': RECIPIENT_ADDRESS, 'scopedMetadataKey': '0000000000000001'}}
 			]
 		}
@@ -300,7 +300,7 @@ class SymbolPullerMetadataTest(SymbolPullerTestBase):  # pylint: disable=too-man
 		# Assert:
 		self.assertEqual([], keys)
 
-	def _assert_collect_dirty_metadata_keys_prefers_row_target_address(self, transaction_row, expected_key):
+	def _assert_collect_dirty_metadata_keys_selects_row_target_address(self, transaction_row, expected_key):
 		# Arrange:
 		# body targetAddress is an unresolved alias; row target_address is the resolved address.
 
@@ -310,13 +310,13 @@ class SymbolPullerMetadataTest(SymbolPullerTestBase):  # pylint: disable=too-man
 		# Assert:
 		self.assertEqual([expected_key], keys)
 
-	def test_collect_dirty_metadata_keys_prefers_row_target_address_over_body_target_address_for_account_metadata(self):
-		self._assert_collect_dirty_metadata_keys_prefers_row_target_address(
+	def test_collect_dirty_metadata_keys_selects_row_target_address_over_body_target_address_for_account_metadata(self):
+		self._assert_collect_dirty_metadata_keys_selects_row_target_address(
 			{
 				'type': TransactionType.ACCOUNT_METADATA.value,
 				'signer_address': bytes.fromhex(SIGNER_ADDRESS),
 				'target_address': bytes.fromhex(TARGET_ADDRESS),
-				'metadata_target_id': None,
+				'mosaic_metadata_target_id': None,
 				'body': {'targetAddress': ALIAS_ADDRESS, 'scopedMetadataKey': '0000000000000004'}
 			},
 			{
@@ -327,13 +327,13 @@ class SymbolPullerMetadataTest(SymbolPullerTestBase):  # pylint: disable=too-man
 				'target_id': None
 			})
 
-	def test_collect_dirty_metadata_keys_prefers_row_target_address_over_body_target_address_for_mosaic_metadata(self):
-		self._assert_collect_dirty_metadata_keys_prefers_row_target_address(
+	def test_collect_dirty_metadata_keys_selects_row_target_address_over_body_target_address_for_mosaic_metadata(self):
+		self._assert_collect_dirty_metadata_keys_selects_row_target_address(
 			{
 				'type': TransactionType.MOSAIC_METADATA.value,
 				'signer_address': bytes.fromhex(SIGNER_ADDRESS),
 				'target_address': bytes.fromhex(TARGET_ADDRESS),
-				'metadata_target_id': MOSAIC_ID,
+				'mosaic_metadata_target_id': MOSAIC_ID,
 				'body': {
 					'targetAddress': ALIAS_ADDRESS,
 					'targetMosaicId': MOSAIC_ID,
@@ -348,13 +348,13 @@ class SymbolPullerMetadataTest(SymbolPullerTestBase):  # pylint: disable=too-man
 				'target_id': MOSAIC_ID
 			})
 
-	def test_collect_dirty_metadata_keys_prefers_row_target_address_over_body_target_address_for_namespace_metadata(self):
-		self._assert_collect_dirty_metadata_keys_prefers_row_target_address(
+	def test_collect_dirty_metadata_keys_selects_row_target_address_over_body_target_address_for_namespace_metadata(self):
+		self._assert_collect_dirty_metadata_keys_selects_row_target_address(
 			{
 				'type': TransactionType.NAMESPACE_METADATA.value,
 				'signer_address': bytes.fromhex(SIGNER_ADDRESS),
 				'target_address': bytes.fromhex(TARGET_ADDRESS),
-				'metadata_target_id': None,
+				'mosaic_metadata_target_id': None,
 				'body': {
 					'targetAddress': ALIAS_ADDRESS,
 					'targetNamespaceId': NAMESPACE_ID,
@@ -376,7 +376,7 @@ class SymbolPullerMetadataTest(SymbolPullerTestBase):  # pylint: disable=too-man
 			'type': TransactionType.MOSAIC_METADATA.value,
 			'signer_address': bytes.fromhex(SIGNER_ADDRESS),
 			'target_address': bytes.fromhex(TARGET_ADDRESS),
-			'metadata_target_id': MOSAIC_ID,
+			'mosaic_metadata_target_id': MOSAIC_ID,
 			'body': {
 				'targetAddress': RECIPIENT_ADDRESS,
 				'targetMosaicId': alias_mosaic_id,

--- a/explorer/puller/tests/facade/symbol/test_PullerMetadata.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerMetadata.py
@@ -1,0 +1,1150 @@
+# pylint: disable=too-many-lines
+import asyncio
+import copy
+
+from psycopg2 import Error as PsycopgError
+from symbolchain.sc import TransactionType
+from symbolchain.symbol.Network import Address
+
+from puller.facade.SymbolPuller import METADATA_FETCH_CONCURRENCY
+from tests.test.SymbolMetadataTestUtils import (
+	MOSAIC_ID,
+	NAMESPACE_ID,
+	SCOPED_METADATA_KEY,
+	SOURCE_ADDRESS,
+	TARGET_ADDRESS,
+	create_expected_metadata_row,
+	create_metadata_item,
+	fetch_metadata_rows,
+	metadata_path
+)
+from tests.test.SymbolMosaicTestUtils import create_mosaic_item
+from tests.test.SymbolNamespaceTestUtils import create_namespace_item
+from tests.test.SymbolTestConstants import RECIPIENT_ADDRESS, SIGNER_ADDRESS
+
+from .puller_test_utils import (
+	BoundedMetadataConnector,
+	FakeConnector,
+	SymbolPullerTestBase,
+	create_account_item,
+	create_embedded_node_transaction,
+	create_node_block,
+	create_node_transaction,
+	create_resolution_statement,
+	resolution_path,
+	set_symbol_connector,
+	transaction_path
+)
+
+ALIAS_ADDRESS = '99065A28385EB5AE88000000000000000000000000000000'
+ALIAS_MOSAIC_ID = 'E74B99BA41F4AFEE'
+DECOY_MOSAIC_ID = '6BED913FA20223F8'
+RESOLVED_MOSAIC_ID = MOSAIC_ID
+METADATA_COMPOSITE_HASH = 'AB' * 32
+ACCOUNT_METADATA_COMPOSITE_HASH = 'CD' * 32
+NAMESPACE_METADATA_COMPOSITE_HASH = 'EF' * 32
+
+
+class MalformedMosaicResolutionConnector(FakeConnector):
+	async def get(self, url_path, *args):
+		if url_path.startswith('statements/resolutions/mosaic?'):
+			self.paths.append(url_path)
+			return {'pagination': {'pageNumber': 1}}
+
+		return await super().get(url_path, *args)
+
+
+def _create_metadata_fetch_fixture():
+	key_specs = [
+		(4, 'account', None, '0000000000000004'),
+		(1, 'mosaic', MOSAIC_ID, '0000000000000001'),
+		(10, 'namespace', NAMESPACE_ID, '000000000000000A'),
+		(0, 'account', None, '0000000000000000'),
+		(9, 'mosaic', MOSAIC_ID, '0000000000000009'),
+		(2, 'namespace', NAMESPACE_ID, '0000000000000002'),
+		(8, 'account', None, '0000000000000008'),
+		(3, 'mosaic', MOSAIC_ID, '0000000000000003'),
+		(7, 'namespace', NAMESPACE_ID, '0000000000000007'),
+		(5, 'account', None, '0000000000000005'),
+		(6, 'mosaic', MOSAIC_ID, '0000000000000006')
+	]
+	type_numbers = {'account': 0, 'mosaic': 1, 'namespace': 2}
+	keys = [{
+		'metadata_type': metadata_type,
+		'source_address': bytes.fromhex(SOURCE_ADDRESS),
+		'target_address': bytes.fromhex(TARGET_ADDRESS),
+		'scoped_metadata_key': scoped_metadata_key,
+		'target_id': target_id
+	} for _, metadata_type, target_id, scoped_metadata_key in key_specs]
+	metadata_by_query = {}
+	expected_paths = []
+	for index, metadata_type, target_id, scoped_metadata_key in key_specs:
+		path = metadata_path(
+			type_numbers[metadata_type],
+			target_id,
+			source_address=SOURCE_ADDRESS,
+			target_address=TARGET_ADDRESS,
+			scoped_metadata_key=scoped_metadata_key)
+		expected_paths.append(path)
+		metadata_by_query[path] = {'data': [create_metadata_item(
+			composite_hash=f'{index + 1:064X}',
+			metadata_type=type_numbers[metadata_type],
+			target_id=target_id or '0000000000000000',
+			source_address=SOURCE_ADDRESS,
+			target_address=TARGET_ADDRESS,
+			scoped_metadata_key=scoped_metadata_key)]}
+
+	return keys, metadata_by_query, expected_paths, key_specs
+
+
+def _create_metadata_node_transaction(height, **transaction_fields):
+	transaction = create_node_transaction(height, **transaction_fields)
+	del transaction['transaction']['recipientAddress']
+	del transaction['transaction']['mosaics']
+	return transaction
+
+
+def _create_metadata_embedded_transaction(height, aggregate_hash, embedded_index, **transaction_fields):
+	transaction = create_embedded_node_transaction(height, aggregate_hash, embedded_index, **transaction_fields)
+	del transaction['transaction']['recipientAddress']
+	del transaction['transaction']['mosaics']
+	return transaction
+
+
+def _create_metadata_block(transactions_count, total_transactions_count):
+	block = create_node_block(1)
+	block['meta'].update({
+		'transactionsCount': transactions_count,
+		'totalTransactionsCount': total_transactions_count
+	})
+	return block
+
+
+def _create_embedded_metadata_transactions(
+	transaction_type,
+	include_decoy=False,
+	decoy_address=RECIPIENT_ADDRESS,
+	decoy_mosaic_id=DECOY_MOSAIC_ID,
+	**transaction_fields
+):  # pylint: disable=too-many-arguments,too-many-positional-arguments
+	decoy_transaction = None
+	if include_decoy:
+		decoy_transaction = create_node_transaction(
+			1,
+			transaction_hash='D' * 64,
+			transaction_id='decoy-transfer',
+			block_index=0,
+			recipientAddress=decoy_address,
+			mosaics=[{'id': decoy_mosaic_id, 'amount': '1000'}])
+
+	aggregate_hash = 'A' * 64
+	parent_transaction = _create_metadata_node_transaction(
+		1,
+		transaction_hash=aggregate_hash,
+		transaction_id='aggregate',
+		block_index=1 if include_decoy else 0,
+		type=TransactionType.AGGREGATE_COMPLETE.value,
+		transactionsHash='9' * 64,
+		cosignatures=[])
+	embedded_transaction = _create_metadata_embedded_transaction(
+		1,
+		aggregate_hash,
+		0,
+		transaction_id='embedded-metadata',
+		type=transaction_type,
+		**transaction_fields)
+	transactions = [parent_transaction, embedded_transaction]
+	if decoy_transaction is not None:
+		transactions.insert(0, decoy_transaction)
+
+	return decoy_transaction, parent_transaction, embedded_transaction, transactions
+
+
+def _create_embedded_metadata_fixture(
+	target_address,
+	target_mosaic_id,
+	resolved_address=RECIPIENT_ADDRESS,
+	resolved_mosaic_id=RESOLVED_MOSAIC_ID,
+	address_resolution_entries=None,
+	mosaic_resolution_entries=None,
+	include_decoy=False,
+	decoy_address=RECIPIENT_ADDRESS,
+	decoy_mosaic_id=DECOY_MOSAIC_ID,
+	connector_class=FakeConnector
+):  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
+	decoy_transaction, parent_transaction, embedded_transaction, transactions = _create_embedded_metadata_transactions(
+		TransactionType.MOSAIC_METADATA.value,
+		include_decoy=include_decoy,
+		decoy_address=decoy_address,
+		decoy_mosaic_id=decoy_mosaic_id,
+		targetAddress=target_address,
+		targetMosaicId=target_mosaic_id,
+		scopedMetadataKey=SCOPED_METADATA_KEY,
+		valueSizeDelta=5,
+		value='68656C6C6F')
+	metadata_item = create_metadata_item(
+		metadata_type=1,
+		target_id=resolved_mosaic_id,
+		composite_hash=METADATA_COMPOSITE_HASH,
+		target_address=resolved_address,
+		item_id='embedded-metadata-result')
+	address_resolution_items = [] if address_resolution_entries is None else [create_resolution_statement(
+		1, target_address, address_resolution_entries)]
+	mosaic_resolution_items = [] if mosaic_resolution_entries is None else [create_resolution_statement(
+		1, target_mosaic_id, mosaic_resolution_entries)]
+	connector = connector_class(
+		1,
+		{0: [_create_metadata_block(
+			2 if decoy_transaction is not None else 1,
+			3 if decoy_transaction is not None else 2)]},
+		transactions_by_path={transaction_path(1, 1): {'data': transactions}},
+		address_resolutions_by_height={1: address_resolution_items},
+		mosaic_resolutions_by_height={1: mosaic_resolution_items},
+		metadata_by_query={metadata_path(
+			1,
+			resolved_mosaic_id,
+			source_address=SOURCE_ADDRESS,
+			target_address=resolved_address,
+			scoped_metadata_key=SCOPED_METADATA_KEY): {'data': [metadata_item]}})
+	return connector, decoy_transaction, parent_transaction, embedded_transaction, transactions, metadata_item
+
+
+def _create_resolution_entry(primary_id, secondary_id, resolved):
+	return {'source': {'primaryId': primary_id, 'secondaryId': secondary_id}, 'resolved': resolved}
+
+
+class SymbolPullerMetadataTest(SymbolPullerTestBase):  # pylint: disable=too-many-public-methods
+	def test_collect_dirty_metadata_keys_maps_account_mosaic_and_namespace_transactions(self):
+		# Arrange:
+		rows = {
+			1: [
+				{'type': TransactionType.ACCOUNT_METADATA.value, 'signer_address': bytes.fromhex(SIGNER_ADDRESS),
+					'target_address': bytes.fromhex(RECIPIENT_ADDRESS), 'metadata_target_id': None,
+					'body': {'targetAddress': RECIPIENT_ADDRESS, 'scopedMetadataKey': '0000000000000001'}},
+				{'type': TransactionType.MOSAIC_METADATA.value, 'signer_address': bytes.fromhex(SIGNER_ADDRESS),
+					'target_address': bytes.fromhex(RECIPIENT_ADDRESS), 'metadata_target_id': MOSAIC_ID,
+					'body': {'targetAddress': RECIPIENT_ADDRESS, 'targetMosaicId': MOSAIC_ID, 'scopedMetadataKey': '0000000000000002'}},
+				{'type': TransactionType.NAMESPACE_METADATA.value, 'signer_address': bytes.fromhex(SIGNER_ADDRESS),
+					'target_address': bytes.fromhex(RECIPIENT_ADDRESS), 'metadata_target_id': None,
+					'body': {'targetAddress': RECIPIENT_ADDRESS, 'targetNamespaceId': NAMESPACE_ID, 'scopedMetadataKey': '0000000000000003'}}
+			]
+		}
+
+		# Act:
+		keys = self.puller._collect_dirty_metadata_keys_for_batch(rows)  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual([
+			{'metadata_type': 'account', 'source_address': bytes.fromhex(SIGNER_ADDRESS),
+				'target_address': bytes.fromhex(RECIPIENT_ADDRESS), 'scoped_metadata_key': '0000000000000001', 'target_id': None},
+			{'metadata_type': 'mosaic', 'source_address': bytes.fromhex(SIGNER_ADDRESS),
+				'target_address': bytes.fromhex(RECIPIENT_ADDRESS), 'scoped_metadata_key': '0000000000000002', 'target_id': MOSAIC_ID},
+			{'metadata_type': 'namespace', 'source_address': bytes.fromhex(SIGNER_ADDRESS),
+				'target_address': bytes.fromhex(RECIPIENT_ADDRESS), 'scoped_metadata_key': '0000000000000003', 'target_id': NAMESPACE_ID}
+		], keys)
+
+	def test_collect_dirty_metadata_keys_deduplicates_repeated_keys_in_first_encounter_order(self):
+		# Arrange:
+		rows = {
+			1: [
+				{'type': TransactionType.NAMESPACE_METADATA.value, 'signer_address': bytes.fromhex(SIGNER_ADDRESS),
+					'target_address': bytes.fromhex(RECIPIENT_ADDRESS), 'metadata_target_id': None,
+					'body': {'targetAddress': RECIPIENT_ADDRESS, 'targetNamespaceId': NAMESPACE_ID, 'scopedMetadataKey': '0000000000000003'}},
+				{'type': TransactionType.ACCOUNT_METADATA.value, 'signer_address': bytes.fromhex(SIGNER_ADDRESS),
+					'target_address': bytes.fromhex(RECIPIENT_ADDRESS), 'metadata_target_id': None,
+					'body': {'targetAddress': RECIPIENT_ADDRESS, 'scopedMetadataKey': '0000000000000001'}},
+				{'type': TransactionType.MOSAIC_METADATA.value, 'signer_address': bytes.fromhex(SIGNER_ADDRESS),
+					'target_address': bytes.fromhex(RECIPIENT_ADDRESS), 'metadata_target_id': MOSAIC_ID,
+					'body': {'targetAddress': RECIPIENT_ADDRESS, 'targetMosaicId': MOSAIC_ID, 'scopedMetadataKey': '0000000000000002'}},
+				{'type': TransactionType.NAMESPACE_METADATA.value, 'signer_address': bytes.fromhex(SIGNER_ADDRESS),
+					'target_address': bytes.fromhex(RECIPIENT_ADDRESS), 'metadata_target_id': None,
+					'body': {'targetAddress': RECIPIENT_ADDRESS, 'targetNamespaceId': NAMESPACE_ID, 'scopedMetadataKey': '0000000000000003'}},
+				{'type': TransactionType.ACCOUNT_METADATA.value, 'signer_address': bytes.fromhex(SIGNER_ADDRESS),
+					'target_address': bytes.fromhex(RECIPIENT_ADDRESS), 'metadata_target_id': None,
+					'body': {'targetAddress': RECIPIENT_ADDRESS, 'scopedMetadataKey': '0000000000000001'}}
+			]
+		}
+
+		# Act:
+		keys = self.puller._collect_dirty_metadata_keys_for_batch(rows)  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual([
+			{'metadata_type': 'namespace', 'source_address': bytes.fromhex(SIGNER_ADDRESS),
+				'target_address': bytes.fromhex(RECIPIENT_ADDRESS), 'scoped_metadata_key': '0000000000000003', 'target_id': NAMESPACE_ID},
+			{'metadata_type': 'account', 'source_address': bytes.fromhex(SIGNER_ADDRESS),
+				'target_address': bytes.fromhex(RECIPIENT_ADDRESS), 'scoped_metadata_key': '0000000000000001', 'target_id': None},
+			{'metadata_type': 'mosaic', 'source_address': bytes.fromhex(SIGNER_ADDRESS),
+				'target_address': bytes.fromhex(RECIPIENT_ADDRESS), 'scoped_metadata_key': '0000000000000002', 'target_id': MOSAIC_ID}
+		], keys)
+
+	def test_collect_dirty_metadata_keys_ignores_non_metadata_transactions(self):
+		# Arrange:
+		rows = {
+			1: [{'type': TransactionType.TRANSFER.value, 'signer_address': bytes.fromhex(SIGNER_ADDRESS), 'body': {}}]
+		}
+
+		# Act:
+		keys = self.puller._collect_dirty_metadata_keys_for_batch(rows)  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual([], keys)
+
+	def test_collect_dirty_metadata_keys_returns_empty_for_empty_batch(self):
+		# Arrange:
+		rows = {}
+
+		# Act:
+		keys = self.puller._collect_dirty_metadata_keys_for_batch(rows)  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual([], keys)
+
+	def test_collect_dirty_metadata_keys_uses_resolved_target_address_for_account_metadata(self):
+		# Arrange:
+		alias_address = '99065A28385EB5AE88000000000000000000000000000000'
+		row = {
+			'type': TransactionType.ACCOUNT_METADATA.value,
+			'signer_address': bytes.fromhex(SIGNER_ADDRESS),
+			'target_address': bytes.fromhex(TARGET_ADDRESS),
+			'metadata_target_id': None,
+			'body': {'targetAddress': alias_address, 'scopedMetadataKey': '0000000000000004'}
+		}
+
+		# Act:
+		keys = self.puller._collect_dirty_metadata_keys_for_batch({1: [row]})  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual([{
+			'metadata_type': 'account', 'source_address': bytes.fromhex(SIGNER_ADDRESS),
+			'target_address': bytes.fromhex(TARGET_ADDRESS), 'scoped_metadata_key': '0000000000000004', 'target_id': None
+		}], keys)
+
+	def test_collect_dirty_metadata_keys_uses_resolved_target_address_for_mosaic_metadata(self):
+		# Arrange:
+		alias_address = '99065A28385EB5AE88000000000000000000000000000000'
+		row = {
+			'type': TransactionType.MOSAIC_METADATA.value,
+			'signer_address': bytes.fromhex(SIGNER_ADDRESS),
+			'target_address': bytes.fromhex(TARGET_ADDRESS),
+			'metadata_target_id': MOSAIC_ID,
+			'body': {
+				'targetAddress': alias_address,
+				'targetMosaicId': MOSAIC_ID,
+				'scopedMetadataKey': '0000000000000005'
+			}
+		}
+
+		# Act:
+		keys = self.puller._collect_dirty_metadata_keys_for_batch({1: [row]})  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual([{
+			'metadata_type': 'mosaic', 'source_address': bytes.fromhex(SIGNER_ADDRESS),
+			'target_address': bytes.fromhex(TARGET_ADDRESS), 'scoped_metadata_key': '0000000000000005', 'target_id': MOSAIC_ID
+		}], keys)
+
+	def test_collect_dirty_metadata_keys_uses_resolved_target_address_for_namespace_metadata(self):
+		# Arrange:
+		alias_address = '99065A28385EB5AE88000000000000000000000000000000'
+		row = {
+			'type': TransactionType.NAMESPACE_METADATA.value,
+			'signer_address': bytes.fromhex(SIGNER_ADDRESS),
+			'target_address': bytes.fromhex(TARGET_ADDRESS),
+			'metadata_target_id': None,
+			'body': {
+				'targetAddress': alias_address,
+				'targetNamespaceId': NAMESPACE_ID,
+				'scopedMetadataKey': '0000000000000006'
+			}
+		}
+
+		# Act:
+		keys = self.puller._collect_dirty_metadata_keys_for_batch({1: [row]})  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual([{
+			'metadata_type': 'namespace', 'source_address': bytes.fromhex(SIGNER_ADDRESS),
+			'target_address': bytes.fromhex(TARGET_ADDRESS), 'scoped_metadata_key': '0000000000000006', 'target_id': NAMESPACE_ID
+		}], keys)
+
+	def test_collect_dirty_metadata_keys_uses_resolved_mosaic_target_id_for_mosaic_alias(self):
+		# Arrange:
+		alias_mosaic_id = ALIAS_MOSAIC_ID
+		row = {
+			'type': TransactionType.MOSAIC_METADATA.value,
+			'signer_address': bytes.fromhex(SIGNER_ADDRESS),
+			'target_address': bytes.fromhex(TARGET_ADDRESS),
+			'metadata_target_id': MOSAIC_ID,
+			'body': {
+				'targetAddress': RECIPIENT_ADDRESS,
+				'targetMosaicId': alias_mosaic_id,
+				'scopedMetadataKey': '0000000000000007'
+			}
+		}
+
+		# Act:
+		keys = self.puller._collect_dirty_metadata_keys_for_batch({1: [row]})  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual([{
+			'metadata_type': 'mosaic', 'source_address': bytes.fromhex(SIGNER_ADDRESS),
+			'target_address': bytes.fromhex(TARGET_ADDRESS), 'scoped_metadata_key': '0000000000000007', 'target_id': MOSAIC_ID
+		}], keys)
+
+	def test_fetch_dirty_metadata_uses_exact_request_contract_for_each_metadata_type(self):
+		# Arrange:
+		keys = [
+			{'metadata_type': 'account', 'source_address': bytes.fromhex(SIGNER_ADDRESS),
+				'target_address': bytes.fromhex(RECIPIENT_ADDRESS), 'scoped_metadata_key': SCOPED_METADATA_KEY, 'target_id': None},
+			{'metadata_type': 'mosaic', 'source_address': bytes.fromhex(SIGNER_ADDRESS),
+				'target_address': bytes.fromhex(RECIPIENT_ADDRESS), 'scoped_metadata_key': SCOPED_METADATA_KEY, 'target_id': MOSAIC_ID},
+			{'metadata_type': 'namespace', 'source_address': bytes.fromhex(SIGNER_ADDRESS),
+				'target_address': bytes.fromhex(RECIPIENT_ADDRESS), 'scoped_metadata_key': SCOPED_METADATA_KEY, 'target_id': NAMESPACE_ID}
+		]
+		expected_paths = [metadata_path(0), metadata_path(1, MOSAIC_ID), metadata_path(2, NAMESPACE_ID)]
+		metadata_by_query = {
+			expected_paths[0]: {'data': [create_metadata_item(metadata_type=0, scoped_metadata_key=SCOPED_METADATA_KEY)]},
+			expected_paths[1]: {'data': [create_metadata_item(metadata_type=1, target_id=MOSAIC_ID, scoped_metadata_key=SCOPED_METADATA_KEY)]},
+			expected_paths[2]: {'data': [create_metadata_item(metadata_type=2, target_id=NAMESPACE_ID, scoped_metadata_key=SCOPED_METADATA_KEY)]}
+		}
+		connector = FakeConnector(1, {}, metadata_by_query=metadata_by_query)
+		set_symbol_connector(self.puller, connector)
+
+		# Act:
+		asyncio.run(self.puller._fetch_dirty_metadata(keys, 9))  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual(expected_paths, connector.paths)
+
+	def test_fetch_dirty_metadata_preserves_order_across_bounded_chunks(self):
+		# Arrange:
+		keys, metadata_by_query, expected_paths, key_specs = _create_metadata_fetch_fixture()
+		connector = FakeConnector(1, {}, metadata_by_query=metadata_by_query)
+		set_symbol_connector(self.puller, connector)
+
+		# Act:
+		entries = asyncio.run(self.puller._fetch_dirty_metadata(keys, 9))  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual([f'{index + 1:064X}' for index, _, _, _ in key_specs], [
+			entry['row']['composite_hash'].hex().upper() for entry in entries])
+		self.assertEqual(expected_paths, connector.paths)
+
+	def test_fetch_dirty_metadata_limits_bounded_concurrency(self):
+		# Arrange:
+		keys, metadata_by_query, _, _ = _create_metadata_fetch_fixture()
+		connector = BoundedMetadataConnector(1, {}, metadata_by_query=metadata_by_query)
+		set_symbol_connector(self.puller, connector)
+
+		# Act:
+		asyncio.run(self.puller._fetch_dirty_metadata(keys, 9))  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertGreater(connector.max_in_flight_detail_requests, 1)
+		self.assertLessEqual(connector.max_in_flight_detail_requests, METADATA_FETCH_CONCURRENCY)
+		self.assertEqual(0, connector.in_flight_detail_requests)
+		self.assertEqual(11, len(connector.paths))
+
+	def test_fetch_dirty_metadata_returns_delete_entry_for_empty_search(self):
+		# Arrange:
+		key = {
+			'metadata_type': 'mosaic',
+			'source_address': bytes.fromhex(SIGNER_ADDRESS),
+			'target_address': bytes.fromhex(RECIPIENT_ADDRESS),
+			'scoped_metadata_key': SCOPED_METADATA_KEY,
+			'target_id': MOSAIC_ID
+		}
+		connector = FakeConnector(1, {}, metadata_by_query={metadata_path(1, MOSAIC_ID): {'data': []}})
+		set_symbol_connector(self.puller, connector)
+
+		# Act:
+		entries = asyncio.run(self.puller._fetch_dirty_metadata([key], 9))  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual([{'key': key}], entries)
+		self.assertEqual([metadata_path(1, MOSAIC_ID)], connector.paths)
+
+	def test_write_dirty_metadata_deletes_empty_exact_key(self):
+		# Arrange:
+		key = {
+			'metadata_type': 'mosaic',
+			'source_address': bytes.fromhex(SIGNER_ADDRESS),
+			'target_address': bytes.fromhex(RECIPIENT_ADDRESS),
+			'scoped_metadata_key': SCOPED_METADATA_KEY,
+			'target_id': MOSAIC_ID
+		}
+		item = create_metadata_item(metadata_type=1, target_id=MOSAIC_ID, composite_hash='11' * 32)
+		sibling_item = create_metadata_item(metadata_type=1, target_id=NAMESPACE_ID, composite_hash='22' * 32)
+		sibling_row = create_expected_metadata_row(
+			sibling_item, 1, composite_hash=bytes.fromhex('22' * 32), metadata_type='mosaic',
+			target_id=NAMESPACE_ID, value_utf8='hello')
+		self.puller.symbol_db.upsert_metadata(create_expected_metadata_row(
+			item, 1, composite_hash=bytes.fromhex('11' * 32), metadata_type='mosaic',
+			target_id=MOSAIC_ID, value_utf8='hello'))
+		self.puller.symbol_db.upsert_metadata(sibling_row)
+
+		# Act:
+		self.puller._write_dirty_metadata([{'key': key}])  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual([sibling_row], fetch_metadata_rows(self.puller.symbol_db))
+
+	def test_fetch_dirty_metadata_rejects_malformed_response(self):
+		# Arrange:
+		key = {
+			'metadata_type': 'account',
+			'source_address': bytes.fromhex(SIGNER_ADDRESS),
+			'target_address': bytes.fromhex(RECIPIENT_ADDRESS),
+			'scoped_metadata_key': SCOPED_METADATA_KEY,
+			'target_id': None
+		}
+		connector = FakeConnector(1, {}, metadata_by_query={metadata_path(0): None})
+		set_symbol_connector(self.puller, connector)
+
+		# Act:
+		with self.assertRaisesRegex(ValueError, '^Malformed Symbol metadata search response$'):
+			asyncio.run(self.puller._fetch_dirty_metadata([key], 9))  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual([metadata_path(0)], connector.paths)
+
+	def test_fetch_dirty_metadata_rejects_response_missing_data(self):
+		# Arrange:
+		key = {
+			'metadata_type': 'account',
+			'source_address': bytes.fromhex(SIGNER_ADDRESS),
+			'target_address': bytes.fromhex(RECIPIENT_ADDRESS),
+			'scoped_metadata_key': SCOPED_METADATA_KEY,
+			'target_id': None
+		}
+		connector = FakeConnector(1, {}, metadata_by_query={metadata_path(0): {}})
+		set_symbol_connector(self.puller, connector)
+
+		# Act:
+		with self.assertRaisesRegex(ValueError, '^Malformed Symbol metadata search response$'):
+			asyncio.run(self.puller._fetch_dirty_metadata([key], 9))  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual([metadata_path(0)], connector.paths)
+
+	def test_fetch_dirty_metadata_rejects_non_list_data(self):
+		# Arrange:
+		key = {
+			'metadata_type': 'account',
+			'source_address': bytes.fromhex(SIGNER_ADDRESS),
+			'target_address': bytes.fromhex(RECIPIENT_ADDRESS),
+			'scoped_metadata_key': SCOPED_METADATA_KEY,
+			'target_id': None
+		}
+		connector = FakeConnector(1, {}, metadata_by_query={metadata_path(0): {'data': {}}})
+		set_symbol_connector(self.puller, connector)
+
+		# Act:
+		with self.assertRaisesRegex(ValueError, '^Malformed Symbol metadata search data$'):
+			asyncio.run(self.puller._fetch_dirty_metadata([key], 9))  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual([metadata_path(0)], connector.paths)
+
+	def test_fetch_dirty_metadata_rejects_multiple_entries(self):
+		# Arrange:
+		key = {
+			'metadata_type': 'account',
+			'source_address': bytes.fromhex(SIGNER_ADDRESS),
+			'target_address': bytes.fromhex(RECIPIENT_ADDRESS),
+			'scoped_metadata_key': SCOPED_METADATA_KEY,
+			'target_id': None
+		}
+		connector = FakeConnector(1, {}, metadata_by_query={metadata_path(0): {
+			'data': [create_metadata_item(), create_metadata_item(composite_hash='22' * 32)]
+		}})
+		set_symbol_connector(self.puller, connector)
+
+		# Act:
+		with self.assertRaisesRegex(ValueError, '^Symbol metadata exact-key search returned multiple entries$'):
+			asyncio.run(self.puller._fetch_dirty_metadata([key], 9))  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual([metadata_path(0)], connector.paths)
+
+	def test_fetch_dirty_metadata_returns_empty_for_no_keys(self):
+		# Arrange:
+		connector = FakeConnector(1, {})
+		set_symbol_connector(self.puller, connector)
+
+		# Act:
+		entries = asyncio.run(self.puller._fetch_dirty_metadata([], 9))  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual([], entries)
+		self.assertEqual([], connector.paths)
+
+	def _assert_embedded_metadata_persisted(
+		self,
+		connector,
+		transactions_snapshot,
+		embedded_transaction_snapshot,
+		expected_metadata_row,
+		expected_path,
+		expected_resolution_paths,
+		expected_body
+	):  # pylint: disable=too-many-arguments,too-many-positional-arguments
+		# Assert:
+		metadata_paths = [path for path in connector.paths if path.startswith('metadata?')]
+		resolution_paths = [path for path in connector.paths if path.startswith('statements/resolutions/')]
+		self.assertEqual([expected_path], metadata_paths)
+		self.assertEqual(expected_resolution_paths, resolution_paths)
+		self.assertEqual(transactions_snapshot, connector.transactions_by_path[transaction_path(1, 1)]['data'])
+		self.assertEqual([expected_metadata_row], fetch_metadata_rows(self.puller.symbol_db))
+		cursor = self.puller.symbol_db.connection.cursor()
+		cursor.execute(
+			'SELECT body, raw_payload FROM symbol_transactions WHERE aggregate_hash IS NOT NULL')
+		persisted_body, persisted_raw_payload = cursor.fetchone()
+		self.assertEqual(expected_body, persisted_body)
+		self.assertEqual(embedded_transaction_snapshot, persisted_raw_payload)
+
+	def test_sync_block_headers_persists_direct_mosaic_metadata_from_embedded_transaction(self):
+		# Arrange:
+		connector, _, _, embedded_transaction, transactions, metadata_item = _create_embedded_metadata_fixture(
+			RECIPIENT_ADDRESS, MOSAIC_ID)
+		expected_path = metadata_path(1, MOSAIC_ID)
+		transactions_snapshot = copy.deepcopy(transactions)
+		embedded_transaction_snapshot = copy.deepcopy(embedded_transaction)
+		metadata_item_snapshot = copy.deepcopy(metadata_item)
+		expected_metadata_row = create_expected_metadata_row(
+			metadata_item_snapshot,
+			1,
+			composite_hash=bytes.fromhex(METADATA_COMPOSITE_HASH),
+			metadata_type='mosaic',
+			target_id=MOSAIC_ID,
+			value_utf8='hello')
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self._assert_embedded_metadata_persisted(
+			connector, transactions_snapshot, embedded_transaction_snapshot, expected_metadata_row, expected_path, [],
+			{
+				'version': 1,
+				'network': 152,
+				'targetAddress': RECIPIENT_ADDRESS,
+				'targetMosaicId': MOSAIC_ID,
+				'scopedMetadataKey': SCOPED_METADATA_KEY,
+				'valueSizeDelta': 5,
+				'value': '68656C6C6F'
+			})
+
+	def test_sync_block_headers_resolves_address_alias_for_embedded_metadata(self):
+		# Arrange:
+		connector, _, _, embedded_transaction, transactions, metadata_item = _create_embedded_metadata_fixture(
+			ALIAS_ADDRESS,
+			MOSAIC_ID,
+			include_decoy=True,
+			decoy_address=ALIAS_ADDRESS,
+			address_resolution_entries=[
+				_create_resolution_entry(1, 0, SIGNER_ADDRESS),
+				_create_resolution_entry(2, 1, RECIPIENT_ADDRESS)])
+		expected_path = metadata_path(1, MOSAIC_ID)
+		transactions_snapshot = copy.deepcopy(transactions)
+		embedded_transaction_snapshot = copy.deepcopy(embedded_transaction)
+		metadata_item_snapshot = copy.deepcopy(metadata_item)
+		expected_metadata_row = create_expected_metadata_row(
+			metadata_item_snapshot,
+			1,
+			composite_hash=bytes.fromhex(METADATA_COMPOSITE_HASH),
+			metadata_type='mosaic',
+			target_id=MOSAIC_ID,
+			value_utf8='hello')
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self._assert_embedded_metadata_persisted(
+			connector, transactions_snapshot, embedded_transaction_snapshot, expected_metadata_row, expected_path,
+			[resolution_path('address', 1)], {
+				'version': 1,
+				'network': 152,
+				'targetAddress': ALIAS_ADDRESS,
+				'targetMosaicId': MOSAIC_ID,
+				'scopedMetadataKey': SCOPED_METADATA_KEY,
+				'valueSizeDelta': 5,
+				'value': '68656C6C6F'
+			})
+
+	def test_sync_block_headers_resolves_mosaic_target_id_alias_for_embedded_metadata(self):
+		# Arrange:
+		connector, _, _, embedded_transaction, transactions, metadata_item = _create_embedded_metadata_fixture(
+			RECIPIENT_ADDRESS,
+			ALIAS_MOSAIC_ID,
+			include_decoy=True,
+			decoy_mosaic_id=ALIAS_MOSAIC_ID,
+			mosaic_resolution_entries=[
+				_create_resolution_entry(1, 0, DECOY_MOSAIC_ID),
+				_create_resolution_entry(2, 1, RESOLVED_MOSAIC_ID)])
+		expected_path = metadata_path(1, RESOLVED_MOSAIC_ID)
+		transactions_snapshot = copy.deepcopy(transactions)
+		embedded_transaction_snapshot = copy.deepcopy(embedded_transaction)
+		metadata_item_snapshot = copy.deepcopy(metadata_item)
+		expected_metadata_row = create_expected_metadata_row(
+			metadata_item_snapshot,
+			1,
+			composite_hash=bytes.fromhex(METADATA_COMPOSITE_HASH),
+			metadata_type='mosaic',
+			target_id=RESOLVED_MOSAIC_ID,
+			value_utf8='hello')
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self._assert_embedded_metadata_persisted(
+			connector, transactions_snapshot, embedded_transaction_snapshot, expected_metadata_row, expected_path,
+			[resolution_path('mosaic', 1)], {
+				'version': 1,
+				'network': 152,
+				'targetAddress': RECIPIENT_ADDRESS,
+				'targetMosaicId': ALIAS_MOSAIC_ID,
+				'scopedMetadataKey': SCOPED_METADATA_KEY,
+				'valueSizeDelta': 5,
+				'value': '68656C6C6F'
+			})
+
+	def test_sync_block_headers_resolves_address_and_mosaic_aliases_for_embedded_metadata(self):
+		# Arrange:
+		connector, _, _, embedded_transaction, transactions, metadata_item = _create_embedded_metadata_fixture(
+			ALIAS_ADDRESS,
+			ALIAS_MOSAIC_ID,
+			include_decoy=True,
+			decoy_address=ALIAS_ADDRESS,
+			decoy_mosaic_id=ALIAS_MOSAIC_ID,
+			address_resolution_entries=[
+				_create_resolution_entry(1, 0, SIGNER_ADDRESS),
+				_create_resolution_entry(2, 1, RECIPIENT_ADDRESS)],
+			mosaic_resolution_entries=[
+				_create_resolution_entry(1, 0, DECOY_MOSAIC_ID),
+				_create_resolution_entry(2, 1, RESOLVED_MOSAIC_ID)])
+		expected_path = metadata_path(1, RESOLVED_MOSAIC_ID)
+		transactions_snapshot = copy.deepcopy(transactions)
+		embedded_transaction_snapshot = copy.deepcopy(embedded_transaction)
+		metadata_item_snapshot = copy.deepcopy(metadata_item)
+		expected_metadata_row = create_expected_metadata_row(
+			metadata_item_snapshot,
+			1,
+			composite_hash=bytes.fromhex(METADATA_COMPOSITE_HASH),
+			metadata_type='mosaic',
+			target_id=RESOLVED_MOSAIC_ID,
+			value_utf8='hello')
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self._assert_embedded_metadata_persisted(
+			connector, transactions_snapshot, embedded_transaction_snapshot, expected_metadata_row, expected_path,
+			[resolution_path('address', 1), resolution_path('mosaic', 1)],
+			{
+				'version': 1,
+				'network': 152,
+				'targetAddress': ALIAS_ADDRESS,
+				'targetMosaicId': ALIAS_MOSAIC_ID,
+				'scopedMetadataKey': SCOPED_METADATA_KEY,
+				'valueSizeDelta': 5,
+				'value': '68656C6C6F'
+			})
+
+	def test_sync_block_headers_resolves_address_alias_and_persists_account_metadata(self):
+		# Arrange:
+		_, _, embedded_transaction, transactions = _create_embedded_metadata_transactions(
+			TransactionType.ACCOUNT_METADATA.value,
+			include_decoy=True,
+			decoy_address=ALIAS_ADDRESS,
+			targetAddress=ALIAS_ADDRESS,
+			scopedMetadataKey=SCOPED_METADATA_KEY,
+			valueSizeDelta=5,
+			value='68656C6C6F')
+		metadata_item = create_metadata_item(
+			metadata_type=0,
+			target_id='0000000000000000',
+			composite_hash=ACCOUNT_METADATA_COMPOSITE_HASH,
+			item_id='account-metadata-result',
+			target_address=RECIPIENT_ADDRESS)
+		expected_path = metadata_path(
+			0,
+			source_address=SOURCE_ADDRESS,
+			target_address=RECIPIENT_ADDRESS,
+			scoped_metadata_key=SCOPED_METADATA_KEY)
+		connector = FakeConnector(
+			1,
+			{0: [_create_metadata_block(2, 3)]},
+			transactions_by_path={transaction_path(1, 1): {'data': transactions}},
+			address_resolutions_by_height={1: [create_resolution_statement(
+				1, ALIAS_ADDRESS, [
+					_create_resolution_entry(1, 0, SIGNER_ADDRESS),
+					_create_resolution_entry(2, 1, RECIPIENT_ADDRESS)])]},
+			mosaic_resolutions_by_height={1: []},
+			metadata_by_query={expected_path: {'data': [metadata_item]}})
+		transactions_snapshot = copy.deepcopy(transactions)
+		embedded_transaction_snapshot = copy.deepcopy(embedded_transaction)
+		metadata_item_snapshot = copy.deepcopy(metadata_item)
+		expected_metadata_row = create_expected_metadata_row(
+			metadata_item_snapshot,
+			1,
+			composite_hash=bytes.fromhex(ACCOUNT_METADATA_COMPOSITE_HASH),
+			metadata_type='account',
+			target_id=None,
+			value_utf8='hello')
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self._assert_embedded_metadata_persisted(
+			connector, transactions_snapshot, embedded_transaction_snapshot, expected_metadata_row, expected_path,
+			[resolution_path('address', 1)], {
+				'version': 1,
+				'network': 152,
+				'targetAddress': ALIAS_ADDRESS,
+				'scopedMetadataKey': SCOPED_METADATA_KEY,
+				'valueSizeDelta': 5,
+				'value': '68656C6C6F'
+			})
+
+	def test_sync_block_headers_resolves_address_alias_and_persists_namespace_metadata(self):
+		# Arrange:
+		_, _, embedded_transaction, transactions = _create_embedded_metadata_transactions(
+			TransactionType.NAMESPACE_METADATA.value,
+			include_decoy=True,
+			decoy_address=ALIAS_ADDRESS,
+			targetAddress=ALIAS_ADDRESS,
+			targetNamespaceId=NAMESPACE_ID,
+			scopedMetadataKey=SCOPED_METADATA_KEY,
+			valueSizeDelta=5,
+			value='68656C6C6F')
+		metadata_item = create_metadata_item(
+			metadata_type=2,
+			target_id=NAMESPACE_ID,
+			composite_hash=NAMESPACE_METADATA_COMPOSITE_HASH,
+			item_id='namespace-metadata-result',
+			target_address=RECIPIENT_ADDRESS)
+		expected_path = metadata_path(
+			2,
+			NAMESPACE_ID,
+			source_address=SOURCE_ADDRESS,
+			target_address=RECIPIENT_ADDRESS,
+			scoped_metadata_key=SCOPED_METADATA_KEY)
+		connector = FakeConnector(
+			1,
+			{0: [_create_metadata_block(2, 3)]},
+			transactions_by_path={transaction_path(1, 1): {'data': transactions}},
+			address_resolutions_by_height={1: [create_resolution_statement(
+				1, ALIAS_ADDRESS, [
+					_create_resolution_entry(1, 0, SIGNER_ADDRESS),
+					_create_resolution_entry(2, 1, RECIPIENT_ADDRESS)])]},
+			mosaic_resolutions_by_height={1: []},
+			metadata_by_query={expected_path: {'data': [metadata_item]}})
+		transactions_snapshot = copy.deepcopy(transactions)
+		embedded_transaction_snapshot = copy.deepcopy(embedded_transaction)
+		metadata_item_snapshot = copy.deepcopy(metadata_item)
+		expected_metadata_row = create_expected_metadata_row(
+			metadata_item_snapshot,
+			1,
+			composite_hash=bytes.fromhex(NAMESPACE_METADATA_COMPOSITE_HASH),
+			metadata_type='namespace',
+			target_id=NAMESPACE_ID,
+			value_utf8='hello')
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self._assert_embedded_metadata_persisted(
+			connector, transactions_snapshot, embedded_transaction_snapshot, expected_metadata_row, expected_path,
+			[resolution_path('address', 1)],
+			{
+				'version': 1,
+				'network': 152,
+				'targetAddress': ALIAS_ADDRESS,
+				'targetNamespaceId': NAMESPACE_ID,
+				'scopedMetadataKey': SCOPED_METADATA_KEY,
+				'valueSizeDelta': 5,
+				'value': '68656C6C6F'
+			})
+
+	def test_write_dirty_metadata_found_row_failure_preserves_existing_row_without_predelete(self):
+		# Arrange:
+		original_item = create_metadata_item(metadata_type=1, target_id=MOSAIC_ID)
+		original_row = create_expected_metadata_row(
+			original_item,
+			123,
+			composite_hash=bytes.fromhex('11' * 32),
+			metadata_type='mosaic',
+			target_id=MOSAIC_ID,
+			value_utf8='hello')
+		self.puller.symbol_db.upsert_metadata(original_row)
+		invalid_updated_row = {**original_row, 'value_utf8': None}
+
+		# Act:
+		with self.assertRaises(PsycopgError):
+			self.puller._write_dirty_metadata([{'row': invalid_updated_row}])  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual([original_row], fetch_metadata_rows(self.puller.symbol_db))
+
+	def test_write_dirty_metadata_failure_keeps_connection_usable_and_preserves_target_row(self):
+		# Arrange:
+		original_item = create_metadata_item(metadata_type=1, target_id=MOSAIC_ID, composite_hash='11' * 32)
+		original_row = create_expected_metadata_row(
+			original_item,
+			123,
+			composite_hash=bytes.fromhex('11' * 32),
+			metadata_type='mosaic',
+			target_id=MOSAIC_ID,
+			value_utf8='hello')
+		sibling_item = create_metadata_item(
+			metadata_type=2,
+			target_id=NAMESPACE_ID,
+			composite_hash='22' * 32,
+			scoped_metadata_key='0000000000000002')
+		sibling_row = create_expected_metadata_row(
+			sibling_item,
+			123,
+			composite_hash=bytes.fromhex('22' * 32),
+			metadata_type='namespace',
+			scoped_metadata_key='0000000000000002',
+			target_id=NAMESPACE_ID,
+			value_utf8='hello')
+		self.puller.symbol_db.upsert_metadata(original_row)
+		self.puller.symbol_db.upsert_metadata(sibling_row)
+		invalid_updated_row = {**original_row, 'value_utf8': None}
+		valid_updated_sibling_row = {
+			**sibling_row,
+			'value_hex': '776F726C64',
+			'value_utf8': 'world',
+			'updated_at_height': 456
+		}
+
+		# Act:
+		with self.assertRaises(PsycopgError):
+			self.puller._write_dirty_metadata([{'row': invalid_updated_row}])  # pylint: disable=protected-access
+		self.puller._write_dirty_metadata([{'row': valid_updated_sibling_row}])  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual([original_row, valid_updated_sibling_row], fetch_metadata_rows(self.puller.symbol_db))
+
+	def _assert_embedded_mosaic_resolution_failure(self, connector, error_message):
+		# Arrange:
+		set_symbol_connector(self.puller, connector)
+
+		# Act:
+		with self.assertRaisesRegex(ValueError, error_message):
+			asyncio.run(self.puller.sync_block_headers())
+
+		# Assert:
+		cursor = self.puller.symbol_db.connection.cursor()
+		for table in (
+			'symbol_sync_state',
+			'symbol_blocks',
+			'symbol_account_refresh_state',
+			'symbol_accounts',
+			'symbol_account_mosaics',
+			'symbol_multisig',
+			'symbol_account_refresh_accounts',
+			'symbol_account_refresh_mosaics',
+			'symbol_account_list_ranks',
+			'symbol_namespaces',
+			'symbol_alias_names',
+			'symbol_mosaics',
+			'symbol_metadata',
+			'symbol_transactions',
+			'symbol_transaction_mosaics',
+			'symbol_transaction_addresses',
+			'symbol_receipts'
+		):
+			cursor.execute(f'SELECT COUNT(*) FROM {table}')
+			self.assertEqual(0, cursor.fetchone()[0])
+		self.assertEqual([resolution_path('mosaic', 1)], [
+			path for path in connector.paths if path.startswith('statements/resolutions/')])
+		self.assertIsNone(self.puller.symbol_db.get_sync_state())
+
+	def test_sync_block_headers_rejects_missing_mosaic_resolution_statement_for_embedded_metadata(self):
+		# Arrange:
+		connector, _, _, _, _, _ = _create_embedded_metadata_fixture(
+			RECIPIENT_ADDRESS, ALIAS_MOSAIC_ID, include_decoy=True)
+
+		# Act:
+		self._assert_embedded_mosaic_resolution_failure(
+			connector, 'Missing Symbol mosaic resolution at height 1')
+
+	def test_sync_block_headers_rejects_inapplicable_mosaic_resolution_entry_for_embedded_metadata(self):
+		# Arrange:
+		connector, _, _, _, _, _ = _create_embedded_metadata_fixture(
+			RECIPIENT_ADDRESS,
+			ALIAS_MOSAIC_ID,
+			include_decoy=True,
+			mosaic_resolution_entries=[_create_resolution_entry(3, 1, RESOLVED_MOSAIC_ID)])
+
+		# Act:
+		self._assert_embedded_mosaic_resolution_failure(
+			connector, 'Missing Symbol mosaic resolution entry at height 1')
+
+	def test_sync_block_headers_rejects_malformed_mosaic_resolution_response_for_embedded_metadata(self):
+		# Arrange:
+		connector, _, _, _, _, _ = _create_embedded_metadata_fixture(
+			RECIPIENT_ADDRESS,
+			ALIAS_MOSAIC_ID,
+			include_decoy=True,
+			connector_class=MalformedMosaicResolutionConnector)
+
+		# Act:
+		self._assert_embedded_mosaic_resolution_failure(
+			connector, 'Malformed Symbol mosaic resolution page response')
+
+	def test_sync_block_headers_converges_metadata_when_restarted_from_existing_blocks(self):
+		# Arrange:
+		connector, _, _, embedded_transaction, transactions, metadata_item = _create_embedded_metadata_fixture(
+			RECIPIENT_ADDRESS, MOSAIC_ID)
+		expected_path = metadata_path(1, MOSAIC_ID)
+		transactions_snapshot = copy.deepcopy(transactions)
+		embedded_transaction_snapshot = copy.deepcopy(embedded_transaction)
+		metadata_item_snapshot = copy.deepcopy(metadata_item)
+		expected_metadata_row = create_expected_metadata_row(
+			metadata_item_snapshot,
+			1,
+			composite_hash=bytes.fromhex(METADATA_COMPOSITE_HASH),
+			metadata_type='mosaic',
+			target_id=MOSAIC_ID,
+			value_utf8='hello')
+
+		# Act:
+		self._sync_with_connector(connector)
+		first_state = fetch_metadata_rows(self.puller.symbol_db)
+		self._assert_embedded_metadata_persisted(
+			connector, transactions_snapshot, embedded_transaction_snapshot, expected_metadata_row, expected_path, [],
+			{
+				'version': 1,
+				'network': 152,
+				'targetAddress': RECIPIENT_ADDRESS,
+				'targetMosaicId': MOSAIC_ID,
+				'scopedMetadataKey': SCOPED_METADATA_KEY,
+				'valueSizeDelta': 5,
+				'value': '68656C6C6F'
+			})
+		connector.paths.clear()
+		cursor = self.puller.symbol_db.connection.cursor()
+		cursor.execute('DELETE FROM symbol_sync_state')
+		self.puller.symbol_db.connection.commit()
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual(first_state, fetch_metadata_rows(self.puller.symbol_db))
+		self._assert_embedded_metadata_persisted(
+			connector, transactions_snapshot, embedded_transaction_snapshot, expected_metadata_row, expected_path, [],
+			{
+				'version': 1,
+				'network': 152,
+				'targetAddress': RECIPIENT_ADDRESS,
+				'targetMosaicId': MOSAIC_ID,
+				'scopedMetadataKey': SCOPED_METADATA_KEY,
+				'valueSizeDelta': 5,
+				'value': '68656C6C6F'
+			})
+
+	def test_sync_block_headers_leaves_no_partial_writes_when_metadata_fetch_fails(self):  # pylint: disable=too-many-locals
+		# Arrange:
+		dirty_mosaic_id = '6BED913FA20223F8'
+		namespace_transaction = _create_metadata_node_transaction(
+			1,
+			transaction_hash='B' * 64,
+			transaction_id='namespace-registration',
+			block_index=0,
+			type=TransactionType.NAMESPACE_REGISTRATION.value,
+			id=NAMESPACE_ID,
+			name='metadata-namespace',
+			registrationType=0,
+			duration='0')
+		mosaic_transaction = _create_metadata_node_transaction(
+			1,
+			transaction_hash='C' * 64,
+			transaction_id='mosaic-definition',
+			block_index=1,
+			type=TransactionType.MOSAIC_DEFINITION.value,
+			id=dirty_mosaic_id,
+			duration='0',
+			nonce=0,
+			flags=2,
+			divisibility=6)
+		aggregate_hash = 'A' * 64
+		parent_transaction = _create_metadata_node_transaction(
+			1,
+			transaction_hash=aggregate_hash,
+			transaction_id='aggregate-parent',
+			block_index=2,
+			type=TransactionType.AGGREGATE_COMPLETE.value,
+			transactionsHash='9' * 64,
+			cosignatures=[])
+		embedded_transaction = _create_metadata_embedded_transaction(
+			1,
+			aggregate_hash,
+			0,
+			transaction_id='embedded-metadata',
+			type=TransactionType.MOSAIC_METADATA.value,
+			targetAddress=RECIPIENT_ADDRESS,
+			targetMosaicId=MOSAIC_ID,
+			scopedMetadataKey=SCOPED_METADATA_KEY,
+			valueSizeDelta=5,
+			value='68656C6C6F')
+		transactions = [namespace_transaction, mosaic_transaction, parent_transaction, embedded_transaction]
+		transactions_snapshot = copy.deepcopy(transactions)
+		account_addresses = [
+			str(Address(bytes.fromhex(SIGNER_ADDRESS))),
+			str(Address(bytes.fromhex(RECIPIENT_ADDRESS)))
+		]
+		metadata_failure_path = metadata_path(1, MOSAIC_ID)
+		connector = FakeConnector(
+			1,
+			{0: [_create_metadata_block(3, 4)]},
+			transactions_by_path={transaction_path(1, 1): {'data': transactions}},
+			account_by_address={
+				str(Address(bytes.fromhex(SIGNER_ADDRESS))): create_account_item(
+					address_hex=SIGNER_ADDRESS, item_id='signer-account'),
+				str(Address(bytes.fromhex(RECIPIENT_ADDRESS))): create_account_item(
+					address_hex=RECIPIENT_ADDRESS, item_id='recipient-account')},
+			namespace_by_id={NAMESPACE_ID: create_namespace_item(namespace_id=NAMESPACE_ID, root_id=NAMESPACE_ID)},
+			namespace_names={NAMESPACE_ID: 'metadata-namespace'},
+			mosaics_by_id={dirty_mosaic_id: create_mosaic_item(mosaic_id=dirty_mosaic_id)},
+			metadata_by_query={metadata_failure_path: RuntimeError('metadata fetch failed')})
+
+		# Act:
+		with self.assertRaisesRegex(RuntimeError, 'metadata fetch failed'):
+			self._sync_with_connector(connector)
+
+		# Assert:
+		transactions = connector.transactions_by_path[transaction_path(1, 1)]['data']
+		self.assertEqual(transactions_snapshot, transactions)
+		cursor = self.puller.symbol_db.connection.cursor()
+		for table in (
+			'symbol_blocks', 'symbol_transactions', 'symbol_accounts', 'symbol_namespaces', 'symbol_alias_names',
+			'symbol_mosaics', 'symbol_metadata'
+		):
+			cursor.execute(f'SELECT COUNT(*) FROM {table}')
+			self.assertEqual(0, cursor.fetchone()[0])
+		self.assertIsNone(self.puller.symbol_db.get_sync_state())
+		self.assertEqual([f'namespaces/{NAMESPACE_ID}'], [
+			path for path in connector.paths if path.startswith('namespaces/') and path != 'namespaces/names'])
+		self.assertEqual(['mosaics'], [path for path in connector.paths if 'mosaics' == path])
+		self.assertEqual(['accounts'], [path for path in connector.paths if 'accounts' == path])
+		self.assertEqual([metadata_failure_path], [path for path in connector.paths if path.startswith('metadata?')])
+		self.assertEqual([{'addresses': account_addresses}], [
+			payload for path, payload in connector.post_requests if 'accounts' == path])
+		self.assertEqual([{'namespaceIds': [NAMESPACE_ID]}], [
+			payload for path, payload in connector.post_requests if 'namespaces/names' == path])
+		self.assertEqual([{'mosaicIds': [dirty_mosaic_id]}], [
+			payload for path, payload in connector.post_requests if 'mosaics' == path])
+		metadata_request_index = connector.paths.index(metadata_failure_path)
+		for request_path in ('accounts', f'namespaces/{NAMESPACE_ID}', 'mosaics'):
+			self.assertLess(connector.paths.index(request_path), metadata_request_index)

--- a/explorer/puller/tests/facade/symbol/test_PullerRollback.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerRollback.py
@@ -4,6 +4,8 @@ import asyncio
 from symbolchain.symbol.Network import Address
 
 from puller.facade.SymbolPuller import SymbolRollbackError
+from tests.test.SymbolDatabaseTestUtils import fetch_full_block_state, fetch_normalized_sync_state
+from tests.test.SymbolMetadataTestUtils import create_expected_metadata_row, create_metadata_item, fetch_metadata_rows, metadata_path
 from tests.test.SymbolMosaicTestUtils import (
 	create_expected_mosaic_row,
 	create_mosaic_item,
@@ -221,6 +223,151 @@ class SymbolPullerRollbackTest(SymbolPullerTestBase):
 		self.assertEqual(original_sync_state, self.puller.symbol_db.get_sync_state())
 		self.assertEqual(original_mosaic_state, fetch_mosaic_state(self.puller.symbol_db))
 		self.assertEqual(original_namespace_state, self._fetch_namespace_rows())
+
+	def test_sync_block_headers_refreshes_metadata_at_or_above_rollback_height_and_deletes_fork_only_rows(self):
+		# Arrange:
+		mosaic_id = '72C0212E67A08BCE'
+		before_fork_item = create_metadata_item(
+			metadata_type=1,
+			target_id=mosaic_id,
+			composite_hash='11' * 32,
+			scoped_metadata_key='0000000000000001',
+			value='6265666F7265')
+		survivor_item = create_metadata_item(
+			metadata_type=1,
+			target_id=mosaic_id,
+			composite_hash='22' * 32,
+			scoped_metadata_key='0000000000000002',
+			value='6F6C64')
+		fork_only_item = create_metadata_item(
+			metadata_type=1,
+			target_id=mosaic_id,
+			composite_hash='33' * 32,
+			scoped_metadata_key='0000000000000003',
+			value='666F726B')
+		canonical_survivor_item = create_metadata_item(
+			metadata_type=1,
+			target_id=mosaic_id,
+			composite_hash='22' * 32,
+			scoped_metadata_key='0000000000000002',
+			value='6E6577',
+			item_id='canonical-survivor-item-id')
+		self._seed_blocks(
+			self.puller.symbol_db,
+			[1, 2, 3],
+			{2: b'local mismatch'.hex()})
+		self.puller.symbol_db.upsert_sync_state(create_sync_state())
+		self.puller.symbol_db.upsert_metadata(create_expected_metadata_row(
+			before_fork_item, 1, composite_hash=bytes.fromhex('11' * 32), metadata_type='mosaic',
+			scoped_metadata_key='0000000000000001', target_id=mosaic_id, value_hex='6265666F7265', value_utf8='before'))
+		self.puller.symbol_db.upsert_metadata(create_expected_metadata_row(
+			survivor_item, 2, composite_hash=bytes.fromhex('22' * 32), metadata_type='mosaic',
+			scoped_metadata_key='0000000000000002', target_id=mosaic_id, value_hex='6F6C64', value_utf8='old'))
+		self.puller.symbol_db.upsert_metadata(create_expected_metadata_row(
+			fork_only_item, 3, composite_hash=bytes.fromhex('33' * 32), metadata_type='mosaic',
+			scoped_metadata_key='0000000000000003', target_id=mosaic_id, value_hex='666F726B', value_utf8='fork'))
+		connector = FakeConnector(
+			3,
+			{1: [create_node_block(2), create_node_block(3)]},
+			{2: create_node_block(2)},
+			metadata_by_query={
+				metadata_path(1, mosaic_id, scoped_metadata_key='0000000000000002'): {
+					'data': [canonical_survivor_item]},
+				metadata_path(1, mosaic_id, scoped_metadata_key='0000000000000003'): {'data': []}})
+		set_symbol_connector(self.puller, connector)
+
+		# Act:
+		asyncio.run(self.puller.sync_block_headers())
+
+		# Assert:
+		expected_rows = [
+			create_expected_metadata_row(
+				before_fork_item, 1, composite_hash=bytes.fromhex('11' * 32), metadata_type='mosaic',
+				scoped_metadata_key='0000000000000001', target_id=mosaic_id, value_hex='6265666F7265', value_utf8='before'),
+			create_expected_metadata_row(
+				canonical_survivor_item, 1, composite_hash=bytes.fromhex('22' * 32), metadata_type='mosaic',
+				scoped_metadata_key='0000000000000002', target_id=mosaic_id, value_hex='6E6577', value_utf8='new')
+		]
+		self.assertEqual(expected_rows, fetch_metadata_rows(self.puller.symbol_db))
+		metadata_paths = [path for path in connector.paths if path.startswith('metadata?')]
+		self.assertEqual([
+			metadata_path(1, mosaic_id, scoped_metadata_key='0000000000000002'),
+			metadata_path(1, mosaic_id, scoped_metadata_key='0000000000000003')
+		], metadata_paths)
+		self.assertEqual(3, self.puller.symbol_db.get_sync_state()['last_synced_height'])
+
+	def test_sync_block_headers_leaves_metadata_rollback_state_unchanged_when_metadata_fetch_fails(self):
+		# Arrange:
+		mosaic_id = '72C0212E67A08BCE'
+		orphaned_namespace_item = create_namespace_item(
+			alias={'type': 1, 'mosaicId': mosaic_id},
+			owner_address=SIGNER_ADDRESS,
+			end_height='5')
+		canonical_namespace_item = create_namespace_item(
+			alias={'type': 2, 'address': RECIPIENT_ADDRESS},
+			owner_address=RECIPIENT_ADDRESS,
+			end_height='50')
+		orphaned_mosaic_item = create_mosaic_item(mosaic_id=mosaic_id, supply='222')
+		canonical_mosaic_item = create_mosaic_item(
+			mosaic_id=mosaic_id,
+			owner_address=RECIPIENT_ADDRESS,
+			supply='999')
+		item = create_metadata_item(metadata_type=1, target_id=mosaic_id, value='6F6C64')
+		self._seed_blocks(
+			self.puller.symbol_db,
+			[1, 2, 3],
+			{2: b'local mismatch'.hex()})
+		self.puller.symbol_db.upsert_sync_state(create_sync_state())
+		seed_namespace(
+			self.puller.symbol_db,
+			orphaned_namespace_item,
+			{NAMESPACE_ROOT_ID: 'root'},
+			2)
+		self.puller.symbol_db.upsert_mosaic(create_expected_mosaic_row(orphaned_mosaic_item, 2))
+		self.puller.symbol_db.upsert_metadata(create_expected_metadata_row(
+			item, 2, composite_hash=bytes.fromhex('11' * 32), metadata_type='mosaic',
+			target_id=mosaic_id, value_hex='6F6C64', value_utf8='old'))
+		original_block_state = fetch_full_block_state(self.puller.symbol_db)
+		original_sync_state = fetch_normalized_sync_state(self.puller.symbol_db)
+		original_namespace_state = fetch_namespace_state(self.puller.symbol_db.connection)
+		original_mosaic_state = fetch_mosaic_state(self.puller.symbol_db)
+		original_metadata_rows = fetch_metadata_rows(self.puller.symbol_db)
+		connector = FakeConnector(
+			3,
+			{},
+			{2: create_node_block(2)},
+			namespace_by_id={NAMESPACE_ROOT_ID: canonical_namespace_item},
+			namespace_names={NAMESPACE_ROOT_ID: 'root'},
+			mosaics_by_id={mosaic_id: canonical_mosaic_item},
+			metadata_by_query={metadata_path(1, mosaic_id): RuntimeError('metadata fetch failed')})
+		set_symbol_connector(self.puller, connector)
+
+		# Act / Assert:
+		with self.assertRaisesRegex(RuntimeError, 'metadata fetch failed'):
+			asyncio.run(self.puller.sync_block_headers())
+
+		# Assert:
+		self.assertEqual(original_block_state, fetch_full_block_state(self.puller.symbol_db))
+		self.assertEqual(original_sync_state, fetch_normalized_sync_state(self.puller.symbol_db))
+		self.assertEqual(original_namespace_state, fetch_namespace_state(self.puller.symbol_db.connection))
+		self.assertEqual(original_mosaic_state, fetch_mosaic_state(self.puller.symbol_db))
+		self.assertEqual(original_metadata_rows, fetch_metadata_rows(self.puller.symbol_db))
+		namespace_paths = [
+			path for path in connector.paths
+			if path.startswith('namespaces/') and path != 'namespaces/names'
+		]
+		self.assertEqual([f'namespaces/{NAMESPACE_ROOT_ID}'], namespace_paths)
+		self.assertEqual(['mosaics'], [path for path in connector.paths if 'mosaics' == path])
+		self.assertEqual([metadata_path(1, mosaic_id)], [
+			path for path in connector.paths if path.startswith('metadata?')])
+		self.assertEqual([{'namespaceIds': [NAMESPACE_ROOT_ID]}], [
+			payload for path, payload in connector.post_requests if 'namespaces/names' == path])
+		self.assertEqual([{'mosaicIds': [mosaic_id]}], [
+			payload for path, payload in connector.post_requests if 'mosaics' == path])
+		self.assertLess(
+			connector.paths.index(f'namespaces/{NAMESPACE_ROOT_ID}'),
+			connector.paths.index(metadata_path(1, mosaic_id)))
+		self.assertLess(connector.paths.index('mosaics'), connector.paths.index(metadata_path(1, mosaic_id)))
 
 	def test_sync_block_headers_refreshes_orphaned_namespace_state_to_canonical_state_during_rollback(self):
 		# Arrange:

--- a/explorer/puller/tests/facade/symbol/test_PullerRollback.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerRollback.py
@@ -332,6 +332,9 @@ class SymbolPullerRollbackTest(SymbolPullerTestBase):
 		original_namespace_state = fetch_namespace_state(self.puller.symbol_db.connection)
 		original_mosaic_state = fetch_mosaic_state(self.puller.symbol_db)
 		original_metadata_rows = fetch_metadata_rows(self.puller.symbol_db)
+		self.assertEqual(1, len(original_namespace_state[0]))
+		self.assertEqual(1, len(original_mosaic_state))
+		self.assertEqual(1, len(original_metadata_rows))
 		connector = FakeConnector(
 			3,
 			{},
@@ -352,22 +355,19 @@ class SymbolPullerRollbackTest(SymbolPullerTestBase):
 		self.assertEqual(original_namespace_state, fetch_namespace_state(self.puller.symbol_db.connection))
 		self.assertEqual(original_mosaic_state, fetch_mosaic_state(self.puller.symbol_db))
 		self.assertEqual(original_metadata_rows, fetch_metadata_rows(self.puller.symbol_db))
-		namespace_paths = [
+		self.assertEqual([
+			f'namespaces/{NAMESPACE_ROOT_ID}',
+			'namespaces/names',
+			'mosaics',
+			metadata_path(1, mosaic_id)
+		], [
 			path for path in connector.paths
-			if path.startswith('namespaces/') and path != 'namespaces/names'
-		]
-		self.assertEqual([f'namespaces/{NAMESPACE_ROOT_ID}'], namespace_paths)
-		self.assertEqual(['mosaics'], [path for path in connector.paths if 'mosaics' == path])
-		self.assertEqual([metadata_path(1, mosaic_id)], [
-			path for path in connector.paths if path.startswith('metadata?')])
+			if path in (f'namespaces/{NAMESPACE_ROOT_ID}', 'namespaces/names', 'mosaics') or path.startswith('metadata?')
+		])
 		self.assertEqual([{'namespaceIds': [NAMESPACE_ROOT_ID]}], [
 			payload for path, payload in connector.post_requests if 'namespaces/names' == path])
 		self.assertEqual([{'mosaicIds': [mosaic_id]}], [
 			payload for path, payload in connector.post_requests if 'mosaics' == path])
-		self.assertLess(
-			connector.paths.index(f'namespaces/{NAMESPACE_ROOT_ID}'),
-			connector.paths.index(metadata_path(1, mosaic_id)))
-		self.assertLess(connector.paths.index('mosaics'), connector.paths.index(metadata_path(1, mosaic_id)))
 
 	def test_sync_block_headers_refreshes_orphaned_namespace_state_to_canonical_state_during_rollback(self):
 		# Arrange:

--- a/explorer/puller/tests/facade/symbol/test_PullerSync.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerSync.py
@@ -683,7 +683,7 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):  # pylint: disable=too-many-pu
 		# Assert:
 		self.assertEqual(
 			[f'namespaces/{namespace_id}' for namespace_id in namespace_ids],
-			connector.namespace_paths)
+			connector.detail_paths)
 		self._assert_namespace_requests(
 			connector,
 			namespace_ids,
@@ -691,9 +691,9 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):  # pylint: disable=too-many-pu
 				{'namespaceIds': namespace_ids[:MAX_PAGE_SIZE]},
 				{'namespaceIds': namespace_ids[MAX_PAGE_SIZE:]}
 			])
-		self.assertGreater(connector.max_in_flight_namespace_requests, 1)
-		self.assertLessEqual(connector.max_in_flight_namespace_requests, MAX_PAGE_SIZE)
-		self.assertEqual(0, connector.in_flight_namespace_requests)
+		self.assertGreater(connector.max_in_flight_detail_requests, 1)
+		self.assertLessEqual(connector.max_in_flight_detail_requests, MAX_PAGE_SIZE)
+		self.assertEqual(0, connector.in_flight_detail_requests)
 
 	def _assert_sync_request_counts(self, connector, block_page_count, batch_count):
 		# Assert:

--- a/explorer/puller/tests/model/symbol/test_Metadata.py
+++ b/explorer/puller/tests/model/symbol/test_Metadata.py
@@ -1,0 +1,86 @@
+from unittest import TestCase
+
+from symbolchain.sc import TransactionType
+
+from puller.model.symbol.Metadata import METADATA_TRANSACTION_TYPE_LABELS, METADATA_TYPE_LABELS, METADATA_TYPE_NUMBERS, create_metadata_row
+from tests.test.SymbolMetadataTestUtils import create_expected_metadata_row, create_metadata_item
+
+
+class MetadataTest(TestCase):
+	def test_metadata_type_labels_match_independent_expected_values(self):
+		self.assertEqual({0: 'account', 1: 'mosaic', 2: 'namespace'}, METADATA_TYPE_LABELS)
+
+	def test_metadata_type_numbers_match_independent_expected_values(self):
+		self.assertEqual({'account': 0, 'mosaic': 1, 'namespace': 2}, METADATA_TYPE_NUMBERS)
+
+	def test_metadata_transaction_type_labels_match_independent_expected_values(self):
+		self.assertEqual({
+			TransactionType.ACCOUNT_METADATA.value: 'account',
+			TransactionType.MOSAIC_METADATA.value: 'mosaic',
+			TransactionType.NAMESPACE_METADATA.value: 'namespace'
+		}, METADATA_TRANSACTION_TYPE_LABELS)
+
+	def test_create_metadata_row_normalizes_account_and_preserves_wrapper(self):
+		# Arrange:
+		item = create_metadata_item()
+		expected_row = create_expected_metadata_row(
+			item, 123, composite_hash=bytes.fromhex('11' * 32), metadata_type='account',
+			target_id=None, value_utf8='hello')
+
+		# Act:
+		row = create_metadata_row(item, 123)
+
+		# Assert:
+		self.assertEqual(expected_row, row)
+
+	def test_create_metadata_row_preserves_mosaic_target_id(self):
+		# Arrange:
+		mosaic_item = create_metadata_item(metadata_type=1, target_id='72C0212E67A08BCE')
+
+		# Act:
+		row = create_metadata_row(mosaic_item, 123)
+
+		# Assert:
+		self.assertEqual(create_expected_metadata_row(
+			mosaic_item, 123, composite_hash=bytes.fromhex('11' * 32), metadata_type='mosaic',
+			target_id='72C0212E67A08BCE', value_utf8='hello'), row)
+
+	def test_create_metadata_row_preserves_namespace_target_id(self):
+		# Arrange:
+		namespace_item = create_metadata_item(metadata_type=2, target_id='A95F1F8A96159516')
+
+		# Act:
+		row = create_metadata_row(namespace_item, 123)
+
+		# Assert:
+		self.assertEqual(create_expected_metadata_row(
+			namespace_item, 123, composite_hash=bytes.fromhex('11' * 32), metadata_type='namespace',
+			target_id='A95F1F8A96159516', value_utf8='hello'), row)
+
+	def test_create_metadata_row_decodes_clean_utf8_value(self):
+		# Arrange:
+		clean_item = create_metadata_item(value='E38182E38184')
+
+		# Act:
+		row = create_metadata_row(clean_item, 123)
+
+		# Assert:
+		self.assertEqual('あい', row['value_utf8'])
+
+	def test_create_metadata_row_replaces_invalid_utf8_value(self):
+		# Arrange:
+		invalid_item = create_metadata_item(value='C3')
+
+		# Act:
+		row = create_metadata_row(invalid_item, 123)
+
+		# Assert:
+		self.assertEqual('�', row['value_utf8'])
+
+	def test_create_metadata_row_rejects_unsupported_type(self):
+		# Arrange:
+		item = create_metadata_item(metadata_type=99)
+
+		# Act / Assert:
+		with self.assertRaisesRegex(ValueError, '^Unsupported Symbol metadata type 99$'):
+			create_metadata_row(item, 123)

--- a/explorer/puller/tests/model/symbol/test_Transaction.py
+++ b/explorer/puller/tests/model/symbol/test_Transaction.py
@@ -1,3 +1,4 @@
+import copy
 # pylint: disable=duplicate-code,too-many-lines
 from datetime import datetime, timezone
 from unittest import TestCase
@@ -117,6 +118,7 @@ def _expected_top_level_row(item, **overrides):
 		'signer_address': bytes.fromhex(SIGNER_ADDRESS),
 		'recipient_address': bytes.fromhex(RECIPIENT_ADDRESS),
 		'target_address': None,
+		'metadata_target_id': None,
 		'deadline': datetime.fromtimestamp(102, timezone.utc),
 		'network_deadline': 2000,
 		'max_fee': 1000,
@@ -190,6 +192,7 @@ class TransactionTest(TestCase):  # pylint: disable=too-many-public-methods
 			'signer_address': bytes.fromhex(SIGNER_ADDRESS),
 			'recipient_address': bytes.fromhex(RECIPIENT_ADDRESS),
 			'target_address': None,
+			'metadata_target_id': None,
 			'deadline': None,
 			'network_deadline': None,
 			'max_fee': None,
@@ -214,6 +217,35 @@ class TransactionTest(TestCase):  # pylint: disable=too-many-public-methods
 				{'address': bytes.fromhex(RECIPIENT_ADDRESS), 'role': 'recipient'}
 			]
 		}, row)
+
+	def test_create_transaction_row_keeps_mosaic_metadata_target_id_non_persisted(self):
+		# Arrange:
+		alias_mosaic_id = 'A95F1F8A96159516'
+		item = _create_embedded_item({
+			'signerPublicKey': SIGNER_PUBLIC_KEY,
+			'version': 1,
+			'network': 152,
+			'type': TransactionType.MOSAIC_METADATA.value,
+			'targetAddress': TARGET_ADDRESS,
+			'targetMosaicId': alias_mosaic_id,
+			'scopedMetadataKey': '0102030405060708',
+			'valueSizeDelta': 5,
+			'value': '68656C6C6F'
+		})
+		expected_raw_payload = copy.deepcopy(item)
+
+		# Act:
+		row = create_transaction_row(item, Network.TESTNET, 100)
+
+		# Assert:
+		self.assertEqual(alias_mosaic_id, row['metadata_target_id'])
+		self.assertEqual([], row['mosaic_rows'])
+		self.assertEqual(True, row['is_embedded'])
+		self.assertEqual(bytes.fromhex('B' * 64), row['aggregate_hash'])
+		self.assertEqual(2, row['embedded_index'])
+		self.assertEqual(expected_raw_payload, row['raw_payload'])
+		self.assertEqual(TARGET_ADDRESS, row['body']['targetAddress'])
+		self.assertEqual(alias_mosaic_id, row['body']['targetMosaicId'])
 
 	def test_sdk_enum_values_build_transaction_labels(self):
 		transactions = [
@@ -474,10 +506,22 @@ class TransactionTest(TestCase):  # pylint: disable=too-many-public-methods
 				transaction_fields = {'targetAddress': TARGET_ADDRESS}
 				if TransactionType.MOSAIC_ADDRESS_RESTRICTION.value == transaction_type:
 					transaction_fields['mosaicId'] = '1111111111111111'
-				item = _create_item(_create_top_level_transaction(
-					transaction_type,
-					**transaction_fields
-				))
+					item = _create_item(_create_top_level_transaction(transaction_type, **transaction_fields))
+				else:
+					transaction_fields['scopedMetadataKey'] = '0102030405060708'
+					transaction_fields['valueSizeDelta'] = 5
+					transaction_fields['value'] = '68656C6C6F'
+					if TransactionType.MOSAIC_METADATA.value == transaction_type:
+						transaction_fields['targetMosaicId'] = '1111111111111111'
+					elif TransactionType.NAMESPACE_METADATA.value == transaction_type:
+						transaction_fields['targetNamespaceId'] = '2222222222222222'
+					item = _create_embedded_item({
+						'signerPublicKey': SIGNER_PUBLIC_KEY,
+						'version': 1,
+						'network': 152,
+						'type': transaction_type,
+						**transaction_fields
+					})
 
 				# Act:
 				row = create_transaction_row(item, Network.TESTNET, 100)

--- a/explorer/puller/tests/model/symbol/test_Transaction.py
+++ b/explorer/puller/tests/model/symbol/test_Transaction.py
@@ -118,7 +118,7 @@ def _expected_top_level_row(item, **overrides):
 		'signer_address': bytes.fromhex(SIGNER_ADDRESS),
 		'recipient_address': bytes.fromhex(RECIPIENT_ADDRESS),
 		'target_address': None,
-		'metadata_target_id': None,
+		'mosaic_metadata_target_id': None,
 		'deadline': datetime.fromtimestamp(102, timezone.utc),
 		'network_deadline': 2000,
 		'max_fee': 1000,
@@ -192,7 +192,7 @@ class TransactionTest(TestCase):  # pylint: disable=too-many-public-methods
 			'signer_address': bytes.fromhex(SIGNER_ADDRESS),
 			'recipient_address': bytes.fromhex(RECIPIENT_ADDRESS),
 			'target_address': None,
-			'metadata_target_id': None,
+			'mosaic_metadata_target_id': None,
 			'deadline': None,
 			'network_deadline': None,
 			'max_fee': None,
@@ -238,7 +238,7 @@ class TransactionTest(TestCase):  # pylint: disable=too-many-public-methods
 		row = create_transaction_row(item, Network.TESTNET, 100)
 
 		# Assert:
-		self.assertEqual(alias_mosaic_id, row['metadata_target_id'])
+		self.assertEqual(alias_mosaic_id, row['mosaic_metadata_target_id'])
 		self.assertEqual([], row['mosaic_rows'])
 		self.assertEqual(True, row['is_embedded'])
 		self.assertEqual(bytes.fromhex('B' * 64), row['aggregate_hash'])

--- a/explorer/puller/tests/test/SymbolDatabaseTestUtils.py
+++ b/explorer/puller/tests/test/SymbolDatabaseTestUtils.py
@@ -1,0 +1,19 @@
+def fetch_full_block_state(database):
+	cursor = database.connection.cursor()
+	cursor.execute('SELECT * FROM symbol_blocks ORDER BY height')
+	return [
+		tuple(bytes(value) if isinstance(value, memoryview) else value for value in row)
+		for row in cursor.fetchall()
+	]
+
+
+def fetch_normalized_sync_state(database):
+	sync_state = database.get_sync_state()
+	if sync_state is None:
+		return None
+
+	return {
+		**sync_state,
+		'finalized_hash': bytes(sync_state['finalized_hash']),
+		'last_synced_block_hash': bytes(sync_state['last_synced_block_hash'])
+	}

--- a/explorer/puller/tests/test/SymbolMetadataTestUtils.py
+++ b/explorer/puller/tests/test/SymbolMetadataTestUtils.py
@@ -1,0 +1,109 @@
+import copy
+
+from symbolchain.symbol.Network import Address
+
+from tests.test.SymbolTestConstants import RECIPIENT_ADDRESS, SIGNER_ADDRESS
+
+COMPOSITE_HASH = '11' * 32
+SOURCE_ADDRESS = SIGNER_ADDRESS
+TARGET_ADDRESS = RECIPIENT_ADDRESS
+SCOPED_METADATA_KEY = 'B41438ACBBA3E696'
+MOSAIC_ID = '72C0212E67A08BCE'
+NAMESPACE_ID = 'A95F1F8A96159516'
+
+
+def metadata_path(
+	metadata_type,
+	target_id=None,
+	source_address=SIGNER_ADDRESS,
+	target_address=RECIPIENT_ADDRESS,
+	scoped_metadata_key=SCOPED_METADATA_KEY
+):
+	path = (
+		f'metadata?sourceAddress={Address(bytes.fromhex(source_address))}'
+		f'&targetAddress={Address(bytes.fromhex(target_address))}'
+		f'&scopedMetadataKey={scoped_metadata_key}&metadataType={metadata_type}'
+	)
+	return path if target_id is None else f'{path}&targetId={target_id}'
+
+
+def create_metadata_item(
+	metadata_type=0,
+	target_id='0000000000000000',
+	item_id='metadata-item-id',
+	composite_hash=COMPOSITE_HASH,
+	source_address=SOURCE_ADDRESS,
+	target_address=TARGET_ADDRESS,
+	scoped_metadata_key=SCOPED_METADATA_KEY,
+	value='68656C6C6F'
+):  # pylint: disable=too-many-arguments,too-many-positional-arguments
+	entry = {
+		'version': 1,
+		'compositeHash': composite_hash,
+		'sourceAddress': source_address,
+		'targetAddress': target_address,
+		'scopedMetadataKey': scoped_metadata_key,
+		'targetId': target_id,
+		'metadataType': metadata_type,
+		'valueSize': len(bytes.fromhex(value)),
+		'value': value
+	}
+	return {'metadataEntry': entry, 'id': item_id}
+
+
+def create_expected_metadata_row(
+	metadata_item,
+	observed_height,
+	composite_hash,
+	metadata_type,
+	target_id,
+	value_utf8,
+	scoped_metadata_key=SCOPED_METADATA_KEY,
+	source_address=bytes.fromhex(SOURCE_ADDRESS),
+	target_address=bytes.fromhex(TARGET_ADDRESS),
+	value_hex='68656C6C6F'
+):  # pylint: disable=too-many-arguments,too-many-positional-arguments
+	return {
+		'composite_hash': composite_hash,
+		'metadata_type': metadata_type,
+		'scoped_metadata_key': scoped_metadata_key,
+		'source_address': source_address,
+		'target_address': target_address,
+		'target_id': target_id,
+		'value_hex': value_hex,
+		'value_utf8': value_utf8,
+		'raw_payload': copy.deepcopy(metadata_item),
+		'updated_at_height': observed_height
+	}
+
+
+def fetch_metadata_rows(database):
+	cursor = database.connection.cursor()
+	cursor.execute(
+		'''
+		SELECT composite_hash, metadata_type, scoped_metadata_key, source_address, target_address, target_id,
+			value_hex, value_utf8, raw_payload, updated_at_height
+		FROM symbol_metadata
+		ORDER BY composite_hash
+		''')
+	return [
+		{
+			'composite_hash': bytes(row[0]),
+			'metadata_type': row[1],
+			'scoped_metadata_key': row[2],
+			'source_address': bytes(row[3]),
+			'target_address': bytes(row[4]) if row[4] is not None else None,
+			'target_id': row[5],
+			'value_hex': row[6],
+			'value_utf8': row[7],
+			'raw_payload': row[8],
+			'updated_at_height': row[9]
+		}
+		for row in cursor.fetchall()
+	]
+
+
+def fetch_metadata_row(database, composite_hash):
+	return next(
+		(row for row in fetch_metadata_rows(database) if row['composite_hash'] == composite_hash),
+		None)

--- a/explorer/puller/tests/test/SymbolMetadataTestUtils.py
+++ b/explorer/puller/tests/test/SymbolMetadataTestUtils.py
@@ -103,7 +103,7 @@ def fetch_metadata_rows(database):
 	]
 
 
-def fetch_metadata_row(database, composite_hash):
+def find_metadata_row(database, composite_hash):
 	return next(
 		(row for row in fetch_metadata_rows(database) if row['composite_hash'] == composite_hash),
 		None)


### PR DESCRIPTION
## Summary

Added current-state synchronization for Symbol account, mosaic, and namespace metadata. The puller now collects dirty metadata keys from embedded transactions, resolves address and mosaic aliases, fetches canonical metadata through bounded exact-key node searches, and upserts or deletes rows in the new `symbol_metadata` table.

## How have you changed the behavior?

- Added the `symbol_metadata` table, enum, indexes, and database operations for:
- Added metadata normalization for account, mosaic, and namespace metadata.
- Added dirty-key collection and bounded metadata fetching.
- Extended transaction alias resolution for metadata.
- Extended rollback repair to refresh namespace, mosaic, and metadata state in one database transaction.
- Moved `RollbackRefreshEntries` to `SymbolDatabase.py`, which owns the rollback repair contract.