### PR TITLE
[explorer/puller] fix: flush harvested fees for the trailing block batch

### DIFF
--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -334,6 +334,17 @@ class NemPuller:
 				last_height
 			)
 
+	def _flush_pending_account_state(self, cursor, pending_addresses, accounts_harvested_fee):
+		"""Flushes accumulated account and harvested fee state, clearing both accumulators."""
+
+		if pending_addresses:
+			asyncio.run(self._process_account_batch(cursor, pending_addresses))
+			pending_addresses.clear()
+
+		if accounts_harvested_fee:
+			self._process_harvested_fees(cursor, accounts_harvested_fee)
+			accounts_harvested_fee.clear()
+
 	async def refresh_accounts(self, batch_size):
 		"""Refresh vested balance and importance for stored accounts."""
 
@@ -618,9 +629,8 @@ class NemPuller:
 			if block is None:
 				log.info('Received stop signal, ending DB writer thread')
 
-				# Process any remaining addresses before exiting
-				if pending_addresses:
-					asyncio.run(self._process_account_batch(cursor, pending_addresses))
+				# Process any remaining addresses and harvested fees before exiting
+				self._flush_pending_account_state(cursor, pending_addresses, accounts_harvested_fee)
 
 				block_queue.task_done()
 				break
@@ -644,11 +654,7 @@ class NemPuller:
 
 			# Batch commits
 			if processed % batch_size == 0:
-				asyncio.run(self._process_account_batch(cursor, pending_addresses))
-				pending_addresses.clear()
-
-				self._process_harvested_fees(cursor, accounts_harvested_fee)
-				accounts_harvested_fee.clear()
+				self._flush_pending_account_state(cursor, pending_addresses, accounts_harvested_fee)
 
 				self._commit_blocks(f'Committed {processed} blocks')
 

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -400,6 +400,12 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		mock_get_blocks_after.return_value = NEM_CONNECTOR_RESPONSE_BLOCKS
 		mock_process_account_batch.return_value = AsyncMock()
 
+		# the accumulator is cleared after each flush, so snapshot it at call time
+		captured_address_heights = []
+		mock_process_account_batch.side_effect = lambda _cursor, address_heights: captured_address_heights.append(
+			dict(address_heights)
+		)
+
 		with self.puller.nem_db as databases:
 			databases.create_tables()
 
@@ -454,8 +460,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 				2052
 			))
 
-			call_args = mock_process_account_batch.call_args_list[0]
-			address_heights = call_args[0][1]
+			address_heights = captured_address_heights[0]
 			self.assertEqual(len(address_heights), 21)
 			self.assertIn(1, address_heights.values())
 			self.assertIn(2, address_heights.values())
@@ -520,6 +525,12 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		mock_process_harvested_fees.return_value = Mock()
 		mock_process_transactions.return_value = Mock()
 
+		# the accumulator is cleared after each flush, so snapshot it at call time
+		captured_harvested_fees = []
+		mock_process_harvested_fees.side_effect = lambda _cursor, harvested_fees: captured_harvested_fees.append(
+			dict(harvested_fees)
+		)
+
 		with self.puller.nem_db as databases:
 			databases.create_tables()
 
@@ -542,10 +553,12 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			actual_calls = [call[0][0] if call[0] else None for call in mock_commit_blocks.call_args_list]
 			self.assertEqual(actual_calls, expected_calls)
 
-			process_harvested_fees_calls = mock_process_harvested_fees.call_args_list
-			self.assertEqual(len(process_harvested_fees_calls), 2)
-			self.assertEqual(process_harvested_fees_calls[0][0][1], ({Address('T' + 'A' * 39): (1000000, 5)}))
-			self.assertEqual(process_harvested_fees_calls[1][0][1], ({Address('T' + 'A' * 39): (1000000, 5)}))
+			# two batch flushes plus a trailing flush for the fifth block
+			self.assertEqual(captured_harvested_fees, [
+				{Address('T' + 'A' * 39): (2000000, 2)},
+				{Address('T' + 'A' * 39): (2000000, 4)},
+				{Address('T' + 'A' * 39): (1000000, 5)}
+			])
 
 			process_transactions_calls = mock_process_transactions.call_args_list
 			self.assertEqual(len(process_transactions_calls), 5)


### PR DESCRIPTION
## Problem

`accounts.harvested_fees` silently under-counts. On a local testnet database the deficit was **-150,000** against the sum of `blocks.total_fee`, and `last_harvested_height` value.

## Root cause

`_db_writer` keeps two accumulators, `pending_addresses` and `accounts_harvested_fee`, and flushes both every `batch_size` blocks:

```python
if processed % batch_size == 0:
    asyncio.run(self._process_account_batch(cursor, pending_addresses))
    pending_addresses.clear()
    self._process_harvested_fees(cursor, accounts_harvested_fee)   # flushed
    accounts_harvested_fee.clear()
```

The shutdown path, entered after the stop signal, flushed only the first one:
```python
  if block is None:
      if pending_addresses:
          asyncio.run(self._process_account_batch(cursor, pending_addresses))
      block_queue.task_done()
      break
  ```     
      
`accounts_harvested_fee` was dropped, but `if processed % batch_size != 0: self._commit_blocks()` committed the blocks regardless. Since `update_account_harvested_fees` accumulates (`harvested_fees = harvested_fees + %s`) and the next run resumes from `SELECT MAX(height) FROM blocks`, the skipped fees were never recovered.

 ## Fix

Extract `_flush_pending_account_state`, which flushes and clears both accumulators, and call it from both the batch path and the shutdown path. The duplication that allowed the two paths to diverge is gone.

As a side effect `_process_account_batch` is no longer invoked with an empty dict, removing misleading `Processing batch of 0 addresses` log lines.