### PR TITLE
[explorer/puller] feat: add Symbol lock state synchronization

### DIFF
--- a/explorer/common/tests/PostgresTestUtils.py
+++ b/explorer/common/tests/PostgresTestUtils.py
@@ -39,6 +39,8 @@ def drop_symbol_block_tables_if_present(database):
 	cursor = database.connection.cursor()
 	cursor.execute('DROP TABLE IF EXISTS symbol_mosaics')
 	cursor.execute('DROP TABLE IF EXISTS symbol_metadata')
+	cursor.execute('DROP TABLE IF EXISTS symbol_secret_locks')
+	cursor.execute('DROP TABLE IF EXISTS symbol_hash_locks')
 	cursor.execute('DROP TABLE IF EXISTS symbol_alias_names')
 	cursor.execute('DROP TABLE IF EXISTS symbol_namespaces')
 	cursor.execute('DROP TABLE IF EXISTS symbol_transaction_mosaics')
@@ -63,6 +65,8 @@ def drop_symbol_block_tables_if_present(database):
 	cursor.execute('DROP TYPE IF EXISTS symbol_namespace_alias_type')
 	cursor.execute('DROP TYPE IF EXISTS symbol_alias_artifact_type')
 	cursor.execute('DROP TYPE IF EXISTS symbol_metadata_type')
+	cursor.execute('DROP TYPE IF EXISTS symbol_lock_hash_algorithm')
+	cursor.execute('DROP TYPE IF EXISTS symbol_lock_status')
 	database.connection.commit()
 
 

--- a/explorer/puller/puller/db/SymbolDatabase.py
+++ b/explorer/puller/puller/db/SymbolDatabase.py
@@ -11,7 +11,7 @@ from puller.model.symbol.Lock import (
 	LOCK_HASH_ALGORITHM_LABELS,
 	LOCK_STATUS_LABELS,
 	RollbackLockKeys,
-	create_hash_lock_key_from_hex,
+	create_hash_lock_key,
 	create_secret_lock_search_key,
 	create_secret_lock_search_key_from_hex_secret,
 	lock_hash_algorithm_label
@@ -1005,19 +1005,20 @@ class SymbolDatabase(DatabaseConnection):  # pylint: disable=too-many-public-met
 
 		cursor = self.connection.cursor()
 		cursor.execute(
-			'SELECT hash FROM symbol_hash_locks WHERE updated_at_height >= %s ORDER BY hash',
+			'SELECT hash FROM symbol_hash_locks WHERE updated_at_height >= %s ORDER BY updated_at_height, hash',
 			(height,))
 
-		return [create_hash_lock_key_from_hex(bytes(row[0]).hex()) for row in cursor.fetchall()]
+		return [create_hash_lock_key(bytes(row[0])) for row in cursor.fetchall()]
 
 	def get_secret_lock_search_keys_updated_from_height(self, height):  # pylint: disable=invalid-name
 		"""Gets Secret Lock logical keys whose current state was observed at or after a height."""
 
 		return self._get_secret_lock_search_keys(
 			'updated_at_height >= %s',
-			(height,))
+			(height,),
+			'updated_at_height')
 
-	def get_hash_lock_hashes_expiring_between(self, start_height, end_height):  # pylint: disable=invalid-name
+	def get_hash_lock_hashes_reaching_end_height_between(self, start_height, end_height):  # pylint: disable=invalid-name
 		"""Gets Hash Lock keys whose end height is inside an inclusive range."""
 
 		cursor = self.connection.cursor()
@@ -1026,27 +1027,33 @@ class SymbolDatabase(DatabaseConnection):  # pylint: disable=too-many-public-met
 			SELECT hash
 			FROM symbol_hash_locks
 			WHERE end_height BETWEEN %s AND %s
-			ORDER BY hash
+			ORDER BY end_height, hash
 			''',
 			(start_height, end_height))
 
-		return [create_hash_lock_key_from_hex(bytes(row[0]).hex()) for row in cursor.fetchall()]
+		return [create_hash_lock_key(bytes(row[0])) for row in cursor.fetchall()]
 
-	def get_secret_lock_search_keys_expiring_between(self, start_height, end_height):  # pylint: disable=invalid-name
+	def get_secret_lock_search_keys_reaching_end_height_between(self, start_height, end_height):  # pylint: disable=invalid-name
 		"""Gets Secret Lock logical keys whose end height is inside an inclusive range."""
 
 		return self._get_secret_lock_search_keys(
 			'end_height BETWEEN %s AND %s',
-			(start_height, end_height))
+			(start_height, end_height),
+			'end_height')
 
-	def _get_secret_lock_search_keys(self, predicate, parameters):
+	def _get_secret_lock_search_keys(self, predicate, parameters, sort_column):
+		# Keep interpolated SQL identifiers restricted to the two fixed query contracts.
+		sort_column = {
+			'updated_at_height': 'updated_at_height',
+			'end_height': 'end_height'
+		}[sort_column]
 		cursor = self.connection.cursor()
 		cursor.execute(
 			f'''
 			SELECT owner_address, recipient_address, secret, hash_algorithm
 			FROM symbol_secret_locks
 			WHERE {predicate}
-			ORDER BY composite_hash
+			ORDER BY {sort_column}, composite_hash
 			''',
 			parameters)
 
@@ -1062,7 +1069,7 @@ class SymbolDatabase(DatabaseConnection):  # pylint: disable=too-many-public-met
 		cursor = self.connection.cursor()
 		cursor.execute(
 			'''
-			SELECT type, is_embedded, hash, signer_address, recipient_address, body
+			SELECT type, hash, signer_address, recipient_address, body
 			FROM symbol_transactions
 			WHERE height >= %s
 				AND type IN (%s, %s, %s, %s)
@@ -1076,27 +1083,25 @@ class SymbolDatabase(DatabaseConnection):  # pylint: disable=too-many-public-met
 				TransactionType.AGGREGATE_BONDED.value
 			))
 
-		hash_keys = {}
-		secret_keys = {}
-		for transaction_type, is_embedded, transaction_hash, signer_address, recipient_address, body in cursor.fetchall():
+		hash_keys = []
+		secret_keys = []
+		for transaction_type, transaction_hash, signer_address, recipient_address, body in cursor.fetchall():
 			if TransactionType.HASH_LOCK.value == transaction_type:
-				hash_key = create_hash_lock_key_from_hex(body['hash'])
-				hash_keys[hash_key] = None
-			elif TransactionType.AGGREGATE_BONDED.value == transaction_type and not is_embedded:
-				hash_key = create_hash_lock_key_from_hex(bytes(transaction_hash).hex())
-				hash_keys[hash_key] = None
+				hash_keys.append(create_hash_lock_key(body['hash']))
+			elif TransactionType.AGGREGATE_BONDED.value == transaction_type:
+				hash_keys.append(create_hash_lock_key(bytes(transaction_hash)))
 			elif TransactionType.SECRET_LOCK.value == transaction_type:
-				secret_key = create_secret_lock_search_key_from_hex_secret(
+				secret_keys.append(create_secret_lock_search_key_from_hex_secret(
 					bytes(signer_address), bytes(recipient_address), body['secret'],
-					lock_hash_algorithm_label(body['hashAlgorithm']))
-				secret_keys[secret_key] = None
+					lock_hash_algorithm_label(body['hashAlgorithm'])))
 			elif TransactionType.SECRET_PROOF.value == transaction_type:
-				secret_key = create_secret_lock_search_key_from_hex_secret(
+				secret_keys.append(create_secret_lock_search_key_from_hex_secret(
 					None, bytes(recipient_address), body['secret'],
-					lock_hash_algorithm_label(body['hashAlgorithm']))
-				secret_keys[secret_key] = None
+					lock_hash_algorithm_label(body['hashAlgorithm'])))
 
-		return RollbackLockKeys(list(hash_keys), list(secret_keys))
+		return RollbackLockKeys(
+			list(dict.fromkeys(hash_keys)),
+			list(dict.fromkeys(secret_keys)))
 
 	def delete_namespace(self, namespace_id):
 		"""Deletes one namespace and its derived alias-name rows when it exists."""

--- a/explorer/puller/puller/db/SymbolDatabase.py
+++ b/explorer/puller/puller/db/SymbolDatabase.py
@@ -3,9 +3,19 @@ from collections import namedtuple
 from contextlib import contextmanager
 
 from psycopg2.extras import Json
+from symbolchain.sc import TransactionType
 
 from puller.model.symbol.Account import ACCOUNT_TYPE_VALUES
 from puller.model.symbol.Block import BLOCK_TYPE_VALUES
+from puller.model.symbol.Lock import (
+	LOCK_HASH_ALGORITHM_LABELS,
+	LOCK_STATUS_LABELS,
+	RollbackLockKeys,
+	create_hash_lock_key_from_hex,
+	create_secret_lock_search_key,
+	create_secret_lock_search_key_from_hex_secret,
+	lock_hash_algorithm_label
+)
 from puller.model.symbol.Metadata import METADATA_TYPE_LABELS
 from puller.model.symbol.Namespace import NAMESPACE_ALIAS_TYPE_LABELS, NAMESPACE_REGISTRATION_TYPE_LABELS
 from puller.model.symbol.Receipt import RECEIPT_TYPE_LABELS
@@ -14,7 +24,9 @@ from puller.model.symbol.Transaction import MESSAGE_TYPE_LABELS, TRANSACTION_TYP
 from .DatabaseConnection import DatabaseConnection
 
 RollbackRefreshEntries = namedtuple(
-	'RollbackRefreshEntries', ['namespace_entries', 'mosaic_entries', 'metadata_entries'], defaults=((), (), ()))
+	'RollbackRefreshEntries',
+	['namespace_entries', 'mosaic_entries', 'metadata_entries', 'hash_lock_entries', 'secret_lock_entries'],
+	defaults=((), (), (), (), ()))
 
 SYNC_STATE_COLUMNS = [
 	'status',
@@ -38,6 +50,8 @@ SYMBOL_NAMESPACE_REGISTRATION_TYPE_VALUES = tuple(NAMESPACE_REGISTRATION_TYPE_LA
 SYMBOL_NAMESPACE_ALIAS_TYPE_VALUES = tuple(NAMESPACE_ALIAS_TYPE_LABELS.values())
 SYMBOL_ALIAS_ARTIFACT_TYPE_VALUES = ('mosaic', 'namespace', 'account')
 SYMBOL_METADATA_TYPE_VALUES = tuple(METADATA_TYPE_LABELS.values())
+SYMBOL_LOCK_STATUS_VALUES = tuple(LOCK_STATUS_LABELS.values())
+SYMBOL_LOCK_HASH_ALGORITHM_VALUES = tuple(LOCK_HASH_ALGORITHM_LABELS.values())
 ACCOUNT_REFRESH_STATE_STATUS_VALUES = ('healthy', 'refreshing', 'stale', 'unhealthy')
 ACCOUNT_REFRESH_STATE_COLUMNS = [
 	'last_successful_run_id',
@@ -302,6 +316,57 @@ SYMBOL_METADATA_INDEXES = [
 	'CREATE INDEX IF NOT EXISTS idx_symbol_metadata_target_id ON symbol_metadata(target_id)',
 	'CREATE INDEX IF NOT EXISTS idx_symbol_metadata_updated_height ON symbol_metadata(updated_at_height)'
 ]
+SYMBOL_HASH_LOCK_DEFINITIONS = [
+	'hash bytea PRIMARY KEY',
+	'owner_address bytea NOT NULL',
+	'mosaic_id varchar(16) NOT NULL',
+	'amount bigint NOT NULL',
+	'end_height bigint NOT NULL',
+	'status symbol_lock_status NOT NULL',
+	'raw_payload jsonb NOT NULL',
+	'updated_at_height bigint NOT NULL'
+]
+SYMBOL_SECRET_LOCK_DEFINITIONS = [
+	'composite_hash bytea PRIMARY KEY',
+	'owner_address bytea NOT NULL',
+	'recipient_address bytea NOT NULL',
+	'secret bytea NOT NULL',
+	'hash_algorithm symbol_lock_hash_algorithm NOT NULL',
+	'mosaic_id varchar(16) NOT NULL',
+	'amount bigint NOT NULL',
+	'end_height bigint NOT NULL',
+	'status symbol_lock_status NOT NULL',
+	'raw_payload jsonb NOT NULL',
+	'updated_at_height bigint NOT NULL'
+]
+SYMBOL_LOCK_INDEXES = [
+	'CREATE INDEX IF NOT EXISTS idx_symbol_hash_locks_owner_end_height '
+	'ON symbol_hash_locks(owner_address, end_height DESC, hash DESC)',
+	'CREATE INDEX IF NOT EXISTS idx_symbol_hash_locks_mosaic_end_height '
+	'ON symbol_hash_locks(mosaic_id, end_height DESC, hash DESC)',
+	'CREATE INDEX IF NOT EXISTS idx_symbol_hash_locks_status_end_height '
+	'ON symbol_hash_locks(status, end_height DESC, hash DESC)',
+	'CREATE INDEX IF NOT EXISTS idx_symbol_hash_locks_end_height '
+	'ON symbol_hash_locks(end_height DESC, hash DESC)',
+	'CREATE INDEX IF NOT EXISTS idx_symbol_hash_locks_updated_at_height '
+	'ON symbol_hash_locks(updated_at_height)',
+	'CREATE INDEX IF NOT EXISTS idx_symbol_secret_locks_owner_end_height '
+	'ON symbol_secret_locks(owner_address, end_height DESC, composite_hash DESC)',
+	'CREATE INDEX IF NOT EXISTS idx_symbol_secret_locks_recipient_end_height '
+	'ON symbol_secret_locks(recipient_address, end_height DESC, composite_hash DESC)',
+	'CREATE INDEX IF NOT EXISTS idx_symbol_secret_locks_mosaic_end_height '
+	'ON symbol_secret_locks(mosaic_id, end_height DESC, composite_hash DESC)',
+	'CREATE INDEX IF NOT EXISTS idx_symbol_secret_locks_status_end_height '
+	'ON symbol_secret_locks(status, end_height DESC, composite_hash DESC)',
+	'CREATE INDEX IF NOT EXISTS idx_symbol_secret_locks_hash_algorithm_end_height '
+	'ON symbol_secret_locks(hash_algorithm, end_height DESC, composite_hash DESC)',
+	'CREATE INDEX IF NOT EXISTS idx_symbol_secret_locks_end_height '
+	'ON symbol_secret_locks(end_height DESC, composite_hash DESC)',
+	'CREATE INDEX IF NOT EXISTS idx_symbol_secret_locks_updated_at_height '
+	'ON symbol_secret_locks(updated_at_height)',
+	'CREATE INDEX IF NOT EXISTS idx_symbol_secret_locks_search '
+	'ON symbol_secret_locks(secret, recipient_address, hash_algorithm, owner_address)'
+]
 SYMBOL_TRANSACTION_DEFINITIONS = [
 	'id bigserial PRIMARY KEY',
 	'hash bytea UNIQUE',
@@ -414,6 +479,8 @@ class SymbolDatabase(DatabaseConnection):  # pylint: disable=too-many-public-met
 		_create_enum_type(cursor, 'symbol_namespace_alias_type', SYMBOL_NAMESPACE_ALIAS_TYPE_VALUES)
 		_create_enum_type(cursor, 'symbol_alias_artifact_type', SYMBOL_ALIAS_ARTIFACT_TYPE_VALUES)
 		_create_enum_type(cursor, 'symbol_metadata_type', SYMBOL_METADATA_TYPE_VALUES)
+		_create_enum_type(cursor, 'symbol_lock_status', SYMBOL_LOCK_STATUS_VALUES)
+		_create_enum_type(cursor, 'symbol_lock_hash_algorithm', SYMBOL_LOCK_HASH_ALGORITHM_VALUES)
 		_create_table(cursor, 'symbol_sync_state', SYMBOL_SYNC_STATE_DEFINITIONS)
 		_create_table(cursor, 'symbol_blocks', SYMBOL_BLOCK_DEFINITIONS)
 		_create_table(cursor, 'symbol_account_refresh_state', SYMBOL_ACCOUNT_REFRESH_STATE_DEFINITIONS)
@@ -436,6 +503,10 @@ class SymbolDatabase(DatabaseConnection):  # pylint: disable=too-many-public-met
 			cursor.execute(index_sql)
 		_create_table(cursor, 'symbol_metadata', SYMBOL_METADATA_DEFINITIONS)
 		for index_sql in SYMBOL_METADATA_INDEXES:
+			cursor.execute(index_sql)
+		_create_table(cursor, 'symbol_hash_locks', SYMBOL_HASH_LOCK_DEFINITIONS)
+		_create_table(cursor, 'symbol_secret_locks', SYMBOL_SECRET_LOCK_DEFINITIONS)
+		for index_sql in SYMBOL_LOCK_INDEXES:
 			cursor.execute(index_sql)
 		cursor.execute('CREATE SEQUENCE IF NOT EXISTS symbol_transaction_list_sequence_seq')
 		_create_table(cursor, 'symbol_transactions', SYMBOL_TRANSACTION_DEFINITIONS)
@@ -654,6 +725,19 @@ class SymbolDatabase(DatabaseConnection):  # pylint: disable=too-many-public-met
 				SymbolDatabase._execute_upsert_metadata(cursor, entry['row'])
 
 	@staticmethod
+	def _execute_hash_lock_entries(cursor, hash_lock_entries):
+		for entry in hash_lock_entries:
+			if 'hash' in entry:
+				SymbolDatabase._execute_delete_hash_lock(cursor, entry['hash'])
+			else:
+				SymbolDatabase._execute_upsert_hash_lock(cursor, entry['row'])
+
+	@staticmethod
+	def _execute_secret_lock_entries(cursor, secret_lock_entries):
+		for entry in secret_lock_entries:
+			SymbolDatabase._execute_replace_secret_locks(cursor, entry['key'], entry['rows'])
+
+	@staticmethod
 	def _execute_refresh_mosaic_alias_names(cursor, mosaic_ids):
 		for mosaic_id in mosaic_ids:
 			cursor.execute(
@@ -821,6 +905,198 @@ class SymbolDatabase(DatabaseConnection):  # pylint: disable=too-many-public-met
 			}
 			for row in cursor.fetchall()
 		]
+
+	def upsert_hash_lock(self, hash_lock_row):
+		"""Upserts one Hash Lock current-state row by its aggregate bonded hash."""
+
+		with self._database_transaction() as cursor:
+			self._execute_upsert_hash_lock(cursor, hash_lock_row)
+
+	def delete_hash_lock(self, hash_lock):
+		"""Deletes one Hash Lock current-state row by its aggregate bonded hash."""
+
+		with self._database_transaction() as cursor:
+			self._execute_delete_hash_lock(cursor, hash_lock)
+
+	@staticmethod
+	def _execute_upsert_hash_lock(cursor, hash_lock_row):
+		cursor.execute(
+			'''
+			INSERT INTO symbol_hash_locks (
+				hash, owner_address, mosaic_id, amount, end_height, status, raw_payload, updated_at_height
+			)
+			VALUES (
+				%(hash)s, %(owner_address)s, %(mosaic_id)s, %(amount)s, %(end_height)s, %(status)s,
+				%(raw_payload)s, %(updated_at_height)s
+			)
+			ON CONFLICT (hash) DO UPDATE SET
+				owner_address = EXCLUDED.owner_address,
+				mosaic_id = EXCLUDED.mosaic_id,
+				amount = EXCLUDED.amount,
+				end_height = EXCLUDED.end_height,
+				status = EXCLUDED.status,
+				raw_payload = EXCLUDED.raw_payload,
+				updated_at_height = EXCLUDED.updated_at_height
+			''',
+			{**hash_lock_row, 'raw_payload': Json(hash_lock_row['raw_payload'])})
+
+	@staticmethod
+	def _execute_delete_hash_lock(cursor, hash_lock):
+		cursor.execute('DELETE FROM symbol_hash_locks WHERE hash = %s', (hash_lock.hash,))
+
+	def replace_secret_locks(self, search_key, secret_lock_rows):
+		"""Replaces all Secret Lock rows matching one logical key, including an empty replacement."""
+
+		with self._database_transaction() as cursor:
+			self._execute_replace_secret_locks(cursor, search_key, secret_lock_rows)
+
+	@staticmethod
+	def _execute_replace_secret_locks(cursor, search_key, secret_lock_rows):
+		SymbolDatabase._execute_delete_secret_locks(cursor, search_key)
+		for secret_lock_row in secret_lock_rows:
+			SymbolDatabase._execute_upsert_secret_lock(cursor, secret_lock_row)
+
+	@staticmethod
+	def _execute_delete_secret_locks(cursor, search_key):
+		where_clause = '''
+			WHERE recipient_address = %(recipient_address)s
+				AND secret = %(secret)s
+				AND hash_algorithm = %(hash_algorithm)s
+		'''
+		parameters = {
+			'recipient_address': search_key.recipient_address,
+			'secret': search_key.secret,
+			'hash_algorithm': search_key.hash_algorithm
+		}
+		if search_key.owner_address is not None:
+			where_clause += ' AND owner_address = %(owner_address)s'
+			parameters['owner_address'] = search_key.owner_address
+
+		cursor.execute(f'DELETE FROM symbol_secret_locks {where_clause}', parameters)
+
+	@staticmethod
+	def _execute_upsert_secret_lock(cursor, secret_lock_row):
+		cursor.execute(
+			'''
+			INSERT INTO symbol_secret_locks (
+				composite_hash, owner_address, recipient_address, secret, hash_algorithm, mosaic_id,
+				amount, end_height, status, raw_payload, updated_at_height
+			)
+			VALUES (
+				%(composite_hash)s, %(owner_address)s, %(recipient_address)s, %(secret)s, %(hash_algorithm)s,
+				%(mosaic_id)s, %(amount)s, %(end_height)s, %(status)s, %(raw_payload)s, %(updated_at_height)s
+			)
+			ON CONFLICT (composite_hash) DO UPDATE SET
+				owner_address = EXCLUDED.owner_address,
+				recipient_address = EXCLUDED.recipient_address,
+				secret = EXCLUDED.secret,
+				hash_algorithm = EXCLUDED.hash_algorithm,
+				mosaic_id = EXCLUDED.mosaic_id,
+				amount = EXCLUDED.amount,
+				end_height = EXCLUDED.end_height,
+				status = EXCLUDED.status,
+				raw_payload = EXCLUDED.raw_payload,
+				updated_at_height = EXCLUDED.updated_at_height
+			''',
+			{**secret_lock_row, 'raw_payload': Json(secret_lock_row['raw_payload'])})
+
+	def get_hash_lock_hashes_updated_from_height(self, height):  # pylint: disable=invalid-name
+		"""Gets Hash Lock keys whose current state was observed at or after a height."""
+
+		cursor = self.connection.cursor()
+		cursor.execute(
+			'SELECT hash FROM symbol_hash_locks WHERE updated_at_height >= %s ORDER BY hash',
+			(height,))
+
+		return [create_hash_lock_key_from_hex(bytes(row[0]).hex()) for row in cursor.fetchall()]
+
+	def get_secret_lock_search_keys_updated_from_height(self, height):  # pylint: disable=invalid-name
+		"""Gets Secret Lock logical keys whose current state was observed at or after a height."""
+
+		return self._get_secret_lock_search_keys(
+			'updated_at_height >= %s',
+			(height,))
+
+	def get_hash_lock_hashes_expiring_between(self, start_height, end_height):  # pylint: disable=invalid-name
+		"""Gets Hash Lock keys whose end height is inside an inclusive range."""
+
+		cursor = self.connection.cursor()
+		cursor.execute(
+			'''
+			SELECT hash
+			FROM symbol_hash_locks
+			WHERE end_height BETWEEN %s AND %s
+			ORDER BY hash
+			''',
+			(start_height, end_height))
+
+		return [create_hash_lock_key_from_hex(bytes(row[0]).hex()) for row in cursor.fetchall()]
+
+	def get_secret_lock_search_keys_expiring_between(self, start_height, end_height):  # pylint: disable=invalid-name
+		"""Gets Secret Lock logical keys whose end height is inside an inclusive range."""
+
+		return self._get_secret_lock_search_keys(
+			'end_height BETWEEN %s AND %s',
+			(start_height, end_height))
+
+	def _get_secret_lock_search_keys(self, predicate, parameters):
+		cursor = self.connection.cursor()
+		cursor.execute(
+			f'''
+			SELECT owner_address, recipient_address, secret, hash_algorithm
+			FROM symbol_secret_locks
+			WHERE {predicate}
+			ORDER BY composite_hash
+			''',
+			parameters)
+
+		return [
+			create_secret_lock_search_key(
+				bytes(row[0]), bytes(row[1]), bytes(row[2]), row[3])
+			for row in cursor.fetchall()
+		]
+
+	def get_lock_keys_from_confirmed_transactions_from_height(self, height):  # pylint: disable=invalid-name
+		"""Gets Lock keys from persisted confirmed transactions at or above a rollback height."""
+
+		cursor = self.connection.cursor()
+		cursor.execute(
+			'''
+			SELECT type, is_embedded, hash, signer_address, recipient_address, body
+			FROM symbol_transactions
+			WHERE height >= %s
+				AND type IN (%s, %s, %s, %s)
+			ORDER BY id
+			''',
+			(
+				height,
+				TransactionType.HASH_LOCK.value,
+				TransactionType.SECRET_LOCK.value,
+				TransactionType.SECRET_PROOF.value,
+				TransactionType.AGGREGATE_BONDED.value
+			))
+
+		hash_keys = {}
+		secret_keys = {}
+		for transaction_type, is_embedded, transaction_hash, signer_address, recipient_address, body in cursor.fetchall():
+			if TransactionType.HASH_LOCK.value == transaction_type:
+				hash_key = create_hash_lock_key_from_hex(body['hash'])
+				hash_keys[hash_key] = None
+			elif TransactionType.AGGREGATE_BONDED.value == transaction_type and not is_embedded:
+				hash_key = create_hash_lock_key_from_hex(bytes(transaction_hash).hex())
+				hash_keys[hash_key] = None
+			elif TransactionType.SECRET_LOCK.value == transaction_type:
+				secret_key = create_secret_lock_search_key_from_hex_secret(
+					bytes(signer_address), bytes(recipient_address), body['secret'],
+					lock_hash_algorithm_label(body['hashAlgorithm']))
+				secret_keys[secret_key] = None
+			elif TransactionType.SECRET_PROOF.value == transaction_type:
+				secret_key = create_secret_lock_search_key_from_hex_secret(
+					None, bytes(recipient_address), body['secret'],
+					lock_hash_algorithm_label(body['hashAlgorithm']))
+				secret_keys[secret_key] = None
+
+		return RollbackLockKeys(list(hash_keys), list(secret_keys))
 
 	def delete_namespace(self, namespace_id):
 		"""Deletes one namespace and its derived alias-name rows when it exists."""
@@ -1274,6 +1550,8 @@ class SymbolDatabase(DatabaseConnection):  # pylint: disable=too-many-public-met
 			self._execute_namespace_entries(cursor, refresh_entries.namespace_entries)
 			self._execute_mosaic_entries(cursor, refresh_entries.mosaic_entries)
 			self._execute_metadata_entries(cursor, refresh_entries.metadata_entries)
+			self._execute_hash_lock_entries(cursor, refresh_entries.hash_lock_entries)
+			self._execute_secret_lock_entries(cursor, refresh_entries.secret_lock_entries)
 			self._execute_upsert_sync_state(cursor, sync_state)
 
 	@staticmethod
@@ -1286,6 +1564,8 @@ class SymbolDatabase(DatabaseConnection):  # pylint: disable=too-many-public-met
 		cursor.execute('DELETE FROM symbol_multisig WHERE updated_at_height >= %s', (height,))
 		cursor.execute('DELETE FROM symbol_account_mosaics WHERE updated_at_height >= %s', (height,))
 		cursor.execute('DELETE FROM symbol_accounts WHERE last_seen_height >= %s', (height,))
+		cursor.execute('DELETE FROM symbol_hash_locks WHERE updated_at_height >= %s', (height,))
+		cursor.execute('DELETE FROM symbol_secret_locks WHERE updated_at_height >= %s', (height,))
 
 	def upsert_transactions_for_height(self, height, transaction_entries):
 		"""Replaces persisted Symbol transactions and child index rows for one height."""

--- a/explorer/puller/puller/db/SymbolDatabase.py
+++ b/explorer/puller/puller/db/SymbolDatabase.py
@@ -3,19 +3,10 @@ from collections import namedtuple
 from contextlib import contextmanager
 
 from psycopg2.extras import Json
-from symbolchain.sc import TransactionType
 
 from puller.model.symbol.Account import ACCOUNT_TYPE_VALUES
 from puller.model.symbol.Block import BLOCK_TYPE_VALUES
-from puller.model.symbol.Lock import (
-	LOCK_HASH_ALGORITHM_LABELS,
-	LOCK_STATUS_LABELS,
-	RollbackLockKeys,
-	create_hash_lock_key,
-	create_secret_lock_search_key,
-	create_secret_lock_search_key_from_hex_secret,
-	lock_hash_algorithm_label
-)
+from puller.model.symbol.Lock import LOCK_HASH_ALGORITHM_LABELS, LOCK_STATUS_LABELS, create_hash_lock_key, create_secret_lock_search_key
 from puller.model.symbol.Metadata import METADATA_TYPE_LABELS
 from puller.model.symbol.Namespace import NAMESPACE_ALIAS_TYPE_LABELS, NAMESPACE_REGISTRATION_TYPE_LABELS
 from puller.model.symbol.Receipt import RECEIPT_TYPE_LABELS
@@ -1018,31 +1009,31 @@ class SymbolDatabase(DatabaseConnection):  # pylint: disable=too-many-public-met
 			(height,),
 			'updated_at_height')
 
-	def get_hash_lock_hashes_reaching_end_height_between(self, start_height, end_height):  # pylint: disable=invalid-name
-		"""Gets Hash Lock keys whose end height is inside an inclusive range."""
+	def get_hash_lock_hashes_reaching_finalized_height(self, finalized_height):  # pylint: disable=invalid-name
+		"""Gets Hash Lock keys whose end height has reached finalization."""
 
 		cursor = self.connection.cursor()
 		cursor.execute(
 			'''
 			SELECT hash
 			FROM symbol_hash_locks
-			WHERE end_height BETWEEN %s AND %s
+			WHERE end_height <= %s
 			ORDER BY end_height, hash
 			''',
-			(start_height, end_height))
+			(finalized_height,))
 
 		return [create_hash_lock_key(bytes(row[0])) for row in cursor.fetchall()]
 
-	def get_secret_lock_search_keys_reaching_end_height_between(self, start_height, end_height):  # pylint: disable=invalid-name
-		"""Gets Secret Lock logical keys whose end height is inside an inclusive range."""
+	def get_secret_lock_search_keys_reaching_finalized_height(self, finalized_height):  # pylint: disable=invalid-name
+		"""Gets Secret Lock logical keys whose end height has reached finalization."""
 
 		return self._get_secret_lock_search_keys(
-			'end_height BETWEEN %s AND %s',
-			(start_height, end_height),
+			'end_height <= %s',
+			(finalized_height,),
 			'end_height')
 
 	def _get_secret_lock_search_keys(self, predicate, parameters, sort_column):
-		# Keep interpolated SQL identifiers restricted to the two fixed query contracts.
+		# Keep the interpolated ORDER BY identifier restricted to the updated-height and finalized-height contracts.
 		sort_column = {
 			'updated_at_height': 'updated_at_height',
 			'end_height': 'end_height'
@@ -1063,45 +1054,12 @@ class SymbolDatabase(DatabaseConnection):  # pylint: disable=too-many-public-met
 			for row in cursor.fetchall()
 		]
 
-	def get_lock_keys_from_confirmed_transactions_from_height(self, height):  # pylint: disable=invalid-name
-		"""Gets Lock keys from persisted confirmed transactions at or above a rollback height."""
+	def apply_finalization_lock_entries(self, hash_lock_entries, secret_lock_entries):
+		"""Applies finalized Hash and Secret Lock replacements in one transaction."""
 
-		cursor = self.connection.cursor()
-		cursor.execute(
-			'''
-			SELECT type, hash, signer_address, recipient_address, body
-			FROM symbol_transactions
-			WHERE height >= %s
-				AND type IN (%s, %s, %s, %s)
-			ORDER BY id
-			''',
-			(
-				height,
-				TransactionType.HASH_LOCK.value,
-				TransactionType.SECRET_LOCK.value,
-				TransactionType.SECRET_PROOF.value,
-				TransactionType.AGGREGATE_BONDED.value
-			))
-
-		hash_keys = []
-		secret_keys = []
-		for transaction_type, transaction_hash, signer_address, recipient_address, body in cursor.fetchall():
-			if TransactionType.HASH_LOCK.value == transaction_type:
-				hash_keys.append(create_hash_lock_key(body['hash']))
-			elif TransactionType.AGGREGATE_BONDED.value == transaction_type:
-				hash_keys.append(create_hash_lock_key(bytes(transaction_hash)))
-			elif TransactionType.SECRET_LOCK.value == transaction_type:
-				secret_keys.append(create_secret_lock_search_key_from_hex_secret(
-					bytes(signer_address), bytes(recipient_address), body['secret'],
-					lock_hash_algorithm_label(body['hashAlgorithm'])))
-			elif TransactionType.SECRET_PROOF.value == transaction_type:
-				secret_keys.append(create_secret_lock_search_key_from_hex_secret(
-					None, bytes(recipient_address), body['secret'],
-					lock_hash_algorithm_label(body['hashAlgorithm'])))
-
-		return RollbackLockKeys(
-			list(dict.fromkeys(hash_keys)),
-			list(dict.fromkeys(secret_keys)))
+		with self._database_transaction() as cursor:
+			self._execute_hash_lock_entries(cursor, hash_lock_entries)
+			self._execute_secret_lock_entries(cursor, secret_lock_entries)
 
 	def delete_namespace(self, namespace_id):
 		"""Deletes one namespace and its derived alias-name rows when it exists."""

--- a/explorer/puller/puller/facade/SymbolPuller.py
+++ b/explorer/puller/puller/facade/SymbolPuller.py
@@ -203,6 +203,8 @@ class SymbolPuller:
 			if not finalized_hash:
 				raise ValueError(f'Unable to determine finalized hash for height {finalized_height}')
 
+		await self._sync_finalization_lock_cleanup(finalized_height)
+
 		self.symbol_db.upsert_sync_state({
 			'status': 'healthy',
 			'chain_height': chain_height,
@@ -302,15 +304,10 @@ class SymbolPuller:
 		mosaic_entries = await self._fetch_dirty_mosaics(mosaic_ids, height - 1)
 		metadata_keys = self.symbol_db.get_metadata_keys_updated_from_height(height)
 		metadata_entries = await self._fetch_dirty_metadata(metadata_keys, height - 1)
-		# Current rows recover Lock state still present after the fork, while rollback-range transactions recover
-		# exact keys for Locks already deleted on the orphan branch. Collect both before chain-row deletion.
-		rollback_transaction_keys = self.symbol_db.get_lock_keys_from_confirmed_transactions_from_height(height)
-		hash_lock_keys = self._union_lock_keys(
-			self.symbol_db.get_hash_lock_hashes_updated_from_height(height),
-			rollback_transaction_keys.hash_keys)
-		secret_lock_keys = self._union_lock_keys(
-			self.symbol_db.get_secret_lock_search_keys_updated_from_height(height),
-			rollback_transaction_keys.secret_keys)
+		# Current rows recover Lock state still present after the fork. Finalized rows cannot be part of this
+		# unfinalized repair range, so transaction history is not an authoritative rollback key source.
+		hash_lock_keys = self.symbol_db.get_hash_lock_hashes_updated_from_height(height)
+		secret_lock_keys = self.symbol_db.get_secret_lock_search_keys_updated_from_height(height)
 		hash_lock_entries = await self._fetch_dirty_hash_locks(hash_lock_keys, height - 1)
 		secret_lock_entries = await self._fetch_dirty_secret_locks(secret_lock_keys, height - 1)
 		self.symbol_db.repair_rollback_from_height(height, {
@@ -402,9 +399,7 @@ class SymbolPuller:
 		dirty_mosaic_entries = await self._fetch_dirty_mosaics(dirty_mosaic_ids, observed_height)
 		dirty_metadata_keys = self._collect_dirty_metadata_keys_for_batch(transaction_rows_by_height)
 		dirty_metadata_entries = await self._fetch_dirty_metadata(dirty_metadata_keys, observed_height)
-		dirty_lock_keys = self._collect_dirty_lock_keys_for_batch(
-			batch_rows,
-			transaction_rows_by_height)
+		dirty_lock_keys = self._collect_dirty_lock_keys_for_batch(transaction_rows_by_height)
 		dirty_hash_lock_entries = await self._fetch_dirty_hash_locks(dirty_lock_keys.hash_keys, observed_height)
 		dirty_secret_lock_entries = await self._fetch_dirty_secret_locks(dirty_lock_keys.secret_keys, observed_height)
 		self._sync_block_batch(batch_rows, transaction_rows_by_height, receipt_rows_by_height)
@@ -414,6 +409,16 @@ class SymbolPuller:
 		self._write_dirty_metadata(dirty_metadata_entries)
 		self._write_dirty_hash_locks(dirty_hash_lock_entries)
 		self._write_dirty_secret_locks(dirty_secret_lock_entries)
+
+	async def _sync_finalization_lock_cleanup(self, finalized_height):
+		"""Reconciles all current Lock rows whose end height has reached finalization."""
+
+		hash_lock_keys = self.symbol_db.get_hash_lock_hashes_reaching_finalized_height(finalized_height)
+		secret_lock_keys = self.symbol_db.get_secret_lock_search_keys_reaching_finalized_height(finalized_height)
+		# Fetch every replacement before the first cleanup write so a failed request leaves all state untouched.
+		hash_lock_entries = await self._fetch_dirty_hash_locks(hash_lock_keys, finalized_height)
+		secret_lock_entries = await self._fetch_dirty_secret_locks(secret_lock_keys, finalized_height)
+		self.symbol_db.apply_finalization_lock_entries(hash_lock_entries, secret_lock_entries)
 
 	def _sync_block_batch(self, batch_rows, transaction_rows_by_height, receipt_rows_by_height):
 		"""Writes previously-fetched block, transaction, and receipt rows for one batch.
@@ -937,12 +942,8 @@ class SymbolPuller:
 		if address is not None and Address(address).is_alias():
 			raise ValueError(f'Unresolved Symbol transaction {field_name} reached Lock dirty-key collection')
 
-	@staticmethod
-	def _union_lock_keys(*key_lists):
-		return list(dict.fromkeys(key for key_list in key_lists for key in key_list))
-
-	def _collect_dirty_lock_keys_for_batch(self, block_rows, transaction_rows_by_height):
-		"""Collects Hash and Secret Lock dirty keys from transactions and expiring current rows."""
+	def _collect_dirty_lock_keys_for_batch(self, transaction_rows_by_height):
+		"""Collects Hash and Secret Lock dirty keys from transactions in the current batch."""
 
 		hash_keys = []
 		secret_keys = []
@@ -964,17 +965,7 @@ class SymbolPuller:
 						body['secret'],
 						lock_hash_algorithm_label(body['hashAlgorithm'])))
 
-		start_height = block_rows[0]['height']
-		end_height = block_rows[-1]['height']
-		# Rows reaching end height in this batch must be rechecked because the node may already have pruned them.
-		ending_hash_keys = self.symbol_db.get_hash_lock_hashes_reaching_end_height_between(
-			start_height, end_height)
-		ending_secret_keys = self.symbol_db.get_secret_lock_search_keys_reaching_end_height_between(
-			start_height, end_height)
-
-		return RollbackLockKeys(
-			self._union_lock_keys(hash_keys, ending_hash_keys),
-			self._union_lock_keys(secret_keys, ending_secret_keys))
+		return RollbackLockKeys(list(dict.fromkeys(hash_keys)), list(dict.fromkeys(secret_keys)))
 
 	async def _fetch_dirty_hash_locks(self, hash_keys, observed_height):
 		"""Fetches Hash Lock detail state in bounded concurrent batches."""

--- a/explorer/puller/puller/facade/SymbolPuller.py
+++ b/explorer/puller/puller/facade/SymbolPuller.py
@@ -21,7 +21,7 @@ from puller.model.symbol.Account import HARVESTING_ACTIVE_WINDOW_DAYS, create_ac
 from puller.model.symbol.Block import create_block_row
 from puller.model.symbol.Lock import (
 	RollbackLockKeys,
-	create_hash_lock_key_from_hex,
+	create_hash_lock_key,
 	create_hash_lock_row,
 	create_secret_lock_row,
 	create_secret_lock_search_key_from_hex_secret,
@@ -302,11 +302,13 @@ class SymbolPuller:
 		mosaic_entries = await self._fetch_dirty_mosaics(mosaic_ids, height - 1)
 		metadata_keys = self.symbol_db.get_metadata_keys_updated_from_height(height)
 		metadata_entries = await self._fetch_dirty_metadata(metadata_keys, height - 1)
+		# Current rows recover Lock state still present after the fork, while rollback-range transactions recover
+		# exact keys for Locks already deleted on the orphan branch. Collect both before chain-row deletion.
 		rollback_transaction_keys = self.symbol_db.get_lock_keys_from_confirmed_transactions_from_height(height)
-		hash_lock_keys = self._union_hash_lock_keys(
+		hash_lock_keys = self._union_lock_keys(
 			self.symbol_db.get_hash_lock_hashes_updated_from_height(height),
 			rollback_transaction_keys.hash_keys)
-		secret_lock_keys = self._union_secret_lock_keys(
+		secret_lock_keys = self._union_lock_keys(
 			self.symbol_db.get_secret_lock_search_keys_updated_from_height(height),
 			rollback_transaction_keys.secret_keys)
 		hash_lock_entries = await self._fetch_dirty_hash_locks(hash_lock_keys, height - 1)
@@ -936,56 +938,43 @@ class SymbolPuller:
 			raise ValueError(f'Unresolved Symbol transaction {field_name} reached Lock dirty-key collection')
 
 	@staticmethod
-	def _union_hash_lock_keys(*key_lists):
-		keys = {}
-		for key_list in key_lists:
-			for key in key_list:
-				keys[key] = None
-
-		return list(keys)
-
-	@staticmethod
-	def _union_secret_lock_keys(*key_lists):
-		keys = {}
-		for key_list in key_lists:
-			for key in key_list:
-				keys[key] = None
-
-		return list(keys)
+	def _union_lock_keys(*key_lists):
+		return list(dict.fromkeys(key for key_list in key_lists for key in key_list))
 
 	def _collect_dirty_lock_keys_for_batch(self, block_rows, transaction_rows_by_height):
 		"""Collects Hash and Secret Lock dirty keys from transactions and expiring current rows."""
 
-		hash_keys = {}
-		secret_keys = {}
+		hash_keys = []
+		secret_keys = []
 		for transaction_rows in transaction_rows_by_height.values():
 			for transaction_row in transaction_rows:
 				transaction_type = transaction_row['type']
 				body = transaction_row['body']
 				if TransactionType.HASH_LOCK.value == transaction_type:
-					hash_keys[create_hash_lock_key_from_hex(body['hash'])] = None
-				elif TransactionType.AGGREGATE_BONDED.value == transaction_type and not transaction_row['is_embedded']:
-					hash_keys[create_hash_lock_key_from_hex(transaction_row['hash'].hex())] = None
+					hash_keys.append(create_hash_lock_key(body['hash']))
+				elif TransactionType.AGGREGATE_BONDED.value == transaction_type:
+					hash_keys.append(create_hash_lock_key(transaction_row['hash']))
 				elif transaction_type in (TransactionType.SECRET_LOCK.value, TransactionType.SECRET_PROOF.value):
 					self._assert_resolved_transaction_address(transaction_row['recipient_address'], 'recipient_address')
 					owner_address = transaction_row['signer_address'] if TransactionType.SECRET_LOCK.value == transaction_type else None
 					self._assert_resolved_transaction_address(owner_address, 'signer_address')
-					secret_key = create_secret_lock_search_key_from_hex_secret(
+					secret_keys.append(create_secret_lock_search_key_from_hex_secret(
 						owner_address,
 						transaction_row['recipient_address'],
 						body['secret'],
-						lock_hash_algorithm_label(body['hashAlgorithm']))
-					secret_keys[secret_key] = None
+						lock_hash_algorithm_label(body['hashAlgorithm'])))
 
 		start_height = block_rows[0]['height']
 		end_height = block_rows[-1]['height']
-		hash_keys.update({key: None for key in self.symbol_db.get_hash_lock_hashes_expiring_between(start_height, end_height)})
-		secret_keys.update({
-			key: None
-			for key in self.symbol_db.get_secret_lock_search_keys_expiring_between(start_height, end_height)
-		})
+		# Rows reaching end height in this batch must be rechecked because the node may already have pruned them.
+		ending_hash_keys = self.symbol_db.get_hash_lock_hashes_reaching_end_height_between(
+			start_height, end_height)
+		ending_secret_keys = self.symbol_db.get_secret_lock_search_keys_reaching_end_height_between(
+			start_height, end_height)
 
-		return RollbackLockKeys(list(hash_keys), list(secret_keys))
+		return RollbackLockKeys(
+			self._union_lock_keys(hash_keys, ending_hash_keys),
+			self._union_lock_keys(secret_keys, ending_secret_keys))
 
 	async def _fetch_dirty_hash_locks(self, hash_keys, observed_height):
 		"""Fetches Hash Lock detail state in bounded concurrent batches."""

--- a/explorer/puller/puller/facade/SymbolPuller.py
+++ b/explorer/puller/puller/facade/SymbolPuller.py
@@ -19,6 +19,14 @@ from puller.db.SymbolDatabase import RollbackRefreshEntries, SymbolDatabase
 from puller.facade.RequestRateLimiter import RequestRateLimiter
 from puller.model.symbol.Account import HARVESTING_ACTIVE_WINDOW_DAYS, create_account_row, create_multisig_row
 from puller.model.symbol.Block import create_block_row
+from puller.model.symbol.Lock import (
+	RollbackLockKeys,
+	create_hash_lock_key_from_hex,
+	create_hash_lock_row,
+	create_secret_lock_row,
+	create_secret_lock_search_key_from_hex_secret,
+	lock_hash_algorithm_label
+)
 from puller.model.symbol.Metadata import METADATA_TRANSACTION_TYPE_LABELS, METADATA_TYPE_NUMBERS, create_metadata_row
 from puller.model.symbol.Mosaic import create_mosaic_row
 from puller.model.symbol.Namespace import create_alias_name_rows, create_namespace_row
@@ -42,6 +50,7 @@ ACCOUNT_BATCH_FETCH_SIZE = MAX_PAGE_SIZE
 BLOCK_PAGE_FETCH_CONCURRENCY = 10
 RESOLUTION_FETCH_CONCURRENCY = 10
 METADATA_FETCH_CONCURRENCY = 10
+LOCK_FETCH_CONCURRENCY = 10
 DEFAULT_MAX_REQUESTS_PER_SECOND = 20
 ACCOUNT_PAGE_SIZE = 100
 
@@ -293,12 +302,26 @@ class SymbolPuller:
 		mosaic_entries = await self._fetch_dirty_mosaics(mosaic_ids, height - 1)
 		metadata_keys = self.symbol_db.get_metadata_keys_updated_from_height(height)
 		metadata_entries = await self._fetch_dirty_metadata(metadata_keys, height - 1)
+		rollback_transaction_keys = self.symbol_db.get_lock_keys_from_confirmed_transactions_from_height(height)
+		hash_lock_keys = self._union_hash_lock_keys(
+			self.symbol_db.get_hash_lock_hashes_updated_from_height(height),
+			rollback_transaction_keys.hash_keys)
+		secret_lock_keys = self._union_secret_lock_keys(
+			self.symbol_db.get_secret_lock_search_keys_updated_from_height(height),
+			rollback_transaction_keys.secret_keys)
+		hash_lock_entries = await self._fetch_dirty_hash_locks(hash_lock_keys, height - 1)
+		secret_lock_entries = await self._fetch_dirty_secret_locks(secret_lock_keys, height - 1)
 		self.symbol_db.repair_rollback_from_height(height, {
 			**sync_state,
 			'status': 'repairing',
 			'last_synced_height': height - 1,
 			'last_synced_block_hash': self.symbol_db.get_block_hash(height - 1)
-		}, RollbackRefreshEntries(namespace_entries, mosaic_entries, metadata_entries))
+		}, RollbackRefreshEntries(
+			namespace_entries,
+			mosaic_entries,
+			metadata_entries,
+			hash_lock_entries,
+			secret_lock_entries))
 		return height
 
 	async def _sync_block_pages(  # pylint: disable=too-many-locals
@@ -348,7 +371,7 @@ class SymbolPuller:
 
 		return last_synced_height, last_synced_block_hash
 
-	async def _sync_block_batch_with_dirty_state(
+	async def _sync_block_batch_with_dirty_state(  # pylint: disable=too-many-locals
 		self,
 		batch_rows,
 		epoch_adjustment_seconds,
@@ -377,11 +400,18 @@ class SymbolPuller:
 		dirty_mosaic_entries = await self._fetch_dirty_mosaics(dirty_mosaic_ids, observed_height)
 		dirty_metadata_keys = self._collect_dirty_metadata_keys_for_batch(transaction_rows_by_height)
 		dirty_metadata_entries = await self._fetch_dirty_metadata(dirty_metadata_keys, observed_height)
+		dirty_lock_keys = self._collect_dirty_lock_keys_for_batch(
+			batch_rows,
+			transaction_rows_by_height)
+		dirty_hash_lock_entries = await self._fetch_dirty_hash_locks(dirty_lock_keys.hash_keys, observed_height)
+		dirty_secret_lock_entries = await self._fetch_dirty_secret_locks(dirty_lock_keys.secret_keys, observed_height)
 		self._sync_block_batch(batch_rows, transaction_rows_by_height, receipt_rows_by_height)
 		self._write_dirty_accounts_for_batch(dirty_account_rows)
 		self.symbol_db.apply_namespace_entries(dirty_namespace_entries)
 		self._write_dirty_mosaics(dirty_mosaic_entries)
 		self._write_dirty_metadata(dirty_metadata_entries)
+		self._write_dirty_hash_locks(dirty_hash_lock_entries)
+		self._write_dirty_secret_locks(dirty_secret_lock_entries)
 
 	def _sync_block_batch(self, batch_rows, transaction_rows_by_height, receipt_rows_by_height):
 		"""Writes previously-fetched block, transaction, and receipt rows for one batch.
@@ -899,6 +929,147 @@ class SymbolPuller:
 				self.symbol_db.delete_metadata_by_key(entry['key'])
 			else:
 				self.symbol_db.upsert_metadata(entry['row'])
+
+	@staticmethod
+	def _assert_resolved_transaction_address(address, field_name):
+		if address is not None and Address(address).is_alias():
+			raise ValueError(f'Unresolved Symbol transaction {field_name} reached Lock dirty-key collection')
+
+	@staticmethod
+	def _union_hash_lock_keys(*key_lists):
+		keys = {}
+		for key_list in key_lists:
+			for key in key_list:
+				keys[key] = None
+
+		return list(keys)
+
+	@staticmethod
+	def _union_secret_lock_keys(*key_lists):
+		keys = {}
+		for key_list in key_lists:
+			for key in key_list:
+				keys[key] = None
+
+		return list(keys)
+
+	def _collect_dirty_lock_keys_for_batch(self, block_rows, transaction_rows_by_height):
+		"""Collects Hash and Secret Lock dirty keys from transactions and expiring current rows."""
+
+		hash_keys = {}
+		secret_keys = {}
+		for transaction_rows in transaction_rows_by_height.values():
+			for transaction_row in transaction_rows:
+				transaction_type = transaction_row['type']
+				body = transaction_row['body']
+				if TransactionType.HASH_LOCK.value == transaction_type:
+					hash_keys[create_hash_lock_key_from_hex(body['hash'])] = None
+				elif TransactionType.AGGREGATE_BONDED.value == transaction_type and not transaction_row['is_embedded']:
+					hash_keys[create_hash_lock_key_from_hex(transaction_row['hash'].hex())] = None
+				elif transaction_type in (TransactionType.SECRET_LOCK.value, TransactionType.SECRET_PROOF.value):
+					self._assert_resolved_transaction_address(transaction_row['recipient_address'], 'recipient_address')
+					owner_address = transaction_row['signer_address'] if TransactionType.SECRET_LOCK.value == transaction_type else None
+					self._assert_resolved_transaction_address(owner_address, 'signer_address')
+					secret_key = create_secret_lock_search_key_from_hex_secret(
+						owner_address,
+						transaction_row['recipient_address'],
+						body['secret'],
+						lock_hash_algorithm_label(body['hashAlgorithm']))
+					secret_keys[secret_key] = None
+
+		start_height = block_rows[0]['height']
+		end_height = block_rows[-1]['height']
+		hash_keys.update({key: None for key in self.symbol_db.get_hash_lock_hashes_expiring_between(start_height, end_height)})
+		secret_keys.update({
+			key: None
+			for key in self.symbol_db.get_secret_lock_search_keys_expiring_between(start_height, end_height)
+		})
+
+		return RollbackLockKeys(list(hash_keys), list(secret_keys))
+
+	async def _fetch_dirty_hash_locks(self, hash_keys, observed_height):
+		"""Fetches Hash Lock detail state in bounded concurrent batches."""
+
+		async def fetch_entry(hash_key):
+			path = f'/lock/hash/{hash_key.hash.hex().upper()}'
+			response = await self.get_symbol_node(path, not_found_as_error=False)
+			if _is_not_found_response(response):
+				return {'hash': hash_key}
+
+			row = create_hash_lock_row(response, observed_height)
+			if row['hash'] != hash_key.hash:
+				raise ValueError('Symbol Hash Lock response hash does not match dirty key')
+
+			return {'row': row}
+
+		entries = []
+		for chunk_start in range(0, len(hash_keys), LOCK_FETCH_CONCURRENCY):
+			chunk = hash_keys[chunk_start:chunk_start + LOCK_FETCH_CONCURRENCY]
+			entries.extend(await asyncio.gather(*(fetch_entry(hash_key) for hash_key in chunk)))
+
+		return entries
+
+	async def _fetch_dirty_secret_locks(self, search_keys, observed_height):
+		"""Fetches and exactly filters paginated Secret Lock search results in bounded concurrent batches."""
+
+		async def fetch_entry(search_key):
+			page_number = 1
+			matching_rows = []
+			composite_hashes = set()
+			while True:
+				path = '/lock/secret?'
+				if search_key.owner_address is not None:
+					path += f'address={Address(search_key.owner_address)}&'
+				path += f'secret={search_key.secret.hex().upper()}&pageSize={MAX_PAGE_SIZE}&pageNumber={page_number}'
+				response = await self.get_symbol_node(path, not_found_as_error=False)
+				if _is_not_found_response(response):
+					items = []
+				else:
+					if not isinstance(response, dict) or not isinstance(response.get('data'), list):
+						raise ValueError('Malformed Symbol Secret Lock search response')
+					items = response['data']
+
+				for item in items:
+					row = create_secret_lock_row(item, observed_height)
+					if row['composite_hash'] in composite_hashes:
+						raise ValueError('Duplicate Symbol Secret Lock composite hash')
+					composite_hashes.add(row['composite_hash'])
+					if search_key.owner_address is not None and row['owner_address'] != search_key.owner_address:
+						continue
+					if row['recipient_address'] != search_key.recipient_address:
+						continue
+					if row['secret'] != search_key.secret:
+						continue
+					if row['hash_algorithm'] != search_key.hash_algorithm:
+						continue
+					matching_rows.append(row)
+
+				if len(items) < MAX_PAGE_SIZE:
+					return {'key': search_key, 'rows': matching_rows}
+
+				page_number += 1
+
+		entries = []
+		for chunk_start in range(0, len(search_keys), LOCK_FETCH_CONCURRENCY):
+			chunk = search_keys[chunk_start:chunk_start + LOCK_FETCH_CONCURRENCY]
+			entries.extend(await asyncio.gather(*(fetch_entry(search_key) for search_key in chunk)))
+
+		return entries
+
+	def _write_dirty_hash_locks(self, entries):
+		"""Writes fetched Hash Lock current-state changes after all batch fetches complete."""
+
+		for entry in entries:
+			if 'hash' in entry:
+				self.symbol_db.delete_hash_lock(entry['hash'])
+			else:
+				self.symbol_db.upsert_hash_lock(entry['row'])
+
+	def _write_dirty_secret_locks(self, entries):
+		"""Replaces fetched Secret Lock logical keys after all batch fetches complete."""
+
+		for entry in entries:
+			self.symbol_db.replace_secret_locks(entry['key'], entry['rows'])
 
 	async def _fetch_dirty_accounts_for_batch(  # pylint: disable=too-many-locals
 		self,

--- a/explorer/puller/puller/facade/SymbolPuller.py
+++ b/explorer/puller/puller/facade/SymbolPuller.py
@@ -400,8 +400,10 @@ class SymbolPuller:
 		dirty_metadata_keys = self._collect_dirty_metadata_keys_for_batch(transaction_rows_by_height)
 		dirty_metadata_entries = await self._fetch_dirty_metadata(dirty_metadata_keys, observed_height)
 		dirty_lock_keys = self._collect_dirty_lock_keys_for_batch(transaction_rows_by_height)
-		dirty_hash_lock_entries = await self._fetch_dirty_hash_locks(dirty_lock_keys.hash_keys, observed_height)
-		dirty_secret_lock_entries = await self._fetch_dirty_secret_locks(dirty_lock_keys.secret_keys, observed_height)
+		dirty_hash_lock_entries = await self._fetch_dirty_hash_locks(
+			list(dirty_lock_keys.hash_keys), observed_height)
+		dirty_secret_lock_entries = await self._fetch_dirty_secret_locks(
+			list(dirty_lock_keys.secret_keys), observed_height)
 		self._sync_block_batch(batch_rows, transaction_rows_by_height, receipt_rows_by_height)
 		self._write_dirty_accounts_for_batch(dirty_account_rows)
 		self.symbol_db.apply_namespace_entries(dirty_namespace_entries)
@@ -945,27 +947,27 @@ class SymbolPuller:
 	def _collect_dirty_lock_keys_for_batch(self, transaction_rows_by_height):
 		"""Collects Hash and Secret Lock dirty keys from transactions in the current batch."""
 
-		hash_keys = []
-		secret_keys = []
+		hash_keys = set()
+		secret_keys = set()
 		for transaction_rows in transaction_rows_by_height.values():
 			for transaction_row in transaction_rows:
 				transaction_type = transaction_row['type']
 				body = transaction_row['body']
 				if TransactionType.HASH_LOCK.value == transaction_type:
-					hash_keys.append(create_hash_lock_key(body['hash']))
+					hash_keys.add(create_hash_lock_key(body['hash']))
 				elif TransactionType.AGGREGATE_BONDED.value == transaction_type:
-					hash_keys.append(create_hash_lock_key(transaction_row['hash']))
+					hash_keys.add(create_hash_lock_key(transaction_row['hash']))
 				elif transaction_type in (TransactionType.SECRET_LOCK.value, TransactionType.SECRET_PROOF.value):
 					self._assert_resolved_transaction_address(transaction_row['recipient_address'], 'recipient_address')
 					owner_address = transaction_row['signer_address'] if TransactionType.SECRET_LOCK.value == transaction_type else None
 					self._assert_resolved_transaction_address(owner_address, 'signer_address')
-					secret_keys.append(create_secret_lock_search_key_from_hex_secret(
+					secret_keys.add(create_secret_lock_search_key_from_hex_secret(
 						owner_address,
 						transaction_row['recipient_address'],
 						body['secret'],
 						lock_hash_algorithm_label(body['hashAlgorithm'])))
 
-		return RollbackLockKeys(list(dict.fromkeys(hash_keys)), list(dict.fromkeys(secret_keys)))
+		return RollbackLockKeys(hash_keys, secret_keys)
 
 	async def _fetch_dirty_hash_locks(self, hash_keys, observed_height):
 		"""Fetches Hash Lock detail state in bounded concurrent batches."""

--- a/explorer/puller/puller/model/symbol/Lock.py
+++ b/explorer/puller/puller/model/symbol/Lock.py
@@ -2,7 +2,9 @@
 
 from collections import namedtuple
 
+from symbolchain.CryptoTypes import Hash256
 from symbolchain.sc import LockHashAlgorithm
+from symbolchain.symbol.Network import Address
 
 from puller.model.symbol.format import label_for_type
 
@@ -39,24 +41,17 @@ def lock_hash_algorithm_label(hash_algorithm):
 
 
 def create_hash_lock_key(hash_value):
-	"""Creates a validated Hash Lock dirty key from a 32-byte value."""
+	"""Creates a validated Hash Lock dirty key from bytes or hexadecimal text."""
 
-	if not isinstance(hash_value, bytes) or 32 != len(hash_value):
-		raise ValueError('Invalid Symbol Hash Lock key')
-
-	return HashLockKey(hash_value)
-
-
-def create_hash_lock_key_from_hex(hash_value):
-	"""Creates a validated Hash Lock dirty key from a hexadecimal hash."""
-
-	if not isinstance(hash_value, str):
+	if not isinstance(hash_value, (bytes, str)):
 		raise ValueError('Invalid Symbol Hash Lock key')
 
 	try:
-		return create_hash_lock_key(bytes.fromhex(hash_value))
+		normalized_hash = Hash256(hash_value).bytes
 	except ValueError as exception:
 		raise ValueError('Invalid Symbol Hash Lock key') from exception
+
+	return HashLockKey(normalized_hash)
 
 
 def create_secret_lock_search_key_from_hex_secret(owner_address, recipient_address, secret, hash_algorithm):  # pylint: disable=invalid-name
@@ -66,7 +61,7 @@ def create_secret_lock_search_key_from_hex_secret(owner_address, recipient_addre
 		raise ValueError('Invalid Symbol Secret Lock secret')
 
 	try:
-		secret_bytes = bytes.fromhex(secret)
+		secret_bytes = Hash256(secret).bytes
 	except ValueError as exception:
 		raise ValueError('Invalid Symbol Secret Lock secret') from exception
 
@@ -76,16 +71,15 @@ def create_secret_lock_search_key_from_hex_secret(owner_address, recipient_addre
 def create_secret_lock_search_key(owner_address, recipient_address, secret, hash_algorithm):
 	"""Creates a validated Secret Lock logical search key."""
 
-	if owner_address is not None and (not isinstance(owner_address, bytes) or 24 != len(owner_address)):
-		raise ValueError('Invalid Symbol Secret Lock owner address')
-	if not isinstance(recipient_address, bytes) or 24 != len(recipient_address):
-		raise ValueError('Invalid Symbol Secret Lock recipient address')
-	if not isinstance(secret, bytes) or 32 != len(secret):
-		raise ValueError('Invalid Symbol Secret Lock secret')
+	normalized_owner_address = None
+	if owner_address is not None:
+		normalized_owner_address = _address_from_bytes(owner_address, 'owner address')
+	normalized_recipient_address = _address_from_bytes(recipient_address, 'recipient address')
+	normalized_secret = _hash_from_bytes(secret, 'secret')
 	if hash_algorithm not in LOCK_HASH_ALGORITHM_LABELS.values():
 		raise ValueError(f'Unsupported Symbol Secret Lock hash algorithm {hash_algorithm}')
 
-	return SecretLockSearchKey(owner_address, recipient_address, secret, hash_algorithm)
+	return SecretLockSearchKey(normalized_owner_address, normalized_recipient_address, normalized_secret, hash_algorithm)
 
 
 def _required_lock(item, lock_type):
@@ -95,13 +89,44 @@ def _required_lock(item, lock_type):
 	return item['lock']
 
 
-def _hex_bytes(lock, field_name, byte_length, lock_type):
+def _address_from_bytes(value, field_name):
+	if not isinstance(value, bytes):
+		raise ValueError(f'Invalid Symbol Secret Lock {field_name}')
+
+	try:
+		return Address(value).bytes
+	except ValueError as exception:
+		raise ValueError(f'Invalid Symbol Secret Lock {field_name}') from exception
+
+
+def _hash_from_bytes(value, field_name):
+	if not isinstance(value, bytes):
+		raise ValueError(f'Invalid Symbol Secret Lock {field_name}')
+
+	try:
+		return Hash256(value).bytes
+	except ValueError as exception:
+		raise ValueError(f'Invalid Symbol Secret Lock {field_name}') from exception
+
+
+def _decoded_address_from_hex(lock, field_name, lock_type):
 	value = lock.get(field_name)
-	if not isinstance(value, str) or len(value) != byte_length * 2:
+	if not isinstance(value, str):
 		raise ValueError(f'Invalid Symbol {lock_type} Lock {field_name}')
 
 	try:
-		return bytes.fromhex(value)
+		return Address.from_decoded_address_hex_string(value).bytes
+	except ValueError as exception:
+		raise ValueError(f'Invalid Symbol {lock_type} Lock {field_name}') from exception
+
+
+def _hash_from_hex(lock, field_name, lock_type):
+	value = lock.get(field_name)
+	if not isinstance(value, str):
+		raise ValueError(f'Invalid Symbol {lock_type} Lock {field_name}')
+
+	try:
+		return Hash256(value).bytes
 	except ValueError as exception:
 		raise ValueError(f'Invalid Symbol {lock_type} Lock {field_name}') from exception
 
@@ -134,8 +159,8 @@ def create_hash_lock_row(item, observed_height):
 
 	lock = _required_lock(item, 'Hash')
 	return {
-		'hash': _hex_bytes(lock, 'hash', 32, 'Hash'),
-		'owner_address': _hex_bytes(lock, 'ownerAddress', 24, 'Hash'),
+		'hash': _hash_from_hex(lock, 'hash', 'Hash'),
+		'owner_address': _decoded_address_from_hex(lock, 'ownerAddress', 'Hash'),
 		'mosaic_id': _mosaic_id(lock, 'Hash'),
 		'amount': _integer(lock, 'amount', 'Hash'),
 		'end_height': _integer(lock, 'endHeight', 'Hash'),
@@ -149,10 +174,10 @@ def create_secret_lock_row(item, observed_height):
 	"""Creates one persisted Secret Lock row from a Symbol node response wrapper."""
 
 	lock = _required_lock(item, 'Secret')
-	composite_hash = _hex_bytes(lock, 'compositeHash', 32, 'Secret')
-	owner_address = _hex_bytes(lock, 'ownerAddress', 24, 'Secret')
-	recipient_address = _hex_bytes(lock, 'recipientAddress', 24, 'Secret')
-	secret = _hex_bytes(lock, 'secret', 32, 'Secret')
+	composite_hash = _hash_from_hex(lock, 'compositeHash', 'Secret')
+	owner_address = _decoded_address_from_hex(lock, 'ownerAddress', 'Secret')
+	recipient_address = _decoded_address_from_hex(lock, 'recipientAddress', 'Secret')
+	secret = _hash_from_hex(lock, 'secret', 'Secret')
 	hash_algorithm = lock_hash_algorithm_label(lock.get('hashAlgorithm'))
 	create_secret_lock_search_key(owner_address, recipient_address, secret, hash_algorithm)
 

--- a/explorer/puller/puller/model/symbol/Lock.py
+++ b/explorer/puller/puller/model/symbol/Lock.py
@@ -1,0 +1,171 @@
+"""Normalization helpers for Symbol hash and secret lock current state."""
+
+from collections import namedtuple
+
+from symbolchain.sc import LockHashAlgorithm
+
+from puller.model.symbol.format import label_for_type
+
+LOCK_STATUS_LABELS = {0: 'unused', 1: 'used'}
+LOCK_HASH_ALGORITHM_LABELS = {
+	LockHashAlgorithm.SHA3_256.value: 'sha3_256',
+	LockHashAlgorithm.HASH_160.value: 'hash160',
+	LockHashAlgorithm.HASH_256.value: 'hash256'
+}
+
+HashLockKey = namedtuple('HashLockKey', ['hash'])
+SecretLockSearchKey = namedtuple(
+	'SecretLockSearchKey',
+	['owner_address', 'recipient_address', 'secret', 'hash_algorithm'])
+RollbackLockKeys = namedtuple('RollbackLockKeys', ['hash_keys', 'secret_keys'], defaults=((), ()))
+
+
+def lock_status_label(status):
+	"""Maps a Symbol Lock status number to its canonical database label."""
+
+	if not isinstance(status, int) or isinstance(status, bool):
+		raise ValueError(f'Unsupported Symbol lock status type {status}')
+
+	return label_for_type(LOCK_STATUS_LABELS, status, 'lock status')
+
+
+def lock_hash_algorithm_label(hash_algorithm):
+	"""Maps a Symbol Lock hash algorithm number to its canonical database label."""
+
+	if not isinstance(hash_algorithm, int) or isinstance(hash_algorithm, bool):
+		raise ValueError(f'Unsupported Symbol lock hash algorithm type {hash_algorithm}')
+
+	return label_for_type(LOCK_HASH_ALGORITHM_LABELS, hash_algorithm, 'lock hash algorithm')
+
+
+def create_hash_lock_key(hash_value):
+	"""Creates a validated Hash Lock dirty key from a 32-byte value."""
+
+	if not isinstance(hash_value, bytes) or 32 != len(hash_value):
+		raise ValueError('Invalid Symbol Hash Lock key')
+
+	return HashLockKey(hash_value)
+
+
+def create_hash_lock_key_from_hex(hash_value):
+	"""Creates a validated Hash Lock dirty key from a hexadecimal hash."""
+
+	if not isinstance(hash_value, str):
+		raise ValueError('Invalid Symbol Hash Lock key')
+
+	try:
+		return create_hash_lock_key(bytes.fromhex(hash_value))
+	except ValueError as exception:
+		raise ValueError('Invalid Symbol Hash Lock key') from exception
+
+
+def create_secret_lock_search_key_from_hex_secret(owner_address, recipient_address, secret, hash_algorithm):  # pylint: disable=invalid-name
+	"""Creates a Secret Lock logical search key from a hexadecimal secret and mapped algorithm."""
+
+	if not isinstance(secret, str):
+		raise ValueError('Invalid Symbol Secret Lock secret')
+
+	try:
+		secret_bytes = bytes.fromhex(secret)
+	except ValueError as exception:
+		raise ValueError('Invalid Symbol Secret Lock secret') from exception
+
+	return create_secret_lock_search_key(owner_address, recipient_address, secret_bytes, hash_algorithm)
+
+
+def create_secret_lock_search_key(owner_address, recipient_address, secret, hash_algorithm):
+	"""Creates a validated Secret Lock logical search key."""
+
+	if owner_address is not None and (not isinstance(owner_address, bytes) or 24 != len(owner_address)):
+		raise ValueError('Invalid Symbol Secret Lock owner address')
+	if not isinstance(recipient_address, bytes) or 24 != len(recipient_address):
+		raise ValueError('Invalid Symbol Secret Lock recipient address')
+	if not isinstance(secret, bytes) or 32 != len(secret):
+		raise ValueError('Invalid Symbol Secret Lock secret')
+	if hash_algorithm not in LOCK_HASH_ALGORITHM_LABELS.values():
+		raise ValueError(f'Unsupported Symbol Secret Lock hash algorithm {hash_algorithm}')
+
+	return SecretLockSearchKey(owner_address, recipient_address, secret, hash_algorithm)
+
+
+def _required_lock(item, lock_type):
+	if not isinstance(item, dict) or not isinstance(item.get('lock'), dict):
+		raise ValueError(f'Malformed Symbol {lock_type} Lock response')
+
+	return item['lock']
+
+
+def _hex_bytes(lock, field_name, byte_length, lock_type):
+	value = lock.get(field_name)
+	if not isinstance(value, str) or len(value) != byte_length * 2:
+		raise ValueError(f'Invalid Symbol {lock_type} Lock {field_name}')
+
+	try:
+		return bytes.fromhex(value)
+	except ValueError as exception:
+		raise ValueError(f'Invalid Symbol {lock_type} Lock {field_name}') from exception
+
+
+def _mosaic_id(lock, lock_type):
+	value = lock.get('mosaicId')
+	if not isinstance(value, str) or len(value) != 16:
+		raise ValueError(f'Invalid Symbol {lock_type} Lock mosaicId')
+
+	try:
+		bytes.fromhex(value)
+	except ValueError as exception:
+		raise ValueError(f'Invalid Symbol {lock_type} Lock mosaicId') from exception
+
+	return value.upper()
+
+
+def _integer(lock, field_name, lock_type):
+	value = lock.get(field_name)
+	if isinstance(value, int) and not isinstance(value, bool) and 0 <= value:
+		return value
+	if isinstance(value, str) and value.isascii() and value.isdecimal():
+		return int(value)
+
+	raise ValueError(f'Invalid Symbol {lock_type} Lock {field_name}')
+
+
+def create_hash_lock_row(item, observed_height):
+	"""Creates one persisted Hash Lock row from a Symbol node response wrapper."""
+
+	lock = _required_lock(item, 'Hash')
+	return {
+		'hash': _hex_bytes(lock, 'hash', 32, 'Hash'),
+		'owner_address': _hex_bytes(lock, 'ownerAddress', 24, 'Hash'),
+		'mosaic_id': _mosaic_id(lock, 'Hash'),
+		'amount': _integer(lock, 'amount', 'Hash'),
+		'end_height': _integer(lock, 'endHeight', 'Hash'),
+		'status': lock_status_label(lock.get('status')),
+		'raw_payload': item,
+		'updated_at_height': observed_height
+	}
+
+
+def create_secret_lock_row(item, observed_height):
+	"""Creates one persisted Secret Lock row from a Symbol node response wrapper."""
+
+	lock = _required_lock(item, 'Secret')
+	composite_hash = _hex_bytes(lock, 'compositeHash', 32, 'Secret')
+	owner_address = _hex_bytes(lock, 'ownerAddress', 24, 'Secret')
+	recipient_address = _hex_bytes(lock, 'recipientAddress', 24, 'Secret')
+	secret = _hex_bytes(lock, 'secret', 32, 'Secret')
+	hash_algorithm = lock_hash_algorithm_label(lock.get('hashAlgorithm'))
+	create_secret_lock_search_key(owner_address, recipient_address, secret, hash_algorithm)
+
+	return {
+		'composite_hash': composite_hash,
+		'owner_address': owner_address,
+		'recipient_address': recipient_address,
+		'secret': secret,
+		'hash_algorithm': hash_algorithm,
+		'mosaic_id': _mosaic_id(lock, 'Secret'),
+		'amount': _integer(lock, 'amount', 'Secret'),
+		'end_height': _integer(lock, 'endHeight', 'Secret'),
+		'status': lock_status_label(lock.get('status')),
+		'raw_payload': item,
+		'updated_at_height': observed_height
+	}

--- a/explorer/puller/tests/db/test_SymbolDatabase.py
+++ b/explorer/puller/tests/db/test_SymbolDatabase.py
@@ -13,7 +13,7 @@ from symbolchain.symbol.Network import Network
 
 from puller.db.SymbolDatabase import RollbackRefreshEntries, SymbolDatabase
 from puller.model.symbol.Account import create_account_row
-from puller.model.symbol.Lock import create_hash_lock_key_from_hex, create_secret_lock_search_key
+from puller.model.symbol.Lock import create_hash_lock_key, create_secret_lock_search_key
 from puller.model.symbol.Transaction import TRANSACTION_TYPE_LABELS
 from tests.facade.symbol.puller_test_utils import NATIVE_MOSAIC_ID, create_account_item
 from tests.test.SymbolDatabaseTestUtils import fetch_full_block_state, fetch_normalized_sync_state
@@ -4236,7 +4236,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 				'CREATE UNIQUE INDEX symbol_secret_locks_pkey ON public.symbol_secret_locks USING btree (composite_hash)')
 		], cursor.fetchall())
 
-	def test_create_tables_creates_exact_lock_enum_labels_and_column_types(self):
+	def test_create_tables_creates_exact_lock_enum_labels(self):
 		# Arrange:
 		database = self._create_uninitialized_database()
 		cursor = database.connection.cursor()
@@ -4260,6 +4260,16 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 			('symbol_lock_status', 'unused'),
 			('symbol_lock_status', 'used')
 		], cursor.fetchall())
+
+	def test_create_tables_uses_lock_enum_types_for_lock_columns(self):
+		# Arrange:
+		database = self._create_uninitialized_database()
+		cursor = database.connection.cursor()
+
+		# Act:
+		database.create_tables()
+
+		# Assert:
 		cursor.execute(
 			'''
 			SELECT table_name, column_name, udt_name
@@ -4331,7 +4341,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 			''')
 		self.assertEqual([], cursor.fetchall())
 
-	def test_hash_lock_upsert_update_and_delete_persist_current_state(self):
+	def test_hash_lock_upsert_and_update_persist_current_state(self):
 		# Arrange:
 		database = self._create_database()
 		initial_row = _create_hash_lock_row()
@@ -4342,14 +4352,23 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		database.upsert_hash_lock(updated_row)
 		cursor = database.connection.cursor()
 		cursor.execute('SELECT hash, amount, end_height, status, updated_at_height FROM symbol_hash_locks')
-		updated_state = cursor.fetchall()
-		database.delete_hash_lock(create_hash_lock_key_from_hex(LOCK_HASH.hex()))
 
 		# Assert:
 		self.assertEqual(
 			[(LOCK_HASH, 1234, 200, 'used', 2)],
 			[(bytes(lock_hash), amount, end_height, status, updated_at_height)
-				for lock_hash, amount, end_height, status, updated_at_height in updated_state])
+				for lock_hash, amount, end_height, status, updated_at_height in cursor.fetchall()])
+
+	def test_delete_hash_lock_removes_current_state(self):
+		# Arrange:
+		database = self._create_database()
+		database.upsert_hash_lock(_create_hash_lock_row())
+
+		# Act:
+		database.delete_hash_lock(create_hash_lock_key(LOCK_HASH))
+
+		# Assert:
+		cursor = database.connection.cursor()
 		cursor.execute('SELECT hash FROM symbol_hash_locks')
 		self.assertEqual([], cursor.fetchall())
 
@@ -4376,10 +4395,12 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 	def test_secret_lock_unknown_owner_replace_removes_all_owner_siblings(self):
 		# Arrange:
 		database = self._create_database()
-		rows = [_create_secret_lock_row(), _create_secret_lock_row(
-			composite_hash=LOCK_COMPOSITE_HASH_2, owner_address=LOCK_OWNER_2)]
 		database.replace_secret_locks(
-			create_secret_lock_search_key(None, LOCK_RECIPIENT, LOCK_SECRET, 'hash160'), rows)
+			create_secret_lock_search_key(LOCK_OWNER, LOCK_RECIPIENT, LOCK_SECRET, 'hash160'),
+			[_create_secret_lock_row()])
+		database.replace_secret_locks(
+			create_secret_lock_search_key(LOCK_OWNER_2, LOCK_RECIPIENT, LOCK_SECRET, 'hash160'),
+			[_create_secret_lock_row(composite_hash=LOCK_COMPOSITE_HASH_2, owner_address=LOCK_OWNER_2)])
 
 		# Act:
 		database.replace_secret_locks(
@@ -4456,10 +4477,11 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		database = self._create_database()
 		height_rows = (
 			(9, b'\x50' * 32),
+			(10, b'\x40' * 32),
 			(10, b'\x30' * 32),
 			(11, b'\x10' * 32),
-			(12, b'\x40' * 32),
-			(13, b'\x20' * 32)
+			(12, b'\x20' * 32),
+			(13, b'\x60' * 32)
 		)
 		for observed_height, lock_hash in height_rows:
 			database.upsert_hash_lock(_create_hash_lock_row(observed_height, lock_hash, end_height=1))
@@ -4468,36 +4490,49 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		keys = database.get_hash_lock_hashes_updated_from_height(10)
 
 		# Assert:
-		self.assertEqual([b'\x10' * 32, b'\x20' * 32, b'\x30' * 32, b'\x40' * 32], [key.hash for key in keys])
+		self.assertEqual([
+			b'\x30' * 32,
+			b'\x40' * 32,
+			b'\x10' * 32,
+			b'\x20' * 32,
+			b'\x60' * 32
+		], [key.hash for key in keys])
 
-	def test_get_hash_lock_hashes_expiring_between_returns_ordered_boundary_rows(self):
+	def test_get_hash_lock_hashes_reaching_end_height_between_returns_height_ordered_boundary_rows(self):
 		# Arrange:
 		database = self._create_database()
 		height_rows = (
 			(9, b'\x50' * 32),
 			(10, b'\x40' * 32),
+			(10, b'\x30' * 32),
 			(11, b'\x10' * 32),
-			(12, b'\x30' * 32),
-			(13, b'\x20' * 32)
+			(12, b'\x20' * 32),
+			(13, b'\x60' * 32)
 		)
 		for end_height, lock_hash in height_rows:
 			database.upsert_hash_lock(_create_hash_lock_row(observed_height=1, lock_hash=lock_hash, end_height=end_height))
 
 		# Act:
-		keys = database.get_hash_lock_hashes_expiring_between(10, 12)
+		keys = database.get_hash_lock_hashes_reaching_end_height_between(10, 12)
 
 		# Assert:
-		self.assertEqual([b'\x10' * 32, b'\x30' * 32, b'\x40' * 32], [key.hash for key in keys])
+		self.assertEqual([
+			b'\x30' * 32,
+			b'\x40' * 32,
+			b'\x10' * 32,
+			b'\x20' * 32
+		], [key.hash for key in keys])
 
 	def test_get_secret_lock_search_keys_updated_from_height_returns_ordered_boundary_rows(self):
 		# Arrange:
 		database = self._create_database()
 		height_rows = (
 			(9, b'\x50' * 32, b'\x59' * 32),
-			(10, b'\x30' * 32, b'\x39' * 32),
+			(10, b'\x40' * 32, b'\x01' * 32),
+			(10, b'\x30' * 32, b'\x99' * 32),
 			(11, b'\x10' * 32, b'\x19' * 32),
-			(12, b'\x40' * 32, b'\x49' * 32),
-			(13, b'\x20' * 32, b'\x29' * 32)
+			(12, b'\x20' * 32, b'\x29' * 32),
+			(13, b'\x60' * 32, b'\x49' * 32)
 		)
 		for observed_height, composite_hash, secret in height_rows:
 			row = _create_secret_lock_row(observed_height, composite_hash, secret=secret, end_height=1)
@@ -4509,21 +4544,23 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 
 		# Assert:
 		self.assertEqual([
+			(LOCK_OWNER, LOCK_RECIPIENT, b'\x99' * 32, 'hash160'),
+			(LOCK_OWNER, LOCK_RECIPIENT, b'\x01' * 32, 'hash160'),
 			(LOCK_OWNER, LOCK_RECIPIENT, b'\x19' * 32, 'hash160'),
 			(LOCK_OWNER, LOCK_RECIPIENT, b'\x29' * 32, 'hash160'),
-			(LOCK_OWNER, LOCK_RECIPIENT, b'\x39' * 32, 'hash160'),
 			(LOCK_OWNER, LOCK_RECIPIENT, b'\x49' * 32, 'hash160')
 		], keys)
 
-	def test_get_secret_lock_search_keys_expiring_between_returns_ordered_boundary_rows(self):
+	def test_get_secret_lock_search_keys_reaching_end_height_between_returns_height_ordered_boundary_rows(self):
 		# Arrange:
 		database = self._create_database()
 		height_rows = (
 			(9, b'\x50' * 32, b'\x59' * 32),
-			(10, b'\x40' * 32, b'\x49' * 32),
+			(10, b'\x40' * 32, b'\x01' * 32),
+			(10, b'\x30' * 32, b'\x99' * 32),
 			(11, b'\x10' * 32, b'\x19' * 32),
-			(12, b'\x30' * 32, b'\x39' * 32),
-			(13, b'\x20' * 32, b'\x29' * 32)
+			(12, b'\x20' * 32, b'\x29' * 32),
+			(13, b'\x60' * 32, b'\x49' * 32)
 		)
 		for end_height, composite_hash, secret in height_rows:
 			row = _create_secret_lock_row(observed_height=1, composite_hash=composite_hash, secret=secret, end_height=end_height)
@@ -4531,13 +4568,14 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 				create_secret_lock_search_key(LOCK_OWNER, LOCK_RECIPIENT, secret, 'hash160'), [row])
 
 		# Act:
-		keys = database.get_secret_lock_search_keys_expiring_between(10, 12)
+		keys = database.get_secret_lock_search_keys_reaching_end_height_between(10, 12)
 
 		# Assert:
 		self.assertEqual([
+			(LOCK_OWNER, LOCK_RECIPIENT, b'\x99' * 32, 'hash160'),
+			(LOCK_OWNER, LOCK_RECIPIENT, b'\x01' * 32, 'hash160'),
 			(LOCK_OWNER, LOCK_RECIPIENT, b'\x19' * 32, 'hash160'),
-			(LOCK_OWNER, LOCK_RECIPIENT, b'\x39' * 32, 'hash160'),
-			(LOCK_OWNER, LOCK_RECIPIENT, b'\x49' * 32, 'hash160')
+			(LOCK_OWNER, LOCK_RECIPIENT, b'\x29' * 32, 'hash160')
 		], keys)
 
 	def test_confirmed_transaction_lock_key_collection_includes_only_authoritative_sources(self):
@@ -4562,23 +4600,9 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 			type_name=TRANSACTION_TYPE_LABELS[TransactionType.SECRET_PROOF.value],
 			signer_address=LOCK_OWNER_2, recipient_address=LOCK_RECIPIENT,
 			body={'secret': LOCK_SECRET.hex().upper(), 'hashAlgorithm': 0})
-		secret_proof_after = create_transaction_entry(
-			2, 'secret-proof-after', type=TransactionType.SECRET_PROOF.value,
-			type_name=TRANSACTION_TYPE_LABELS[TransactionType.SECRET_PROOF.value],
-			signer_address=LOCK_OWNER, recipient_address=LOCK_RECIPIENT,
-			body={'secret': LOCK_SECRET.hex().upper(), 'hashAlgorithm': 0})
-		embedded_aggregate_transaction = create_transaction_entry(
-			2, 'embedded-aggregate', is_embedded=True,
-			type=TransactionType.AGGREGATE_BONDED.value,
-			type_name=TRANSACTION_TYPE_LABELS[TransactionType.AGGREGATE_BONDED.value])
-		hash_lock_after_proof = create_transaction_entry(
-			2, 'hash-lock-after-proof', type=TransactionType.HASH_LOCK.value,
-			type_name=TRANSACTION_TYPE_LABELS[TransactionType.HASH_LOCK.value],
-			body={'hash': LOCK_HASH.hex().upper()})
 		database.upsert_transactions_for_height(2, [
 			hash_lock_transaction, aggregate_transaction, secret_lock_transaction,
-			secret_proof_transaction, secret_proof_after, embedded_aggregate_transaction,
-			hash_lock_after_proof])
+			secret_proof_transaction])
 
 		# Act:
 		keys = database.get_lock_keys_from_confirmed_transactions_from_height(2)
@@ -4588,6 +4612,54 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		self.assertEqual([
 			(LOCK_OWNER, LOCK_RECIPIENT, LOCK_SECRET, 'sha3_256'),
 			(None, LOCK_RECIPIENT, LOCK_SECRET, 'sha3_256')
+		], keys.secret_keys)
+
+	def test_confirmed_transaction_lock_key_collection_deduplicates_in_first_encounter_order(self):
+		# Arrange:
+		database = self._create_database()
+		database.upsert_blocks([_create_block(2)])
+		first_hash = b'\x30' * 32
+		second_hash = b'\x10' * 32
+		first_secret = b'\x40' * 32
+		second_secret = b'\x20' * 32
+		database.upsert_transactions_for_height(2, [
+			create_transaction_entry(
+				2, 'first-hash-lock', type=TransactionType.HASH_LOCK.value,
+				type_name=TRANSACTION_TYPE_LABELS[TransactionType.HASH_LOCK.value],
+				body={'hash': first_hash.hex().upper()}),
+			create_transaction_entry(
+				2, 'aggregate-bonded', type=TransactionType.AGGREGATE_BONDED.value,
+				type_name=TRANSACTION_TYPE_LABELS[TransactionType.AGGREGATE_BONDED.value],
+				hash=second_hash),
+			create_transaction_entry(
+				2, 'duplicate-hash-lock', type=TransactionType.HASH_LOCK.value,
+				type_name=TRANSACTION_TYPE_LABELS[TransactionType.HASH_LOCK.value],
+				body={'hash': first_hash.hex().upper()}),
+			create_transaction_entry(
+				2, 'first-secret-proof', type=TransactionType.SECRET_PROOF.value,
+				type_name=TRANSACTION_TYPE_LABELS[TransactionType.SECRET_PROOF.value],
+				recipient_address=LOCK_RECIPIENT,
+				body={'secret': first_secret.hex().upper(), 'hashAlgorithm': 0}),
+			create_transaction_entry(
+				2, 'secret-lock', type=TransactionType.SECRET_LOCK.value,
+				type_name=TRANSACTION_TYPE_LABELS[TransactionType.SECRET_LOCK.value],
+				signer_address=LOCK_OWNER, recipient_address=LOCK_RECIPIENT,
+				body={'secret': second_secret.hex().upper(), 'hashAlgorithm': 0}),
+			create_transaction_entry(
+				2, 'duplicate-secret-proof', type=TransactionType.SECRET_PROOF.value,
+				type_name=TRANSACTION_TYPE_LABELS[TransactionType.SECRET_PROOF.value],
+				recipient_address=LOCK_RECIPIENT,
+				body={'secret': first_secret.hex().upper(), 'hashAlgorithm': 0})
+		])
+
+		# Act:
+		keys = database.get_lock_keys_from_confirmed_transactions_from_height(2)
+
+		# Assert:
+		self.assertEqual([first_hash, second_hash], [key.hash for key in keys.hash_keys])
+		self.assertEqual([
+			(None, LOCK_RECIPIENT, first_secret, 'sha3_256'),
+			(LOCK_OWNER, LOCK_RECIPIENT, second_secret, 'sha3_256')
 		], keys.secret_keys)
 
 	def test_confirmed_transaction_lock_key_collection_includes_creation_and_completion_at_or_after_fork_height(self):
@@ -4705,13 +4777,40 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 			2,
 			_create_sync_state(status='repairing', last_synced_height=1, last_synced_block_hash=b'hash 1'),
 			RollbackRefreshEntries(hash_lock_entries=[{
-				'hash': create_hash_lock_key_from_hex(LOCK_HASH.hex())
+				'hash': create_hash_lock_key(LOCK_HASH)
 			}]))
 
 		# Assert:
 		cursor = database.connection.cursor()
 		cursor.execute('SELECT hash FROM symbol_hash_locks')
 		self.assertEqual([], cursor.fetchall())
+
+	def test_repair_rollback_applies_empty_secret_lock_replacement_and_preserves_siblings(self):
+		# Arrange:
+		database = self._create_database()
+		target_key = create_secret_lock_search_key(LOCK_OWNER, LOCK_RECIPIENT, LOCK_SECRET, 'hash160')
+		sibling_key = create_secret_lock_search_key(LOCK_OWNER_2, LOCK_RECIPIENT, LOCK_SECRET, 'hash160')
+		database.replace_secret_locks(target_key, [_create_secret_lock_row()])
+		database.replace_secret_locks(
+			sibling_key,
+			[_create_secret_lock_row(composite_hash=LOCK_COMPOSITE_HASH_2, owner_address=LOCK_OWNER_2)])
+
+		# Act:
+		database.repair_rollback_from_height(
+			2,
+			_create_sync_state(status='repairing', last_synced_height=1, last_synced_block_hash=b'hash 1'),
+			RollbackRefreshEntries(secret_lock_entries=[{
+				'key': target_key,
+				'rows': []
+			}]))
+
+		# Assert:
+		cursor = database.connection.cursor()
+		cursor.execute('SELECT composite_hash, owner_address FROM symbol_secret_locks ORDER BY composite_hash')
+		self.assertEqual(
+			[(LOCK_COMPOSITE_HASH_2, LOCK_OWNER_2)],
+			[(bytes(composite_hash), bytes(owner_address)) for composite_hash, owner_address in cursor.fetchall()])
+		self.assertEqual('repairing', database.get_sync_state()['status'])
 
 	def test_repair_rollback_restores_chain_and_lock_state_when_later_secret_lock_write_fails(self):  # pylint: disable=too-many-locals
 		# Arrange:

--- a/explorer/puller/tests/db/test_SymbolDatabase.py
+++ b/explorer/puller/tests/db/test_SymbolDatabase.py
@@ -4390,28 +4390,155 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		cursor.execute('SELECT composite_hash FROM symbol_secret_locks')
 		self.assertEqual([], cursor.fetchall())
 
-	def test_lock_height_queries_return_updated_and_expiring_logical_keys(self):
+	def test_replace_secret_locks_rolls_back_delete_and_prior_insert_when_a_later_row_is_invalid(self):
 		# Arrange:
 		database = self._create_database()
-		hash_row = _create_hash_lock_row(observed_height=5, end_height=8)
-		secret_row = _create_secret_lock_row(observed_height=5, end_height=8)
-		database.upsert_hash_lock(hash_row)
+		key = create_secret_lock_search_key(LOCK_OWNER, LOCK_RECIPIENT, LOCK_SECRET, 'hash160')
+		initial_row = _create_secret_lock_row()
+		sibling_row = _create_secret_lock_row(composite_hash=LOCK_COMPOSITE_HASH_2, owner_address=LOCK_OWNER_2)
+		database.replace_secret_locks(key, [initial_row])
 		database.replace_secret_locks(
-			create_secret_lock_search_key(LOCK_OWNER, LOCK_RECIPIENT, LOCK_SECRET, 'hash160'), [secret_row])
+			create_secret_lock_search_key(LOCK_OWNER_2, LOCK_RECIPIENT, LOCK_SECRET, 'hash160'), [sibling_row])
+		invalid_row = {**_create_secret_lock_row(composite_hash=b'\xFF' * 32), 'hash_algorithm': 'invalid'}
 
-		# Act:
-		updated_hashes = database.get_hash_lock_hashes_updated_from_height(5)
-		updated_secrets = database.get_secret_lock_search_keys_updated_from_height(5)
-		expiring_hashes = database.get_hash_lock_hashes_expiring_between(8, 8)
-		expiring_secrets = database.get_secret_lock_search_keys_expiring_between(8, 8)
+		# Act / Assert:
+		with self.assertRaises(PsycopgError):
+			database.replace_secret_locks(key, [_create_secret_lock_row(status='used'), invalid_row])
 
 		# Assert:
-		self.assertEqual([LOCK_HASH], [key.hash for key in updated_hashes])
-		self.assertEqual([LOCK_HASH], [key.hash for key in expiring_hashes])
+		cursor = database.connection.cursor()
+		cursor.execute('SELECT composite_hash, owner_address, status FROM symbol_secret_locks ORDER BY composite_hash')
 		self.assertEqual([
-			(LOCK_OWNER, LOCK_RECIPIENT, LOCK_SECRET, 'hash160')
-		], updated_secrets)
-		self.assertEqual(updated_secrets, expiring_secrets)
+			(LOCK_COMPOSITE_HASH, LOCK_OWNER, 'unused'),
+			(LOCK_COMPOSITE_HASH_2, LOCK_OWNER_2, 'unused')
+		], [
+			(bytes(composite_hash), bytes(owner_address), status)
+			for composite_hash, owner_address, status in cursor.fetchall()
+		])
+
+	def test_get_hash_lock_hashes_updated_from_height_rejects_an_out_of_band_invalid_hash_length(self):
+		# Arrange:
+		database = self._create_database()
+		row = _create_hash_lock_row(lock_hash=b'bad')
+		cursor = database.connection.cursor()
+		cursor.execute(
+			'''INSERT INTO symbol_hash_locks
+				(hash, owner_address, mosaic_id, amount, end_height, status, raw_payload, updated_at_height)
+				VALUES (%(hash)s, %(owner_address)s, %(mosaic_id)s, %(amount)s, %(end_height)s, %(status)s,
+				%(raw_payload)s, %(updated_at_height)s)''',
+			{**row, 'raw_payload': Json(row['raw_payload'])})
+		database.connection.commit()
+
+		# Act / Assert:
+		with self.assertRaisesRegex(ValueError, '^Invalid Symbol Hash Lock key$'):
+			database.get_hash_lock_hashes_updated_from_height(1)
+
+	def test_get_secret_lock_search_keys_updated_from_height_rejects_an_out_of_band_invalid_owner_length(self):
+		# Arrange:
+		database = self._create_database()
+		row = _create_secret_lock_row(owner_address=b'bad')
+		cursor = database.connection.cursor()
+		cursor.execute(
+			'''INSERT INTO symbol_secret_locks
+				(composite_hash, owner_address, recipient_address, secret, hash_algorithm, mosaic_id, amount, end_height,
+				status, raw_payload, updated_at_height)
+				VALUES (%(composite_hash)s, %(owner_address)s, %(recipient_address)s, %(secret)s, %(hash_algorithm)s,
+				%(mosaic_id)s, %(amount)s, %(end_height)s, %(status)s, %(raw_payload)s, %(updated_at_height)s)''',
+			{**row, 'raw_payload': Json(row['raw_payload'])})
+		database.connection.commit()
+
+		# Act / Assert:
+		with self.assertRaisesRegex(ValueError, '^Invalid Symbol Secret Lock owner address$'):
+			database.get_secret_lock_search_keys_updated_from_height(1)
+
+	def test_get_hash_lock_hashes_updated_from_height_returns_ordered_boundary_rows(self):
+		# Arrange:
+		database = self._create_database()
+		height_rows = (
+			(9, b'\x50' * 32),
+			(10, b'\x30' * 32),
+			(11, b'\x10' * 32),
+			(12, b'\x40' * 32),
+			(13, b'\x20' * 32)
+		)
+		for observed_height, lock_hash in height_rows:
+			database.upsert_hash_lock(_create_hash_lock_row(observed_height, lock_hash, end_height=1))
+
+		# Act:
+		keys = database.get_hash_lock_hashes_updated_from_height(10)
+
+		# Assert:
+		self.assertEqual([b'\x10' * 32, b'\x20' * 32, b'\x30' * 32, b'\x40' * 32], [key.hash for key in keys])
+
+	def test_get_hash_lock_hashes_expiring_between_returns_ordered_boundary_rows(self):
+		# Arrange:
+		database = self._create_database()
+		height_rows = (
+			(9, b'\x50' * 32),
+			(10, b'\x40' * 32),
+			(11, b'\x10' * 32),
+			(12, b'\x30' * 32),
+			(13, b'\x20' * 32)
+		)
+		for end_height, lock_hash in height_rows:
+			database.upsert_hash_lock(_create_hash_lock_row(observed_height=1, lock_hash=lock_hash, end_height=end_height))
+
+		# Act:
+		keys = database.get_hash_lock_hashes_expiring_between(10, 12)
+
+		# Assert:
+		self.assertEqual([b'\x10' * 32, b'\x30' * 32, b'\x40' * 32], [key.hash for key in keys])
+
+	def test_get_secret_lock_search_keys_updated_from_height_returns_ordered_boundary_rows(self):
+		# Arrange:
+		database = self._create_database()
+		height_rows = (
+			(9, b'\x50' * 32, b'\x59' * 32),
+			(10, b'\x30' * 32, b'\x39' * 32),
+			(11, b'\x10' * 32, b'\x19' * 32),
+			(12, b'\x40' * 32, b'\x49' * 32),
+			(13, b'\x20' * 32, b'\x29' * 32)
+		)
+		for observed_height, composite_hash, secret in height_rows:
+			row = _create_secret_lock_row(observed_height, composite_hash, secret=secret, end_height=1)
+			database.replace_secret_locks(
+				create_secret_lock_search_key(LOCK_OWNER, LOCK_RECIPIENT, secret, 'hash160'), [row])
+
+		# Act:
+		keys = database.get_secret_lock_search_keys_updated_from_height(10)
+
+		# Assert:
+		self.assertEqual([
+			(LOCK_OWNER, LOCK_RECIPIENT, b'\x19' * 32, 'hash160'),
+			(LOCK_OWNER, LOCK_RECIPIENT, b'\x29' * 32, 'hash160'),
+			(LOCK_OWNER, LOCK_RECIPIENT, b'\x39' * 32, 'hash160'),
+			(LOCK_OWNER, LOCK_RECIPIENT, b'\x49' * 32, 'hash160')
+		], keys)
+
+	def test_get_secret_lock_search_keys_expiring_between_returns_ordered_boundary_rows(self):
+		# Arrange:
+		database = self._create_database()
+		height_rows = (
+			(9, b'\x50' * 32, b'\x59' * 32),
+			(10, b'\x40' * 32, b'\x49' * 32),
+			(11, b'\x10' * 32, b'\x19' * 32),
+			(12, b'\x30' * 32, b'\x39' * 32),
+			(13, b'\x20' * 32, b'\x29' * 32)
+		)
+		for end_height, composite_hash, secret in height_rows:
+			row = _create_secret_lock_row(observed_height=1, composite_hash=composite_hash, secret=secret, end_height=end_height)
+			database.replace_secret_locks(
+				create_secret_lock_search_key(LOCK_OWNER, LOCK_RECIPIENT, secret, 'hash160'), [row])
+
+		# Act:
+		keys = database.get_secret_lock_search_keys_expiring_between(10, 12)
+
+		# Assert:
+		self.assertEqual([
+			(LOCK_OWNER, LOCK_RECIPIENT, b'\x19' * 32, 'hash160'),
+			(LOCK_OWNER, LOCK_RECIPIENT, b'\x39' * 32, 'hash160'),
+			(LOCK_OWNER, LOCK_RECIPIENT, b'\x49' * 32, 'hash160')
+		], keys)
 
 	def test_confirmed_transaction_lock_key_collection_includes_only_authoritative_sources(self):
 		# Arrange:
@@ -4461,6 +4588,63 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		self.assertEqual([
 			(LOCK_OWNER, LOCK_RECIPIENT, LOCK_SECRET, 'sha3_256'),
 			(None, LOCK_RECIPIENT, LOCK_SECRET, 'sha3_256')
+		], keys.secret_keys)
+
+	def test_confirmed_transaction_lock_key_collection_includes_creation_and_completion_at_or_after_fork_height(self):
+		# Arrange:
+		database = self._create_database()
+		for height in (1, 2, 3):
+			database.upsert_blocks([_create_block(height)])
+			hash_lock_hash = bytes([height]) * 32
+			aggregate_hash = bytes([height + 16]) * 32
+			secret_lock_secret = bytes([height + 32]) * 32
+			secret_proof_secret = bytes([height + 48]) * 32
+			database.upsert_transactions_for_height(height, [
+				create_transaction_entry(
+					height,
+					f'hash-lock-{height}',
+					type=TransactionType.HASH_LOCK.value,
+					type_name=TRANSACTION_TYPE_LABELS[TransactionType.HASH_LOCK.value],
+					body={'hash': hash_lock_hash.hex().upper()}),
+				create_transaction_entry(
+					height,
+					f'aggregate-{height}',
+					type=TransactionType.AGGREGATE_BONDED.value,
+					type_name=TRANSACTION_TYPE_LABELS[TransactionType.AGGREGATE_BONDED.value],
+					hash=aggregate_hash),
+				create_transaction_entry(
+					height,
+					f'secret-lock-{height}',
+					type=TransactionType.SECRET_LOCK.value,
+					type_name=TRANSACTION_TYPE_LABELS[TransactionType.SECRET_LOCK.value],
+					signer_address=LOCK_OWNER,
+					recipient_address=LOCK_RECIPIENT,
+					body={'secret': secret_lock_secret.hex().upper(), 'hashAlgorithm': 1}),
+				create_transaction_entry(
+					height,
+					f'secret-proof-{height}',
+					type=TransactionType.SECRET_PROOF.value,
+					type_name=TRANSACTION_TYPE_LABELS[TransactionType.SECRET_PROOF.value],
+					signer_address=LOCK_OWNER,
+					recipient_address=LOCK_RECIPIENT,
+					body={'secret': secret_proof_secret.hex().upper(), 'hashAlgorithm': 1})
+			])
+
+		# Act:
+		keys = database.get_lock_keys_from_confirmed_transactions_from_height(2)
+
+		# Assert:
+		self.assertEqual([
+			bytes([2]) * 32,
+			bytes([18]) * 32,
+			bytes([3]) * 32,
+			bytes([19]) * 32
+		], [key.hash for key in keys.hash_keys])
+		self.assertEqual([
+			(LOCK_OWNER, LOCK_RECIPIENT, bytes([34]) * 32, 'hash160'),
+			(None, LOCK_RECIPIENT, bytes([50]) * 32, 'hash160'),
+			(LOCK_OWNER, LOCK_RECIPIENT, bytes([35]) * 32, 'hash160'),
+			(None, LOCK_RECIPIENT, bytes([51]) * 32, 'hash160')
 		], keys.secret_keys)
 
 	def test_repair_rollback_deletes_lock_rows_at_fork_and_applies_replacements_atomically(self):

--- a/explorer/puller/tests/db/test_SymbolDatabase.py
+++ b/explorer/puller/tests/db/test_SymbolDatabase.py
@@ -8,13 +8,12 @@ from unittest import TestCase
 from common.tests.PostgresTestUtils import PostgresTestDatabase, drop_symbol_block_tables_if_present
 from psycopg2 import Error as PsycopgError
 from psycopg2.extras import Json
-from symbolchain.sc import ReceiptType, TransactionType
+from symbolchain.sc import ReceiptType
 from symbolchain.symbol.Network import Network
 
 from puller.db.SymbolDatabase import RollbackRefreshEntries, SymbolDatabase
 from puller.model.symbol.Account import create_account_row
 from puller.model.symbol.Lock import create_hash_lock_key, create_secret_lock_search_key
-from puller.model.symbol.Transaction import TRANSACTION_TYPE_LABELS
 from tests.facade.symbol.puller_test_utils import NATIVE_MOSAIC_ID, create_account_item
 from tests.test.SymbolDatabaseTestUtils import fetch_full_block_state, fetch_normalized_sync_state
 from tests.test.SymbolMetadataTestUtils import (
@@ -4498,7 +4497,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 			b'\x60' * 32
 		], [key.hash for key in keys])
 
-	def test_get_hash_lock_hashes_reaching_end_height_between_returns_height_ordered_boundary_rows(self):
+	def test_get_hash_lock_hashes_reaching_finalized_height_returns_height_ordered_boundary_rows(self):
 		# Arrange:
 		database = self._create_database()
 		height_rows = (
@@ -4513,10 +4512,11 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 			database.upsert_hash_lock(_create_hash_lock_row(observed_height=1, lock_hash=lock_hash, end_height=end_height))
 
 		# Act:
-		keys = database.get_hash_lock_hashes_reaching_end_height_between(10, 12)
+		keys = database.get_hash_lock_hashes_reaching_finalized_height(12)
 
 		# Assert:
 		self.assertEqual([
+			b'\x50' * 32,
 			b'\x30' * 32,
 			b'\x40' * 32,
 			b'\x10' * 32,
@@ -4551,7 +4551,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 			(LOCK_OWNER, LOCK_RECIPIENT, b'\x49' * 32, 'hash160')
 		], keys)
 
-	def test_get_secret_lock_search_keys_reaching_end_height_between_returns_height_ordered_boundary_rows(self):
+	def test_get_secret_lock_search_keys_reaching_finalized_height_returns_height_ordered_boundary_rows(self):
 		# Arrange:
 		database = self._create_database()
 		height_rows = (
@@ -4568,156 +4568,37 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 				create_secret_lock_search_key(LOCK_OWNER, LOCK_RECIPIENT, secret, 'hash160'), [row])
 
 		# Act:
-		keys = database.get_secret_lock_search_keys_reaching_end_height_between(10, 12)
+		keys = database.get_secret_lock_search_keys_reaching_finalized_height(12)
 
 		# Assert:
 		self.assertEqual([
+			(LOCK_OWNER, LOCK_RECIPIENT, b'\x59' * 32, 'hash160'),
 			(LOCK_OWNER, LOCK_RECIPIENT, b'\x99' * 32, 'hash160'),
 			(LOCK_OWNER, LOCK_RECIPIENT, b'\x01' * 32, 'hash160'),
 			(LOCK_OWNER, LOCK_RECIPIENT, b'\x19' * 32, 'hash160'),
 			(LOCK_OWNER, LOCK_RECIPIENT, b'\x29' * 32, 'hash160')
 		], keys)
 
-	def test_confirmed_transaction_lock_key_collection_includes_only_authoritative_sources(self):
+	def test_apply_finalization_lock_entries_rolls_back_hash_and_secret_writes_together(self):
 		# Arrange:
 		database = self._create_database()
-		database.upsert_blocks([_create_block(2)])
-		hash_lock_transaction = create_transaction_entry(
-			2, 'hash-lock', type=TransactionType.HASH_LOCK.value,
-			type_name=TRANSACTION_TYPE_LABELS[TransactionType.HASH_LOCK.value],
-			body={'hash': LOCK_HASH.hex().upper()})
-		aggregate_transaction = create_transaction_entry(
-			2, 'aggregate-bonded', type=TransactionType.AGGREGATE_BONDED.value,
-			type_name=TRANSACTION_TYPE_LABELS[TransactionType.AGGREGATE_BONDED.value],
-			hash=LOCK_HASH_2)
-		secret_lock_transaction = create_transaction_entry(
-			2, 'secret-lock', type=TransactionType.SECRET_LOCK.value,
-			type_name=TRANSACTION_TYPE_LABELS[TransactionType.SECRET_LOCK.value],
-			signer_address=LOCK_OWNER, recipient_address=LOCK_RECIPIENT,
-			body={'secret': LOCK_SECRET.hex().upper(), 'hashAlgorithm': 0})
-		secret_proof_transaction = create_transaction_entry(
-			2, 'secret-proof', type=TransactionType.SECRET_PROOF.value,
-			type_name=TRANSACTION_TYPE_LABELS[TransactionType.SECRET_PROOF.value],
-			signer_address=LOCK_OWNER_2, recipient_address=LOCK_RECIPIENT,
-			body={'secret': LOCK_SECRET.hex().upper(), 'hashAlgorithm': 0})
-		database.upsert_transactions_for_height(2, [
-			hash_lock_transaction, aggregate_transaction, secret_lock_transaction,
-			secret_proof_transaction])
+		database.upsert_hash_lock(_create_hash_lock_row(status='unused'))
+		secret_key = create_secret_lock_search_key(LOCK_OWNER, LOCK_RECIPIENT, LOCK_SECRET, 'hash160')
+		database.replace_secret_locks(secret_key, [_create_secret_lock_row(status='unused')])
+		invalid_secret_row = {**_create_secret_lock_row(status='used'), 'hash_algorithm': 'invalid'}
 
-		# Act:
-		keys = database.get_lock_keys_from_confirmed_transactions_from_height(2)
+		# Act / Assert:
+		with self.assertRaises(PsycopgError):
+			database.apply_finalization_lock_entries(
+				[{'row': _create_hash_lock_row(status='used')}],
+				[{'key': secret_key, 'rows': [invalid_secret_row]}])
 
 		# Assert:
-		self.assertEqual([LOCK_HASH, LOCK_HASH_2], [key.hash for key in keys.hash_keys])
-		self.assertEqual([
-			(LOCK_OWNER, LOCK_RECIPIENT, LOCK_SECRET, 'sha3_256'),
-			(None, LOCK_RECIPIENT, LOCK_SECRET, 'sha3_256')
-		], keys.secret_keys)
-
-	def test_confirmed_transaction_lock_key_collection_deduplicates_in_first_encounter_order(self):
-		# Arrange:
-		database = self._create_database()
-		database.upsert_blocks([_create_block(2)])
-		first_hash = b'\x30' * 32
-		second_hash = b'\x10' * 32
-		first_secret = b'\x40' * 32
-		second_secret = b'\x20' * 32
-		database.upsert_transactions_for_height(2, [
-			create_transaction_entry(
-				2, 'first-hash-lock', type=TransactionType.HASH_LOCK.value,
-				type_name=TRANSACTION_TYPE_LABELS[TransactionType.HASH_LOCK.value],
-				body={'hash': first_hash.hex().upper()}),
-			create_transaction_entry(
-				2, 'aggregate-bonded', type=TransactionType.AGGREGATE_BONDED.value,
-				type_name=TRANSACTION_TYPE_LABELS[TransactionType.AGGREGATE_BONDED.value],
-				hash=second_hash),
-			create_transaction_entry(
-				2, 'duplicate-hash-lock', type=TransactionType.HASH_LOCK.value,
-				type_name=TRANSACTION_TYPE_LABELS[TransactionType.HASH_LOCK.value],
-				body={'hash': first_hash.hex().upper()}),
-			create_transaction_entry(
-				2, 'first-secret-proof', type=TransactionType.SECRET_PROOF.value,
-				type_name=TRANSACTION_TYPE_LABELS[TransactionType.SECRET_PROOF.value],
-				recipient_address=LOCK_RECIPIENT,
-				body={'secret': first_secret.hex().upper(), 'hashAlgorithm': 0}),
-			create_transaction_entry(
-				2, 'secret-lock', type=TransactionType.SECRET_LOCK.value,
-				type_name=TRANSACTION_TYPE_LABELS[TransactionType.SECRET_LOCK.value],
-				signer_address=LOCK_OWNER, recipient_address=LOCK_RECIPIENT,
-				body={'secret': second_secret.hex().upper(), 'hashAlgorithm': 0}),
-			create_transaction_entry(
-				2, 'duplicate-secret-proof', type=TransactionType.SECRET_PROOF.value,
-				type_name=TRANSACTION_TYPE_LABELS[TransactionType.SECRET_PROOF.value],
-				recipient_address=LOCK_RECIPIENT,
-				body={'secret': first_secret.hex().upper(), 'hashAlgorithm': 0})
-		])
-
-		# Act:
-		keys = database.get_lock_keys_from_confirmed_transactions_from_height(2)
-
-		# Assert:
-		self.assertEqual([first_hash, second_hash], [key.hash for key in keys.hash_keys])
-		self.assertEqual([
-			(None, LOCK_RECIPIENT, first_secret, 'sha3_256'),
-			(LOCK_OWNER, LOCK_RECIPIENT, second_secret, 'sha3_256')
-		], keys.secret_keys)
-
-	def test_confirmed_transaction_lock_key_collection_includes_creation_and_completion_at_or_after_fork_height(self):
-		# Arrange:
-		database = self._create_database()
-		for height in (1, 2, 3):
-			database.upsert_blocks([_create_block(height)])
-			hash_lock_hash = bytes([height]) * 32
-			aggregate_hash = bytes([height + 16]) * 32
-			secret_lock_secret = bytes([height + 32]) * 32
-			secret_proof_secret = bytes([height + 48]) * 32
-			database.upsert_transactions_for_height(height, [
-				create_transaction_entry(
-					height,
-					f'hash-lock-{height}',
-					type=TransactionType.HASH_LOCK.value,
-					type_name=TRANSACTION_TYPE_LABELS[TransactionType.HASH_LOCK.value],
-					body={'hash': hash_lock_hash.hex().upper()}),
-				create_transaction_entry(
-					height,
-					f'aggregate-{height}',
-					type=TransactionType.AGGREGATE_BONDED.value,
-					type_name=TRANSACTION_TYPE_LABELS[TransactionType.AGGREGATE_BONDED.value],
-					hash=aggregate_hash),
-				create_transaction_entry(
-					height,
-					f'secret-lock-{height}',
-					type=TransactionType.SECRET_LOCK.value,
-					type_name=TRANSACTION_TYPE_LABELS[TransactionType.SECRET_LOCK.value],
-					signer_address=LOCK_OWNER,
-					recipient_address=LOCK_RECIPIENT,
-					body={'secret': secret_lock_secret.hex().upper(), 'hashAlgorithm': 1}),
-				create_transaction_entry(
-					height,
-					f'secret-proof-{height}',
-					type=TransactionType.SECRET_PROOF.value,
-					type_name=TRANSACTION_TYPE_LABELS[TransactionType.SECRET_PROOF.value],
-					signer_address=LOCK_OWNER,
-					recipient_address=LOCK_RECIPIENT,
-					body={'secret': secret_proof_secret.hex().upper(), 'hashAlgorithm': 1})
-			])
-
-		# Act:
-		keys = database.get_lock_keys_from_confirmed_transactions_from_height(2)
-
-		# Assert:
-		self.assertEqual([
-			bytes([2]) * 32,
-			bytes([18]) * 32,
-			bytes([3]) * 32,
-			bytes([19]) * 32
-		], [key.hash for key in keys.hash_keys])
-		self.assertEqual([
-			(LOCK_OWNER, LOCK_RECIPIENT, bytes([34]) * 32, 'hash160'),
-			(None, LOCK_RECIPIENT, bytes([50]) * 32, 'hash160'),
-			(LOCK_OWNER, LOCK_RECIPIENT, bytes([35]) * 32, 'hash160'),
-			(None, LOCK_RECIPIENT, bytes([51]) * 32, 'hash160')
-		], keys.secret_keys)
+		cursor = database.connection.cursor()
+		cursor.execute('SELECT status FROM symbol_hash_locks WHERE hash = %s', (LOCK_HASH,))
+		self.assertEqual([('unused',)], cursor.fetchall())
+		cursor.execute('SELECT status FROM symbol_secret_locks WHERE composite_hash = %s', (LOCK_COMPOSITE_HASH,))
+		self.assertEqual([('unused',)], cursor.fetchall())
 
 	def test_repair_rollback_deletes_lock_rows_at_fork_and_applies_replacements_atomically(self):
 		# Arrange:

--- a/explorer/puller/tests/db/test_SymbolDatabase.py
+++ b/explorer/puller/tests/db/test_SymbolDatabase.py
@@ -8,11 +8,13 @@ from unittest import TestCase
 from common.tests.PostgresTestUtils import PostgresTestDatabase, drop_symbol_block_tables_if_present
 from psycopg2 import Error as PsycopgError
 from psycopg2.extras import Json
-from symbolchain.sc import ReceiptType
+from symbolchain.sc import ReceiptType, TransactionType
 from symbolchain.symbol.Network import Network
 
 from puller.db.SymbolDatabase import RollbackRefreshEntries, SymbolDatabase
 from puller.model.symbol.Account import create_account_row
+from puller.model.symbol.Lock import create_hash_lock_key_from_hex, create_secret_lock_search_key
+from puller.model.symbol.Transaction import TRANSACTION_TYPE_LABELS
 from tests.facade.symbol.puller_test_utils import NATIVE_MOSAIC_ID, create_account_item
 from tests.test.SymbolDatabaseTestUtils import fetch_full_block_state, fetch_normalized_sync_state
 from tests.test.SymbolMetadataTestUtils import (
@@ -48,6 +50,50 @@ ADDRESS1 = '9889432DE263BB8FE88444A4DA28D3609BD8BB8FAE18AE95'
 ADDRESS2 = '9889432DE263BB8FE88444A4DA28D3609BD8BB8FAE18AE96'
 ADDRESS3 = '9889432DE263BB8FE88444A4DA28D3609BD8BB8FAE18AE97'
 ADDRESS4 = '98' + '11' * 23
+LOCK_HASH = bytes.fromhex('AA' * 32)
+LOCK_HASH_2 = bytes.fromhex('BB' * 32)
+LOCK_SECRET = bytes.fromhex('CC' * 32)
+LOCK_COMPOSITE_HASH = bytes.fromhex('DD' * 32)
+LOCK_COMPOSITE_HASH_2 = bytes.fromhex('EE' * 32)
+LOCK_OWNER = bytes.fromhex(ADDRESS1)
+LOCK_OWNER_2 = bytes.fromhex(ADDRESS2)
+LOCK_RECIPIENT = bytes.fromhex(ADDRESS3)
+
+
+def _create_hash_lock_row(observed_height=1, lock_hash=LOCK_HASH, end_height=100, status='unused'):
+	return {
+		'hash': lock_hash,
+		'owner_address': LOCK_OWNER,
+		'mosaic_id': NATIVE_MOSAIC_ID,
+		'amount': 1234,
+		'end_height': end_height,
+		'status': status,
+		'raw_payload': {'lock': {'hash': lock_hash.hex()}},
+		'updated_at_height': observed_height
+	}
+
+
+def _create_secret_lock_row(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+	observed_height=1,
+	composite_hash=LOCK_COMPOSITE_HASH,
+	owner_address=LOCK_OWNER,
+	secret=LOCK_SECRET,
+	end_height=100,
+	status='unused'
+):
+	return {
+		'composite_hash': composite_hash,
+		'owner_address': owner_address,
+		'recipient_address': LOCK_RECIPIENT,
+		'secret': secret,
+		'hash_algorithm': 'hash160',
+		'mosaic_id': NATIVE_MOSAIC_ID,
+		'amount': 1234,
+		'end_height': end_height,
+		'status': status,
+		'raw_payload': {'lock': {'compositeHash': composite_hash.hex()}},
+		'updated_at_height': observed_height
+	}
 
 
 def _create_block(height, block_hash=None, **overrides):
@@ -1759,11 +1805,13 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 			'symbol_accounts',
 			'symbol_alias_names',
 			'symbol_blocks',
+			'symbol_hash_locks',
 			'symbol_metadata',
 			'symbol_mosaics',
 			'symbol_multisig',
 			'symbol_namespaces',
 			'symbol_receipts',
+			'symbol_secret_locks',
 			'symbol_sync_state',
 			'symbol_transaction_addresses',
 			'symbol_transaction_mosaics',
@@ -4007,3 +4055,546 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 			bytes(b'hash 1'),
 			bytes(sync_state['last_synced_block_hash'])
 		)
+
+	def test_create_tables_creates_exact_hash_lock_columns_types_and_nullability(self):
+		# Arrange:
+		database = self._create_uninitialized_database()
+		cursor = database.connection.cursor()
+
+		# Act:
+		database.create_tables()
+
+		# Assert:
+		cursor.execute(
+			'''
+			SELECT table_name, column_name, udt_name, is_nullable, character_maximum_length
+			FROM information_schema.columns
+			WHERE table_name = 'symbol_hash_locks'
+			ORDER BY ordinal_position
+			''')
+		self.assertEqual([
+			('symbol_hash_locks', 'hash', 'bytea', 'NO', None),
+			('symbol_hash_locks', 'owner_address', 'bytea', 'NO', None),
+			('symbol_hash_locks', 'mosaic_id', 'varchar', 'NO', 16),
+			('symbol_hash_locks', 'amount', 'int8', 'NO', None),
+			('symbol_hash_locks', 'end_height', 'int8', 'NO', None),
+			('symbol_hash_locks', 'status', 'symbol_lock_status', 'NO', None),
+			('symbol_hash_locks', 'raw_payload', 'jsonb', 'NO', None),
+			('symbol_hash_locks', 'updated_at_height', 'int8', 'NO', None)
+		], cursor.fetchall())
+
+	def test_create_tables_creates_exact_hash_lock_primary_key_constraint(self):
+		# Arrange:
+		database = self._create_uninitialized_database()
+		cursor = database.connection.cursor()
+
+		# Act:
+		database.create_tables()
+
+		# Assert:
+		cursor.execute(
+			'''
+			SELECT table_constraints.constraint_type, key_column_usage.column_name
+			FROM information_schema.table_constraints AS table_constraints
+			JOIN information_schema.key_column_usage AS key_column_usage
+				USING (constraint_catalog, constraint_schema, constraint_name)
+			WHERE table_constraints.table_name = 'symbol_hash_locks'
+				AND table_constraints.constraint_type = 'PRIMARY KEY'
+			ORDER BY key_column_usage.ordinal_position
+			''')
+		self.assertEqual([('PRIMARY KEY', 'hash')], cursor.fetchall())
+
+	def test_create_tables_creates_exact_hash_lock_index_set(self):
+		# Arrange:
+		database = self._create_uninitialized_database()
+		cursor = database.connection.cursor()
+
+		# Act:
+		database.create_tables()
+
+		# Assert:
+		cursor.execute(
+			'''
+			SELECT indexname, indexdef
+			FROM pg_indexes
+			WHERE tablename = 'symbol_hash_locks'
+			ORDER BY indexname
+			''')
+		self.assertEqual([
+			('idx_symbol_hash_locks_end_height',
+				'CREATE INDEX idx_symbol_hash_locks_end_height ON public.symbol_hash_locks '
+				'USING btree (end_height DESC, hash DESC)'),
+			('idx_symbol_hash_locks_mosaic_end_height',
+				'CREATE INDEX idx_symbol_hash_locks_mosaic_end_height ON public.symbol_hash_locks '
+				'USING btree (mosaic_id, end_height DESC, hash DESC)'),
+			('idx_symbol_hash_locks_owner_end_height',
+				'CREATE INDEX idx_symbol_hash_locks_owner_end_height ON public.symbol_hash_locks '
+				'USING btree (owner_address, end_height DESC, hash DESC)'),
+			('idx_symbol_hash_locks_status_end_height',
+				'CREATE INDEX idx_symbol_hash_locks_status_end_height ON public.symbol_hash_locks '
+				'USING btree (status, end_height DESC, hash DESC)'),
+			('idx_symbol_hash_locks_updated_at_height',
+				'CREATE INDEX idx_symbol_hash_locks_updated_at_height ON public.symbol_hash_locks '
+				'USING btree (updated_at_height)'),
+			('symbol_hash_locks_pkey',
+				'CREATE UNIQUE INDEX symbol_hash_locks_pkey ON public.symbol_hash_locks USING btree (hash)')
+		], cursor.fetchall())
+
+	def test_create_tables_creates_exact_secret_lock_columns_types_and_nullability(self):
+		# Arrange:
+		database = self._create_uninitialized_database()
+		cursor = database.connection.cursor()
+
+		# Act:
+		database.create_tables()
+
+		# Assert:
+		cursor.execute(
+			'''
+			SELECT table_name, column_name, udt_name, is_nullable, character_maximum_length
+			FROM information_schema.columns
+			WHERE table_name = 'symbol_secret_locks'
+			ORDER BY ordinal_position
+			''')
+		self.assertEqual([
+			('symbol_secret_locks', 'composite_hash', 'bytea', 'NO', None),
+			('symbol_secret_locks', 'owner_address', 'bytea', 'NO', None),
+			('symbol_secret_locks', 'recipient_address', 'bytea', 'NO', None),
+			('symbol_secret_locks', 'secret', 'bytea', 'NO', None),
+			('symbol_secret_locks', 'hash_algorithm', 'symbol_lock_hash_algorithm', 'NO', None),
+			('symbol_secret_locks', 'mosaic_id', 'varchar', 'NO', 16),
+			('symbol_secret_locks', 'amount', 'int8', 'NO', None),
+			('symbol_secret_locks', 'end_height', 'int8', 'NO', None),
+			('symbol_secret_locks', 'status', 'symbol_lock_status', 'NO', None),
+			('symbol_secret_locks', 'raw_payload', 'jsonb', 'NO', None),
+			('symbol_secret_locks', 'updated_at_height', 'int8', 'NO', None)
+		], cursor.fetchall())
+
+	def test_create_tables_creates_exact_secret_lock_primary_key_constraint(self):
+		# Arrange:
+		database = self._create_uninitialized_database()
+		cursor = database.connection.cursor()
+
+		# Act:
+		database.create_tables()
+
+		# Assert:
+		cursor.execute(
+			'''
+			SELECT table_constraints.constraint_type, key_column_usage.column_name
+			FROM information_schema.table_constraints AS table_constraints
+			JOIN information_schema.key_column_usage AS key_column_usage
+				USING (constraint_catalog, constraint_schema, constraint_name)
+			WHERE table_constraints.table_name = 'symbol_secret_locks'
+				AND table_constraints.constraint_type = 'PRIMARY KEY'
+			ORDER BY key_column_usage.ordinal_position
+			''')
+		self.assertEqual([('PRIMARY KEY', 'composite_hash')], cursor.fetchall())
+
+	def test_create_tables_creates_exact_secret_lock_index_set(self):
+		# Arrange:
+		database = self._create_uninitialized_database()
+		cursor = database.connection.cursor()
+
+		# Act:
+		database.create_tables()
+
+		# Assert:
+		cursor.execute(
+			'''
+			SELECT indexname, indexdef
+			FROM pg_indexes
+			WHERE tablename = 'symbol_secret_locks'
+			ORDER BY indexname
+			''')
+		self.assertEqual([
+			('idx_symbol_secret_locks_end_height',
+				'CREATE INDEX idx_symbol_secret_locks_end_height ON public.symbol_secret_locks '
+				'USING btree (end_height DESC, composite_hash DESC)'),
+			('idx_symbol_secret_locks_hash_algorithm_end_height',
+				'CREATE INDEX idx_symbol_secret_locks_hash_algorithm_end_height ON public.symbol_secret_locks '
+				'USING btree (hash_algorithm, end_height DESC, composite_hash DESC)'),
+			('idx_symbol_secret_locks_mosaic_end_height',
+				'CREATE INDEX idx_symbol_secret_locks_mosaic_end_height ON public.symbol_secret_locks '
+				'USING btree (mosaic_id, end_height DESC, composite_hash DESC)'),
+			('idx_symbol_secret_locks_owner_end_height',
+				'CREATE INDEX idx_symbol_secret_locks_owner_end_height ON public.symbol_secret_locks '
+				'USING btree (owner_address, end_height DESC, composite_hash DESC)'),
+			('idx_symbol_secret_locks_recipient_end_height',
+				'CREATE INDEX idx_symbol_secret_locks_recipient_end_height ON public.symbol_secret_locks '
+				'USING btree (recipient_address, end_height DESC, composite_hash DESC)'),
+			('idx_symbol_secret_locks_search',
+				'CREATE INDEX idx_symbol_secret_locks_search ON public.symbol_secret_locks '
+				'USING btree (secret, recipient_address, hash_algorithm, owner_address)'),
+			('idx_symbol_secret_locks_status_end_height',
+				'CREATE INDEX idx_symbol_secret_locks_status_end_height ON public.symbol_secret_locks '
+				'USING btree (status, end_height DESC, composite_hash DESC)'),
+			('idx_symbol_secret_locks_updated_at_height',
+				'CREATE INDEX idx_symbol_secret_locks_updated_at_height ON public.symbol_secret_locks '
+				'USING btree (updated_at_height)'),
+			('symbol_secret_locks_pkey',
+				'CREATE UNIQUE INDEX symbol_secret_locks_pkey ON public.symbol_secret_locks USING btree (composite_hash)')
+		], cursor.fetchall())
+
+	def test_create_tables_creates_exact_lock_enum_labels_and_column_types(self):
+		# Arrange:
+		database = self._create_uninitialized_database()
+		cursor = database.connection.cursor()
+
+		# Act:
+		database.create_tables()
+
+		# Assert:
+		cursor.execute(
+			'''
+			SELECT pg_type.typname, enumlabel
+			FROM pg_enum
+			JOIN pg_type ON pg_type.oid = pg_enum.enumtypid
+			WHERE pg_type.typname IN ('symbol_lock_status', 'symbol_lock_hash_algorithm')
+			ORDER BY pg_type.typname, enumsortorder
+			''')
+		self.assertEqual([
+			('symbol_lock_hash_algorithm', 'sha3_256'),
+			('symbol_lock_hash_algorithm', 'hash160'),
+			('symbol_lock_hash_algorithm', 'hash256'),
+			('symbol_lock_status', 'unused'),
+			('symbol_lock_status', 'used')
+		], cursor.fetchall())
+		cursor.execute(
+			'''
+			SELECT table_name, column_name, udt_name
+			FROM information_schema.columns
+			WHERE table_name IN ('symbol_hash_locks', 'symbol_secret_locks')
+				AND column_name IN ('hash_algorithm', 'status')
+			ORDER BY table_name, column_name
+			''')
+		self.assertEqual([
+			('symbol_hash_locks', 'status', 'symbol_lock_status'),
+			('symbol_secret_locks', 'hash_algorithm', 'symbol_lock_hash_algorithm'),
+			('symbol_secret_locks', 'status', 'symbol_lock_status')
+		], cursor.fetchall())
+
+	def test_create_tables_does_not_add_lock_column_defaults(self):
+		# Arrange:
+		database = self._create_uninitialized_database()
+		cursor = database.connection.cursor()
+
+		# Act:
+		database.create_tables()
+
+		# Assert:
+		cursor.execute(
+			'''
+			SELECT table_name, column_name, column_default
+			FROM information_schema.columns
+			WHERE table_name IN ('symbol_hash_locks', 'symbol_secret_locks')
+				AND column_default IS NOT NULL
+			ORDER BY table_name, ordinal_position
+			''')
+		self.assertEqual([], cursor.fetchall())
+
+	def test_create_tables_does_not_add_lock_foreign_keys(self):
+		# Arrange:
+		database = self._create_uninitialized_database()
+		cursor = database.connection.cursor()
+
+		# Act:
+		database.create_tables()
+
+		# Assert:
+		cursor.execute(
+			'''
+			SELECT table_name, constraint_name
+			FROM information_schema.table_constraints
+			WHERE table_name IN ('symbol_hash_locks', 'symbol_secret_locks')
+				AND constraint_type = 'FOREIGN KEY'
+			ORDER BY table_name, constraint_name
+			''')
+		self.assertEqual([], cursor.fetchall())
+
+	def test_create_tables_does_not_add_lock_check_constraints(self):
+		# Arrange:
+		database = self._create_uninitialized_database()
+		cursor = database.connection.cursor()
+
+		# Act:
+		database.create_tables()
+
+		# Assert:
+		cursor.execute(
+			'''
+			SELECT conrelid::regclass::text, pg_get_constraintdef(oid)
+			FROM pg_constraint
+			WHERE conrelid IN ('symbol_hash_locks'::regclass, 'symbol_secret_locks'::regclass)
+				AND contype = 'c'
+			ORDER BY conrelid::regclass::text, conname
+			''')
+		self.assertEqual([], cursor.fetchall())
+
+	def test_hash_lock_upsert_update_and_delete_persist_current_state(self):
+		# Arrange:
+		database = self._create_database()
+		initial_row = _create_hash_lock_row()
+		updated_row = _create_hash_lock_row(observed_height=2, end_height=200, status='used')
+
+		# Act:
+		database.upsert_hash_lock(initial_row)
+		database.upsert_hash_lock(updated_row)
+		cursor = database.connection.cursor()
+		cursor.execute('SELECT hash, amount, end_height, status, updated_at_height FROM symbol_hash_locks')
+		updated_state = cursor.fetchall()
+		database.delete_hash_lock(create_hash_lock_key_from_hex(LOCK_HASH.hex()))
+
+		# Assert:
+		self.assertEqual(
+			[(LOCK_HASH, 1234, 200, 'used', 2)],
+			[(bytes(lock_hash), amount, end_height, status, updated_at_height)
+				for lock_hash, amount, end_height, status, updated_at_height in updated_state])
+		cursor.execute('SELECT hash FROM symbol_hash_locks')
+		self.assertEqual([], cursor.fetchall())
+
+	def test_secret_lock_replace_empty_removes_logical_key_and_preserves_siblings(self):
+		# Arrange:
+		database = self._create_database()
+		first_row = _create_secret_lock_row()
+		sibling_row = _create_secret_lock_row(composite_hash=LOCK_COMPOSITE_HASH_2, owner_address=LOCK_OWNER_2)
+		database.replace_secret_locks(
+			create_secret_lock_search_key(LOCK_OWNER, LOCK_RECIPIENT, LOCK_SECRET, 'hash160'),
+			[first_row, sibling_row])
+
+		# Act:
+		database.replace_secret_locks(
+			create_secret_lock_search_key(LOCK_OWNER, LOCK_RECIPIENT, LOCK_SECRET, 'hash160'), [])
+
+		# Assert:
+		cursor = database.connection.cursor()
+		cursor.execute('SELECT composite_hash, owner_address FROM symbol_secret_locks ORDER BY composite_hash')
+		self.assertEqual(
+			[(LOCK_COMPOSITE_HASH_2, LOCK_OWNER_2)],
+			[(bytes(composite_hash), bytes(owner_address)) for composite_hash, owner_address in cursor.fetchall()])
+
+	def test_secret_lock_unknown_owner_replace_removes_all_owner_siblings(self):
+		# Arrange:
+		database = self._create_database()
+		rows = [_create_secret_lock_row(), _create_secret_lock_row(
+			composite_hash=LOCK_COMPOSITE_HASH_2, owner_address=LOCK_OWNER_2)]
+		database.replace_secret_locks(
+			create_secret_lock_search_key(None, LOCK_RECIPIENT, LOCK_SECRET, 'hash160'), rows)
+
+		# Act:
+		database.replace_secret_locks(
+			create_secret_lock_search_key(None, LOCK_RECIPIENT, LOCK_SECRET, 'hash160'), [])
+
+		# Assert:
+		cursor = database.connection.cursor()
+		cursor.execute('SELECT composite_hash FROM symbol_secret_locks')
+		self.assertEqual([], cursor.fetchall())
+
+	def test_lock_height_queries_return_updated_and_expiring_logical_keys(self):
+		# Arrange:
+		database = self._create_database()
+		hash_row = _create_hash_lock_row(observed_height=5, end_height=8)
+		secret_row = _create_secret_lock_row(observed_height=5, end_height=8)
+		database.upsert_hash_lock(hash_row)
+		database.replace_secret_locks(
+			create_secret_lock_search_key(LOCK_OWNER, LOCK_RECIPIENT, LOCK_SECRET, 'hash160'), [secret_row])
+
+		# Act:
+		updated_hashes = database.get_hash_lock_hashes_updated_from_height(5)
+		updated_secrets = database.get_secret_lock_search_keys_updated_from_height(5)
+		expiring_hashes = database.get_hash_lock_hashes_expiring_between(8, 8)
+		expiring_secrets = database.get_secret_lock_search_keys_expiring_between(8, 8)
+
+		# Assert:
+		self.assertEqual([LOCK_HASH], [key.hash for key in updated_hashes])
+		self.assertEqual([LOCK_HASH], [key.hash for key in expiring_hashes])
+		self.assertEqual([
+			(LOCK_OWNER, LOCK_RECIPIENT, LOCK_SECRET, 'hash160')
+		], updated_secrets)
+		self.assertEqual(updated_secrets, expiring_secrets)
+
+	def test_confirmed_transaction_lock_key_collection_includes_only_authoritative_sources(self):
+		# Arrange:
+		database = self._create_database()
+		database.upsert_blocks([_create_block(2)])
+		hash_lock_transaction = create_transaction_entry(
+			2, 'hash-lock', type=TransactionType.HASH_LOCK.value,
+			type_name=TRANSACTION_TYPE_LABELS[TransactionType.HASH_LOCK.value],
+			body={'hash': LOCK_HASH.hex().upper()})
+		aggregate_transaction = create_transaction_entry(
+			2, 'aggregate-bonded', type=TransactionType.AGGREGATE_BONDED.value,
+			type_name=TRANSACTION_TYPE_LABELS[TransactionType.AGGREGATE_BONDED.value],
+			hash=LOCK_HASH_2)
+		secret_lock_transaction = create_transaction_entry(
+			2, 'secret-lock', type=TransactionType.SECRET_LOCK.value,
+			type_name=TRANSACTION_TYPE_LABELS[TransactionType.SECRET_LOCK.value],
+			signer_address=LOCK_OWNER, recipient_address=LOCK_RECIPIENT,
+			body={'secret': LOCK_SECRET.hex().upper(), 'hashAlgorithm': 0})
+		secret_proof_transaction = create_transaction_entry(
+			2, 'secret-proof', type=TransactionType.SECRET_PROOF.value,
+			type_name=TRANSACTION_TYPE_LABELS[TransactionType.SECRET_PROOF.value],
+			signer_address=LOCK_OWNER_2, recipient_address=LOCK_RECIPIENT,
+			body={'secret': LOCK_SECRET.hex().upper(), 'hashAlgorithm': 0})
+		secret_proof_after = create_transaction_entry(
+			2, 'secret-proof-after', type=TransactionType.SECRET_PROOF.value,
+			type_name=TRANSACTION_TYPE_LABELS[TransactionType.SECRET_PROOF.value],
+			signer_address=LOCK_OWNER, recipient_address=LOCK_RECIPIENT,
+			body={'secret': LOCK_SECRET.hex().upper(), 'hashAlgorithm': 0})
+		embedded_aggregate_transaction = create_transaction_entry(
+			2, 'embedded-aggregate', is_embedded=True,
+			type=TransactionType.AGGREGATE_BONDED.value,
+			type_name=TRANSACTION_TYPE_LABELS[TransactionType.AGGREGATE_BONDED.value])
+		hash_lock_after_proof = create_transaction_entry(
+			2, 'hash-lock-after-proof', type=TransactionType.HASH_LOCK.value,
+			type_name=TRANSACTION_TYPE_LABELS[TransactionType.HASH_LOCK.value],
+			body={'hash': LOCK_HASH.hex().upper()})
+		database.upsert_transactions_for_height(2, [
+			hash_lock_transaction, aggregate_transaction, secret_lock_transaction,
+			secret_proof_transaction, secret_proof_after, embedded_aggregate_transaction,
+			hash_lock_after_proof])
+
+		# Act:
+		keys = database.get_lock_keys_from_confirmed_transactions_from_height(2)
+
+		# Assert:
+		self.assertEqual([LOCK_HASH, LOCK_HASH_2], [key.hash for key in keys.hash_keys])
+		self.assertEqual([
+			(LOCK_OWNER, LOCK_RECIPIENT, LOCK_SECRET, 'sha3_256'),
+			(None, LOCK_RECIPIENT, LOCK_SECRET, 'sha3_256')
+		], keys.secret_keys)
+
+	def test_repair_rollback_deletes_lock_rows_at_fork_and_applies_replacements_atomically(self):
+		# Arrange:
+		database = self._create_database()
+		kept_hash_row = _create_hash_lock_row(observed_height=1, lock_hash=LOCK_HASH)
+		orphaned_hash_row = _create_hash_lock_row(observed_height=2, lock_hash=LOCK_HASH_2)
+		kept_secret_row = _create_secret_lock_row(observed_height=1)
+		orphaned_secret_row = _create_secret_lock_row(observed_height=2, composite_hash=LOCK_COMPOSITE_HASH_2)
+		database.upsert_hash_lock(kept_hash_row)
+		database.upsert_hash_lock(orphaned_hash_row)
+		database.replace_secret_locks(
+			create_secret_lock_search_key(LOCK_OWNER, LOCK_RECIPIENT, LOCK_SECRET, 'hash160'), [kept_secret_row])
+		database.replace_secret_locks(
+			create_secret_lock_search_key(LOCK_OWNER_2, LOCK_RECIPIENT, LOCK_SECRET, 'hash160'), [orphaned_secret_row])
+		refreshed_hash_row = _create_hash_lock_row(observed_height=1, lock_hash=LOCK_HASH_2, status='used')
+		refreshed_secret_row = _create_secret_lock_row(
+			observed_height=1, composite_hash=LOCK_COMPOSITE_HASH_2, owner_address=LOCK_OWNER_2, status='used')
+		refresh_entries = RollbackRefreshEntries(
+			hash_lock_entries=[{'row': refreshed_hash_row}],
+			secret_lock_entries=[{
+				'key': create_secret_lock_search_key(LOCK_OWNER_2, LOCK_RECIPIENT, LOCK_SECRET, 'hash160'),
+				'rows': [refreshed_secret_row]
+			}])
+
+		# Act:
+		database.repair_rollback_from_height(
+			2,
+			_create_sync_state(status='repairing', last_synced_height=1, last_synced_block_hash=b'hash 1'),
+			refresh_entries)
+
+		# Assert:
+		cursor = database.connection.cursor()
+		cursor.execute('SELECT hash, status, updated_at_height FROM symbol_hash_locks ORDER BY hash')
+		self.assertEqual([
+			(LOCK_HASH, 'unused', 1),
+			(LOCK_HASH_2, 'used', 1)
+		], [
+			(bytes(lock_hash), status, updated_at_height)
+			for lock_hash, status, updated_at_height in cursor.fetchall()])
+		cursor.execute('SELECT composite_hash, status, updated_at_height FROM symbol_secret_locks ORDER BY composite_hash')
+		self.assertEqual([
+			(LOCK_COMPOSITE_HASH, 'unused', 1),
+			(LOCK_COMPOSITE_HASH_2, 'used', 1)
+		], [
+			(bytes(composite_hash), status, updated_at_height)
+			for composite_hash, status, updated_at_height in cursor.fetchall()])
+		self.assertEqual('repairing', database.get_sync_state()['status'])
+		self.assertEqual(1, database.get_sync_state()['last_synced_height'])
+
+	def test_repair_rollback_applies_hash_lock_delete_entries(self):
+		# Arrange:
+		database = self._create_database()
+		database.upsert_hash_lock(_create_hash_lock_row(observed_height=1))
+
+		# Act:
+		database.repair_rollback_from_height(
+			2,
+			_create_sync_state(status='repairing', last_synced_height=1, last_synced_block_hash=b'hash 1'),
+			RollbackRefreshEntries(hash_lock_entries=[{
+				'hash': create_hash_lock_key_from_hex(LOCK_HASH.hex())
+			}]))
+
+		# Assert:
+		cursor = database.connection.cursor()
+		cursor.execute('SELECT hash FROM symbol_hash_locks')
+		self.assertEqual([], cursor.fetchall())
+
+	def test_repair_rollback_restores_chain_and_lock_state_when_later_secret_lock_write_fails(self):  # pylint: disable=too-many-locals
+		# Arrange:
+		database = self._create_database()
+		database.upsert_blocks([_create_block(1), _create_block(2)])
+		database.upsert_sync_state(_create_sync_state())
+		original_namespace_row = _create_namespace_row(observed_height=2)
+		database.upsert_namespace(original_namespace_row, _create_alias_name_rows(original_namespace_row))
+		original_mosaic_row = create_expected_mosaic_row(create_mosaic_item(supply='1234'), 2)
+		database.upsert_mosaic(original_mosaic_row)
+		original_metadata_item = create_metadata_item(metadata_type=1, target_id='72C0212E67A08BCE')
+		original_metadata_row = create_expected_metadata_row(
+			original_metadata_item, 2, bytes.fromhex('11' * 32), 'mosaic', '72C0212E67A08BCE', 'hello')
+		database.upsert_metadata(original_metadata_row)
+		original_hash_row = _create_hash_lock_row(observed_height=2, status='unused')
+		original_secret_row = _create_secret_lock_row(observed_height=2, status='unused')
+		database.upsert_hash_lock(original_hash_row)
+		database.replace_secret_locks(
+			create_secret_lock_search_key(LOCK_OWNER, LOCK_RECIPIENT, LOCK_SECRET, 'hash160'), [original_secret_row])
+		original_blocks = fetch_full_block_state(database)
+		original_sync_state = fetch_normalized_sync_state(database)
+		original_namespace_state = fetch_namespace_state(database.connection)
+		original_mosaic_state = fetch_mosaic_state(database)
+		original_metadata_state = fetch_metadata_rows(database)
+		invalid_secret_row = {
+			**_create_secret_lock_row(observed_height=1, status='used'),
+			'hash_algorithm': 'invalid'
+		}
+		canonical_namespace_row = _create_namespace_row(full_name='canonical', observed_height=1)
+		refresh_entries = RollbackRefreshEntries(
+			namespace_entries=[{
+				'row': canonical_namespace_row,
+				'alias_rows': _create_alias_name_rows(canonical_namespace_row)
+			}],
+			mosaic_entries=[{
+				'row': create_expected_mosaic_row(create_mosaic_item(supply='9999'), 1)
+			}],
+			metadata_entries=[{
+				'row': create_expected_metadata_row(
+					create_metadata_item(metadata_type=1, target_id='72C0212E67A08BCE', value='776F726C64'),
+					1, bytes.fromhex('11' * 32), 'mosaic', '72C0212E67A08BCE', 'world', value_hex='776F726C64')
+			}],
+			hash_lock_entries=[{'row': _create_hash_lock_row(observed_height=1, status='used')}],
+			secret_lock_entries=[{
+				'key': create_secret_lock_search_key(LOCK_OWNER, LOCK_RECIPIENT, LOCK_SECRET, 'hash160'),
+				'rows': [invalid_secret_row]
+			}])
+
+		# Act / Assert:
+		with self.assertRaises(PsycopgError):
+			database.repair_rollback_from_height(2, _create_sync_state(
+				status='repairing', last_synced_height=1, last_synced_block_hash=b'hash 1'), refresh_entries)
+
+		# Assert:
+		self.assertEqual(original_blocks, fetch_full_block_state(database))
+		self.assertEqual(original_sync_state, fetch_normalized_sync_state(database))
+		self.assertEqual(original_namespace_state, fetch_namespace_state(database.connection))
+		self.assertEqual(original_mosaic_state, fetch_mosaic_state(database))
+		self.assertEqual(original_metadata_state, fetch_metadata_rows(database))
+		cursor = database.connection.cursor()
+		cursor.execute('SELECT hash, status, updated_at_height FROM symbol_hash_locks')
+		self.assertEqual([(LOCK_HASH, 'unused', 2)], [
+			(bytes(lock_hash), status, updated_at_height)
+			for lock_hash, status, updated_at_height in cursor.fetchall()
+		])
+		cursor.execute('SELECT composite_hash, status, updated_at_height FROM symbol_secret_locks')
+		self.assertEqual([(LOCK_COMPOSITE_HASH, 'unused', 2)], [
+			(bytes(composite_hash), status, updated_at_height)
+			for composite_hash, status, updated_at_height in cursor.fetchall()
+		])

--- a/explorer/puller/tests/facade/symbol/puller_test_utils.py
+++ b/explorer/puller/tests/facade/symbol/puller_test_utils.py
@@ -210,6 +210,29 @@ def create_embedded_node_transaction(height, aggregate_hash, embedded_index, tra
 	}
 
 
+def create_complete_aggregate_pair(
+	height,
+	aggregate_hash,
+	embedded_index,
+	transaction_id=None,
+	**embedded_transaction_overrides
+):
+	return [
+		create_node_transaction(
+			height,
+			transaction_hash=aggregate_hash,
+			type=TransactionType.AGGREGATE_COMPLETE.value,
+			transactionsHash='9' * 64,
+			cosignatures=[]),
+		create_embedded_node_transaction(
+			height,
+			aggregate_hash,
+			embedded_index,
+			transaction_id=transaction_id,
+			**embedded_transaction_overrides)
+	]
+
+
 def transaction_path(start_height, end_height, page_number=1):
 	return (
 		f'transactions/confirmed?fromHeight={start_height}&toHeight={end_height}'

--- a/explorer/puller/tests/facade/symbol/test_PullerLocks.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerLocks.py
@@ -4,13 +4,13 @@
 import asyncio
 import copy
 
-from psycopg2 import Error as PsycopgError
 from symbolchain.sc import TransactionType
 from symbolchain.symbol.Network import Address
 
 from puller.model.symbol.Account import create_account_row
 from puller.model.symbol.Lock import create_hash_lock_key, create_hash_lock_row, create_secret_lock_row, create_secret_lock_search_key
 from puller.model.symbol.Receipt import create_receipt_rows
+from tests.test.SymbolDatabaseTestUtils import fetch_normalized_sync_state
 from tests.test.SymbolLockTestUtils import create_expected_secret_lock_row
 from tests.test.SymbolLockTestUtils import create_secret_lock_item as create_secret_lock_item_fixture
 from tests.test.SymbolMetadataTestUtils import create_expected_metadata_row, create_metadata_item
@@ -240,6 +240,24 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			state[table_name] = cursor.fetchall()
 
 		return state
+
+	def _seed_rollback_batch_state(self):
+		self._seed_blocks(self.puller.symbol_db, [1, 2], {2: b'local mismatch'.hex()})
+		self.puller.symbol_db.upsert_sync_state(create_sync_state(
+			chain_height=2,
+			last_synced_height=2,
+			last_synced_block_hash=bytes.fromhex('02' * 32)))
+		namespace_item = create_namespace_item(owner_address=SIGNER_ADDRESS)
+		seed_namespace(self.puller.symbol_db, namespace_item, {NAMESPACE_ROOT_ID: 'original'}, 1)
+		self.puller.symbol_db.upsert_mosaic(create_expected_mosaic_row(create_mosaic_item(supply='1234'), 1))
+		metadata_item = create_metadata_item(metadata_type=1, target_id=MOSAIC_ID)
+		self.puller.symbol_db.upsert_metadata(create_expected_metadata_row(
+			metadata_item, 1, bytes.fromhex('11' * 32), 'mosaic', MOSAIC_ID, 'hello'))
+		self.puller.symbol_db.upsert_hash_lock(create_hash_lock_row(create_hash_lock_item(status=1), 2))
+		secret_key = create_secret_lock_search_key(
+			bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160')
+		self.puller.symbol_db.replace_secret_locks(
+			secret_key, [create_secret_lock_row(create_secret_lock_item(status=1), 2)])
 
 	def _assert_sync_failure_preserves_complete_batch_state(self, connector, exception_type, error):
 		# Arrange:
@@ -914,6 +932,36 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			secret_key, [create_secret_lock_row(create_secret_lock_item(endHeight=str(end_height)), 1)])
 
 	@staticmethod
+	def _expected_finalized_hash_lock_row():
+		item = create_hash_lock_item(endHeight='2')
+		return {
+			'hash': bytes.fromhex(LOCK_HASH),
+			'owner_address': bytes.fromhex(SIGNER_ADDRESS),
+			'mosaic_id': MOSAIC_ID,
+			'amount': 1234,
+			'end_height': 2,
+			'status': 'unused',
+			'raw_payload': item,
+			'updated_at_height': 2
+		}
+
+	@staticmethod
+	def _expected_finalized_secret_lock_row():
+		item = create_secret_lock_item(endHeight='2')
+		return create_expected_secret_lock_row(
+			item,
+			2,
+			composite_hash=bytes.fromhex(COMPOSITE_HASH),
+			owner_address=bytes.fromhex(SIGNER_ADDRESS),
+			recipient_address=bytes.fromhex(RECIPIENT_ADDRESS),
+			secret=bytes.fromhex(SECRET),
+			hash_algorithm='hash160',
+			mosaic_id=MOSAIC_ID,
+			amount=1234,
+			end_height=2,
+			status='unused')
+
+	@staticmethod
 	def _finalization_connector(finalized_height=2, hash_responses=None, secret_responses=None, chain_height=2):
 		return LockConnector(
 			chain_height,
@@ -922,67 +970,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			hash_responses=hash_responses,
 			secret_responses=secret_responses)
 
-	def test_sync_block_headers_removes_an_unused_hash_lock_after_finalization_when_node_drops_it(self):
-		# Arrange:
-		self._seed_finalized_lock_state()
-		connector = self._finalization_connector(
-			hash_responses={'lock/hash/' + LOCK_HASH: {'code': 'ResourceNotFound', 'message': 'not found'}},
-			secret_responses={_secret_search_path(SIGNER_ADDRESS, SECRET): {'data': [create_secret_lock_item()]}})
-
-		# Act:
-		self._sync_with_connector(connector)
-
-		# Assert:
-		self.assertEqual([], self._fetch_persisted_lock_state()[0])
-		self.assertEqual(['lock/hash/' + LOCK_HASH, _secret_search_path(SIGNER_ADDRESS, SECRET)], [
-			path for path in connector.paths if path.startswith('lock/')])
-
-	def test_sync_block_headers_removes_a_used_hash_lock_after_finalization_when_node_drops_it(self):
-		# Arrange:
-		self._seed_finalized_lock_state()
-		cursor = self.puller.symbol_db.connection.cursor()
-		cursor.execute("UPDATE symbol_hash_locks SET status = 'used' WHERE hash = %s", (bytes.fromhex(LOCK_HASH),))
-		self.puller.symbol_db.connection.commit()
-		connector = self._finalization_connector(
-			hash_responses={'lock/hash/' + LOCK_HASH: {'code': 'ResourceNotFound', 'message': 'not found'}},
-			secret_responses={_secret_search_path(SIGNER_ADDRESS, SECRET): {'data': [create_secret_lock_item()]}})
-
-		# Act:
-		self._sync_with_connector(connector)
-
-		# Assert:
-		self.assertEqual([], self._fetch_persisted_lock_state()[0])
-
-	def test_sync_block_headers_removes_an_unused_secret_lock_after_finalization_when_node_drops_it(self):
-		# Arrange:
-		self._seed_finalized_lock_state()
-		connector = self._finalization_connector(
-			hash_responses={'lock/hash/' + LOCK_HASH: create_hash_lock_item()},
-			secret_responses={_secret_search_path(SIGNER_ADDRESS, SECRET): {'data': []}})
-
-		# Act:
-		self._sync_with_connector(connector)
-
-		# Assert:
-		self.assertEqual([], self._fetch_persisted_lock_state()[1])
-
-	def test_sync_block_headers_removes_a_used_secret_lock_after_finalization_when_node_drops_it(self):
-		# Arrange:
-		self._seed_finalized_lock_state()
-		cursor = self.puller.symbol_db.connection.cursor()
-		cursor.execute("UPDATE symbol_secret_locks SET status = 'used' WHERE composite_hash = %s", (bytes.fromhex(COMPOSITE_HASH),))
-		self.puller.symbol_db.connection.commit()
-		connector = self._finalization_connector(
-			hash_responses={'lock/hash/' + LOCK_HASH: create_hash_lock_item()},
-			secret_responses={_secret_search_path(SIGNER_ADDRESS, SECRET): {'data': []}})
-
-		# Act:
-		self._sync_with_connector(connector)
-
-		# Assert:
-		self.assertEqual([], self._fetch_persisted_lock_state()[1])
-
-	def test_sync_block_headers_runs_finalization_cleanup_without_new_blocks(self):
+	def test_sync_block_headers_removes_unused_hash_and_secret_locks_after_finalization_without_new_blocks(self):
 		# Arrange:
 		self._seed_finalized_lock_state()
 		connector = self._finalization_connector(
@@ -994,30 +982,102 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 
 		# Assert:
 		self.assertEqual(([], []), self._fetch_persisted_lock_state())
+		self.assertEqual(['lock/hash/' + LOCK_HASH, _secret_search_path(SIGNER_ADDRESS, SECRET)], [
+			path for path in connector.paths if path.startswith('lock/')])
 		self.assertEqual([], [path for path in connector.paths if path.startswith('blocks?')])
 
-	def test_sync_block_headers_keeps_a_finalized_lock_when_node_still_returns_it(self):
+	def test_sync_block_headers_removes_a_used_hash_lock_after_finalization_when_node_drops_it(self):
 		# Arrange:
 		self._seed_finalized_lock_state()
+		cursor = self.puller.symbol_db.connection.cursor()
+		cursor.execute("UPDATE symbol_hash_locks SET status = 'used' WHERE hash = %s", (bytes.fromhex(LOCK_HASH),))
+		self.puller.symbol_db.connection.commit()
 		connector = self._finalization_connector(
-			hash_responses={'lock/hash/' + LOCK_HASH: create_hash_lock_item()},
-			secret_responses={_secret_search_path(SIGNER_ADDRESS, SECRET): {'data': [create_secret_lock_item()]}})
+			hash_responses={'lock/hash/' + LOCK_HASH: {'code': 'ResourceNotFound', 'message': 'not found'}},
+			secret_responses={_secret_search_path(SIGNER_ADDRESS, SECRET): {
+				'data': [create_secret_lock_item(endHeight='2')]
+			}})
 
 		# Act:
 		self._sync_with_connector(connector)
 
 		# Assert:
-		hash_rows, secret_rows = self._fetch_persisted_lock_state()
-		self.assertEqual(1, len(hash_rows))
-		self.assertEqual(1, len(secret_rows))
+		self.assertEqual(([], [self._expected_finalized_secret_lock_row()]), self._fetch_persisted_lock_state())
+		self.assertEqual(['lock/hash/' + LOCK_HASH, _secret_search_path(SIGNER_ADDRESS, SECRET)], [
+			path for path in connector.paths if path.startswith('lock/')])
 
-	def test_sync_block_headers_reselects_a_still_present_finalized_lock_on_the_next_run(self):
+	def test_sync_block_headers_removes_an_unused_secret_lock_after_finalization_when_node_drops_it(self):
+		# Arrange:
+		self._seed_finalized_lock_state()
+		connector = self._finalization_connector(
+			hash_responses={'lock/hash/' + LOCK_HASH: create_hash_lock_item(endHeight='2')},
+			secret_responses={_secret_search_path(SIGNER_ADDRESS, SECRET): {'data': []}})
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual(([self._expected_finalized_hash_lock_row()], []), self._fetch_persisted_lock_state())
+		self.assertEqual(['lock/hash/' + LOCK_HASH, _secret_search_path(SIGNER_ADDRESS, SECRET)], [
+			path for path in connector.paths if path.startswith('lock/')])
+
+	def test_sync_block_headers_removes_a_used_secret_lock_after_finalization_when_node_drops_it(self):
+		# Arrange:
+		self._seed_finalized_lock_state()
+		cursor = self.puller.symbol_db.connection.cursor()
+		cursor.execute("UPDATE symbol_secret_locks SET status = 'used' WHERE composite_hash = %s", (bytes.fromhex(COMPOSITE_HASH),))
+		self.puller.symbol_db.connection.commit()
+		connector = self._finalization_connector(
+			hash_responses={'lock/hash/' + LOCK_HASH: create_hash_lock_item(endHeight='2')},
+			secret_responses={_secret_search_path(SIGNER_ADDRESS, SECRET): {'data': []}})
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual(([self._expected_finalized_hash_lock_row()], []), self._fetch_persisted_lock_state())
+		self.assertEqual(['lock/hash/' + LOCK_HASH, _secret_search_path(SIGNER_ADDRESS, SECRET)], [
+			path for path in connector.paths if path.startswith('lock/')])
+
+	def test_sync_block_headers_refreshes_finalized_lock_state_when_node_still_returns_it(self):
+		# Arrange:
+		self._seed_finalized_lock_state()
+		connector = self._finalization_connector(
+			hash_responses={'lock/hash/' + LOCK_HASH: create_hash_lock_item(endHeight='2')},
+			secret_responses={_secret_search_path(SIGNER_ADDRESS, SECRET): {
+				'data': [create_secret_lock_item(endHeight='2')]
+			}})
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual((
+			[self._expected_finalized_hash_lock_row()],
+			[self._expected_finalized_secret_lock_row()]
+		), self._fetch_persisted_lock_state())
+		self.assertEqual(['lock/hash/' + LOCK_HASH, _secret_search_path(SIGNER_ADDRESS, SECRET)], [
+			path for path in connector.paths if path.startswith('lock/')])
+
+	def test_sync_block_headers_rechecks_finalized_lock_state_until_node_drops_it(self):
 		# Arrange:
 		self._seed_finalized_lock_state()
 		first_connector = self._finalization_connector(
 			hash_responses={'lock/hash/' + LOCK_HASH: create_hash_lock_item(endHeight='2')},
 			secret_responses={_secret_search_path(SIGNER_ADDRESS, SECRET): {'data': [create_secret_lock_item(endHeight='2')]}})
+
+		# Act:
 		self._sync_with_connector(first_connector)
+
+		# Assert:
+		self.assertEqual((
+			[self._expected_finalized_hash_lock_row()],
+			[self._expected_finalized_secret_lock_row()]
+		), self._fetch_persisted_lock_state())
+		self.assertEqual(['lock/hash/' + LOCK_HASH, _secret_search_path(SIGNER_ADDRESS, SECRET)], [
+			path for path in first_connector.paths if path.startswith('lock/')])
+
+		# Arrange:
 		second_connector = self._finalization_connector(
 			hash_responses={'lock/hash/' + LOCK_HASH: {'code': 'ResourceNotFound', 'message': 'not found'}},
 			secret_responses={_secret_search_path(SIGNER_ADDRESS, SECRET): {'data': []}})
@@ -1061,8 +1121,8 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 	def test_sync_block_headers_defers_finalization_cleanup_above_max_height_until_a_later_run(self):
 		# Arrange:
 		self._seed_finalized_lock_state(end_height=2)
-		self.puller.symbol_db.upsert_hash_lock(create_hash_lock_row(
-			create_hash_lock_item(lock_hash=LOCK_HASH_2, endHeight='3'), 1))
+		deferred_hash_item = create_hash_lock_item(lock_hash=LOCK_HASH_2, endHeight='3')
+		self.puller.symbol_db.upsert_hash_lock(create_hash_lock_row(deferred_hash_item, 1))
 		capped_connector = LockConnector(
 			3,
 			{},
@@ -1074,9 +1134,9 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		self._sync_with_connector(capped_connector, max_height=2)
 
 		# Assert:
-		cursor = self.puller.symbol_db.connection.cursor()
-		cursor.execute('SELECT hash FROM symbol_hash_locks ORDER BY hash')
-		self.assertEqual([bytes.fromhex(LOCK_HASH_2)], [bytes(row[0]) for row in cursor.fetchall()])
+		self.assertEqual(([create_hash_lock_row(deferred_hash_item, 1)], []), self._fetch_persisted_lock_state())
+		self.assertEqual(['lock/hash/' + LOCK_HASH, _secret_search_path(SIGNER_ADDRESS, SECRET)], [
+			path for path in capped_connector.paths if path.startswith('lock/')])
 
 		# Act:
 		uncapped_connector = LockConnector(
@@ -1091,37 +1151,8 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 
 		# Assert:
 		self.assertEqual(([], []), self._fetch_persisted_lock_state())
-
-	def test_sync_block_headers_rolls_back_finalization_lock_writes_after_secret_constraint_failure(self):
-		# Arrange:
-		self._seed_finalized_lock_state()
-		original_state = self._fetch_complete_batch_state()
-		constraint_name = 'test_symbol_secret_locks_reject_used'
-		cursor = self.puller.symbol_db.connection.cursor()
-		cursor.execute(
-			f"ALTER TABLE symbol_secret_locks ADD CONSTRAINT {constraint_name} CHECK (status <> 'used')")
-		self.puller.symbol_db.connection.commit()
-		connector = self._finalization_connector(
-			hash_responses={'lock/hash/' + LOCK_HASH: create_hash_lock_item(status=1, endHeight='2')},
-			secret_responses={_secret_search_path(SIGNER_ADDRESS, SECRET): {
-				'data': [create_secret_lock_item(status=1, endHeight='2')]
-			}})
-
-		# Act / Assert:
-		try:
-			with self.assertRaises(PsycopgError):
-				self._sync_with_connector(connector)
-		finally:
-			cursor = self.puller.symbol_db.connection.cursor()
-			cursor.execute(f'ALTER TABLE symbol_secret_locks DROP CONSTRAINT {constraint_name}')
-			self.puller.symbol_db.connection.commit()
-
-		# Assert:
-		self.assertEqual(original_state, self._fetch_complete_batch_state())
-		self.assertEqual([
-			'lock/hash/' + LOCK_HASH,
-			_secret_search_path(SIGNER_ADDRESS, SECRET)
-		], [path for path in connector.paths if path.startswith('lock/')])
+		self.assertEqual(['lock/hash/' + LOCK_HASH_2], [
+			path for path in uncapped_connector.paths if path.startswith('lock/')])
 
 	def test_sync_block_headers_persists_a_hash_lock_without_an_aggregate_bonded_transaction(self):
 		# Arrange:
@@ -1704,7 +1735,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			path for path in connector.paths if path.startswith('lock/')
 		])
 
-	def test_sync_block_headers_restores_a_deleted_hash_lock_from_a_current_row_key(self):
+	def test_sync_block_headers_refreshes_a_rollback_affected_hash_lock_from_a_current_row_key(self):
 		# Arrange:
 		# The local block 2 hash differs from the node block 2 hash, which triggers rollback repair.
 		self._seed_blocks(self.puller.symbol_db, [1, 2], {2: b'local mismatch'.hex()})
@@ -1737,12 +1768,21 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		# Assert:
 		self.assertEqual(([expected_row], []), self._fetch_persisted_lock_state())
 		self.assertEqual([1, 2], self._fetch_block_heights(self.puller.symbol_db))
-		self.assertEqual(2, self.puller.symbol_db.get_sync_state()['last_synced_height'])
+		self.assertEqual(bytes.fromhex(f'{2:064X}'), self._fetch_block_hash(self.puller.symbol_db, 2))
+		self.assertEqual(create_sync_state(
+			chain_height=2,
+			finalized_height=1,
+			finalized_hash=bytes.fromhex(f'{1:064X}'),
+			finalized_epoch=4,
+			finalized_point=5,
+			last_synced_height=2,
+			last_synced_block_hash=bytes.fromhex(f'{2:064X}')),
+			fetch_normalized_sync_state(self.puller.symbol_db))
 		self.assertEqual(['lock/hash/' + LOCK_HASH], [
 			path for path in connector.paths if path.startswith('lock/')
 		])
 
-	def test_sync_block_headers_restores_a_deleted_secret_lock_from_a_current_row_key(self):
+	def test_sync_block_headers_refreshes_a_rollback_affected_secret_lock_from_a_current_row_key(self):
 		# Arrange:
 		# The local block 2 hash differs from the node block 2 hash, which triggers rollback repair.
 		self._seed_blocks(self.puller.symbol_db, [1, 2], {2: b'local mismatch'.hex()})
@@ -1781,10 +1821,16 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		# Assert:
 		self.assertEqual(([], [expected_row]), self._fetch_persisted_lock_state())
 		self.assertEqual([1, 2], self._fetch_block_heights(self.puller.symbol_db))
-		cursor = self.puller.symbol_db.connection.cursor()
-		cursor.execute('SELECT height, type FROM symbol_transactions WHERE height >= 2 ORDER BY height, id')
-		self.assertEqual([], cursor.fetchall())
-		self.assertEqual(2, self.puller.symbol_db.get_sync_state()['last_synced_height'])
+		self.assertEqual(bytes.fromhex(f'{2:064X}'), self._fetch_block_hash(self.puller.symbol_db, 2))
+		self.assertEqual(create_sync_state(
+			chain_height=2,
+			finalized_height=1,
+			finalized_hash=bytes.fromhex(f'{1:064X}'),
+			finalized_epoch=4,
+			finalized_point=5,
+			last_synced_height=2,
+			last_synced_block_hash=bytes.fromhex(f'{2:064X}')),
+			fetch_normalized_sync_state(self.puller.symbol_db))
 		self.assertEqual([path], [path for path in connector.paths if path.startswith('lock/')])
 
 	def test_sync_block_headers_deletes_fork_only_hash_and_secret_locks_from_current_row_keys(self):  # pylint: disable=too-many-locals
@@ -1841,16 +1887,14 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		self._sync_with_connector(connector)
 
 		# Assert:
-		hash_rows, secret_rows = self._fetch_persisted_lock_state()
-		self.assertEqual([expected_survivor_hash], hash_rows)
-		self.assertEqual([expected_survivor_secret], secret_rows)
+		self.assertEqual((
+			[expected_survivor_hash],
+			[expected_survivor_secret]
+		), self._fetch_persisted_lock_state())
 		self.assertEqual([fork_hash_path, fork_secret_path], [
 			path for path in connector.paths if path.startswith('lock/')])
 		self.assertEqual([1, 2], self._fetch_block_heights(self.puller.symbol_db))
 		self.assertEqual(bytes.fromhex(f'{2:064X}'), self._fetch_block_hash(self.puller.symbol_db, 2))
-		actual_sync_state = self.puller.symbol_db.get_sync_state()
-		actual_sync_state['finalized_hash'] = bytes(actual_sync_state['finalized_hash'])
-		actual_sync_state['last_synced_block_hash'] = bytes(actual_sync_state['last_synced_block_hash'])
 		self.assertEqual(create_sync_state(
 			chain_height=2,
 			finalized_height=1,
@@ -1858,17 +1902,12 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			finalized_epoch=4,
 			finalized_point=5,
 			last_synced_height=2,
-			last_synced_block_hash=bytes.fromhex(f'{2:064X}')), actual_sync_state)
+			last_synced_block_hash=bytes.fromhex(f'{2:064X}')),
+			fetch_normalized_sync_state(self.puller.symbol_db))
 
-	def test_sync_block_headers_keeps_rollback_state_unchanged_when_lock_replacement_fetch_fails(self):
+	def test_sync_block_headers_keeps_all_rollback_state_unchanged_when_hash_lock_replacement_fetch_fails(self):
 		# Arrange:
-		# The local block 2 hash differs from the node block 2 hash, which triggers rollback repair.
-		self._seed_blocks(self.puller.symbol_db, [1, 2], {2: b'local mismatch'.hex()})
-		self.puller.symbol_db.upsert_sync_state(create_sync_state(
-			chain_height=2,
-			last_synced_height=2,
-			last_synced_block_hash=bytes.fromhex('02' * 32)))
-		self.puller.symbol_db.upsert_hash_lock(create_hash_lock_row(create_hash_lock_item(status=1), 2))
+		self._seed_rollback_batch_state()
 		original_state = self._fetch_complete_batch_state()
 		connector = LockConnector(
 			2,
@@ -1882,33 +1921,20 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 
 		# Assert:
 		self.assertEqual(original_state, self._fetch_complete_batch_state())
+		self.assertEqual(['lock/hash/' + LOCK_HASH], [
+			path for path in connector.paths if path.startswith('lock/')])
 
 	def test_sync_block_headers_keeps_all_rollback_state_unchanged_when_secret_lock_replacement_fetch_fails(self):
 		# Arrange:
-		# The local block 2 hash differs from the node block 2 hash, which triggers rollback repair.
-		self._seed_blocks(self.puller.symbol_db, [1, 2], {2: b'local mismatch'.hex()})
-		self.puller.symbol_db.upsert_sync_state(create_sync_state(
-			chain_height=2,
-			last_synced_height=2,
-			last_synced_block_hash=bytes.fromhex('02' * 32)))
-		namespace_item = create_namespace_item(owner_address=SIGNER_ADDRESS)
-		seed_namespace(self.puller.symbol_db, namespace_item, {NAMESPACE_ROOT_ID: 'original'}, 1)
-		self.puller.symbol_db.upsert_mosaic(create_expected_mosaic_row(create_mosaic_item(supply='1234'), 1))
-		metadata_item = create_metadata_item(metadata_type=1, target_id=MOSAIC_ID)
-		self.puller.symbol_db.upsert_metadata(create_expected_metadata_row(
-			metadata_item, 1, bytes.fromhex('11' * 32), 'mosaic', MOSAIC_ID, 'hello'))
-		self.puller.symbol_db.upsert_hash_lock(create_hash_lock_row(create_hash_lock_item(status=1), 2))
-		secret_key = create_secret_lock_search_key(
-			bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160')
-		self.puller.symbol_db.replace_secret_locks(
-			secret_key, [create_secret_lock_row(create_secret_lock_item(status=1), 2)])
+		self._seed_rollback_batch_state()
 		original_state = self._fetch_complete_batch_state()
+		secret_path = _secret_search_path(SIGNER_ADDRESS, SECRET)
 		connector = LockConnector(
 			2,
 			{1: [create_node_block(2)]},
 			{2: create_node_block(2)},
 			hash_responses={'lock/hash/' + LOCK_HASH: create_hash_lock_item()},
-			secret_responses={_secret_search_path(SIGNER_ADDRESS, SECRET): RuntimeError('rollback secret lock fetch failed')})
+			secret_responses={secret_path: RuntimeError('rollback secret lock fetch failed')})
 
 		# Act / Assert:
 		with self.assertRaisesRegex(RuntimeError, '^rollback secret lock fetch failed$'):
@@ -1916,14 +1942,8 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 
 		# Assert:
 		self.assertEqual(original_state, self._fetch_complete_batch_state())
-
-	def _fetch_lock_state(self):
-		cursor = self.puller.symbol_db.connection.cursor()
-		cursor.execute('SELECT hash, status, updated_at_height FROM symbol_hash_locks ORDER BY hash')
-		hash_rows = [tuple([bytes(row[0]), *row[1:]]) for row in cursor.fetchall()]
-		cursor.execute('SELECT composite_hash, hash_algorithm, updated_at_height FROM symbol_secret_locks ORDER BY composite_hash')
-		secret_rows = [tuple([bytes(row[0]), *row[1:]]) for row in cursor.fetchall()]
-		return hash_rows, secret_rows
+		self.assertEqual(['lock/hash/' + LOCK_HASH, secret_path], [
+			path for path in connector.paths if path.startswith('lock/')])
 
 	def test_sync_block_headers_does_not_partially_write_when_lock_fetch_fails(self):
 		# Arrange:

--- a/explorer/puller/tests/facade/symbol/test_PullerLocks.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerLocks.py
@@ -1,3 +1,5 @@
+"""Lock-specific sync and rollback integration cases normally split across PullerSync and PullerRollback tests."""
+
 # pylint: disable=too-many-lines,too-many-public-methods
 import asyncio
 import copy
@@ -6,14 +8,8 @@ from symbolchain.sc import TransactionType
 from symbolchain.symbol.Network import Address
 
 from puller.model.symbol.Account import create_account_row
-from puller.model.symbol.Lock import (
-	create_hash_lock_key_from_hex,
-	create_hash_lock_row,
-	create_secret_lock_row,
-	create_secret_lock_search_key
-)
+from puller.model.symbol.Lock import create_hash_lock_key, create_hash_lock_row, create_secret_lock_row, create_secret_lock_search_key
 from puller.model.symbol.Receipt import create_receipt_rows
-from tests.test.SymbolDatabaseTestUtils import fetch_normalized_sync_state
 from tests.test.SymbolLockTestUtils import create_expected_secret_lock_row
 from tests.test.SymbolLockTestUtils import create_secret_lock_item as create_secret_lock_item_fixture
 from tests.test.SymbolMetadataTestUtils import create_expected_metadata_row, create_metadata_item
@@ -70,15 +66,15 @@ def create_secret_lock_item(
 	return create_secret_lock_item_fixture(
 		composite_hash=composite_hash,
 		owner_address=owner_address,
-		recipient_address=RECIPIENT_ADDRESS,
+		recipient_address=overrides.pop('recipientAddress', RECIPIENT_ADDRESS),
 		secret=secret,
-		hash_algorithm=1,
-		mosaic_id=MOSAIC_ID,
-		amount='1234',
-		end_height='100',
-		status=0,
+		hash_algorithm=overrides.pop('hashAlgorithm', 1),
+		mosaic_id=overrides.pop('mosaicId', MOSAIC_ID),
+		amount=overrides.pop('amount', '1234'),
+		end_height=overrides.pop('endHeight', '100'),
+		status=overrides.pop('status', 0),
 		item_id='secret-lock',
-		lock_overrides=overrides)
+		**overrides)
 
 
 class LockConnector(FakeConnector):
@@ -107,18 +103,18 @@ class LockConnector(FakeConnector):
 
 
 class BoundedLockConnector(LockConnector):
-	def __init__(self, *args, **kwargs):
+	def __init__(self, lock_path_prefix, *args, **kwargs):
 		super().__init__(*args, **kwargs)
+		self.lock_path_prefix = lock_path_prefix
 		self.in_flight_lock_requests = 0
 		self.max_in_flight_lock_requests = 0
 		self._requests_released = asyncio.Event()
 		self._release_scheduled = False
 
 	async def get(self, url_path, *args):
-		if not url_path.startswith('lock/secret?'):
+		if not url_path.startswith(self.lock_path_prefix):
 			return await super().get(url_path, *args)
 
-		self.paths.append(url_path)
 		self.in_flight_lock_requests += 1
 		self.max_in_flight_lock_requests = max(
 			self.max_in_flight_lock_requests,
@@ -128,37 +124,7 @@ class BoundedLockConnector(LockConnector):
 				self._release_scheduled = True
 				asyncio.get_running_loop().call_soon(self._requests_released.set)
 			await self._requests_released.wait()
-			response = self.secret_responses.get(url_path, {'data': []})
-			if isinstance(response, Exception):
-				raise response
-			return response
-		finally:
-			self.in_flight_lock_requests -= 1
-
-
-class BoundedHashLockConnector(LockConnector):
-	def __init__(self, *args, **kwargs):
-		super().__init__(*args, **kwargs)
-		self.in_flight_lock_requests = 0
-		self.max_in_flight_lock_requests = 0
-		self._requests_released = asyncio.Event()
-		self._release_scheduled = False
-
-	async def get(self, url_path, *args):
-		if not url_path.startswith('lock/hash/'):
 			return await super().get(url_path, *args)
-
-		self.paths.append(url_path)
-		self.in_flight_lock_requests += 1
-		self.max_in_flight_lock_requests = max(
-			self.max_in_flight_lock_requests,
-			self.in_flight_lock_requests)
-		try:
-			if not self._release_scheduled:
-				self._release_scheduled = True
-				asyncio.get_running_loop().call_soon(self._requests_released.set)
-			await self._requests_released.wait()
-			return self.hash_responses[url_path]
 		finally:
 			self.in_flight_lock_requests -= 1
 
@@ -350,7 +316,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		connector = LockConnector(
 			hash_responses={'lock/hash/' + LOCK_HASH: item})
 		set_symbol_connector(self.puller, connector)
-		key = create_hash_lock_key_from_hex(LOCK_HASH)
+		key = create_hash_lock_key(LOCK_HASH)
 
 		# Act:
 		entries = asyncio.run(self.puller._fetch_dirty_hash_locks([key], 12))  # pylint: disable=protected-access
@@ -378,7 +344,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 				'message': 'not found'
 			}})
 		set_symbol_connector(self.puller, connector)
-		key = create_hash_lock_key_from_hex(LOCK_HASH)
+		key = create_hash_lock_key(LOCK_HASH)
 
 		# Act:
 		entries = asyncio.run(self.puller._fetch_dirty_hash_locks([key], 12))  # pylint: disable=protected-access
@@ -397,7 +363,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		# Act / Assert:
 		with self.assertRaisesRegex(ValueError, '^Symbol Hash Lock response hash does not match dirty key$'):
 			asyncio.run(self.puller._fetch_dirty_hash_locks(  # pylint: disable=protected-access
-				[create_hash_lock_key_from_hex(LOCK_HASH)], 12))
+				[create_hash_lock_key(LOCK_HASH)], 12))
 
 	def _assert_sync_rejects_malformed_hash_lock_response(self, response, expected_error):
 		# Arrange:
@@ -418,10 +384,10 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		# Act / Assert:
 		self._assert_sync_failure_preserves_complete_batch_state(connector, ValueError, expected_error)
 
-	def test_sync_block_headers_rejects_non_dict_hash_lock_response_without_writes(self):
+	def test_sync_block_headers_rejects_non_dict_hash_lock_response(self):
 		self._assert_sync_rejects_malformed_hash_lock_response([], '^Malformed Symbol Hash Lock response$')
 
-	def test_sync_block_headers_rejects_hash_lock_response_with_invalid_required_field_without_writes(self):
+	def test_sync_block_headers_rejects_hash_lock_response_with_invalid_required_field(self):
 		self._assert_sync_rejects_malformed_hash_lock_response(
 			create_hash_lock_item(hash='GG' * 32),
 			'^Invalid Symbol Hash Lock hash$')
@@ -450,19 +416,19 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		# Assert:
 		self.assertEqual([path], [request_path for request_path in connector.paths if request_path.startswith('lock/')])
 
-	def test_sync_block_headers_rejects_non_dict_secret_lock_search_response_without_writes(self):
+	def test_sync_block_headers_rejects_non_dict_secret_lock_search_response(self):
 		self._assert_sync_rejects_malformed_secret_lock_response([], '^Malformed Symbol Secret Lock search response$')
 
-	def test_sync_block_headers_rejects_secret_lock_search_response_without_data_without_writes(self):
+	def test_sync_block_headers_rejects_secret_lock_search_response_without_data(self):
 		self._assert_sync_rejects_malformed_secret_lock_response({}, '^Malformed Symbol Secret Lock search response$')
 
-	def test_sync_block_headers_rejects_secret_lock_search_response_with_non_list_data_without_writes(self):
+	def test_sync_block_headers_rejects_secret_lock_search_response_with_non_list_data(self):
 		self._assert_sync_rejects_malformed_secret_lock_response({'data': {}}, '^Malformed Symbol Secret Lock search response$')
 
-	def test_sync_block_headers_rejects_secret_lock_search_response_with_malformed_item_without_writes(self):
+	def test_sync_block_headers_rejects_secret_lock_search_response_with_malformed_item(self):
 		self._assert_sync_rejects_malformed_secret_lock_response({'data': [{}]}, '^Malformed Symbol Secret Lock response$')
 
-	def _assert_sync_rejects_second_secret_lock_page_without_writes(self, second_page_response, exception_type, error):
+	def _assert_sync_rejects_second_secret_lock_page(self, second_page_response, exception_type, error):
 		# Arrange:
 		transaction = create_node_transaction(
 			1, transaction_hash='01' * 32, type=TransactionType.SECRET_LOCK.value,
@@ -483,20 +449,20 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		# Assert:
 		self.assertEqual([page_one_path, page_two_path], [path for path in connector.paths if path.startswith('lock/')])
 
-	def test_sync_block_headers_rejects_a_duplicate_secret_lock_composite_hash_across_pages_without_writes(self):
+	def test_sync_block_headers_rejects_a_duplicate_secret_lock_composite_hash_across_pages(self):
 		# Arrange:
 		duplicate_item = create_secret_lock_item(composite_hash=f'{1:064X}')
 
 		# Act / Assert:
-		self._assert_sync_rejects_second_secret_lock_page_without_writes(
+		self._assert_sync_rejects_second_secret_lock_page(
 			{'data': [duplicate_item]}, ValueError, '^Duplicate Symbol Secret Lock composite hash$')
 
-	def test_sync_block_headers_rejects_a_malformed_second_secret_lock_page_without_writes(self):
-		self._assert_sync_rejects_second_secret_lock_page_without_writes(
+	def test_sync_block_headers_rejects_a_malformed_second_secret_lock_page(self):
+		self._assert_sync_rejects_second_secret_lock_page(
 			{}, ValueError, '^Malformed Symbol Secret Lock search response$')
 
-	def test_sync_block_headers_propagates_a_second_secret_lock_page_request_failure_without_writes(self):
-		self._assert_sync_rejects_second_secret_lock_page_without_writes(
+	def test_sync_block_headers_propagates_a_second_secret_lock_page_request_failure(self):
+		self._assert_sync_rejects_second_secret_lock_page(
 			RuntimeError('second page failed'), RuntimeError, '^second page failed$')
 
 	def test_fetch_secret_lock_paginates_full_and_short_pages_in_node_order(self):
@@ -659,7 +625,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 				bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(secret), 'hash160')
 			for secret in secrets
 		]
-		connector = BoundedLockConnector(secret_responses={
+		connector = BoundedLockConnector('lock/secret?', secret_responses={
 			_secret_search_path(SIGNER_ADDRESS, secret): {
 				'data': [create_secret_lock_item(composite_hash=secret, secret=secret)]
 			}
@@ -684,8 +650,8 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 	def test_fetch_hash_locks_uses_ten_request_chunks_and_preserves_non_sorted_first_encounter_order(self):
 		# Arrange:
 		hashes = [f'{index:064X}' for index in (3, 1, 11, 2, 10, 4, 9, 5, 8, 6, 7)]
-		keys = [create_hash_lock_key_from_hex(lock_hash) for lock_hash in hashes]
-		connector = BoundedHashLockConnector(hash_responses={
+		keys = [create_hash_lock_key(lock_hash) for lock_hash in hashes]
+		connector = BoundedLockConnector('lock/hash/', hash_responses={
 			'lock/hash/' + lock_hash: create_hash_lock_item(lock_hash=lock_hash)
 			for lock_hash in hashes
 		})
@@ -727,18 +693,6 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 
 		# Assert:
 		self.assertEqual([bytes.fromhex(LOCK_HASH_2)], [key.hash for key in keys.hash_keys])
-		self.assertEqual([], keys.secret_keys)
-
-	def test_collect_dirty_lock_keys_excludes_embedded_aggregate_bonded_hash(self):
-		# Arrange:
-		embedded = self._create_lock_transaction_row(
-			TransactionType.AGGREGATE_BONDED.value, {}, is_embedded=True, hash=bytes.fromhex(LOCK_HASH_2))
-
-		# Act:
-		keys = self._collect_lock_keys([embedded])
-
-		# Assert:
-		self.assertEqual([], keys.hash_keys)
 		self.assertEqual([], keys.secret_keys)
 
 	def test_collect_dirty_lock_keys_uses_resolved_secret_lock_recipient(self):
@@ -815,7 +769,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			(bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160')
 		], keys.secret_keys)
 
-	def test_collect_dirty_lock_keys_includes_hash_lock_expiry_key(self):
+	def test_collect_dirty_lock_keys_includes_hash_lock_key_for_row_reaching_end_height(self):
 		# Arrange:
 		self.puller.symbol_db.upsert_hash_lock(create_hash_lock_row(create_hash_lock_item(endHeight='10'), 1))
 
@@ -826,7 +780,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		self.assertEqual([bytes.fromhex(LOCK_HASH)], [key.hash for key in keys.hash_keys])
 		self.assertEqual([], keys.secret_keys)
 
-	def test_collect_dirty_lock_keys_includes_secret_lock_expiry_key(self):
+	def test_collect_dirty_lock_keys_includes_secret_lock_key_for_row_reaching_end_height(self):
 		# Arrange:
 		key = create_secret_lock_search_key(
 			bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160')
@@ -884,7 +838,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 				[{'height': 1}], {1: [transaction_row]})
 
 	@staticmethod
-	def _create_lock_sync_connector():
+	def _create_hash_lock_sync_connector():
 		hash_transaction = create_node_transaction(
 			1,
 			transaction_hash='01' * 32,
@@ -892,6 +846,15 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			hash=LOCK_HASH,
 			mosaicId=MOSAIC_ID,
 			amount='1234')
+		return LockConnector(
+			1,
+			{0: [create_node_block(1)]},
+			hash_responses={'lock/hash/' + LOCK_HASH: create_hash_lock_item()},
+			transactions_by_path={transaction_path(1, 1): {'data': [hash_transaction]}},
+			statement_pages={statement_path(1, 1): {'data': []}})
+
+	@staticmethod
+	def _create_secret_lock_sync_connector():
 		secret_transaction = create_node_transaction(
 			1,
 			transaction_hash='02' * 32,
@@ -903,14 +866,13 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		return LockConnector(
 			1,
 			{0: [create_node_block(1)]},
-			hash_responses={'lock/hash/' + LOCK_HASH: create_hash_lock_item()},
 			secret_responses={_secret_search_path(SIGNER_ADDRESS, SECRET): {
 				'data': [create_secret_lock_item()]}},
-			transactions_by_path={transaction_path(1, 1): {'data': [hash_transaction, secret_transaction]}},
+			transactions_by_path={transaction_path(1, 1): {'data': [secret_transaction]}},
 			statement_pages={statement_path(1, 1): {'data': []}})
 
 	@staticmethod
-	def _expected_persisted_lock_state():
+	def _expected_persisted_hash_lock_state():
 		return ([{
 			'hash': bytes.fromhex(LOCK_HASH),
 			'owner_address': bytes.fromhex(SIGNER_ADDRESS),
@@ -930,7 +892,11 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 				'id': 'hash-lock'
 			},
 			'updated_at_height': 1
-		}], [create_expected_secret_lock_row(
+		}], [])
+
+	@staticmethod
+	def _expected_persisted_secret_lock_state():
+		return ([], [create_expected_secret_lock_row(
 			create_secret_lock_item(),
 			1,
 			composite_hash=bytes.fromhex(COMPOSITE_HASH),
@@ -978,10 +944,10 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			status, raw_payload, updated_at_height in cursor.fetchall()]
 		return hash_locks, secret_locks
 
-	def test_sync_block_headers_persists_hash_and_secret_locks(self):
+	def test_sync_block_headers_persists_a_hash_lock(self):
 		# Arrange:
-		connector = self._create_lock_sync_connector()
-		expected_lock_state = self._expected_persisted_lock_state()
+		connector = self._create_hash_lock_sync_connector()
+		expected_lock_state = self._expected_persisted_hash_lock_state()
 
 		# Act:
 		self._sync_with_connector(connector)
@@ -989,10 +955,36 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		# Assert:
 		self.assertEqual(expected_lock_state, self._fetch_persisted_lock_state())
 
-	def test_sync_block_headers_converges_hash_and_secret_locks_when_restarted_from_existing_blocks(self):
+	def test_sync_block_headers_persists_a_secret_lock(self):
 		# Arrange:
-		connector = self._create_lock_sync_connector()
-		expected_lock_state = self._expected_persisted_lock_state()
+		connector = self._create_secret_lock_sync_connector()
+		expected_lock_state = self._expected_persisted_secret_lock_state()
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual(expected_lock_state, self._fetch_persisted_lock_state())
+
+	def test_sync_block_headers_converges_a_hash_lock_when_restarted_from_existing_blocks(self):
+		# Arrange:
+		connector = self._create_hash_lock_sync_connector()
+		expected_lock_state = self._expected_persisted_hash_lock_state()
+		self._sync_with_connector(connector)
+		cursor = self.puller.symbol_db.connection.cursor()
+		cursor.execute('DELETE FROM symbol_sync_state')
+		self.puller.symbol_db.connection.commit()
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual(expected_lock_state, self._fetch_persisted_lock_state())
+
+	def test_sync_block_headers_converges_a_secret_lock_when_restarted_from_existing_blocks(self):
+		# Arrange:
+		connector = self._create_secret_lock_sync_connector()
+		expected_lock_state = self._expected_persisted_secret_lock_state()
 		self._sync_with_connector(connector)
 		cursor = self.puller.symbol_db.connection.cursor()
 		cursor.execute('DELETE FROM symbol_sync_state')
@@ -1112,7 +1104,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			path for path in connector.paths if path.startswith('lock/')
 		])
 
-	def test_sync_block_headers_converges_new_locks_created_and_expired_in_the_same_batch_to_empty(self):
+	def test_sync_block_headers_converges_locks_created_then_pruned_by_the_batch_end_to_empty(self):
 		# Arrange:
 		hash_lock_transaction = create_node_transaction(
 			1,
@@ -1172,7 +1164,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			secret_path
 		], [path for path in connector.paths if path.startswith('lock/')])
 
-	def test_sync_block_headers_updates_a_hash_lock_to_used_from_a_top_level_aggregate_bonded_transaction(self):
+	def test_sync_block_headers_updates_an_existing_hash_lock_to_used_when_completion_arrives_in_a_later_batch(self):
 		# Arrange:
 		self._seed_blocks(self.puller.symbol_db, [1])
 		self.puller.symbol_db.upsert_sync_state(create_sync_state(
@@ -1202,7 +1194,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		self.assertEqual(2, self.puller.symbol_db.get_sync_state()['last_synced_height'])
 		self.assertEqual(['lock/hash/' + LOCK_HASH], [path for path in connector.paths if path.startswith('lock/')])
 
-	def test_sync_block_headers_updates_a_secret_lock_to_used_from_a_secret_proof_transaction(self):
+	def test_sync_block_headers_updates_an_existing_secret_lock_to_used_when_completion_arrives_in_a_later_batch(self):
 		# Arrange:
 		self._seed_blocks(self.puller.symbol_db, [1])
 		self.puller.symbol_db.upsert_sync_state(create_sync_state(
@@ -1428,7 +1420,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			path for path in connector.paths if path.startswith('statements/resolutions/')
 		])
 
-	def test_sync_block_headers_rejects_a_missing_hash_lock_mosaic_alias_resolution_without_writes(self):
+	def test_sync_block_headers_rejects_a_missing_hash_lock_mosaic_alias_resolution(self):
 		# Arrange:
 		transaction = create_node_transaction(
 			1,
@@ -1460,7 +1452,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			'symbol_sync_state': 0
 		}, self._fetch_lock_alias_failure_state())
 
-	def test_sync_block_headers_rejects_an_inapplicable_secret_proof_recipient_alias_resolution_without_writes(self):
+	def test_sync_block_headers_rejects_an_inapplicable_secret_proof_recipient_alias_resolution(self):
 		# Arrange:
 		transaction = create_node_transaction(
 			1,
@@ -1500,25 +1492,36 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		# Arrange:
 		other_owner = '98' + '33' * 23
 		sibling_secret = '99' * 32
+		existing_owner_match_hash = '44' * 32
+		existing_other_owner_match_hash = '55' * 32
+		node_owner_replacement_hash = '11' * 32
+		node_other_owner_replacement_hash = '22' * 32
+		surviving_different_secret_hash = 'FF' * 32
 		target_key = create_secret_lock_search_key(
 			bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160')
 		other_owner_key = create_secret_lock_search_key(
 			bytes.fromhex(other_owner), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160')
-		sibling_key = create_secret_lock_search_key(
-			bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(sibling_secret), 'hash160')
 		self.puller.symbol_db.replace_secret_locks(target_key, [create_secret_lock_row(create_secret_lock_item(
-			composite_hash='44' * 32, status=1), 1)])
+			composite_hash=existing_owner_match_hash, status=1), 1)])
 		self.puller.symbol_db.replace_secret_locks(other_owner_key, [create_secret_lock_row(create_secret_lock_item(
-			composite_hash='55' * 32, owner_address=other_owner, status=1), 1)])
-		self.puller.symbol_db.replace_secret_locks(sibling_key, [create_secret_lock_row(create_secret_lock_item(
-			composite_hash='FF' * 32, secret=sibling_secret), 1)])
+			composite_hash=existing_other_owner_match_hash, owner_address=other_owner, status=1), 1)])
+		self.puller.symbol_db.replace_secret_locks(
+			create_secret_lock_search_key(
+				bytes.fromhex(SIGNER_ADDRESS),
+				bytes.fromhex(RECIPIENT_ADDRESS),
+				bytes.fromhex(sibling_secret),
+				'hash160'),
+			[create_secret_lock_row(create_secret_lock_item(
+				composite_hash=surviving_different_secret_hash, secret=sibling_secret), 1)])
 		proof_transaction = create_node_transaction(
 			1,
 			type=TransactionType.SECRET_PROOF.value,
 			secret=SECRET,
 			hashAlgorithm=1)
-		first_match = create_secret_lock_item(composite_hash='11' * 32, owner_address=SIGNER_ADDRESS, status=1)
-		second_match = create_secret_lock_item(composite_hash='22' * 32, owner_address=other_owner, status=1)
+		first_match = create_secret_lock_item(
+			composite_hash=node_owner_replacement_hash, owner_address=SIGNER_ADDRESS, status=1)
+		second_match = create_secret_lock_item(
+			composite_hash=node_other_owner_replacement_hash, owner_address=other_owner, status=1)
 		connector = LockConnector(
 			1,
 			{0: [create_node_block(1)]},
@@ -1533,13 +1536,17 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			statement_pages={statement_path(1, 1): {'data': []}})
 		expected_rows = [
 			create_expected_secret_lock_row(
-				first_match, 1, bytes.fromhex('11' * 32), bytes.fromhex(SIGNER_ADDRESS),
+				first_match, 1, bytes.fromhex(node_owner_replacement_hash), bytes.fromhex(SIGNER_ADDRESS),
 				bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160', MOSAIC_ID, 1234, 100, 'used'),
 			create_expected_secret_lock_row(
-				second_match, 1, bytes.fromhex('22' * 32), bytes.fromhex(other_owner),
+				second_match, 1, bytes.fromhex(node_other_owner_replacement_hash), bytes.fromhex(other_owner),
 				bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160', MOSAIC_ID, 1234, 100, 'used'),
 			create_expected_secret_lock_row(
-				create_secret_lock_item(composite_hash='FF' * 32, secret=sibling_secret), 1, bytes.fromhex('FF' * 32),
+				create_secret_lock_item(
+					composite_hash=surviving_different_secret_hash,
+					secret=sibling_secret),
+				1,
+				bytes.fromhex(surviving_different_secret_hash),
 				bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(sibling_secret), 'hash160',
 				MOSAIC_ID, 1234, 100, 'unused')
 		]
@@ -1555,6 +1562,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 
 	def test_sync_block_headers_restores_a_deleted_hash_lock_from_rollback_transaction_key(self):
 		# Arrange:
+		# The local block 2 hash differs from the node block 2 hash, which triggers rollback repair.
 		self._seed_blocks(self.puller.symbol_db, [1, 2], {2: b'local mismatch'.hex()})
 		self.puller.symbol_db.upsert_sync_state(create_sync_state(
 			chain_height=2,
@@ -1567,10 +1575,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			body={'hash': LOCK_HASH})
 		self.puller.symbol_db.upsert_transactions_for_height(2, [transaction])
 		self.puller.symbol_db.upsert_hash_lock(create_hash_lock_row(create_hash_lock_item(), 2))
-		self.puller.symbol_db.delete_hash_lock(create_hash_lock_key_from_hex(LOCK_HASH))
-		cursor = self.puller.symbol_db.connection.cursor()
-		cursor.execute('SELECT hash FROM symbol_hash_locks')
-		self.assertEqual([], cursor.fetchall())
+		self.puller.symbol_db.delete_hash_lock(create_hash_lock_key(LOCK_HASH))
 		connector = LockConnector(
 			2,
 			{1: [create_node_block(2)]},
@@ -1583,6 +1588,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		self._sync_with_connector(connector)
 
 		# Assert:
+		cursor = self.puller.symbol_db.connection.cursor()
 		cursor.execute('SELECT hash, status, updated_at_height FROM symbol_hash_locks')
 		lock_state = [
 			(bytes(lock_hash), status, updated_at_height)
@@ -1594,6 +1600,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 
 	def test_sync_block_headers_restores_a_deleted_secret_lock_from_rollback_transaction_key(self):
 		# Arrange:
+		# The local block 2 hash differs from the node block 2 hash, which triggers rollback repair.
 		self._seed_blocks(self.puller.symbol_db, [1, 2], {2: b'local mismatch'.hex()})
 		self.puller.symbol_db.upsert_sync_state(create_sync_state(
 			chain_height=2,
@@ -1616,9 +1623,6 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		self.puller.symbol_db.replace_secret_locks(
 			secret_key, [create_secret_lock_row(create_secret_lock_item(), 2)])
 		self.puller.symbol_db.replace_secret_locks(secret_key, [])
-		cursor = self.puller.symbol_db.connection.cursor()
-		cursor.execute('SELECT composite_hash FROM symbol_secret_locks')
-		self.assertEqual([], cursor.fetchall())
 		connector = LockConnector(
 			2,
 			{1: [create_node_block(2)]},
@@ -1633,6 +1637,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		self._sync_with_connector(connector)
 
 		# Assert:
+		cursor = self.puller.symbol_db.connection.cursor()
 		cursor.execute('SELECT composite_hash, status, updated_at_height FROM symbol_secret_locks')
 		self.assertEqual([
 			(bytes.fromhex(COMPOSITE_HASH), 'used', 1)
@@ -1645,16 +1650,14 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 
 	def test_sync_block_headers_restores_a_deleted_hash_lock_from_a_rollback_aggregate_bonded_key(self):
 		# Arrange:
+		# The local block 2 hash differs from the node block 2 hash, which triggers rollback repair.
 		self._seed_blocks(self.puller.symbol_db, [1, 2], {2: b'local mismatch'.hex()})
 		self.puller.symbol_db.upsert_sync_state(create_sync_state(
 			chain_height=2,
 			last_synced_height=2,
 			last_synced_block_hash=bytes.fromhex('02' * 32)))
 		self.puller.symbol_db.upsert_hash_lock(create_hash_lock_row(create_hash_lock_item(), 2))
-		self.puller.symbol_db.delete_hash_lock(create_hash_lock_key_from_hex(LOCK_HASH))
-		cursor = self.puller.symbol_db.connection.cursor()
-		cursor.execute('SELECT hash FROM symbol_hash_locks')
-		self.assertEqual([], cursor.fetchall())
+		self.puller.symbol_db.delete_hash_lock(create_hash_lock_key(LOCK_HASH))
 		self.puller.symbol_db.upsert_transactions_for_height(2, [create_transaction_entry(
 			2,
 			'rollback-aggregate-bonded',
@@ -1695,6 +1698,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 
 	def test_sync_block_headers_restores_a_deleted_secret_lock_from_a_rollback_secret_proof_key(self):
 		# Arrange:
+		# The local block 2 hash differs from the node block 2 hash, which triggers rollback repair.
 		self._seed_blocks(self.puller.symbol_db, [1, 2], {2: b'local mismatch'.hex()})
 		self.puller.symbol_db.upsert_sync_state(create_sync_state(
 			chain_height=2,
@@ -1705,9 +1709,6 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		self.puller.symbol_db.replace_secret_locks(
 			secret_key, [create_secret_lock_row(create_secret_lock_item(), 2)])
 		self.puller.symbol_db.replace_secret_locks(secret_key, [])
-		cursor = self.puller.symbol_db.connection.cursor()
-		cursor.execute('SELECT composite_hash FROM symbol_secret_locks')
-		self.assertEqual([], cursor.fetchall())
 		self.puller.symbol_db.upsert_transactions_for_height(2, [create_transaction_entry(
 			2,
 			'rollback-secret-proof',
@@ -1754,12 +1755,12 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 
 	def test_sync_block_headers_keeps_rollback_state_unchanged_when_lock_replacement_fetch_fails(self):
 		# Arrange:
+		# The local block 2 hash differs from the node block 2 hash, which triggers rollback repair.
 		self._seed_blocks(self.puller.symbol_db, [1, 2], {2: b'local mismatch'.hex()})
-		original_sync_state = create_sync_state(
+		self.puller.symbol_db.upsert_sync_state(create_sync_state(
 			chain_height=2,
 			last_synced_height=2,
-			last_synced_block_hash=bytes.fromhex('02' * 32))
-		self.puller.symbol_db.upsert_sync_state(original_sync_state)
+			last_synced_block_hash=bytes.fromhex('02' * 32)))
 		transaction = create_transaction_entry(
 			2,
 			'rollback-fetch-failure',
@@ -1767,8 +1768,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			body={'hash': LOCK_HASH})
 		self.puller.symbol_db.upsert_transactions_for_height(2, [transaction])
 		self.puller.symbol_db.upsert_hash_lock(create_hash_lock_row(create_hash_lock_item(status=1), 2))
-		original_lock_state = self._fetch_lock_state()
-		original_sync_state = fetch_normalized_sync_state(self.puller.symbol_db)
+		original_state = self._fetch_complete_batch_state()
 		connector = LockConnector(
 			2,
 			{1: [create_node_block(2)]},
@@ -1780,15 +1780,11 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			self._sync_with_connector(connector)
 
 		# Assert:
-		cursor = self.puller.symbol_db.connection.cursor()
-		cursor.execute('SELECT height, type FROM symbol_transactions ORDER BY height, id')
-		self.assertEqual([(2, TransactionType.HASH_LOCK.value)], cursor.fetchall())
-		self.assertEqual([1, 2], self._fetch_block_heights(self.puller.symbol_db))
-		self.assertEqual(original_lock_state, self._fetch_lock_state())
-		self.assertEqual(original_sync_state, fetch_normalized_sync_state(self.puller.symbol_db))
+		self.assertEqual(original_state, self._fetch_complete_batch_state())
 
 	def test_sync_block_headers_keeps_all_rollback_state_unchanged_when_secret_lock_replacement_fetch_fails(self):
 		# Arrange:
+		# The local block 2 hash differs from the node block 2 hash, which triggers rollback repair.
 		self._seed_blocks(self.puller.symbol_db, [1, 2], {2: b'local mismatch'.hex()})
 		self.puller.symbol_db.upsert_sync_state(create_sync_state(
 			chain_height=2,
@@ -1828,10 +1824,10 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		# Assert:
 		self.assertEqual(original_state, self._fetch_complete_batch_state())
 
-	def test_sync_block_headers_preserves_the_approved_residual_window_for_pruned_unused_pre_fork_locks(self):
+	def test_sync_block_headers_does_not_restore_pruned_unused_pre_fork_locks_after_rollback_below_end_height(self):
 		self._assert_residual_window_for_pruned_pre_fork_locks(0)
 
-	def test_sync_block_headers_preserves_the_approved_residual_window_for_pruned_used_pre_fork_locks(self):
+	def test_sync_block_headers_does_not_restore_pruned_used_pre_fork_locks_after_rollback_below_end_height(self):
 		self._assert_residual_window_for_pruned_pre_fork_locks(1)
 
 	def _assert_residual_window_for_pruned_pre_fork_locks(self, status_number):

--- a/explorer/puller/tests/facade/symbol/test_PullerLocks.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerLocks.py
@@ -4,6 +4,7 @@
 import asyncio
 import copy
 
+from psycopg2 import Error as PsycopgError
 from symbolchain.sc import TransactionType
 from symbolchain.symbol.Network import Address
 
@@ -160,7 +161,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 
 	def _collect_lock_keys(self, transaction_rows):
 		return self.puller._collect_dirty_lock_keys_for_batch(  # pylint: disable=protected-access
-			[{'height': 10}], {10: transaction_rows})
+			{10: transaction_rows})
 
 	def _seed_complete_batch_state(self):
 		database = self.puller.symbol_db
@@ -584,6 +585,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 
 		# Assert:
 		self.assertEqual([{'key': key, 'rows': []}], entries)
+		self.assertEqual([path], connector.paths)
 
 	def test_fetch_secret_lock_supports_secret_only_search_without_address(self):
 		# Arrange:
@@ -769,57 +771,6 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			(bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160')
 		], keys.secret_keys)
 
-	def test_collect_dirty_lock_keys_includes_hash_lock_key_for_row_reaching_end_height(self):
-		# Arrange:
-		self.puller.symbol_db.upsert_hash_lock(create_hash_lock_row(create_hash_lock_item(endHeight='10'), 1))
-
-		# Act:
-		keys = self._collect_lock_keys([])
-
-		# Assert:
-		self.assertEqual([bytes.fromhex(LOCK_HASH)], [key.hash for key in keys.hash_keys])
-		self.assertEqual([], keys.secret_keys)
-
-	def test_collect_dirty_lock_keys_includes_secret_lock_key_for_row_reaching_end_height(self):
-		# Arrange:
-		key = create_secret_lock_search_key(
-			bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160')
-		self.puller.symbol_db.replace_secret_locks(
-			key, [create_secret_lock_row(create_secret_lock_item(endHeight='10'), 1)])
-
-		# Act:
-		keys = self._collect_lock_keys([])
-
-		# Assert:
-		self.assertEqual([], keys.hash_keys)
-		self.assertEqual([key], keys.secret_keys)
-
-	def test_collect_dirty_lock_keys_deduplicates_transaction_and_expiry_hash_key(self):
-		# Arrange:
-		self.puller.symbol_db.upsert_hash_lock(create_hash_lock_row(create_hash_lock_item(endHeight='10'), 1))
-		transaction_row = self._create_lock_transaction_row(TransactionType.HASH_LOCK.value, {'hash': LOCK_HASH})
-
-		# Act:
-		keys = self._collect_lock_keys([transaction_row])
-
-		# Assert:
-		self.assertEqual([bytes.fromhex(LOCK_HASH)], [key.hash for key in keys.hash_keys])
-
-	def test_collect_dirty_lock_keys_deduplicates_transaction_and_expiry_secret_key(self):
-		# Arrange:
-		key = create_secret_lock_search_key(
-			bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160')
-		self.puller.symbol_db.replace_secret_locks(
-			key, [create_secret_lock_row(create_secret_lock_item(endHeight='10'), 1)])
-		transaction_row = self._create_lock_transaction_row(
-			TransactionType.SECRET_LOCK.value, {'secret': SECRET, 'hashAlgorithm': 1})
-
-		# Act:
-		keys = self._collect_lock_keys([transaction_row])
-
-		# Assert:
-		self.assertEqual([key], keys.secret_keys)
-
 	def test_collect_dirty_lock_keys_rejects_surviving_alias_recipient(self):
 		# Arrange:
 		alias_address = bytes.fromhex(ALIAS_ADDRESS)
@@ -835,7 +786,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		# Act / Assert:
 		with self.assertRaisesRegex(ValueError, 'recipient_address'):
 			self.puller._collect_dirty_lock_keys_for_batch(  # pylint: disable=protected-access
-				[{'height': 1}], {1: [transaction_row]})
+				{1: [transaction_row]})
 
 	@staticmethod
 	def _create_hash_lock_sync_connector():
@@ -943,6 +894,230 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		} for composite_hash, owner_address, recipient_address, secret, hash_algorithm, mosaic_id, amount, end_height,
 			status, raw_payload, updated_at_height in cursor.fetchall()]
 		return hash_locks, secret_locks
+
+	def _seed_finalized_lock_state(self, end_height=2):
+		self._seed_blocks(self.puller.symbol_db, [1, 2, 3])
+		self.puller.symbol_db.upsert_sync_state(create_sync_state(
+			chain_height=2,
+			finalized_height=1,
+			last_synced_height=2,
+			last_synced_block_hash=bytes.fromhex(f'{2:064X}')))
+		self.puller.symbol_db.upsert_hash_lock(create_hash_lock_row(create_hash_lock_item(
+			endHeight=str(end_height)), 1))
+		secret_key = create_secret_lock_search_key(
+			bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160')
+		self.puller.symbol_db.replace_secret_locks(
+			secret_key, [create_secret_lock_row(create_secret_lock_item(endHeight=str(end_height)), 1)])
+
+	@staticmethod
+	def _finalization_connector(finalized_height=2, hash_responses=None, secret_responses=None, chain_height=2):
+		return LockConnector(
+			chain_height,
+			{},
+			finalized_height=finalized_height,
+			hash_responses=hash_responses,
+			secret_responses=secret_responses)
+
+	def test_sync_block_headers_removes_an_unused_hash_lock_after_finalization_when_node_drops_it(self):
+		# Arrange:
+		self._seed_finalized_lock_state()
+		connector = self._finalization_connector(
+			hash_responses={'lock/hash/' + LOCK_HASH: {'code': 'ResourceNotFound', 'message': 'not found'}},
+			secret_responses={_secret_search_path(SIGNER_ADDRESS, SECRET): {'data': [create_secret_lock_item()]}})
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual([], self._fetch_persisted_lock_state()[0])
+		self.assertEqual(['lock/hash/' + LOCK_HASH, _secret_search_path(SIGNER_ADDRESS, SECRET)], [
+			path for path in connector.paths if path.startswith('lock/')])
+
+	def test_sync_block_headers_removes_a_used_hash_lock_after_finalization_when_node_drops_it(self):
+		# Arrange:
+		self._seed_finalized_lock_state()
+		cursor = self.puller.symbol_db.connection.cursor()
+		cursor.execute("UPDATE symbol_hash_locks SET status = 'used' WHERE hash = %s", (bytes.fromhex(LOCK_HASH),))
+		self.puller.symbol_db.connection.commit()
+		connector = self._finalization_connector(
+			hash_responses={'lock/hash/' + LOCK_HASH: {'code': 'ResourceNotFound', 'message': 'not found'}},
+			secret_responses={_secret_search_path(SIGNER_ADDRESS, SECRET): {'data': [create_secret_lock_item()]}})
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual([], self._fetch_persisted_lock_state()[0])
+
+	def test_sync_block_headers_removes_an_unused_secret_lock_after_finalization_when_node_drops_it(self):
+		# Arrange:
+		self._seed_finalized_lock_state()
+		connector = self._finalization_connector(
+			hash_responses={'lock/hash/' + LOCK_HASH: create_hash_lock_item()},
+			secret_responses={_secret_search_path(SIGNER_ADDRESS, SECRET): {'data': []}})
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual([], self._fetch_persisted_lock_state()[1])
+
+	def test_sync_block_headers_removes_a_used_secret_lock_after_finalization_when_node_drops_it(self):
+		# Arrange:
+		self._seed_finalized_lock_state()
+		cursor = self.puller.symbol_db.connection.cursor()
+		cursor.execute("UPDATE symbol_secret_locks SET status = 'used' WHERE composite_hash = %s", (bytes.fromhex(COMPOSITE_HASH),))
+		self.puller.symbol_db.connection.commit()
+		connector = self._finalization_connector(
+			hash_responses={'lock/hash/' + LOCK_HASH: create_hash_lock_item()},
+			secret_responses={_secret_search_path(SIGNER_ADDRESS, SECRET): {'data': []}})
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual([], self._fetch_persisted_lock_state()[1])
+
+	def test_sync_block_headers_runs_finalization_cleanup_without_new_blocks(self):
+		# Arrange:
+		self._seed_finalized_lock_state()
+		connector = self._finalization_connector(
+			hash_responses={'lock/hash/' + LOCK_HASH: {'code': 'ResourceNotFound', 'message': 'not found'}},
+			secret_responses={_secret_search_path(SIGNER_ADDRESS, SECRET): {'data': []}})
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual(([], []), self._fetch_persisted_lock_state())
+		self.assertEqual([], [path for path in connector.paths if path.startswith('blocks?')])
+
+	def test_sync_block_headers_keeps_a_finalized_lock_when_node_still_returns_it(self):
+		# Arrange:
+		self._seed_finalized_lock_state()
+		connector = self._finalization_connector(
+			hash_responses={'lock/hash/' + LOCK_HASH: create_hash_lock_item()},
+			secret_responses={_secret_search_path(SIGNER_ADDRESS, SECRET): {'data': [create_secret_lock_item()]}})
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		hash_rows, secret_rows = self._fetch_persisted_lock_state()
+		self.assertEqual(1, len(hash_rows))
+		self.assertEqual(1, len(secret_rows))
+
+	def test_sync_block_headers_reselects_a_still_present_finalized_lock_on_the_next_run(self):
+		# Arrange:
+		self._seed_finalized_lock_state()
+		first_connector = self._finalization_connector(
+			hash_responses={'lock/hash/' + LOCK_HASH: create_hash_lock_item(endHeight='2')},
+			secret_responses={_secret_search_path(SIGNER_ADDRESS, SECRET): {'data': [create_secret_lock_item(endHeight='2')]}})
+		self._sync_with_connector(first_connector)
+		second_connector = self._finalization_connector(
+			hash_responses={'lock/hash/' + LOCK_HASH: {'code': 'ResourceNotFound', 'message': 'not found'}},
+			secret_responses={_secret_search_path(SIGNER_ADDRESS, SECRET): {'data': []}})
+
+		# Act:
+		self._sync_with_connector(second_connector)
+
+		# Assert:
+		self.assertEqual(([], []), self._fetch_persisted_lock_state())
+		self.assertEqual(['lock/hash/' + LOCK_HASH, _secret_search_path(SIGNER_ADDRESS, SECRET)], [
+			path for path in second_connector.paths if path.startswith('lock/')])
+
+	def test_sync_block_headers_keeps_finalized_lock_and_sync_state_when_hash_fetch_fails(self):
+		# Arrange:
+		self._seed_finalized_lock_state()
+		original_state = self._fetch_complete_batch_state()
+		connector = self._finalization_connector(
+			hash_responses={'lock/hash/' + LOCK_HASH: RuntimeError('finalized hash fetch failed')},
+			secret_responses={_secret_search_path(SIGNER_ADDRESS, SECRET): {'data': []}})
+
+		# Act / Assert:
+		with self.assertRaisesRegex(RuntimeError, '^finalized hash fetch failed$'):
+			self._sync_with_connector(connector)
+
+		self.assertEqual(original_state, self._fetch_complete_batch_state())
+
+	def test_sync_block_headers_keeps_finalized_lock_and_sync_state_when_secret_fetch_fails(self):
+		# Arrange:
+		self._seed_finalized_lock_state()
+		original_state = self._fetch_complete_batch_state()
+		connector = self._finalization_connector(
+			hash_responses={'lock/hash/' + LOCK_HASH: create_hash_lock_item()},
+			secret_responses={_secret_search_path(SIGNER_ADDRESS, SECRET): RuntimeError('finalized secret fetch failed')})
+
+		# Act / Assert:
+		with self.assertRaisesRegex(RuntimeError, '^finalized secret fetch failed$'):
+			self._sync_with_connector(connector)
+
+		self.assertEqual(original_state, self._fetch_complete_batch_state())
+
+	def test_sync_block_headers_defers_finalization_cleanup_above_max_height_until_a_later_run(self):
+		# Arrange:
+		self._seed_finalized_lock_state(end_height=2)
+		self.puller.symbol_db.upsert_hash_lock(create_hash_lock_row(
+			create_hash_lock_item(lock_hash=LOCK_HASH_2, endHeight='3'), 1))
+		capped_connector = LockConnector(
+			3,
+			{},
+			finalized_height=3,
+			hash_responses={'lock/hash/' + LOCK_HASH: {'code': 'ResourceNotFound', 'message': 'not found'}},
+			secret_responses={_secret_search_path(SIGNER_ADDRESS, SECRET): {'data': []}})
+
+		# Act:
+		self._sync_with_connector(capped_connector, max_height=2)
+
+		# Assert:
+		cursor = self.puller.symbol_db.connection.cursor()
+		cursor.execute('SELECT hash FROM symbol_hash_locks ORDER BY hash')
+		self.assertEqual([bytes.fromhex(LOCK_HASH_2)], [bytes(row[0]) for row in cursor.fetchall()])
+
+		# Act:
+		uncapped_connector = LockConnector(
+			3,
+			{2: [create_node_block(3)]},
+			{3: create_node_block(3)},
+			finalized_height=3,
+			hash_responses={'lock/hash/' + LOCK_HASH_2: {'code': 'ResourceNotFound', 'message': 'not found'}},
+			transactions_by_path={transaction_path(3, 3): {'data': []}},
+			statement_pages={statement_path(3, 3): {'data': []}})
+		self._sync_with_connector(uncapped_connector)
+
+		# Assert:
+		self.assertEqual(([], []), self._fetch_persisted_lock_state())
+
+	def test_sync_block_headers_rolls_back_finalization_lock_writes_after_secret_constraint_failure(self):
+		# Arrange:
+		self._seed_finalized_lock_state()
+		original_state = self._fetch_complete_batch_state()
+		constraint_name = 'test_symbol_secret_locks_reject_used'
+		cursor = self.puller.symbol_db.connection.cursor()
+		cursor.execute(
+			f"ALTER TABLE symbol_secret_locks ADD CONSTRAINT {constraint_name} CHECK (status <> 'used')")
+		self.puller.symbol_db.connection.commit()
+		connector = self._finalization_connector(
+			hash_responses={'lock/hash/' + LOCK_HASH: create_hash_lock_item(status=1, endHeight='2')},
+			secret_responses={_secret_search_path(SIGNER_ADDRESS, SECRET): {
+				'data': [create_secret_lock_item(status=1, endHeight='2')]
+			}})
+
+		# Act / Assert:
+		try:
+			with self.assertRaises(PsycopgError):
+				self._sync_with_connector(connector)
+		finally:
+			cursor = self.puller.symbol_db.connection.cursor()
+			cursor.execute(f'ALTER TABLE symbol_secret_locks DROP CONSTRAINT {constraint_name}')
+			self.puller.symbol_db.connection.commit()
+
+		# Assert:
+		self.assertEqual(original_state, self._fetch_complete_batch_state())
+		self.assertEqual([
+			'lock/hash/' + LOCK_HASH,
+			_secret_search_path(SIGNER_ADDRESS, SECRET)
+		], [path for path in connector.paths if path.startswith('lock/')])
 
 	def test_sync_block_headers_persists_a_hash_lock(self):
 		# Arrange:
@@ -1103,66 +1278,6 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		self.assertEqual([address_path, secret_only_path], [
 			path for path in connector.paths if path.startswith('lock/')
 		])
-
-	def test_sync_block_headers_converges_locks_created_then_pruned_by_the_batch_end_to_empty(self):
-		# Arrange:
-		hash_lock_transaction = create_node_transaction(
-			1,
-			transaction_hash='01' * 32,
-			block_index=0,
-			type=TransactionType.HASH_LOCK.value,
-			hash=LOCK_HASH,
-			mosaicId=MOSAIC_ID,
-			amount='1234',
-			duration='1')
-		secret_lock_transaction = create_node_transaction(
-			1,
-			transaction_hash='02' * 32,
-			block_index=1,
-			type=TransactionType.SECRET_LOCK.value,
-			secret=SECRET,
-			hashAlgorithm=1,
-			mosaicId=MOSAIC_ID,
-			amount='1234',
-			duration='1')
-		block_one = create_node_block(1)
-		block_one['meta']['transactionsCount'] = 2
-		block_one['meta']['totalTransactionsCount'] = 2
-		block_one['meta']['statementsCount'] = 0
-		block_two = create_node_block(2)
-		block_two['meta']['transactionsCount'] = 0
-		block_two['meta']['totalTransactionsCount'] = 0
-		block_two['meta']['statementsCount'] = 0
-		secret_path = _secret_search_path(SIGNER_ADDRESS, SECRET)
-		connector = LockConnector(
-			2,
-			{0: [block_one, block_two]},
-			hash_responses={
-				'lock/hash/' + LOCK_HASH: {'code': 'ResourceNotFound', 'message': 'not found'}
-			},
-			secret_responses={secret_path: {'data': []}},
-			transactions_by_path={
-				transaction_path(1, 2): {'data': [hash_lock_transaction, secret_lock_transaction]}
-			},
-			statement_pages={statement_path(1, 2): {'data': []}})
-
-		# Act:
-		self._sync_with_connector(connector)
-
-		# Assert:
-		self.assertEqual(([], []), self._fetch_persisted_lock_state())
-		self.assertEqual([1, 2], self._fetch_block_heights(self.puller.symbol_db))
-		cursor = self.puller.symbol_db.connection.cursor()
-		cursor.execute("SELECT height, type, body->>'duration' FROM symbol_transactions ORDER BY height, id")
-		self.assertEqual([
-			(1, TransactionType.HASH_LOCK.value, '1'),
-			(1, TransactionType.SECRET_LOCK.value, '1')
-		], cursor.fetchall())
-		self.assertEqual(2, self.puller.symbol_db.get_sync_state()['last_synced_height'])
-		self.assertEqual([
-			'lock/hash/' + LOCK_HASH,
-			secret_path
-		], [path for path in connector.paths if path.startswith('lock/')])
 
 	def test_sync_block_headers_updates_an_existing_hash_lock_to_used_when_completion_arrives_in_a_later_batch(self):
 		# Arrange:
@@ -1560,95 +1675,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			path for path in connector.paths if path.startswith('lock/')
 		])
 
-	def test_sync_block_headers_restores_a_deleted_hash_lock_from_rollback_transaction_key(self):
-		# Arrange:
-		# The local block 2 hash differs from the node block 2 hash, which triggers rollback repair.
-		self._seed_blocks(self.puller.symbol_db, [1, 2], {2: b'local mismatch'.hex()})
-		self.puller.symbol_db.upsert_sync_state(create_sync_state(
-			chain_height=2,
-			last_synced_height=2,
-			last_synced_block_hash=bytes.fromhex('02' * 32)))
-		transaction = create_transaction_entry(
-			2,
-			'rollback-hash-lock',
-			type=TransactionType.HASH_LOCK.value,
-			body={'hash': LOCK_HASH})
-		self.puller.symbol_db.upsert_transactions_for_height(2, [transaction])
-		self.puller.symbol_db.upsert_hash_lock(create_hash_lock_row(create_hash_lock_item(), 2))
-		self.puller.symbol_db.delete_hash_lock(create_hash_lock_key(LOCK_HASH))
-		connector = LockConnector(
-			2,
-			{1: [create_node_block(2)]},
-			{2: create_node_block(2)},
-			hash_responses={'lock/hash/' + LOCK_HASH: create_hash_lock_item(status=1)},
-			transactions_by_path={transaction_path(2, 2): {'data': []}},
-			statement_pages={statement_path(2, 2): {'data': []}})
-
-		# Act:
-		self._sync_with_connector(connector)
-
-		# Assert:
-		cursor = self.puller.symbol_db.connection.cursor()
-		cursor.execute('SELECT hash, status, updated_at_height FROM symbol_hash_locks')
-		lock_state = [
-			(bytes(lock_hash), status, updated_at_height)
-			for lock_hash, status, updated_at_height in cursor.fetchall()]
-		self.assertEqual([(bytes.fromhex(LOCK_HASH), 'used', 1)], lock_state)
-		self.assertEqual([1, 2], self._fetch_block_heights(self.puller.symbol_db))
-		cursor.execute('SELECT height, type FROM symbol_transactions WHERE height >= 2')
-		self.assertEqual([], cursor.fetchall())
-
-	def test_sync_block_headers_restores_a_deleted_secret_lock_from_rollback_transaction_key(self):
-		# Arrange:
-		# The local block 2 hash differs from the node block 2 hash, which triggers rollback repair.
-		self._seed_blocks(self.puller.symbol_db, [1, 2], {2: b'local mismatch'.hex()})
-		self.puller.symbol_db.upsert_sync_state(create_sync_state(
-			chain_height=2,
-			last_synced_height=2,
-			last_synced_block_hash=bytes.fromhex('02' * 32)))
-		transaction = create_transaction_entry(
-			2,
-			'rollback-secret-lock',
-			type=TransactionType.SECRET_LOCK.value,
-			signer_address=bytes.fromhex(SIGNER_ADDRESS),
-			recipient_address=bytes.fromhex(RECIPIENT_ADDRESS),
-			body={
-				'secret': SECRET,
-				'hashAlgorithm': 1,
-				'recipientAddress': ALIAS_ADDRESS
-			})
-		self.puller.symbol_db.upsert_transactions_for_height(2, [transaction])
-		secret_key = create_secret_lock_search_key(
-			bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160')
-		self.puller.symbol_db.replace_secret_locks(
-			secret_key, [create_secret_lock_row(create_secret_lock_item(), 2)])
-		self.puller.symbol_db.replace_secret_locks(secret_key, [])
-		connector = LockConnector(
-			2,
-			{1: [create_node_block(2)]},
-			{2: create_node_block(2)},
-			secret_responses={_secret_search_path(SIGNER_ADDRESS, SECRET): {
-				'data': [create_secret_lock_item(status=1)]
-			}},
-			transactions_by_path={transaction_path(2, 2): {'data': []}},
-			statement_pages={statement_path(2, 2): {'data': []}})
-
-		# Act:
-		self._sync_with_connector(connector)
-
-		# Assert:
-		cursor = self.puller.symbol_db.connection.cursor()
-		cursor.execute('SELECT composite_hash, status, updated_at_height FROM symbol_secret_locks')
-		self.assertEqual([
-			(bytes.fromhex(COMPOSITE_HASH), 'used', 1)
-		], [
-			(bytes(composite_hash), status, updated_at_height)
-			for composite_hash, status, updated_at_height in cursor.fetchall()
-		])
-		cursor.execute('SELECT height, type FROM symbol_transactions WHERE height >= 2')
-		self.assertEqual([], cursor.fetchall())
-
-	def test_sync_block_headers_restores_a_deleted_hash_lock_from_a_rollback_aggregate_bonded_key(self):
+	def test_sync_block_headers_restores_a_deleted_hash_lock_from_a_current_row_key(self):
 		# Arrange:
 		# The local block 2 hash differs from the node block 2 hash, which triggers rollback repair.
 		self._seed_blocks(self.puller.symbol_db, [1, 2], {2: b'local mismatch'.hex()})
@@ -1657,13 +1684,6 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			last_synced_height=2,
 			last_synced_block_hash=bytes.fromhex('02' * 32)))
 		self.puller.symbol_db.upsert_hash_lock(create_hash_lock_row(create_hash_lock_item(), 2))
-		self.puller.symbol_db.delete_hash_lock(create_hash_lock_key(LOCK_HASH))
-		self.puller.symbol_db.upsert_transactions_for_height(2, [create_transaction_entry(
-			2,
-			'rollback-aggregate-bonded',
-			type=TransactionType.AGGREGATE_BONDED.value,
-			hash=bytes.fromhex(LOCK_HASH),
-			body={})])
 		connector = LockConnector(
 			2,
 			{1: [create_node_block(2)]},
@@ -1688,15 +1708,12 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		# Assert:
 		self.assertEqual(([expected_row], []), self._fetch_persisted_lock_state())
 		self.assertEqual([1, 2], self._fetch_block_heights(self.puller.symbol_db))
-		cursor = self.puller.symbol_db.connection.cursor()
-		cursor.execute('SELECT height, type FROM symbol_transactions WHERE height >= 2 ORDER BY height, id')
-		self.assertEqual([], cursor.fetchall())
 		self.assertEqual(2, self.puller.symbol_db.get_sync_state()['last_synced_height'])
 		self.assertEqual(['lock/hash/' + LOCK_HASH], [
 			path for path in connector.paths if path.startswith('lock/')
 		])
 
-	def test_sync_block_headers_restores_a_deleted_secret_lock_from_a_rollback_secret_proof_key(self):
+	def test_sync_block_headers_restores_a_deleted_secret_lock_from_a_current_row_key(self):
 		# Arrange:
 		# The local block 2 hash differs from the node block 2 hash, which triggers rollback repair.
 		self._seed_blocks(self.puller.symbol_db, [1, 2], {2: b'local mismatch'.hex()})
@@ -1708,19 +1725,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160')
 		self.puller.symbol_db.replace_secret_locks(
 			secret_key, [create_secret_lock_row(create_secret_lock_item(), 2)])
-		self.puller.symbol_db.replace_secret_locks(secret_key, [])
-		self.puller.symbol_db.upsert_transactions_for_height(2, [create_transaction_entry(
-			2,
-			'rollback-secret-proof',
-			type=TransactionType.SECRET_PROOF.value,
-			signer_address=bytes.fromhex(SIGNER_ADDRESS),
-			recipient_address=bytes.fromhex(RECIPIENT_ADDRESS),
-			body={
-				'recipientAddress': ALIAS_ADDRESS,
-				'secret': SECRET,
-				'hashAlgorithm': 1
-			})])
-		path = _secret_only_search_path(SECRET)
+		path = _secret_search_path(SIGNER_ADDRESS, SECRET)
 		connector = LockConnector(
 			2,
 			{1: [create_node_block(2)]},
@@ -1753,6 +1758,79 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		self.assertEqual(2, self.puller.symbol_db.get_sync_state()['last_synced_height'])
 		self.assertEqual([path], [path for path in connector.paths if path.startswith('lock/')])
 
+	def test_sync_block_headers_deletes_fork_only_hash_and_secret_locks_from_current_row_keys(self):  # pylint: disable=too-many-locals
+		# Arrange:
+		self._seed_blocks(self.puller.symbol_db, [1, 2], {2: b'local mismatch'.hex()})
+		self.puller.symbol_db.upsert_sync_state(create_sync_state(
+			chain_height=2,
+			last_synced_height=2,
+			last_synced_block_hash=bytes.fromhex('02' * 32)))
+		survivor_hash_item = create_hash_lock_item()
+		fork_hash_item = create_hash_lock_item(lock_hash=LOCK_HASH_2)
+		self.puller.symbol_db.upsert_hash_lock(create_hash_lock_row(survivor_hash_item, 1))
+		self.puller.symbol_db.upsert_hash_lock(create_hash_lock_row(fork_hash_item, 2))
+		other_owner = '98' + '33' * 23
+		fork_secret = '99' * 32
+		survivor_secret_item = create_secret_lock_item()
+		fork_secret_item = create_secret_lock_item(
+			composite_hash=COMPOSITE_HASH_2,
+			owner_address=other_owner,
+			secret=fork_secret)
+		survivor_secret_key = create_secret_lock_search_key(
+			bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160')
+		fork_secret_key = create_secret_lock_search_key(
+			bytes.fromhex(other_owner), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(fork_secret), 'hash160')
+		self.puller.symbol_db.replace_secret_locks(
+			survivor_secret_key, [create_secret_lock_row(survivor_secret_item, 1)])
+		self.puller.symbol_db.replace_secret_locks(
+			fork_secret_key, [create_secret_lock_row(fork_secret_item, 2)])
+		fork_hash_path = 'lock/hash/' + LOCK_HASH_2
+		fork_secret_path = _secret_search_path(other_owner, fork_secret)
+		connector = LockConnector(
+			2,
+			{1: [create_node_block(2)]},
+			{2: create_node_block(2)},
+			hash_responses={fork_hash_path: {'code': 'ResourceNotFound', 'message': 'not found'}},
+			secret_responses={fork_secret_path: {'data': []}},
+			transactions_by_path={transaction_path(2, 2): {'data': []}},
+			statement_pages={statement_path(2, 2): {'data': []}})
+		expected_survivor_hash = create_hash_lock_row(survivor_hash_item, 1)
+		expected_survivor_secret = create_expected_secret_lock_row(
+			survivor_secret_item,
+			1,
+			composite_hash=bytes.fromhex(COMPOSITE_HASH),
+			owner_address=bytes.fromhex(SIGNER_ADDRESS),
+			recipient_address=bytes.fromhex(RECIPIENT_ADDRESS),
+			secret=bytes.fromhex(SECRET),
+			hash_algorithm='hash160',
+			mosaic_id=MOSAIC_ID,
+			amount=1234,
+			end_height=100,
+			status='unused')
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		hash_rows, secret_rows = self._fetch_persisted_lock_state()
+		self.assertEqual([expected_survivor_hash], hash_rows)
+		self.assertEqual([expected_survivor_secret], secret_rows)
+		self.assertEqual([fork_hash_path, fork_secret_path], [
+			path for path in connector.paths if path.startswith('lock/')])
+		self.assertEqual([1, 2], self._fetch_block_heights(self.puller.symbol_db))
+		self.assertEqual(bytes.fromhex(f'{2:064X}'), self._fetch_block_hash(self.puller.symbol_db, 2))
+		actual_sync_state = self.puller.symbol_db.get_sync_state()
+		actual_sync_state['finalized_hash'] = bytes(actual_sync_state['finalized_hash'])
+		actual_sync_state['last_synced_block_hash'] = bytes(actual_sync_state['last_synced_block_hash'])
+		self.assertEqual(create_sync_state(
+			chain_height=2,
+			finalized_height=1,
+			finalized_hash=bytes.fromhex(f'{1:064X}'),
+			finalized_epoch=4,
+			finalized_point=5,
+			last_synced_height=2,
+			last_synced_block_hash=bytes.fromhex(f'{2:064X}')), actual_sync_state)
+
 	def test_sync_block_headers_keeps_rollback_state_unchanged_when_lock_replacement_fetch_fails(self):
 		# Arrange:
 		# The local block 2 hash differs from the node block 2 hash, which triggers rollback repair.
@@ -1761,12 +1839,6 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			chain_height=2,
 			last_synced_height=2,
 			last_synced_block_hash=bytes.fromhex('02' * 32)))
-		transaction = create_transaction_entry(
-			2,
-			'rollback-fetch-failure',
-			type=TransactionType.HASH_LOCK.value,
-			body={'hash': LOCK_HASH})
-		self.puller.symbol_db.upsert_transactions_for_height(2, [transaction])
 		self.puller.symbol_db.upsert_hash_lock(create_hash_lock_row(create_hash_lock_item(status=1), 2))
 		original_state = self._fetch_complete_batch_state()
 		connector = LockConnector(
@@ -1796,14 +1868,6 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		metadata_item = create_metadata_item(metadata_type=1, target_id=MOSAIC_ID)
 		self.puller.symbol_db.upsert_metadata(create_expected_metadata_row(
 			metadata_item, 1, bytes.fromhex('11' * 32), 'mosaic', MOSAIC_ID, 'hello'))
-		transaction = create_transaction_entry(
-			2,
-			'rollback-secret-fetch-failure',
-			type=TransactionType.SECRET_LOCK.value,
-			signer_address=bytes.fromhex(SIGNER_ADDRESS),
-			recipient_address=bytes.fromhex(RECIPIENT_ADDRESS),
-			body={'secret': SECRET, 'hashAlgorithm': 1})
-		self.puller.symbol_db.upsert_transactions_for_height(2, [transaction])
 		self.puller.symbol_db.upsert_hash_lock(create_hash_lock_row(create_hash_lock_item(status=1), 2))
 		secret_key = create_secret_lock_search_key(
 			bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160')
@@ -1823,85 +1887,6 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 
 		# Assert:
 		self.assertEqual(original_state, self._fetch_complete_batch_state())
-
-	def test_sync_block_headers_does_not_restore_pruned_unused_pre_fork_locks_after_rollback_below_end_height(self):
-		self._assert_residual_window_for_pruned_pre_fork_locks(0)
-
-	def test_sync_block_headers_does_not_restore_pruned_used_pre_fork_locks_after_rollback_below_end_height(self):
-		self._assert_residual_window_for_pruned_pre_fork_locks(1)
-
-	def _assert_residual_window_for_pruned_pre_fork_locks(self, status_number):
-		# Arrange:
-		self._seed_blocks(self.puller.symbol_db, [1])
-		self.puller.symbol_db.upsert_sync_state(create_sync_state(
-			chain_height=1,
-			last_synced_height=1,
-			last_synced_block_hash=bytes.fromhex('01' * 32)))
-		self.puller.symbol_db.upsert_hash_lock(create_hash_lock_row(
-			create_hash_lock_item(status=status_number, endHeight='3'), 1))
-		secret_key = create_secret_lock_search_key(
-			bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160')
-		self.puller.symbol_db.replace_secret_locks(
-			secret_key, [create_secret_lock_row(create_secret_lock_item(status=status_number, endHeight='3'), 1)])
-		orphaned_block_two_hash = 'DD' * 32
-		orphaned_block_three_hash = 'EE' * 32
-		orphaned_connector = LockConnector(
-			3,
-			{1: [
-				create_node_block(2, block_hash=orphaned_block_two_hash),
-				create_node_block(3, block_hash=orphaned_block_three_hash, previous_hash=orphaned_block_two_hash)
-			]},
-			hash_responses={'lock/hash/' + LOCK_HASH: {'code': 'ResourceNotFound', 'message': 'not found'}},
-			secret_responses={_secret_search_path(SIGNER_ADDRESS, SECRET): {'data': []}},
-			transactions_by_path={transaction_path(2, 3): {'data': []}},
-			statement_pages={statement_path(2, 3): {'data': []}})
-
-		# Act: orphaned branch reaches the absolute end height and prunes both rows.
-		self._sync_with_connector(orphaned_connector)
-
-		# Assert:
-		self.assertEqual(([], []), self._fetch_lock_state())
-		self.assertEqual([1, 2, 3], self._fetch_block_heights(self.puller.symbol_db))
-		orphaned_sync_state = self.puller.symbol_db.get_sync_state()
-		self.assertEqual(3, orphaned_sync_state['chain_height'])
-		self.assertEqual(3, orphaned_sync_state['last_synced_height'])
-		self.assertEqual(bytes.fromhex(orphaned_block_three_hash), bytes(orphaned_sync_state['last_synced_block_hash']))
-		self.assertEqual(bytes.fromhex(orphaned_block_three_hash), self._fetch_block_hash(self.puller.symbol_db, 3))
-		self.assertEqual([
-			'lock/hash/' + LOCK_HASH,
-			_secret_search_path(SIGNER_ADDRESS, SECRET)
-		], [path for path in orphaned_connector.paths if path.startswith('lock/')])
-
-		# Act: canonical branch rolls back below the absolute end height.
-		rollback_connector = LockConnector(
-			2,
-			{1: [create_node_block(2, block_hash='FF' * 32)]},
-			{2: create_node_block(2, block_hash='FF' * 32)},
-			transactions_by_path={transaction_path(2, 2): {'data': []}},
-			statement_pages={statement_path(2, 2): {'data': []}})
-		self._sync_with_connector(rollback_connector)
-
-		# Assert:
-		self.assertEqual(([], []), self._fetch_lock_state())
-		self.assertEqual([], [path for path in rollback_connector.paths if path.startswith('lock/')])
-		self.assertEqual([1, 2], self._fetch_block_heights(self.puller.symbol_db))
-		self.assertEqual(2, self.puller.symbol_db.get_sync_state()['last_synced_height'])
-		self.assertEqual(bytes.fromhex('FF' * 32), self._fetch_block_hash(self.puller.symbol_db, 2))
-
-		# Act: canonical branch reaches the same absolute end height.
-		canonical_end_height_connector = LockConnector(
-			3,
-			{2: [create_node_block(3)]},
-			{2: create_node_block(2, block_hash='FF' * 32)},
-			transactions_by_path={transaction_path(3, 3): {'data': []}},
-			statement_pages={statement_path(3, 3): {'data': []}})
-		self._sync_with_connector(canonical_end_height_connector)
-
-		# Assert:
-		self.assertEqual(([], []), self._fetch_lock_state())
-		self.assertEqual([1, 2, 3], self._fetch_block_heights(self.puller.symbol_db))
-		self.assertEqual(3, self.puller.symbol_db.get_sync_state()['last_synced_height'])
-		self.assertEqual([], [path for path in canonical_end_height_connector.paths if path.startswith('lock/')])
 
 	def _fetch_lock_state(self):
 		cursor = self.puller.symbol_db.connection.cursor()

--- a/explorer/puller/tests/facade/symbol/test_PullerLocks.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerLocks.py
@@ -619,7 +619,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		with self.assertRaisesRegex(ValueError, '^Duplicate Symbol Secret Lock composite hash$'):
 			asyncio.run(self.puller._fetch_dirty_secret_locks([key], 12))  # pylint: disable=protected-access
 
-	def test_fetch_secret_locks_uses_ten_request_chunks_and_preserves_non_sorted_first_encounter_order(self):
+	def test_fetch_secret_locks_uses_ten_request_chunks_and_preserves_non_sorted_input_sequence(self):
 		# Arrange:
 		secrets = [f'{index:064X}' for index in (3, 1, 11, 2, 10, 4, 9, 5, 8, 6, 7)]
 		keys = [
@@ -649,7 +649,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			for secret in secrets
 		], [entry['key'] for entry in entries])
 
-	def test_fetch_hash_locks_uses_ten_request_chunks_and_preserves_non_sorted_first_encounter_order(self):
+	def test_fetch_hash_locks_uses_ten_request_chunks_and_preserves_non_sorted_input_sequence(self):
 		# Arrange:
 		hashes = [f'{index:064X}' for index in (3, 1, 11, 2, 10, 4, 9, 5, 8, 6, 7)]
 		keys = [create_hash_lock_key(lock_hash) for lock_hash in hashes]
@@ -682,8 +682,8 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		keys = self._collect_lock_keys([transaction_row])
 
 		# Assert:
-		self.assertEqual([bytes.fromhex(LOCK_HASH_2)], [key.hash for key in keys.hash_keys])
-		self.assertEqual([], keys.secret_keys)
+		self.assertEqual({create_hash_lock_key(LOCK_HASH_2)}, keys.hash_keys)
+		self.assertEqual(set(), keys.secret_keys)
 
 	def test_collect_dirty_lock_keys_uses_top_level_aggregate_bonded_hash(self):
 		# Arrange:
@@ -694,8 +694,8 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		keys = self._collect_lock_keys([top_level])
 
 		# Assert:
-		self.assertEqual([bytes.fromhex(LOCK_HASH_2)], [key.hash for key in keys.hash_keys])
-		self.assertEqual([], keys.secret_keys)
+		self.assertEqual({create_hash_lock_key(LOCK_HASH_2)}, keys.hash_keys)
+		self.assertEqual(set(), keys.secret_keys)
 
 	def test_collect_dirty_lock_keys_uses_resolved_secret_lock_recipient(self):
 		# Arrange:
@@ -707,10 +707,10 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		keys = self._collect_lock_keys([transaction_row])
 
 		# Assert:
-		self.assertEqual([], keys.hash_keys)
-		self.assertEqual([(
+		self.assertEqual(set(), keys.hash_keys)
+		self.assertEqual({(
 			bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160'
-		)], keys.secret_keys)
+		)}, keys.secret_keys)
 
 	def test_collect_dirty_lock_keys_uses_secret_proof_with_unknown_owner(self):
 		# Arrange:
@@ -721,8 +721,8 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		keys = self._collect_lock_keys([transaction_row])
 
 		# Assert:
-		self.assertEqual([], keys.hash_keys)
-		self.assertEqual([(None, bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'sha3_256')], keys.secret_keys)
+		self.assertEqual(set(), keys.hash_keys)
+		self.assertEqual({(None, bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'sha3_256')}, keys.secret_keys)
 
 	def test_collect_dirty_lock_keys_ignores_unrelated_transaction_type(self):
 		# Arrange:
@@ -732,7 +732,8 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		keys = self._collect_lock_keys([unrelated])
 
 		# Assert:
-		self.assertEqual(([], []), (keys.hash_keys, keys.secret_keys))
+		self.assertEqual(set(), keys.hash_keys)
+		self.assertEqual(set(), keys.secret_keys)
 
 	def test_collect_dirty_lock_keys_accepts_empty_transaction_input(self):
 		# Arrange:
@@ -742,9 +743,10 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		keys = self._collect_lock_keys(transaction_rows)
 
 		# Assert:
-		self.assertEqual(([], []), (keys.hash_keys, keys.secret_keys))
+		self.assertEqual(set(), keys.hash_keys)
+		self.assertEqual(set(), keys.secret_keys)
 
-	def test_collect_dirty_lock_keys_deduplicates_hash_keys_in_first_encounter_order(self):
+	def test_collect_dirty_lock_keys_deduplicates_hash_keys(self):
 		# Arrange:
 		first = self._create_lock_transaction_row(TransactionType.HASH_LOCK.value, {'hash': LOCK_HASH_2})
 		second = self._create_lock_transaction_row(TransactionType.HASH_LOCK.value, {'hash': LOCK_HASH})
@@ -754,9 +756,10 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		keys = self._collect_lock_keys([first, second, duplicate])
 
 		# Assert:
-		self.assertEqual([bytes.fromhex(LOCK_HASH_2), bytes.fromhex(LOCK_HASH)], [key.hash for key in keys.hash_keys])
+		self.assertEqual(2, len(keys.hash_keys))
+		self.assertEqual({create_hash_lock_key(LOCK_HASH_2), create_hash_lock_key(LOCK_HASH)}, keys.hash_keys)
 
-	def test_collect_dirty_lock_keys_deduplicates_secret_keys_in_first_encounter_order(self):
+	def test_collect_dirty_lock_keys_deduplicates_secret_keys(self):
 		# Arrange:
 		first = self._create_lock_transaction_row(TransactionType.SECRET_PROOF.value, {'secret': SECRET, 'hashAlgorithm': 0})
 		second = self._create_lock_transaction_row(TransactionType.SECRET_LOCK.value, {'secret': SECRET, 'hashAlgorithm': 1})
@@ -766,10 +769,11 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		keys = self._collect_lock_keys([first, second, duplicate])
 
 		# Assert:
-		self.assertEqual([
+		self.assertEqual(2, len(keys.secret_keys))
+		self.assertEqual({
 			(None, bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'sha3_256'),
 			(bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160')
-		], keys.secret_keys)
+		}, keys.secret_keys)
 
 	def test_collect_dirty_lock_keys_rejects_surviving_alias_recipient(self):
 		# Arrange:
@@ -1275,9 +1279,10 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 
 		# Assert:
 		self.assertEqual(([], [expected_row]), self._fetch_persisted_lock_state())
-		self.assertEqual([address_path, secret_only_path], [
-			path for path in connector.paths if path.startswith('lock/')
-		])
+		lock_paths = [path for path in connector.paths if path.startswith('lock/')]
+		self.assertCountEqual((address_path, secret_only_path), lock_paths)
+		self.assertEqual(1, lock_paths.count(address_path))
+		self.assertEqual(1, lock_paths.count(secret_only_path))
 
 	def test_sync_block_headers_updates_an_existing_hash_lock_to_used_when_completion_arrives_in_a_later_batch(self):
 		# Arrange:

--- a/explorer/puller/tests/facade/symbol/test_PullerLocks.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerLocks.py
@@ -5,25 +5,28 @@ import copy
 from symbolchain.sc import TransactionType
 from symbolchain.symbol.Network import Address
 
-from puller.facade.SymbolPuller import LOCK_FETCH_CONCURRENCY
+from puller.model.symbol.Account import create_account_row
 from puller.model.symbol.Lock import (
 	create_hash_lock_key_from_hex,
 	create_hash_lock_row,
 	create_secret_lock_row,
 	create_secret_lock_search_key
 )
-from tests.test.SymbolDatabaseTestUtils import fetch_full_block_state, fetch_normalized_sync_state
+from puller.model.symbol.Receipt import create_receipt_rows
+from tests.test.SymbolDatabaseTestUtils import fetch_normalized_sync_state
 from tests.test.SymbolLockTestUtils import create_expected_secret_lock_row
 from tests.test.SymbolLockTestUtils import create_secret_lock_item as create_secret_lock_item_fixture
-from tests.test.SymbolMetadataTestUtils import create_expected_metadata_row, create_metadata_item, fetch_metadata_rows
-from tests.test.SymbolMosaicTestUtils import create_expected_mosaic_row, create_mosaic_item, fetch_mosaic_state
-from tests.test.SymbolNamespaceTestUtils import NAMESPACE_ROOT_ID, create_namespace_item, fetch_namespace_state, seed_namespace
-from tests.test.SymbolTestConstants import RECIPIENT_ADDRESS, SIGNER_ADDRESS
+from tests.test.SymbolMetadataTestUtils import create_expected_metadata_row, create_metadata_item
+from tests.test.SymbolMosaicTestUtils import create_expected_mosaic_row, create_mosaic_item
+from tests.test.SymbolNamespaceTestUtils import NAMESPACE_ROOT_ID, create_namespace_item, seed_namespace
+from tests.test.SymbolTestConstants import BENEFICIARY_ADDRESS, RECIPIENT_ADDRESS, SIGNER_ADDRESS
 
 from ...test.SymbolTransactionTestUtils import create_transaction_entry
 from .puller_test_utils import (
 	FakeConnector,
 	SymbolPullerTestBase,
+	create_account_item,
+	create_amount_statement_item,
 	create_complete_aggregate_pair,
 	create_node_block,
 	create_node_transaction,
@@ -193,39 +196,95 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		return self.puller._collect_dirty_lock_keys_for_batch(  # pylint: disable=protected-access
 			[{'height': 10}], {10: transaction_rows})
 
-	def _fetch_complete_rollback_state(self):
+	def _seed_complete_batch_state(self):
+		database = self.puller.symbol_db
+		self._seed_blocks(database, [1], {1: 'FF' * 32})
+		database.upsert_transactions_for_height(1, [create_transaction_entry(
+			1,
+			'decoy',
+			mosaic_rows=[{'mosaic_id': MOSAIC_ID, 'amount': 999, 'role': 'transfer', 'position': 0}],
+			address_rows=[{'address': bytes.fromhex(BENEFICIARY_ADDRESS), 'role': 'recipient'}]
+		)])
+		database.upsert_receipts_for_height(
+			1,
+			create_receipt_rows(create_amount_statement_item(1, 999)),
+			999)
+		account_row, account_mosaic_rows = create_account_row(
+			create_account_item(BENEFICIARY_ADDRESS, importance='999'),
+			self.puller.symbol_facade.network,
+			1,
+			MOSAIC_ID,
+			6)
+		account_row['is_harvesting_active'] = True
+		database.upsert_account_current_state(account_row, account_mosaic_rows)
+		database.upsert_multisig(bytes.fromhex(BENEFICIARY_ADDRESS), {
+			'address': bytes.fromhex(BENEFICIARY_ADDRESS),
+			'min_approval': 2,
+			'min_removal': 1,
+			'cosignatory_addresses': [bytes.fromhex('98' + '11' * 23)],
+			'multisig_addresses': [bytes.fromhex('98' + '22' * 23)],
+			'updated_at_height': 1
+		})
+		namespace_item = create_namespace_item(owner_address=SIGNER_ADDRESS)
+		seed_namespace(database, namespace_item, {NAMESPACE_ROOT_ID: 'decoy'}, 1)
+		database.upsert_mosaic(create_expected_mosaic_row(create_mosaic_item(supply='999'), 1))
+		metadata_item = create_metadata_item(metadata_type=1, target_id=MOSAIC_ID)
+		database.upsert_metadata(create_expected_metadata_row(
+			metadata_item, 1, bytes.fromhex('11' * 32), 'mosaic', MOSAIC_ID, 'hello'))
+		database.upsert_hash_lock(create_hash_lock_row(create_hash_lock_item(status=1), 1))
+		secret_key = create_secret_lock_search_key(
+			bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160')
+		database.replace_secret_locks(
+			secret_key,
+			[create_secret_lock_row(create_secret_lock_item(status=1), 1)])
+		database.upsert_sync_state(create_sync_state(
+			chain_height=0,
+			finalized_height=0,
+			finalized_hash=b'',
+			finalized_epoch=0,
+			finalized_point=0,
+			last_synced_height=0,
+			last_synced_block_hash=b''))
+
+	def _fetch_complete_batch_state(self):
+		table_names = (
+			'symbol_blocks',
+			'symbol_transactions',
+			'symbol_transaction_mosaics',
+			'symbol_transaction_addresses',
+			'symbol_receipts',
+			'symbol_accounts',
+			'symbol_account_mosaics',
+			'symbol_multisig',
+			'symbol_namespaces',
+			'symbol_alias_names',
+			'symbol_mosaics',
+			'symbol_metadata',
+			'symbol_hash_locks',
+			'symbol_secret_locks',
+			'symbol_sync_state'
+		)
 		cursor = self.puller.symbol_db.connection.cursor()
-		cursor.execute('SELECT * FROM symbol_transactions ORDER BY height, id')
-		transactions = [
-			tuple(bytes(value) if isinstance(value, memoryview) else value for value in row)
-			for row in cursor.fetchall()
-		]
-		cursor.execute('SELECT * FROM symbol_receipts ORDER BY height, id')
-		receipts = [
-			tuple(bytes(value) if isinstance(value, memoryview) else value for value in row)
-			for row in cursor.fetchall()
-		]
-		cursor.execute('SELECT * FROM symbol_hash_locks ORDER BY hash')
-		hash_locks = [
-			tuple(bytes(value) if isinstance(value, memoryview) else value for value in row)
-			for row in cursor.fetchall()
-		]
-		cursor.execute('SELECT * FROM symbol_secret_locks ORDER BY composite_hash')
-		secret_locks = [
-			tuple(bytes(value) if isinstance(value, memoryview) else value for value in row)
-			for row in cursor.fetchall()
-		]
-		return {
-			'blocks': fetch_full_block_state(self.puller.symbol_db),
-			'transactions': transactions,
-			'receipts': receipts,
-			'namespace': fetch_namespace_state(self.puller.symbol_db.connection),
-			'mosaic': fetch_mosaic_state(self.puller.symbol_db),
-			'metadata': fetch_metadata_rows(self.puller.symbol_db),
-			'hash_locks': hash_locks,
-			'secret_locks': secret_locks,
-			'sync_state': fetch_normalized_sync_state(self.puller.symbol_db)
-		}
+		state = {}
+		for table_name in table_names:
+			cursor.execute(
+				f'SELECT to_jsonb(table_row) FROM {table_name} AS table_row '
+				'ORDER BY to_jsonb(table_row)::text')
+			state[table_name] = cursor.fetchall()
+
+		return state
+
+	def _assert_sync_failure_preserves_complete_batch_state(self, connector, exception_type, error):
+		# Arrange:
+		self._seed_complete_batch_state()
+		expected_state = self._fetch_complete_batch_state()
+
+		# Act / Assert:
+		with self.assertRaisesRegex(exception_type, error):
+			self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual(expected_state, self._fetch_complete_batch_state())
 
 	def _fetch_lock_alias_failure_state(self):
 		cursor = self.puller.symbol_db.connection.cursor()
@@ -287,6 +346,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 	def test_fetch_hash_lock_success_returns_a_complete_upsert_entry(self):
 		# Arrange:
 		item = create_hash_lock_item()
+		expected_raw_payload = copy.deepcopy(item)
 		connector = LockConnector(
 			hash_responses={'lock/hash/' + LOCK_HASH: item})
 		set_symbol_connector(self.puller, connector)
@@ -304,7 +364,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 				'amount': 1234,
 				'end_height': 100,
 				'status': 'unused',
-				'raw_payload': item,
+				'raw_payload': expected_raw_payload,
 				'updated_at_height': 12
 			}
 		}], entries)
@@ -322,14 +382,10 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 
 		# Act:
 		entries = asyncio.run(self.puller._fetch_dirty_hash_locks([key], 12))  # pylint: disable=protected-access
-		self.puller.symbol_db.upsert_hash_lock(create_hash_lock_row(create_hash_lock_item(), 12))
-		self.puller._write_dirty_hash_locks(entries)  # pylint: disable=protected-access
 
 		# Assert:
 		self.assertEqual([{'hash': key}], entries)
-		cursor = self.puller.symbol_db.connection.cursor()
-		cursor.execute('SELECT COUNT(*) FROM symbol_hash_locks')
-		self.assertEqual(0, cursor.fetchone()[0])
+		self.assertEqual(['lock/hash/' + LOCK_HASH], connector.paths)
 
 	def test_fetch_hash_lock_rejects_a_mismatched_response(self):
 		# Arrange:
@@ -343,7 +399,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			asyncio.run(self.puller._fetch_dirty_hash_locks(  # pylint: disable=protected-access
 				[create_hash_lock_key_from_hex(LOCK_HASH)], 12))
 
-	def _assert_sync_rejects_malformed_hash_lock_response(self, response):
+	def _assert_sync_rejects_malformed_hash_lock_response(self, response, expected_error):
 		# Arrange:
 		transaction = create_node_transaction(
 			1,
@@ -360,27 +416,15 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			statement_pages={statement_path(1, 1): {'data': []}})
 
 		# Act / Assert:
-		with self.assertRaises(ValueError):
-			self._sync_with_connector(connector)
-
-		# Assert:
-		cursor = self.puller.symbol_db.connection.cursor()
-		for table_name in ('symbol_blocks', 'symbol_transactions', 'symbol_receipts', 'symbol_hash_locks', 'symbol_secret_locks'):
-			cursor.execute(f'SELECT COUNT(*) FROM {table_name}')
-			self.assertEqual(0, cursor.fetchone()[0], table_name)
-		self.assertIsNone(self.puller.symbol_db.get_sync_state())
+		self._assert_sync_failure_preserves_complete_batch_state(connector, ValueError, expected_error)
 
 	def test_sync_block_headers_rejects_non_dict_hash_lock_response_without_writes(self):
-		self._assert_sync_rejects_malformed_hash_lock_response([])
-
-	def test_sync_block_headers_rejects_hash_lock_response_without_lock_wrapper_without_writes(self):
-		self._assert_sync_rejects_malformed_hash_lock_response({})
-
-	def test_sync_block_headers_rejects_hash_lock_response_with_non_dict_lock_without_writes(self):
-		self._assert_sync_rejects_malformed_hash_lock_response({'lock': []})
+		self._assert_sync_rejects_malformed_hash_lock_response([], '^Malformed Symbol Hash Lock response$')
 
 	def test_sync_block_headers_rejects_hash_lock_response_with_invalid_required_field_without_writes(self):
-		self._assert_sync_rejects_malformed_hash_lock_response(create_hash_lock_item(hash='GG' * 32))
+		self._assert_sync_rejects_malformed_hash_lock_response(
+			create_hash_lock_item(hash='GG' * 32),
+			'^Invalid Symbol Hash Lock hash$')
 
 	def _assert_sync_rejects_malformed_secret_lock_response(self, response, expected_error):
 		# Arrange:
@@ -401,15 +445,9 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			statement_pages={statement_path(1, 1): {'data': []}})
 
 		# Act / Assert:
-		with self.assertRaisesRegex(ValueError, expected_error):
-			self._sync_with_connector(connector)
+		self._assert_sync_failure_preserves_complete_batch_state(connector, ValueError, expected_error)
 
 		# Assert:
-		cursor = self.puller.symbol_db.connection.cursor()
-		for table_name in ('symbol_blocks', 'symbol_transactions', 'symbol_receipts', 'symbol_hash_locks', 'symbol_secret_locks'):
-			cursor.execute(f'SELECT COUNT(*) FROM {table_name}')
-			self.assertEqual(0, cursor.fetchone()[0], table_name)
-		self.assertIsNone(self.puller.symbol_db.get_sync_state())
 		self.assertEqual([path], [request_path for request_path in connector.paths if request_path.startswith('lock/')])
 
 	def test_sync_block_headers_rejects_non_dict_secret_lock_search_response_without_writes(self):
@@ -440,15 +478,9 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			statement_pages={statement_path(1, 1): {'data': []}})
 
 		# Act / Assert:
-		with self.assertRaisesRegex(exception_type, error):
-			self._sync_with_connector(connector)
+		self._assert_sync_failure_preserves_complete_batch_state(connector, exception_type, error)
 
 		# Assert:
-		cursor = self.puller.symbol_db.connection.cursor()
-		for table_name in ('symbol_blocks', 'symbol_transactions', 'symbol_receipts', 'symbol_hash_locks', 'symbol_secret_locks'):
-			cursor.execute(f'SELECT COUNT(*) FROM {table_name}')
-			self.assertEqual(0, cursor.fetchone()[0], table_name)
-		self.assertIsNone(self.puller.symbol_db.get_sync_state())
 		self.assertEqual([page_one_path, page_two_path], [path for path in connector.paths if path.startswith('lock/')])
 
 	def test_sync_block_headers_rejects_a_duplicate_secret_lock_composite_hash_across_pages_without_writes(self):
@@ -619,46 +651,15 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		with self.assertRaisesRegex(ValueError, '^Duplicate Symbol Secret Lock composite hash$'):
 			asyncio.run(self.puller._fetch_dirty_secret_locks([key], 12))  # pylint: disable=protected-access
 
-	def test_lock_fetch_concurrency_is_the_approved_ten_request_node_bound(self):
-		# Act:
-		concurrency = LOCK_FETCH_CONCURRENCY
-
-		# Assert:
-		self.assertEqual(10, concurrency)
-
-	def test_fetch_secret_locks_uses_bounded_gather_for_more_than_one_chunk(self):
+	def test_fetch_secret_locks_uses_ten_request_chunks_and_preserves_non_sorted_first_encounter_order(self):
 		# Arrange:
-		keys = []
-		responses = {}
-		for index in range(11):
-			secret = f'{index + 1:064X}'
-			key = create_secret_lock_search_key(
-				bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(secret), 'hash160')
-			keys.append(key)
-			responses[_secret_search_path(SIGNER_ADDRESS, secret)] = {
-				'data': [create_secret_lock_item(
-					composite_hash=f'{index + 1:064X}', secret=secret)]}
-		connector = BoundedLockConnector(secret_responses=responses)
-		set_symbol_connector(self.puller, connector)
-
-		# Act:
-		entries = asyncio.run(self.puller._fetch_dirty_secret_locks(keys, 12))  # pylint: disable=protected-access
-
-		# Assert:
-		self.assertLess(LOCK_FETCH_CONCURRENCY, len(keys))
-		self.assertEqual(LOCK_FETCH_CONCURRENCY, connector.max_in_flight_lock_requests)
-		self.assertLessEqual(connector.max_in_flight_lock_requests, LOCK_FETCH_CONCURRENCY)
-		self.assertEqual(11, len(entries))
-
-	def test_fetch_secret_locks_preserves_non_sorted_first_encounter_key_order(self):
-		# Arrange:
-		secrets = [f'{3:064X}', f'{1:064X}', f'{11:064X}', f'{2:064X}']
+		secrets = [f'{index:064X}' for index in (3, 1, 11, 2, 10, 4, 9, 5, 8, 6, 7)]
 		keys = [
 			create_secret_lock_search_key(
 				bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(secret), 'hash160')
 			for secret in secrets
 		]
-		connector = LockConnector(secret_responses={
+		connector = BoundedLockConnector(secret_responses={
 			_secret_search_path(SIGNER_ADDRESS, secret): {
 				'data': [create_secret_lock_item(composite_hash=secret, secret=secret)]
 			}
@@ -670,14 +671,17 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		entries = asyncio.run(self.puller._fetch_dirty_secret_locks(keys, 12))  # pylint: disable=protected-access
 
 		# Assert:
+		self.assertEqual(10, connector.max_in_flight_lock_requests)
 		self.assertEqual([
-			(bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(f'{3:064X}'), 'hash160'),
-			(bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(f'{1:064X}'), 'hash160'),
-			(bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(f'{11:064X}'), 'hash160'),
-			(bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(f'{2:064X}'), 'hash160')
+			_secret_search_path(SIGNER_ADDRESS, secret)
+			for secret in secrets
+		], connector.paths)
+		self.assertEqual([
+			(bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(secret), 'hash160')
+			for secret in secrets
 		], [entry['key'] for entry in entries])
 
-	def test_fetch_hash_locks_uses_the_approved_bounded_gather_concurrency(self):
+	def test_fetch_hash_locks_uses_ten_request_chunks_and_preserves_non_sorted_first_encounter_order(self):
 		# Arrange:
 		hashes = [f'{index:064X}' for index in (3, 1, 11, 2, 10, 4, 9, 5, 8, 6, 7)]
 		keys = [create_hash_lock_key_from_hex(lock_hash) for lock_hash in hashes]
@@ -691,37 +695,15 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		entries = asyncio.run(self.puller._fetch_dirty_hash_locks(keys, 12))  # pylint: disable=protected-access
 
 		# Assert:
-		self.assertLess(LOCK_FETCH_CONCURRENCY, len(keys))
-		self.assertEqual(LOCK_FETCH_CONCURRENCY, connector.max_in_flight_lock_requests)
-		self.assertLessEqual(connector.max_in_flight_lock_requests, LOCK_FETCH_CONCURRENCY)
+		self.assertEqual(10, connector.max_in_flight_lock_requests)
 		self.assertEqual([
-			'lock/hash/' + f'{index:064X}'
-			for index in (3, 1, 11, 2, 10, 4, 9, 5, 8, 6, 7)
+			'lock/hash/' + lock_hash
+			for lock_hash in hashes
 		], connector.paths)
 		self.assertEqual([
-			bytes.fromhex(f'{index:064X}')
-			for index in (3, 1, 11, 2, 10, 4, 9, 5, 8, 6, 7)
-		], [entry['row']['hash'] for entry in entries])
-		self.assertEqual(11, len(entries))
-
-	def test_fetch_hash_locks_preserves_non_sorted_first_encounter_key_order(self):
-		# Arrange:
-		hashes = [f'{index:064X}' for index in (3, 1, 11, 2)]
-		keys = [create_hash_lock_key_from_hex(lock_hash) for lock_hash in hashes]
-		connector = LockConnector(hash_responses={
-			'lock/hash/' + lock_hash: create_hash_lock_item(lock_hash=lock_hash)
+			bytes.fromhex(lock_hash)
 			for lock_hash in hashes
-		})
-		set_symbol_connector(self.puller, connector)
-
-		# Act:
-		entries = asyncio.run(self.puller._fetch_dirty_hash_locks(keys, 12))  # pylint: disable=protected-access
-
-		# Assert:
-		self.assertEqual([bytes.fromhex(lock_hash) for lock_hash in hashes], [
-			entry['row']['hash']
-			for entry in entries
-		])
+		], [entry['row']['hash'] for entry in entries])
 
 	def test_collect_dirty_lock_keys_uses_hash_lock_body_hash(self):
 		# Arrange:
@@ -763,7 +745,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		# Arrange:
 		transaction_row = self._create_lock_transaction_row(
 			TransactionType.SECRET_LOCK.value,
-			{'secret': SECRET, 'hashAlgorithm': 1, 'recipientAddress': '99065A28385EB5AE88000000000000000000000000000000'})
+			{'secret': SECRET, 'hashAlgorithm': 1, 'recipientAddress': ALIAS_ADDRESS})
 
 		# Act:
 		keys = self._collect_lock_keys([transaction_row])
@@ -886,7 +868,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 
 	def test_collect_dirty_lock_keys_rejects_surviving_alias_recipient(self):
 		# Arrange:
-		alias_address = bytes.fromhex('99065A28385EB5AE88000000000000000000000000000000')
+		alias_address = bytes.fromhex(ALIAS_ADDRESS)
 		transaction_row = {
 			'type': TransactionType.SECRET_PROOF.value,
 			'is_embedded': False,
@@ -1021,6 +1003,174 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 
 		# Assert:
 		self.assertEqual(expected_lock_state, self._fetch_persisted_lock_state())
+
+	def test_sync_block_headers_converges_a_new_hash_lock_completed_in_the_same_batch_to_used(self):
+		# Arrange:
+		hash_lock_transaction = create_node_transaction(
+			1,
+			transaction_hash='01' * 32,
+			block_index=0,
+			type=TransactionType.HASH_LOCK.value,
+			hash=LOCK_HASH,
+			mosaicId=MOSAIC_ID,
+			amount='1234')
+		aggregate_bonded_transaction = create_node_transaction(
+			1,
+			transaction_hash=LOCK_HASH,
+			block_index=1,
+			type=TransactionType.AGGREGATE_BONDED.value)
+		block_one = create_node_block(1)
+		block_one['meta']['transactionsCount'] = 2
+		block_one['meta']['totalTransactionsCount'] = 2
+		block_one['meta']['statementsCount'] = 0
+		used_item = create_hash_lock_item(status=1)
+		connector = LockConnector(
+			1,
+			{0: [block_one]},
+			hash_responses={'lock/hash/' + LOCK_HASH: used_item},
+			transactions_by_path={
+				transaction_path(1, 1): {'data': [hash_lock_transaction, aggregate_bonded_transaction]}
+			},
+			statement_pages={statement_path(1, 1): {'data': []}})
+		expected_row = {
+			'hash': bytes.fromhex(LOCK_HASH),
+			'owner_address': bytes.fromhex(SIGNER_ADDRESS),
+			'mosaic_id': MOSAIC_ID,
+			'amount': 1234,
+			'end_height': 100,
+			'status': 'used',
+			'raw_payload': copy.deepcopy(used_item),
+			'updated_at_height': 1
+		}
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual(([expected_row], []), self._fetch_persisted_lock_state())
+		self.assertEqual(['lock/hash/' + LOCK_HASH], [
+			path for path in connector.paths if path.startswith('lock/')
+		])
+
+	def test_sync_block_headers_converges_a_new_secret_lock_completed_in_the_same_batch_to_used(self):
+		# Arrange:
+		secret_lock_transaction = create_node_transaction(
+			1,
+			transaction_hash='01' * 32,
+			block_index=0,
+			type=TransactionType.SECRET_LOCK.value,
+			secret=SECRET,
+			hashAlgorithm=1,
+			mosaicId=MOSAIC_ID,
+			amount='1234')
+		secret_proof_transaction = create_node_transaction(
+			1,
+			transaction_hash='02' * 32,
+			block_index=1,
+			type=TransactionType.SECRET_PROOF.value,
+			secret=SECRET,
+			hashAlgorithm=1)
+		address_response_item = create_secret_lock_item(status=1)
+		secret_only_response_item = create_secret_lock_item(status=1)
+		expected_item = create_secret_lock_item(status=1)
+		block_one = create_node_block(1)
+		block_one['meta']['transactionsCount'] = 2
+		block_one['meta']['totalTransactionsCount'] = 2
+		block_one['meta']['statementsCount'] = 0
+		address_path = _secret_search_path(SIGNER_ADDRESS, SECRET)
+		secret_only_path = _secret_only_search_path(SECRET)
+		connector = LockConnector(
+			1,
+			{0: [block_one]},
+			secret_responses={
+				address_path: {'data': [address_response_item]},
+				secret_only_path: {'data': [secret_only_response_item]}
+			},
+			transactions_by_path={
+				transaction_path(1, 1): {'data': [secret_lock_transaction, secret_proof_transaction]}
+			},
+			statement_pages={statement_path(1, 1): {'data': []}})
+		expected_row = create_expected_secret_lock_row(
+			expected_item,
+			1,
+			composite_hash=bytes.fromhex(COMPOSITE_HASH),
+			owner_address=bytes.fromhex(SIGNER_ADDRESS),
+			recipient_address=bytes.fromhex(RECIPIENT_ADDRESS),
+			secret=bytes.fromhex(SECRET),
+			hash_algorithm='hash160',
+			mosaic_id=MOSAIC_ID,
+			amount=1234,
+			end_height=100,
+			status='used')
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual(([], [expected_row]), self._fetch_persisted_lock_state())
+		self.assertEqual([address_path, secret_only_path], [
+			path for path in connector.paths if path.startswith('lock/')
+		])
+
+	def test_sync_block_headers_converges_new_locks_created_and_expired_in_the_same_batch_to_empty(self):
+		# Arrange:
+		hash_lock_transaction = create_node_transaction(
+			1,
+			transaction_hash='01' * 32,
+			block_index=0,
+			type=TransactionType.HASH_LOCK.value,
+			hash=LOCK_HASH,
+			mosaicId=MOSAIC_ID,
+			amount='1234',
+			duration='1')
+		secret_lock_transaction = create_node_transaction(
+			1,
+			transaction_hash='02' * 32,
+			block_index=1,
+			type=TransactionType.SECRET_LOCK.value,
+			secret=SECRET,
+			hashAlgorithm=1,
+			mosaicId=MOSAIC_ID,
+			amount='1234',
+			duration='1')
+		block_one = create_node_block(1)
+		block_one['meta']['transactionsCount'] = 2
+		block_one['meta']['totalTransactionsCount'] = 2
+		block_one['meta']['statementsCount'] = 0
+		block_two = create_node_block(2)
+		block_two['meta']['transactionsCount'] = 0
+		block_two['meta']['totalTransactionsCount'] = 0
+		block_two['meta']['statementsCount'] = 0
+		secret_path = _secret_search_path(SIGNER_ADDRESS, SECRET)
+		connector = LockConnector(
+			2,
+			{0: [block_one, block_two]},
+			hash_responses={
+				'lock/hash/' + LOCK_HASH: {'code': 'ResourceNotFound', 'message': 'not found'}
+			},
+			secret_responses={secret_path: {'data': []}},
+			transactions_by_path={
+				transaction_path(1, 2): {'data': [hash_lock_transaction, secret_lock_transaction]}
+			},
+			statement_pages={statement_path(1, 2): {'data': []}})
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual(([], []), self._fetch_persisted_lock_state())
+		self.assertEqual([1, 2], self._fetch_block_heights(self.puller.symbol_db))
+		cursor = self.puller.symbol_db.connection.cursor()
+		cursor.execute("SELECT height, type, body->>'duration' FROM symbol_transactions ORDER BY height, id")
+		self.assertEqual([
+			(1, TransactionType.HASH_LOCK.value, '1'),
+			(1, TransactionType.SECRET_LOCK.value, '1')
+		], cursor.fetchall())
+		self.assertEqual(2, self.puller.symbol_db.get_sync_state()['last_synced_height'])
+		self.assertEqual([
+			'lock/hash/' + LOCK_HASH,
+			secret_path
+		], [path for path in connector.paths if path.startswith('lock/')])
 
 	def test_sync_block_headers_updates_a_hash_lock_to_used_from_a_top_level_aggregate_bonded_transaction(self):
 		# Arrange:
@@ -1458,7 +1608,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			body={
 				'secret': SECRET,
 				'hashAlgorithm': 1,
-				'recipientAddress': '99065A28385EB5AE88000000000000000000000000000000'
+				'recipientAddress': ALIAS_ADDRESS
 			})
 		self.puller.symbol_db.upsert_transactions_for_height(2, [transaction])
 		secret_key = create_secret_lock_search_key(
@@ -1565,7 +1715,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			signer_address=bytes.fromhex(SIGNER_ADDRESS),
 			recipient_address=bytes.fromhex(RECIPIENT_ADDRESS),
 			body={
-				'recipientAddress': '99065A28385EB5AE88000000000000000000000000000000',
+				'recipientAddress': ALIAS_ADDRESS,
 				'secret': SECRET,
 				'hashAlgorithm': 1
 			})])
@@ -1663,7 +1813,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160')
 		self.puller.symbol_db.replace_secret_locks(
 			secret_key, [create_secret_lock_row(create_secret_lock_item(status=1), 2)])
-		original_state = self._fetch_complete_rollback_state()
+		original_state = self._fetch_complete_batch_state()
 		connector = LockConnector(
 			2,
 			{1: [create_node_block(2)]},
@@ -1676,7 +1826,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			self._sync_with_connector(connector)
 
 		# Assert:
-		self.assertEqual(original_state, self._fetch_complete_rollback_state())
+		self.assertEqual(original_state, self._fetch_complete_batch_state())
 
 	def test_sync_block_headers_preserves_the_approved_residual_window_for_pruned_unused_pre_fork_locks(self):
 		self._assert_residual_window_for_pruned_pre_fork_locks(0)
@@ -1782,15 +1932,8 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			statement_pages={statement_path(1, 1): {'data': []}})
 
 		# Act / Assert:
-		with self.assertRaisesRegex(RuntimeError, '^lock fetch failed$'):
-			self._sync_with_connector(connector)
-
-		# Assert:
-		cursor = self.puller.symbol_db.connection.cursor()
-		for table_name in ('symbol_blocks', 'symbol_transactions', 'symbol_receipts', 'symbol_hash_locks', 'symbol_secret_locks'):
-			cursor.execute(f'SELECT COUNT(*) FROM {table_name}')
-			self.assertEqual(0, cursor.fetchone()[0], table_name)
-		self.assertIsNone(self.puller.symbol_db.get_sync_state())
+		self._assert_sync_failure_preserves_complete_batch_state(
+			connector, RuntimeError, '^lock fetch failed$')
 
 	def test_sync_block_headers_does_not_partially_write_when_secret_lock_fetch_fails(self):
 		# Arrange:
@@ -1811,15 +1954,8 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			statement_pages={statement_path(1, 1): {'data': []}})
 
 		# Act / Assert:
-		with self.assertRaisesRegex(RuntimeError, '^secret lock fetch failed$'):
-			self._sync_with_connector(connector)
-
-		# Assert:
-		cursor = self.puller.symbol_db.connection.cursor()
-		for table_name in ('symbol_blocks', 'symbol_transactions', 'symbol_receipts', 'symbol_hash_locks', 'symbol_secret_locks'):
-			cursor.execute(f'SELECT COUNT(*) FROM {table_name}')
-			self.assertEqual(0, cursor.fetchone()[0], table_name)
-		self.assertIsNone(self.puller.symbol_db.get_sync_state())
+		self._assert_sync_failure_preserves_complete_batch_state(
+			connector, RuntimeError, '^secret lock fetch failed$')
 
 	def test_sync_block_headers_does_not_write_a_successful_hash_lock_when_a_later_secret_lock_fetch_fails(self):
 		# Arrange:
@@ -1839,13 +1975,8 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			statement_pages={statement_path(1, 1): {'data': []}})
 
 		# Act / Assert:
-		with self.assertRaisesRegex(RuntimeError, '^secret lock fetch failed$'):
-			self._sync_with_connector(connector)
+		self._assert_sync_failure_preserves_complete_batch_state(
+			connector, RuntimeError, '^secret lock fetch failed$')
 
 		# Assert:
-		cursor = self.puller.symbol_db.connection.cursor()
-		for table_name in ('symbol_blocks', 'symbol_transactions', 'symbol_receipts', 'symbol_hash_locks', 'symbol_secret_locks'):
-			cursor.execute(f'SELECT COUNT(*) FROM {table_name}')
-			self.assertEqual(0, cursor.fetchone()[0], table_name)
-		self.assertIsNone(self.puller.symbol_db.get_sync_state())
 		self.assertEqual(['lock/hash/' + LOCK_HASH, secret_path], [path for path in connector.paths if path.startswith('lock/')])

--- a/explorer/puller/tests/facade/symbol/test_PullerLocks.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerLocks.py
@@ -24,9 +24,12 @@ from ...test.SymbolTransactionTestUtils import create_transaction_entry
 from .puller_test_utils import (
 	FakeConnector,
 	SymbolPullerTestBase,
+	create_complete_aggregate_pair,
 	create_node_block,
 	create_node_transaction,
+	create_resolution_statement,
 	create_sync_state,
+	resolution_path,
 	set_symbol_connector,
 	statement_path,
 	transaction_path
@@ -38,6 +41,8 @@ SECRET = 'CC' * 32
 COMPOSITE_HASH = 'DD' * 32
 COMPOSITE_HASH_2 = 'EE' * 32
 MOSAIC_ID = '72C0212E67A08BCE'
+ALIAS_ADDRESS = '99065A28385EB5AE88000000000000000000000000000000'
+ALIAS_MOSAIC_ID = 'E74B99BA41F4AFEE'
 
 
 def create_hash_lock_item(lock_hash=LOCK_HASH, **overrides):
@@ -128,6 +133,33 @@ class BoundedLockConnector(LockConnector):
 			self.in_flight_lock_requests -= 1
 
 
+class BoundedHashLockConnector(LockConnector):
+	def __init__(self, *args, **kwargs):
+		super().__init__(*args, **kwargs)
+		self.in_flight_lock_requests = 0
+		self.max_in_flight_lock_requests = 0
+		self._requests_released = asyncio.Event()
+		self._release_scheduled = False
+
+	async def get(self, url_path, *args):
+		if not url_path.startswith('lock/hash/'):
+			return await super().get(url_path, *args)
+
+		self.paths.append(url_path)
+		self.in_flight_lock_requests += 1
+		self.max_in_flight_lock_requests = max(
+			self.max_in_flight_lock_requests,
+			self.in_flight_lock_requests)
+		try:
+			if not self._release_scheduled:
+				self._release_scheduled = True
+				asyncio.get_running_loop().call_soon(self._requests_released.set)
+			await self._requests_released.wait()
+			return self.hash_responses[url_path]
+		finally:
+			self.in_flight_lock_requests -= 1
+
+
 def _secret_search_path(owner_address, secret, page_number=1):
 	return (
 		f'lock/secret?address={Address(bytes.fromhex(owner_address))}&secret={secret}'
@@ -137,6 +169,10 @@ def _secret_search_path(owner_address, secret, page_number=1):
 
 def _secret_only_search_path(secret, page_number=1):
 	return f'lock/secret?secret={secret}&pageSize=100&pageNumber={page_number}'
+
+
+def _resolution_entry(primary_id, secondary_id, resolved):
+	return {'source': {'primaryId': primary_id, 'secondaryId': secondary_id}, 'resolved': resolved}
 
 
 class SymbolPullerLocksTest(SymbolPullerTestBase):
@@ -190,6 +226,63 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			'secret_locks': secret_locks,
 			'sync_state': fetch_normalized_sync_state(self.puller.symbol_db)
 		}
+
+	def _fetch_lock_alias_failure_state(self):
+		cursor = self.puller.symbol_db.connection.cursor()
+		state = {}
+		for table_name in (
+			'symbol_blocks',
+			'symbol_transactions',
+			'symbol_receipts',
+			'symbol_hash_locks',
+			'symbol_secret_locks',
+			'symbol_sync_state'
+		):
+			cursor.execute(f'SELECT COUNT(*) FROM {table_name}')
+			state[table_name] = cursor.fetchone()[0]
+
+		return state
+
+	def _assert_sync_persists_secret_lock_transaction(
+		self,
+		transactions,
+		expected
+	):
+		# Arrange:
+		lock_item = create_secret_lock_item(owner_address=expected['owner_address'])
+		connector = LockConnector(
+			1,
+			{0: [create_node_block(1)]},
+			secret_responses={expected['lock_path']: {'data': [lock_item]}},
+			transactions_by_path={transaction_path(1, 1): {'data': transactions}},
+			statement_pages={statement_path(1, 1): {'data': []}},
+			address_resolutions_by_height=expected.get('address_resolutions_by_height', {}),
+			mosaic_resolutions_by_height=expected.get('mosaic_resolutions_by_height', {}))
+		expected_row = create_expected_secret_lock_row(
+			lock_item,
+			1,
+			bytes.fromhex(COMPOSITE_HASH),
+			bytes.fromhex(expected['owner_address']),
+			bytes.fromhex(RECIPIENT_ADDRESS),
+			bytes.fromhex(SECRET),
+			'hash160',
+			MOSAIC_ID,
+			1234,
+			100,
+			'unused')
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual(([], [expected_row]), self._fetch_persisted_lock_state())
+		cursor = self.puller.symbol_db.connection.cursor()
+		cursor.execute(
+			'SELECT body FROM symbol_transactions WHERE type = %s AND is_embedded = %s',
+			(expected['transaction_type'], expected['is_embedded']))
+		self.assertEqual(1, len(cursor.fetchall()))
+		self.assertEqual([expected['lock_path']], [path for path in connector.paths if path.startswith('lock/')])
+		return connector
 
 	def test_fetch_hash_lock_success_returns_a_complete_upsert_entry(self):
 		# Arrange:
@@ -330,6 +423,49 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 
 	def test_sync_block_headers_rejects_secret_lock_search_response_with_malformed_item_without_writes(self):
 		self._assert_sync_rejects_malformed_secret_lock_response({'data': [{}]}, '^Malformed Symbol Secret Lock response$')
+
+	def _assert_sync_rejects_second_secret_lock_page_without_writes(self, second_page_response, exception_type, error):
+		# Arrange:
+		transaction = create_node_transaction(
+			1, transaction_hash='01' * 32, type=TransactionType.SECRET_LOCK.value,
+			secret=SECRET, hashAlgorithm=1, mosaicId=MOSAIC_ID, amount='1234')
+		page_one = [create_secret_lock_item(composite_hash=f'{index + 1:064X}') for index in range(100)]
+		page_one_path = _secret_search_path(SIGNER_ADDRESS, SECRET)
+		page_two_path = _secret_search_path(SIGNER_ADDRESS, SECRET, 2)
+		connector = LockConnector(
+			1,
+			{0: [create_node_block(1)]},
+			secret_responses={page_one_path: {'data': page_one}, page_two_path: second_page_response},
+			transactions_by_path={transaction_path(1, 1): {'data': [transaction]}},
+			statement_pages={statement_path(1, 1): {'data': []}})
+
+		# Act / Assert:
+		with self.assertRaisesRegex(exception_type, error):
+			self._sync_with_connector(connector)
+
+		# Assert:
+		cursor = self.puller.symbol_db.connection.cursor()
+		for table_name in ('symbol_blocks', 'symbol_transactions', 'symbol_receipts', 'symbol_hash_locks', 'symbol_secret_locks'):
+			cursor.execute(f'SELECT COUNT(*) FROM {table_name}')
+			self.assertEqual(0, cursor.fetchone()[0], table_name)
+		self.assertIsNone(self.puller.symbol_db.get_sync_state())
+		self.assertEqual([page_one_path, page_two_path], [path for path in connector.paths if path.startswith('lock/')])
+
+	def test_sync_block_headers_rejects_a_duplicate_secret_lock_composite_hash_across_pages_without_writes(self):
+		# Arrange:
+		duplicate_item = create_secret_lock_item(composite_hash=f'{1:064X}')
+
+		# Act / Assert:
+		self._assert_sync_rejects_second_secret_lock_page_without_writes(
+			{'data': [duplicate_item]}, ValueError, '^Duplicate Symbol Secret Lock composite hash$')
+
+	def test_sync_block_headers_rejects_a_malformed_second_secret_lock_page_without_writes(self):
+		self._assert_sync_rejects_second_secret_lock_page_without_writes(
+			{}, ValueError, '^Malformed Symbol Secret Lock search response$')
+
+	def test_sync_block_headers_propagates_a_second_secret_lock_page_request_failure_without_writes(self):
+		self._assert_sync_rejects_second_secret_lock_page_without_writes(
+			RuntimeError('second page failed'), RuntimeError, '^second page failed$')
 
 	def test_fetch_secret_lock_paginates_full_and_short_pages_in_node_order(self):
 		# Arrange:
@@ -511,8 +647,8 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		# Assert:
 		self.assertLess(LOCK_FETCH_CONCURRENCY, len(keys))
 		self.assertEqual(LOCK_FETCH_CONCURRENCY, connector.max_in_flight_lock_requests)
+		self.assertLessEqual(connector.max_in_flight_lock_requests, LOCK_FETCH_CONCURRENCY)
 		self.assertEqual(11, len(entries))
-		self.assertEqual(11, len(connector.paths))
 
 	def test_fetch_secret_locks_preserves_non_sorted_first_encounter_key_order(self):
 		# Arrange:
@@ -540,6 +676,52 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			(bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(f'{11:064X}'), 'hash160'),
 			(bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(f'{2:064X}'), 'hash160')
 		], [entry['key'] for entry in entries])
+
+	def test_fetch_hash_locks_uses_the_approved_bounded_gather_concurrency(self):
+		# Arrange:
+		hashes = [f'{index:064X}' for index in (3, 1, 11, 2, 10, 4, 9, 5, 8, 6, 7)]
+		keys = [create_hash_lock_key_from_hex(lock_hash) for lock_hash in hashes]
+		connector = BoundedHashLockConnector(hash_responses={
+			'lock/hash/' + lock_hash: create_hash_lock_item(lock_hash=lock_hash)
+			for lock_hash in hashes
+		})
+		set_symbol_connector(self.puller, connector)
+
+		# Act:
+		entries = asyncio.run(self.puller._fetch_dirty_hash_locks(keys, 12))  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertLess(LOCK_FETCH_CONCURRENCY, len(keys))
+		self.assertEqual(LOCK_FETCH_CONCURRENCY, connector.max_in_flight_lock_requests)
+		self.assertLessEqual(connector.max_in_flight_lock_requests, LOCK_FETCH_CONCURRENCY)
+		self.assertEqual([
+			'lock/hash/' + f'{index:064X}'
+			for index in (3, 1, 11, 2, 10, 4, 9, 5, 8, 6, 7)
+		], connector.paths)
+		self.assertEqual([
+			bytes.fromhex(f'{index:064X}')
+			for index in (3, 1, 11, 2, 10, 4, 9, 5, 8, 6, 7)
+		], [entry['row']['hash'] for entry in entries])
+		self.assertEqual(11, len(entries))
+
+	def test_fetch_hash_locks_preserves_non_sorted_first_encounter_key_order(self):
+		# Arrange:
+		hashes = [f'{index:064X}' for index in (3, 1, 11, 2)]
+		keys = [create_hash_lock_key_from_hex(lock_hash) for lock_hash in hashes]
+		connector = LockConnector(hash_responses={
+			'lock/hash/' + lock_hash: create_hash_lock_item(lock_hash=lock_hash)
+			for lock_hash in hashes
+		})
+		set_symbol_connector(self.puller, connector)
+
+		# Act:
+		entries = asyncio.run(self.puller._fetch_dirty_hash_locks(keys, 12))  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual([bytes.fromhex(lock_hash) for lock_hash in hashes], [
+			entry['row']['hash']
+			for entry in entries
+		])
 
 	def test_collect_dirty_lock_keys_uses_hash_lock_body_hash(self):
 		# Arrange:
@@ -840,6 +1022,387 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		# Assert:
 		self.assertEqual(expected_lock_state, self._fetch_persisted_lock_state())
 
+	def test_sync_block_headers_updates_a_hash_lock_to_used_from_a_top_level_aggregate_bonded_transaction(self):
+		# Arrange:
+		self._seed_blocks(self.puller.symbol_db, [1])
+		self.puller.symbol_db.upsert_sync_state(create_sync_state(
+			chain_height=1, last_synced_height=1, last_synced_block_hash=bytes.fromhex(f'{1:064X}')))
+		self.puller.symbol_db.upsert_hash_lock(create_hash_lock_row(create_hash_lock_item(), 1))
+		aggregate_transaction = create_node_transaction(
+			2, transaction_hash=LOCK_HASH, type=TransactionType.AGGREGATE_BONDED.value)
+		connector = LockConnector(
+			2,
+			{1: [create_node_block(2)]},
+			{2: create_node_block(2)},
+			hash_responses={'lock/hash/' + LOCK_HASH: create_hash_lock_item(status=1)},
+			transactions_by_path={transaction_path(2, 2): {'data': [aggregate_transaction]}},
+			statement_pages={statement_path(2, 2): {'data': []}})
+		expected_row = {
+			'hash': bytes.fromhex(LOCK_HASH), 'owner_address': bytes.fromhex(SIGNER_ADDRESS), 'mosaic_id': MOSAIC_ID,
+			'amount': 1234, 'end_height': 100, 'status': 'used', 'raw_payload': create_hash_lock_item(status=1),
+			'updated_at_height': 2
+		}
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual(([expected_row], []), self._fetch_persisted_lock_state())
+		self.assertEqual([1, 2], self._fetch_block_heights(self.puller.symbol_db))
+		self.assertEqual(2, self.puller.symbol_db.get_sync_state()['last_synced_height'])
+		self.assertEqual(['lock/hash/' + LOCK_HASH], [path for path in connector.paths if path.startswith('lock/')])
+
+	def test_sync_block_headers_updates_a_secret_lock_to_used_from_a_secret_proof_transaction(self):
+		# Arrange:
+		self._seed_blocks(self.puller.symbol_db, [1])
+		self.puller.symbol_db.upsert_sync_state(create_sync_state(
+			chain_height=1, last_synced_height=1, last_synced_block_hash=bytes.fromhex(f'{1:064X}')))
+		key = create_secret_lock_search_key(
+			bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160')
+		self.puller.symbol_db.replace_secret_locks(key, [create_secret_lock_row(create_secret_lock_item(), 1)])
+		proof_transaction = create_node_transaction(
+			2, type=TransactionType.SECRET_PROOF.value, secret=SECRET, hashAlgorithm=1)
+		path = _secret_only_search_path(SECRET)
+		connector = LockConnector(
+			2,
+			{1: [create_node_block(2)]},
+			{2: create_node_block(2)},
+			secret_responses={path: {'data': [create_secret_lock_item(status=1)]}},
+			transactions_by_path={transaction_path(2, 2): {'data': [proof_transaction]}},
+			statement_pages={statement_path(2, 2): {'data': []}})
+		expected_row = create_expected_secret_lock_row(
+			create_secret_lock_item(status=1), 2,
+			composite_hash=bytes.fromhex(COMPOSITE_HASH), owner_address=bytes.fromhex(SIGNER_ADDRESS),
+			recipient_address=bytes.fromhex(RECIPIENT_ADDRESS), secret=bytes.fromhex(SECRET), hash_algorithm='hash160',
+			mosaic_id=MOSAIC_ID, amount=1234, end_height=100, status='used')
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual(([], [expected_row]), self._fetch_persisted_lock_state())
+		self.assertEqual([1, 2], self._fetch_block_heights(self.puller.symbol_db))
+		self.assertEqual(2, self.puller.symbol_db.get_sync_state()['last_synced_height'])
+		self.assertEqual([path], [request_path for request_path in connector.paths if request_path.startswith('lock/')])
+
+	def test_sync_block_headers_persists_a_top_level_secret_lock(self):
+		# Arrange:
+		transaction = create_node_transaction(
+			1,
+			type=TransactionType.SECRET_LOCK.value,
+			secret=SECRET,
+			hashAlgorithm=1,
+			mosaicId=MOSAIC_ID,
+			amount='1234')
+
+		# Act / Assert:
+		self._assert_sync_persists_secret_lock_transaction(
+			[transaction],
+			{
+				'transaction_type': TransactionType.SECRET_LOCK.value,
+				'is_embedded': False,
+				'lock_path': _secret_search_path(SIGNER_ADDRESS, SECRET),
+				'owner_address': SIGNER_ADDRESS
+			})
+
+	def test_sync_block_headers_persists_a_top_level_secret_proof(self):
+		# Arrange:
+		transaction = create_node_transaction(
+			1,
+			type=TransactionType.SECRET_PROOF.value,
+			secret=SECRET,
+			hashAlgorithm=1)
+
+		# Act / Assert:
+		self._assert_sync_persists_secret_lock_transaction(
+			[transaction],
+			{
+				'transaction_type': TransactionType.SECRET_PROOF.value,
+				'is_embedded': False,
+				'lock_path': _secret_only_search_path(SECRET),
+				'owner_address': SIGNER_ADDRESS
+			})
+
+	def test_sync_block_headers_persists_an_embedded_secret_lock(self):
+		# Arrange:
+		aggregate_hash = 'AB' * 32
+		transactions = create_complete_aggregate_pair(
+			1,
+			aggregate_hash,
+			0,
+			type=TransactionType.SECRET_LOCK.value,
+			secret=SECRET,
+			hashAlgorithm=1,
+			mosaicId=MOSAIC_ID,
+			amount='1234')
+
+		# Act / Assert:
+		self._assert_sync_persists_secret_lock_transaction(
+			transactions,
+			{
+				'transaction_type': TransactionType.SECRET_LOCK.value,
+				'is_embedded': True,
+				'lock_path': _secret_search_path(SIGNER_ADDRESS, SECRET),
+				'owner_address': SIGNER_ADDRESS
+			})
+
+	def test_sync_block_headers_persists_an_embedded_secret_proof(self):
+		# Arrange:
+		aggregate_hash = 'AB' * 32
+		transactions = create_complete_aggregate_pair(
+			1,
+			aggregate_hash,
+			0,
+			type=TransactionType.SECRET_PROOF.value,
+			secret=SECRET,
+			hashAlgorithm=1)
+
+		# Act / Assert:
+		self._assert_sync_persists_secret_lock_transaction(
+			transactions,
+			{
+				'transaction_type': TransactionType.SECRET_PROOF.value,
+				'is_embedded': True,
+				'lock_path': _secret_only_search_path(SECRET),
+				'owner_address': SIGNER_ADDRESS
+			})
+
+	def test_sync_block_headers_resolves_a_hash_lock_mosaic_alias_without_changing_the_raw_payload(self):
+		# Arrange:
+		transaction = create_node_transaction(
+			1,
+			type=TransactionType.HASH_LOCK.value,
+			hash=LOCK_HASH,
+			mosaicId=ALIAS_MOSAIC_ID,
+			amount='1234')
+		connector = LockConnector(
+			1,
+			{0: [create_node_block(1)]},
+			hash_responses={'lock/hash/' + LOCK_HASH: create_hash_lock_item()},
+			transactions_by_path={transaction_path(1, 1): {'data': [transaction]}},
+			statement_pages={statement_path(1, 1): {'data': []}},
+			mosaic_resolutions_by_height={1: [create_resolution_statement(
+				1,
+				ALIAS_MOSAIC_ID,
+				[_resolution_entry(1, 0, MOSAIC_ID)])]})
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		expected_row = {
+			'hash': bytes.fromhex(LOCK_HASH),
+			'owner_address': bytes.fromhex(SIGNER_ADDRESS),
+			'mosaic_id': MOSAIC_ID,
+			'amount': 1234,
+			'end_height': 100,
+			'status': 'unused',
+			'raw_payload': create_hash_lock_item(),
+			'updated_at_height': 1
+		}
+		cursor = self.puller.symbol_db.connection.cursor()
+		cursor.execute('SELECT body->>\'mosaicId\' FROM symbol_transactions')
+		self.assertEqual((ALIAS_MOSAIC_ID,), cursor.fetchone())
+		cursor.execute('SELECT mosaic_id FROM symbol_transaction_mosaics')
+		self.assertEqual([(MOSAIC_ID,)], cursor.fetchall())
+		self.assertEqual(([expected_row], []), self._fetch_persisted_lock_state())
+		self.assertEqual([resolution_path('mosaic', 1)], [
+			path for path in connector.paths if path.startswith('statements/resolutions/')
+		])
+		self.assertEqual(['lock/hash/' + LOCK_HASH], [
+			path for path in connector.paths if path.startswith('lock/')
+		])
+
+	def test_sync_block_headers_resolves_a_secret_lock_mosaic_alias_without_changing_the_raw_payload(self):
+		# Arrange:
+		transaction = create_node_transaction(
+			1,
+			type=TransactionType.SECRET_LOCK.value,
+			secret=SECRET,
+			hashAlgorithm=1,
+			mosaicId=ALIAS_MOSAIC_ID,
+			amount='1234')
+
+		# Act:
+		connector = self._assert_sync_persists_secret_lock_transaction(
+			[transaction],
+			{
+				'transaction_type': TransactionType.SECRET_LOCK.value,
+				'is_embedded': False,
+				'lock_path': _secret_search_path(SIGNER_ADDRESS, SECRET),
+				'owner_address': SIGNER_ADDRESS,
+				'mosaic_resolutions_by_height': {1: [create_resolution_statement(
+					1,
+					ALIAS_MOSAIC_ID,
+					[_resolution_entry(1, 0, MOSAIC_ID)])]}
+			})
+
+		# Assert:
+		cursor = self.puller.symbol_db.connection.cursor()
+		cursor.execute('SELECT body->>\'mosaicId\' FROM symbol_transactions')
+		self.assertEqual((ALIAS_MOSAIC_ID,), cursor.fetchone())
+		cursor.execute('SELECT mosaic_id FROM symbol_transaction_mosaics')
+		self.assertEqual([(MOSAIC_ID,)], cursor.fetchall())
+		self.assertEqual([resolution_path('mosaic', 1)], [
+			path for path in connector.paths if path.startswith('statements/resolutions/')
+		])
+
+	def test_sync_block_headers_resolves_a_secret_proof_recipient_alias_without_changing_the_raw_payload(self):
+		# Arrange:
+		transaction = create_node_transaction(
+			1,
+			type=TransactionType.SECRET_PROOF.value,
+			recipientAddress=ALIAS_ADDRESS,
+			secret=SECRET,
+			hashAlgorithm=1)
+
+		# Act:
+		connector = self._assert_sync_persists_secret_lock_transaction(
+			[transaction],
+			{
+				'transaction_type': TransactionType.SECRET_PROOF.value,
+				'is_embedded': False,
+				'lock_path': _secret_only_search_path(SECRET),
+				'owner_address': SIGNER_ADDRESS,
+				'address_resolutions_by_height': {1: [create_resolution_statement(
+					1,
+					ALIAS_ADDRESS,
+					[_resolution_entry(1, 0, RECIPIENT_ADDRESS)])]}
+			})
+
+		# Assert:
+		cursor = self.puller.symbol_db.connection.cursor()
+		cursor.execute('SELECT body->>\'recipientAddress\', encode(recipient_address, \'hex\') FROM symbol_transactions')
+		self.assertEqual((ALIAS_ADDRESS, RECIPIENT_ADDRESS.lower()), cursor.fetchone())
+		self.assertEqual([resolution_path('address', 1)], [
+			path for path in connector.paths if path.startswith('statements/resolutions/')
+		])
+
+	def test_sync_block_headers_rejects_a_missing_hash_lock_mosaic_alias_resolution_without_writes(self):
+		# Arrange:
+		transaction = create_node_transaction(
+			1,
+			type=TransactionType.HASH_LOCK.value,
+			hash=LOCK_HASH,
+			mosaicId=ALIAS_MOSAIC_ID,
+			amount='1234')
+		connector = LockConnector(
+			1,
+			{0: [create_node_block(1)]},
+			transactions_by_path={transaction_path(1, 1): {'data': [transaction]}},
+			statement_pages={statement_path(1, 1): {'data': []}})
+
+		# Act / Assert:
+		with self.assertRaisesRegex(ValueError, f'height 1.*{ALIAS_MOSAIC_ID}'):
+			self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual([resolution_path('mosaic', 1)], [
+			path for path in connector.paths if path.startswith('statements/resolutions/')
+		])
+		self.assertEqual([], [path for path in connector.paths if path.startswith('lock/')])
+		self.assertEqual({
+			'symbol_blocks': 0,
+			'symbol_transactions': 0,
+			'symbol_receipts': 0,
+			'symbol_hash_locks': 0,
+			'symbol_secret_locks': 0,
+			'symbol_sync_state': 0
+		}, self._fetch_lock_alias_failure_state())
+
+	def test_sync_block_headers_rejects_an_inapplicable_secret_proof_recipient_alias_resolution_without_writes(self):
+		# Arrange:
+		transaction = create_node_transaction(
+			1,
+			type=TransactionType.SECRET_PROOF.value,
+			recipientAddress=ALIAS_ADDRESS,
+			secret=SECRET,
+			hashAlgorithm=1)
+		connector = LockConnector(
+			1,
+			{0: [create_node_block(1)]},
+			transactions_by_path={transaction_path(1, 1): {'data': [transaction]}},
+			statement_pages={statement_path(1, 1): {'data': []}},
+			address_resolutions_by_height={1: [create_resolution_statement(
+				1,
+				ALIAS_ADDRESS,
+				[_resolution_entry(2, 0, RECIPIENT_ADDRESS)])]})
+
+		# Act / Assert:
+		with self.assertRaisesRegex(ValueError, f'entry at height 1.*{ALIAS_ADDRESS}'):
+			self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual([resolution_path('address', 1)], [
+			path for path in connector.paths if path.startswith('statements/resolutions/')
+		])
+		self.assertEqual([], [path for path in connector.paths if path.startswith('lock/')])
+		self.assertEqual({
+			'symbol_blocks': 0,
+			'symbol_transactions': 0,
+			'symbol_receipts': 0,
+			'symbol_hash_locks': 0,
+			'symbol_secret_locks': 0,
+			'symbol_sync_state': 0
+		}, self._fetch_lock_alias_failure_state())
+
+	def test_sync_block_headers_replaces_all_owner_unknown_secret_proof_matches_and_preserves_siblings(self):
+		# Arrange:
+		other_owner = '98' + '33' * 23
+		sibling_secret = '99' * 32
+		target_key = create_secret_lock_search_key(
+			bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160')
+		other_owner_key = create_secret_lock_search_key(
+			bytes.fromhex(other_owner), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160')
+		sibling_key = create_secret_lock_search_key(
+			bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(sibling_secret), 'hash160')
+		self.puller.symbol_db.replace_secret_locks(target_key, [create_secret_lock_row(create_secret_lock_item(
+			composite_hash='44' * 32, status=1), 1)])
+		self.puller.symbol_db.replace_secret_locks(other_owner_key, [create_secret_lock_row(create_secret_lock_item(
+			composite_hash='55' * 32, owner_address=other_owner, status=1), 1)])
+		self.puller.symbol_db.replace_secret_locks(sibling_key, [create_secret_lock_row(create_secret_lock_item(
+			composite_hash='FF' * 32, secret=sibling_secret), 1)])
+		proof_transaction = create_node_transaction(
+			1,
+			type=TransactionType.SECRET_PROOF.value,
+			secret=SECRET,
+			hashAlgorithm=1)
+		first_match = create_secret_lock_item(composite_hash='11' * 32, owner_address=SIGNER_ADDRESS, status=1)
+		second_match = create_secret_lock_item(composite_hash='22' * 32, owner_address=other_owner, status=1)
+		connector = LockConnector(
+			1,
+			{0: [create_node_block(1)]},
+			secret_responses={_secret_only_search_path(SECRET): {'data': [
+				first_match,
+				second_match,
+				create_secret_lock_item(composite_hash='33' * 32, recipientAddress='98' + '44' * 23),
+				create_secret_lock_item(composite_hash='66' * 32, secret='77' * 32),
+				create_secret_lock_item(composite_hash='88' * 32, hashAlgorithm=0)
+			]}},
+			transactions_by_path={transaction_path(1, 1): {'data': [proof_transaction]}},
+			statement_pages={statement_path(1, 1): {'data': []}})
+		expected_rows = [
+			create_expected_secret_lock_row(
+				first_match, 1, bytes.fromhex('11' * 32), bytes.fromhex(SIGNER_ADDRESS),
+				bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160', MOSAIC_ID, 1234, 100, 'used'),
+			create_expected_secret_lock_row(
+				second_match, 1, bytes.fromhex('22' * 32), bytes.fromhex(other_owner),
+				bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160', MOSAIC_ID, 1234, 100, 'used'),
+			create_expected_secret_lock_row(
+				create_secret_lock_item(composite_hash='FF' * 32, secret=sibling_secret), 1, bytes.fromhex('FF' * 32),
+				bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(sibling_secret), 'hash160',
+				MOSAIC_ID, 1234, 100, 'unused')
+		]
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual(([], expected_rows), self._fetch_persisted_lock_state())
+		self.assertEqual([_secret_only_search_path(SECRET)], [
+			path for path in connector.paths if path.startswith('lock/')
+		])
+
 	def test_sync_block_headers_restores_a_deleted_hash_lock_from_rollback_transaction_key(self):
 		# Arrange:
 		self._seed_blocks(self.puller.symbol_db, [1, 2], {2: b'local mismatch'.hex()})
@@ -929,6 +1492,115 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		])
 		cursor.execute('SELECT height, type FROM symbol_transactions WHERE height >= 2')
 		self.assertEqual([], cursor.fetchall())
+
+	def test_sync_block_headers_restores_a_deleted_hash_lock_from_a_rollback_aggregate_bonded_key(self):
+		# Arrange:
+		self._seed_blocks(self.puller.symbol_db, [1, 2], {2: b'local mismatch'.hex()})
+		self.puller.symbol_db.upsert_sync_state(create_sync_state(
+			chain_height=2,
+			last_synced_height=2,
+			last_synced_block_hash=bytes.fromhex('02' * 32)))
+		self.puller.symbol_db.upsert_hash_lock(create_hash_lock_row(create_hash_lock_item(), 2))
+		self.puller.symbol_db.delete_hash_lock(create_hash_lock_key_from_hex(LOCK_HASH))
+		cursor = self.puller.symbol_db.connection.cursor()
+		cursor.execute('SELECT hash FROM symbol_hash_locks')
+		self.assertEqual([], cursor.fetchall())
+		self.puller.symbol_db.upsert_transactions_for_height(2, [create_transaction_entry(
+			2,
+			'rollback-aggregate-bonded',
+			type=TransactionType.AGGREGATE_BONDED.value,
+			hash=bytes.fromhex(LOCK_HASH),
+			body={})])
+		connector = LockConnector(
+			2,
+			{1: [create_node_block(2)]},
+			{2: create_node_block(2)},
+			hash_responses={'lock/hash/' + LOCK_HASH: create_hash_lock_item(status=1)},
+			transactions_by_path={transaction_path(2, 2): {'data': []}},
+			statement_pages={statement_path(2, 2): {'data': []}})
+		expected_row = {
+			'hash': bytes.fromhex(LOCK_HASH),
+			'owner_address': bytes.fromhex(SIGNER_ADDRESS),
+			'mosaic_id': MOSAIC_ID,
+			'amount': 1234,
+			'end_height': 100,
+			'status': 'used',
+			'raw_payload': create_hash_lock_item(status=1),
+			'updated_at_height': 1
+		}
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual(([expected_row], []), self._fetch_persisted_lock_state())
+		self.assertEqual([1, 2], self._fetch_block_heights(self.puller.symbol_db))
+		cursor = self.puller.symbol_db.connection.cursor()
+		cursor.execute('SELECT height, type FROM symbol_transactions WHERE height >= 2 ORDER BY height, id')
+		self.assertEqual([], cursor.fetchall())
+		self.assertEqual(2, self.puller.symbol_db.get_sync_state()['last_synced_height'])
+		self.assertEqual(['lock/hash/' + LOCK_HASH], [
+			path for path in connector.paths if path.startswith('lock/')
+		])
+
+	def test_sync_block_headers_restores_a_deleted_secret_lock_from_a_rollback_secret_proof_key(self):
+		# Arrange:
+		self._seed_blocks(self.puller.symbol_db, [1, 2], {2: b'local mismatch'.hex()})
+		self.puller.symbol_db.upsert_sync_state(create_sync_state(
+			chain_height=2,
+			last_synced_height=2,
+			last_synced_block_hash=bytes.fromhex('02' * 32)))
+		secret_key = create_secret_lock_search_key(
+			bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160')
+		self.puller.symbol_db.replace_secret_locks(
+			secret_key, [create_secret_lock_row(create_secret_lock_item(), 2)])
+		self.puller.symbol_db.replace_secret_locks(secret_key, [])
+		cursor = self.puller.symbol_db.connection.cursor()
+		cursor.execute('SELECT composite_hash FROM symbol_secret_locks')
+		self.assertEqual([], cursor.fetchall())
+		self.puller.symbol_db.upsert_transactions_for_height(2, [create_transaction_entry(
+			2,
+			'rollback-secret-proof',
+			type=TransactionType.SECRET_PROOF.value,
+			signer_address=bytes.fromhex(SIGNER_ADDRESS),
+			recipient_address=bytes.fromhex(RECIPIENT_ADDRESS),
+			body={
+				'recipientAddress': '99065A28385EB5AE88000000000000000000000000000000',
+				'secret': SECRET,
+				'hashAlgorithm': 1
+			})])
+		path = _secret_only_search_path(SECRET)
+		connector = LockConnector(
+			2,
+			{1: [create_node_block(2)]},
+			{2: create_node_block(2)},
+			secret_responses={path: {'data': [create_secret_lock_item(status=1)]}},
+			transactions_by_path={transaction_path(2, 2): {'data': []}},
+			statement_pages={statement_path(2, 2): {'data': []}})
+		expected_row = create_expected_secret_lock_row(
+			create_secret_lock_item(status=1),
+			1,
+			composite_hash=bytes.fromhex(COMPOSITE_HASH),
+			owner_address=bytes.fromhex(SIGNER_ADDRESS),
+			recipient_address=bytes.fromhex(RECIPIENT_ADDRESS),
+			secret=bytes.fromhex(SECRET),
+			hash_algorithm='hash160',
+			mosaic_id=MOSAIC_ID,
+			amount=1234,
+			end_height=100,
+			status='used')
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual(([], [expected_row]), self._fetch_persisted_lock_state())
+		self.assertEqual([1, 2], self._fetch_block_heights(self.puller.symbol_db))
+		cursor = self.puller.symbol_db.connection.cursor()
+		cursor.execute('SELECT height, type FROM symbol_transactions WHERE height >= 2 ORDER BY height, id')
+		self.assertEqual([], cursor.fetchall())
+		self.assertEqual(2, self.puller.symbol_db.get_sync_state()['last_synced_height'])
+		self.assertEqual([path], [path for path in connector.paths if path.startswith('lock/')])
 
 	def test_sync_block_headers_keeps_rollback_state_unchanged_when_lock_replacement_fetch_fails(self):
 		# Arrange:
@@ -1148,3 +1820,32 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			cursor.execute(f'SELECT COUNT(*) FROM {table_name}')
 			self.assertEqual(0, cursor.fetchone()[0], table_name)
 		self.assertIsNone(self.puller.symbol_db.get_sync_state())
+
+	def test_sync_block_headers_does_not_write_a_successful_hash_lock_when_a_later_secret_lock_fetch_fails(self):
+		# Arrange:
+		hash_transaction = create_node_transaction(
+			1, transaction_hash='01' * 32, type=TransactionType.HASH_LOCK.value,
+			hash=LOCK_HASH, mosaicId=MOSAIC_ID, amount='1234')
+		secret_transaction = create_node_transaction(
+			1, transaction_hash='02' * 32, type=TransactionType.SECRET_LOCK.value,
+			secret=SECRET, hashAlgorithm=1, mosaicId=MOSAIC_ID, amount='1234')
+		secret_path = _secret_search_path(SIGNER_ADDRESS, SECRET)
+		connector = LockConnector(
+			1,
+			{0: [create_node_block(1)]},
+			hash_responses={'lock/hash/' + LOCK_HASH: create_hash_lock_item()},
+			secret_responses={secret_path: RuntimeError('secret lock fetch failed')},
+			transactions_by_path={transaction_path(1, 1): {'data': [hash_transaction, secret_transaction]}},
+			statement_pages={statement_path(1, 1): {'data': []}})
+
+		# Act / Assert:
+		with self.assertRaisesRegex(RuntimeError, '^secret lock fetch failed$'):
+			self._sync_with_connector(connector)
+
+		# Assert:
+		cursor = self.puller.symbol_db.connection.cursor()
+		for table_name in ('symbol_blocks', 'symbol_transactions', 'symbol_receipts', 'symbol_hash_locks', 'symbol_secret_locks'):
+			cursor.execute(f'SELECT COUNT(*) FROM {table_name}')
+			self.assertEqual(0, cursor.fetchone()[0], table_name)
+		self.assertIsNone(self.puller.symbol_db.get_sync_state())
+		self.assertEqual(['lock/hash/' + LOCK_HASH, secret_path], [path for path in connector.paths if path.startswith('lock/')])

--- a/explorer/puller/tests/facade/symbol/test_PullerLocks.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerLocks.py
@@ -1119,7 +1119,7 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			_secret_search_path(SIGNER_ADDRESS, SECRET)
 		], [path for path in connector.paths if path.startswith('lock/')])
 
-	def test_sync_block_headers_persists_a_hash_lock(self):
+	def test_sync_block_headers_persists_a_hash_lock_without_an_aggregate_bonded_transaction(self):
 		# Arrange:
 		connector = self._create_hash_lock_sync_connector()
 		expected_lock_state = self._expected_persisted_hash_lock_state()

--- a/explorer/puller/tests/facade/symbol/test_PullerLocks.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerLocks.py
@@ -1134,6 +1134,30 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 		# Assert:
 		self.assertEqual(expected_lock_state, self._fetch_persisted_lock_state())
 
+	def test_sync_block_headers_removes_a_dirty_hash_lock_when_node_returns_not_found(self):
+		# Arrange:
+		self.puller.symbol_db.upsert_hash_lock(create_hash_lock_row(create_hash_lock_item(), 1))
+		connector = self._create_hash_lock_sync_connector()
+		connector.hash_responses['lock/hash/' + LOCK_HASH] = {
+			'code': 'ResourceNotFound',
+			'message': 'not found'
+		}
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual(([], []), self._fetch_persisted_lock_state())
+		self.assertEqual([1], self._fetch_block_heights(self.puller.symbol_db))
+		cursor = self.puller.symbol_db.connection.cursor()
+		cursor.execute('SELECT COUNT(*) FROM symbol_transactions')
+		self.assertEqual(1, cursor.fetchone()[0])
+		sync_state = self.puller.symbol_db.get_sync_state()
+		self.assertEqual(1, sync_state['chain_height'])
+		self.assertEqual(1, sync_state['last_synced_height'])
+		hash_paths = [path for path in connector.paths if path == 'lock/hash/' + LOCK_HASH]
+		self.assertEqual(1, len(hash_paths))
+
 	def test_sync_block_headers_persists_a_secret_lock(self):
 		# Arrange:
 		connector = self._create_secret_lock_sync_connector()

--- a/explorer/puller/tests/facade/symbol/test_PullerLocks.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerLocks.py
@@ -1,0 +1,1163 @@
+# pylint: disable=too-many-lines,too-many-public-methods
+import asyncio
+import copy
+
+from symbolchain.sc import TransactionType
+from symbolchain.symbol.Network import Address
+
+from puller.facade.SymbolPuller import LOCK_FETCH_CONCURRENCY
+from puller.model.symbol.Lock import (
+	create_hash_lock_key_from_hex,
+	create_hash_lock_row,
+	create_secret_lock_row,
+	create_secret_lock_search_key
+)
+from tests.test.SymbolDatabaseTestUtils import fetch_full_block_state, fetch_normalized_sync_state
+from tests.test.SymbolMetadataTestUtils import create_expected_metadata_row, create_metadata_item, fetch_metadata_rows
+from tests.test.SymbolMosaicTestUtils import create_expected_mosaic_row, create_mosaic_item, fetch_mosaic_state
+from tests.test.SymbolNamespaceTestUtils import NAMESPACE_ROOT_ID, create_namespace_item, fetch_namespace_state, seed_namespace
+from tests.test.SymbolTestConstants import RECIPIENT_ADDRESS, SIGNER_ADDRESS
+
+from ...test.SymbolTransactionTestUtils import create_transaction_entry
+from .puller_test_utils import (
+	FakeConnector,
+	SymbolPullerTestBase,
+	create_node_block,
+	create_node_transaction,
+	create_sync_state,
+	set_symbol_connector,
+	statement_path,
+	transaction_path
+)
+
+LOCK_HASH = 'AA' * 32
+LOCK_HASH_2 = 'BB' * 32
+SECRET = 'CC' * 32
+COMPOSITE_HASH = 'DD' * 32
+COMPOSITE_HASH_2 = 'EE' * 32
+MOSAIC_ID = '72C0212E67A08BCE'
+
+
+def create_hash_lock_item(lock_hash=LOCK_HASH, **overrides):
+	lock = {
+		'hash': lock_hash,
+		'ownerAddress': SIGNER_ADDRESS,
+		'mosaicId': MOSAIC_ID,
+		'amount': '1234',
+		'endHeight': '100',
+		'status': 0
+	}
+	lock.update(overrides)
+	return {'lock': lock, 'id': 'hash-lock'}
+
+
+def create_secret_lock_item(
+	composite_hash=COMPOSITE_HASH,
+	owner_address=SIGNER_ADDRESS,
+	secret=SECRET,
+	**overrides
+):
+	lock = {
+		'compositeHash': composite_hash,
+		'ownerAddress': owner_address,
+		'recipientAddress': RECIPIENT_ADDRESS,
+		'secret': secret,
+		'hashAlgorithm': 1,
+		'mosaicId': MOSAIC_ID,
+		'amount': '1234',
+		'endHeight': '100',
+		'status': 0
+	}
+	lock.update(overrides)
+	return {'lock': lock, 'id': 'secret-lock'}
+
+
+class LockConnector(FakeConnector):
+	def __init__(self, *args, hash_responses=None, secret_responses=None, **kwargs):
+		if not args:
+			args = (1, {})
+		super().__init__(*args, **kwargs)
+		self.hash_responses = hash_responses or {}
+		self.secret_responses = secret_responses or {}
+
+	async def get(self, url_path, *args):
+		if url_path.startswith('lock/hash/'):
+			self.paths.append(url_path)
+			response = self.hash_responses[url_path]
+			if isinstance(response, Exception):
+				raise response
+			return response
+		if url_path.startswith('lock/secret?'):
+			self.paths.append(url_path)
+			response = self.secret_responses.get(url_path, {'data': []})
+			if isinstance(response, Exception):
+				raise response
+			return response
+
+		return await super().get(url_path, *args)
+
+
+class BoundedLockConnector(LockConnector):
+	def __init__(self, *args, **kwargs):
+		super().__init__(*args, **kwargs)
+		self.in_flight_lock_requests = 0
+		self.max_in_flight_lock_requests = 0
+		self._requests_released = asyncio.Event()
+		self._release_scheduled = False
+
+	async def get(self, url_path, *args):
+		if not url_path.startswith('lock/secret?'):
+			return await super().get(url_path, *args)
+
+		self.paths.append(url_path)
+		self.in_flight_lock_requests += 1
+		self.max_in_flight_lock_requests = max(
+			self.max_in_flight_lock_requests,
+			self.in_flight_lock_requests)
+		try:
+			if not self._release_scheduled:
+				self._release_scheduled = True
+				asyncio.get_running_loop().call_soon(self._requests_released.set)
+			await self._requests_released.wait()
+			response = self.secret_responses.get(url_path, {'data': []})
+			if isinstance(response, Exception):
+				raise response
+			return response
+		finally:
+			self.in_flight_lock_requests -= 1
+
+
+def _secret_search_path(owner_address, secret, page_number=1):
+	return (
+		f'lock/secret?address={Address(bytes.fromhex(owner_address))}&secret={secret}'
+		f'&pageSize=100&pageNumber={page_number}'
+	)
+
+
+def _secret_only_search_path(secret, page_number=1):
+	return f'lock/secret?secret={secret}&pageSize=100&pageNumber={page_number}'
+
+
+class SymbolPullerLocksTest(SymbolPullerTestBase):
+	@staticmethod
+	def _create_lock_transaction_row(transaction_type, body, **overrides):
+		row = {
+			'type': transaction_type,
+			'is_embedded': False,
+			'hash': bytes.fromhex(LOCK_HASH),
+			'signer_address': bytes.fromhex(SIGNER_ADDRESS),
+			'recipient_address': bytes.fromhex(RECIPIENT_ADDRESS),
+			'body': body
+		}
+		row.update(overrides)
+		return row
+
+	def _collect_lock_keys(self, transaction_rows):
+		return self.puller._collect_dirty_lock_keys_for_batch(  # pylint: disable=protected-access
+			[{'height': 10}], {10: transaction_rows})
+
+	def _fetch_complete_rollback_state(self):
+		cursor = self.puller.symbol_db.connection.cursor()
+		cursor.execute('SELECT * FROM symbol_transactions ORDER BY height, id')
+		transactions = [
+			tuple(bytes(value) if isinstance(value, memoryview) else value for value in row)
+			for row in cursor.fetchall()
+		]
+		cursor.execute('SELECT * FROM symbol_receipts ORDER BY height, id')
+		receipts = [
+			tuple(bytes(value) if isinstance(value, memoryview) else value for value in row)
+			for row in cursor.fetchall()
+		]
+		cursor.execute('SELECT * FROM symbol_hash_locks ORDER BY hash')
+		hash_locks = [
+			tuple(bytes(value) if isinstance(value, memoryview) else value for value in row)
+			for row in cursor.fetchall()
+		]
+		cursor.execute('SELECT * FROM symbol_secret_locks ORDER BY composite_hash')
+		secret_locks = [
+			tuple(bytes(value) if isinstance(value, memoryview) else value for value in row)
+			for row in cursor.fetchall()
+		]
+		return {
+			'blocks': fetch_full_block_state(self.puller.symbol_db),
+			'transactions': transactions,
+			'receipts': receipts,
+			'namespace': fetch_namespace_state(self.puller.symbol_db.connection),
+			'mosaic': fetch_mosaic_state(self.puller.symbol_db),
+			'metadata': fetch_metadata_rows(self.puller.symbol_db),
+			'hash_locks': hash_locks,
+			'secret_locks': secret_locks,
+			'sync_state': fetch_normalized_sync_state(self.puller.symbol_db)
+		}
+
+	def test_fetch_hash_lock_success_returns_a_complete_upsert_entry(self):
+		# Arrange:
+		item = create_hash_lock_item()
+		connector = LockConnector(
+			hash_responses={'lock/hash/' + LOCK_HASH: item})
+		set_symbol_connector(self.puller, connector)
+		key = create_hash_lock_key_from_hex(LOCK_HASH)
+
+		# Act:
+		entries = asyncio.run(self.puller._fetch_dirty_hash_locks([key], 12))  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual([{
+			'row': {
+				'hash': bytes.fromhex(LOCK_HASH),
+				'owner_address': bytes.fromhex(SIGNER_ADDRESS),
+				'mosaic_id': MOSAIC_ID,
+				'amount': 1234,
+				'end_height': 100,
+				'status': 'unused',
+				'raw_payload': item,
+				'updated_at_height': 12
+			}
+		}], entries)
+		self.assertEqual(['lock/hash/' + LOCK_HASH], connector.paths)
+
+	def test_fetch_hash_lock_not_found_returns_a_delete_entry(self):
+		# Arrange:
+		connector = LockConnector(hash_responses={
+			'lock/hash/' + LOCK_HASH: {
+				'code': 'ResourceNotFound',
+				'message': 'not found'
+			}})
+		set_symbol_connector(self.puller, connector)
+		key = create_hash_lock_key_from_hex(LOCK_HASH)
+
+		# Act:
+		entries = asyncio.run(self.puller._fetch_dirty_hash_locks([key], 12))  # pylint: disable=protected-access
+		self.puller.symbol_db.upsert_hash_lock(create_hash_lock_row(create_hash_lock_item(), 12))
+		self.puller._write_dirty_hash_locks(entries)  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual([{'hash': key}], entries)
+		cursor = self.puller.symbol_db.connection.cursor()
+		cursor.execute('SELECT COUNT(*) FROM symbol_hash_locks')
+		self.assertEqual(0, cursor.fetchone()[0])
+
+	def test_fetch_hash_lock_rejects_a_mismatched_response(self):
+		# Arrange:
+		connector = LockConnector(hash_responses={
+			'lock/hash/' + LOCK_HASH: create_hash_lock_item(lock_hash=LOCK_HASH_2)
+		})
+		set_symbol_connector(self.puller, connector)
+
+		# Act / Assert:
+		with self.assertRaisesRegex(ValueError, '^Symbol Hash Lock response hash does not match dirty key$'):
+			asyncio.run(self.puller._fetch_dirty_hash_locks(  # pylint: disable=protected-access
+				[create_hash_lock_key_from_hex(LOCK_HASH)], 12))
+
+	def _assert_sync_rejects_malformed_hash_lock_response(self, response):
+		# Arrange:
+		transaction = create_node_transaction(
+			1,
+			transaction_hash='01' * 32,
+			type=TransactionType.HASH_LOCK.value,
+			hash=LOCK_HASH,
+			mosaicId=MOSAIC_ID,
+			amount='1234')
+		connector = LockConnector(
+			1,
+			{0: [create_node_block(1)]},
+			hash_responses={'lock/hash/' + LOCK_HASH: response},
+			transactions_by_path={transaction_path(1, 1): {'data': [transaction]}},
+			statement_pages={statement_path(1, 1): {'data': []}})
+
+		# Act / Assert:
+		with self.assertRaises(ValueError):
+			self._sync_with_connector(connector)
+
+		# Assert:
+		cursor = self.puller.symbol_db.connection.cursor()
+		for table_name in ('symbol_blocks', 'symbol_transactions', 'symbol_receipts', 'symbol_hash_locks', 'symbol_secret_locks'):
+			cursor.execute(f'SELECT COUNT(*) FROM {table_name}')
+			self.assertEqual(0, cursor.fetchone()[0], table_name)
+		self.assertIsNone(self.puller.symbol_db.get_sync_state())
+
+	def test_sync_block_headers_rejects_non_dict_hash_lock_response_without_writes(self):
+		self._assert_sync_rejects_malformed_hash_lock_response([])
+
+	def test_sync_block_headers_rejects_hash_lock_response_without_lock_wrapper_without_writes(self):
+		self._assert_sync_rejects_malformed_hash_lock_response({})
+
+	def test_sync_block_headers_rejects_hash_lock_response_with_non_dict_lock_without_writes(self):
+		self._assert_sync_rejects_malformed_hash_lock_response({'lock': []})
+
+	def test_sync_block_headers_rejects_hash_lock_response_with_invalid_required_field_without_writes(self):
+		self._assert_sync_rejects_malformed_hash_lock_response(create_hash_lock_item(hash='GG' * 32))
+
+	def _assert_sync_rejects_malformed_secret_lock_response(self, response, expected_error):
+		# Arrange:
+		transaction = create_node_transaction(
+			1,
+			transaction_hash='01' * 32,
+			type=TransactionType.SECRET_LOCK.value,
+			secret=SECRET,
+			hashAlgorithm=1,
+			mosaicId=MOSAIC_ID,
+			amount='1234')
+		path = _secret_search_path(SIGNER_ADDRESS, SECRET)
+		connector = LockConnector(
+			1,
+			{0: [create_node_block(1)]},
+			secret_responses={path: response},
+			transactions_by_path={transaction_path(1, 1): {'data': [transaction]}},
+			statement_pages={statement_path(1, 1): {'data': []}})
+
+		# Act / Assert:
+		with self.assertRaisesRegex(ValueError, expected_error):
+			self._sync_with_connector(connector)
+
+		# Assert:
+		cursor = self.puller.symbol_db.connection.cursor()
+		for table_name in ('symbol_blocks', 'symbol_transactions', 'symbol_receipts', 'symbol_hash_locks', 'symbol_secret_locks'):
+			cursor.execute(f'SELECT COUNT(*) FROM {table_name}')
+			self.assertEqual(0, cursor.fetchone()[0], table_name)
+		self.assertIsNone(self.puller.symbol_db.get_sync_state())
+		self.assertEqual([path], [request_path for request_path in connector.paths if request_path.startswith('lock/')])
+
+	def test_sync_block_headers_rejects_non_dict_secret_lock_search_response_without_writes(self):
+		self._assert_sync_rejects_malformed_secret_lock_response([], '^Malformed Symbol Secret Lock search response$')
+
+	def test_sync_block_headers_rejects_secret_lock_search_response_without_data_without_writes(self):
+		self._assert_sync_rejects_malformed_secret_lock_response({}, '^Malformed Symbol Secret Lock search response$')
+
+	def test_sync_block_headers_rejects_secret_lock_search_response_with_non_list_data_without_writes(self):
+		self._assert_sync_rejects_malformed_secret_lock_response({'data': {}}, '^Malformed Symbol Secret Lock search response$')
+
+	def test_sync_block_headers_rejects_secret_lock_search_response_with_malformed_item_without_writes(self):
+		self._assert_sync_rejects_malformed_secret_lock_response({'data': [{}]}, '^Malformed Symbol Secret Lock response$')
+
+	def test_fetch_secret_lock_paginates_full_and_short_pages_in_node_order(self):
+		# Arrange:
+		key = create_secret_lock_search_key(
+			bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160')
+		page_one = [
+			create_secret_lock_item(
+				composite_hash=f'{index + 1:064X}', amount=str(index + 100), endHeight=str(index + 200))
+			for index in range(100)
+		]
+		page_two = [
+			create_secret_lock_item(
+				composite_hash=f'{index + 1:064X}', amount=str(index + 100), endHeight=str(index + 200))
+			for index in range(100, 102)
+		]
+		expected_rows = [
+			{
+				'composite_hash': bytes.fromhex(f'{index + 1:064X}'),
+				'owner_address': bytes.fromhex(SIGNER_ADDRESS),
+				'recipient_address': bytes.fromhex(RECIPIENT_ADDRESS),
+				'secret': bytes.fromhex(SECRET),
+				'hash_algorithm': 'hash160',
+				'mosaic_id': MOSAIC_ID,
+				'amount': index + 100,
+				'end_height': index + 200,
+				'status': 'unused',
+				'raw_payload': copy.deepcopy(page_one[index] if index < 100 else page_two[index - 100]),
+				'updated_at_height': 12
+			}
+			for index in range(102)
+		]
+		expected_entries = [{
+			'key': (bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160'),
+			'rows': expected_rows
+		}]
+		connector = LockConnector(secret_responses={
+			_secret_search_path(SIGNER_ADDRESS, SECRET, 1): {'data': page_one},
+			_secret_search_path(SIGNER_ADDRESS, SECRET, 2): {'data': page_two}
+		})
+		set_symbol_connector(self.puller, connector)
+
+		# Act:
+		entries = asyncio.run(self.puller._fetch_dirty_secret_locks([key], 12))  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual(expected_entries, entries)
+		self.assertEqual([
+			_secret_search_path(SIGNER_ADDRESS, SECRET, 1),
+			_secret_search_path(SIGNER_ADDRESS, SECRET, 2)
+		], connector.paths)
+
+	def test_fetch_secret_lock_filters_owner_recipient_secret_and_hash_algorithm_node_superset(self):
+		# Arrange:
+		key = create_secret_lock_search_key(
+			bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160')
+		exact_item = create_secret_lock_item(composite_hash=COMPOSITE_HASH_2, amount='222', endHeight='202', status=1)
+		expected_entries = [{
+			'key': (bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160'),
+			'rows': [{
+				'composite_hash': bytes.fromhex(COMPOSITE_HASH_2),
+				'owner_address': bytes.fromhex(SIGNER_ADDRESS),
+				'recipient_address': bytes.fromhex(RECIPIENT_ADDRESS),
+				'secret': bytes.fromhex(SECRET),
+				'hash_algorithm': 'hash160',
+				'mosaic_id': MOSAIC_ID,
+				'amount': 222,
+				'end_height': 202,
+				'status': 'used',
+				'raw_payload': copy.deepcopy(exact_item),
+				'updated_at_height': 12
+			}]
+		}]
+		path = _secret_search_path(SIGNER_ADDRESS, SECRET)
+		connector = LockConnector(secret_responses={path: {'data': [
+			create_secret_lock_item(composite_hash='01' * 32, owner_address='98' + '33' * 23),
+			create_secret_lock_item(composite_hash='02' * 32, recipientAddress='98' + '44' * 23),
+			create_secret_lock_item(composite_hash='03' * 32, secret='DD' * 32),
+			create_secret_lock_item(composite_hash='04' * 32, hashAlgorithm=0),
+			exact_item
+		]}})
+		set_symbol_connector(self.puller, connector)
+
+		# Act:
+		entries = asyncio.run(self.puller._fetch_dirty_secret_locks([key], 12))  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual(expected_entries, entries)
+		self.assertEqual([path], connector.paths)
+
+	def test_fetch_secret_lock_empty_result_returns_an_empty_replacement(self):
+		# Arrange:
+		key = create_secret_lock_search_key(
+			bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160')
+		connector = LockConnector(secret_responses={
+			_secret_search_path(SIGNER_ADDRESS, SECRET): {'data': []}
+		})
+		set_symbol_connector(self.puller, connector)
+
+		# Act:
+		entries = asyncio.run(self.puller._fetch_dirty_secret_locks([key], 12))  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual([{'key': key, 'rows': []}], entries)
+
+	def test_fetch_secret_lock_not_found_returns_an_empty_replacement(self):
+		# Arrange:
+		key = create_secret_lock_search_key(
+			None, bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160')
+		path = _secret_only_search_path(SECRET)
+		connector = LockConnector(secret_responses={path: {
+			'code': 'ResourceNotFound',
+			'message': 'not found'
+		}})
+		set_symbol_connector(self.puller, connector)
+
+		# Act:
+		entries = asyncio.run(self.puller._fetch_dirty_secret_locks([key], 12))  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual([{'key': key, 'rows': []}], entries)
+
+	def test_fetch_secret_lock_supports_secret_only_search_without_address(self):
+		# Arrange:
+		key = create_secret_lock_search_key(
+			None, bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160')
+		path = _secret_only_search_path(SECRET)
+		connector = LockConnector(secret_responses={path: {'data': [create_secret_lock_item()]}})
+		set_symbol_connector(self.puller, connector)
+
+		# Act:
+		entries = asyncio.run(self.puller._fetch_dirty_secret_locks([key], 12))  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual([{
+			'key': key,
+			'rows': [create_secret_lock_row(create_secret_lock_item(), 12)]
+		}], entries)
+		self.assertEqual([path], connector.paths)
+
+	def test_fetch_secret_lock_rejects_duplicate_composite_hash(self):
+		# Arrange:
+		key = create_secret_lock_search_key(
+			bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160')
+		path = _secret_search_path(SIGNER_ADDRESS, SECRET)
+		connector = LockConnector(secret_responses={
+			path: {'data': [create_secret_lock_item(), create_secret_lock_item()]}
+		})
+		set_symbol_connector(self.puller, connector)
+
+		# Act / Assert:
+		with self.assertRaisesRegex(ValueError, '^Duplicate Symbol Secret Lock composite hash$'):
+			asyncio.run(self.puller._fetch_dirty_secret_locks([key], 12))  # pylint: disable=protected-access
+
+	def test_lock_fetch_concurrency_is_the_approved_ten_request_node_bound(self):
+		# Act:
+		concurrency = LOCK_FETCH_CONCURRENCY
+
+		# Assert:
+		self.assertEqual(10, concurrency)
+
+	def test_fetch_secret_locks_uses_bounded_gather_for_more_than_one_chunk(self):
+		# Arrange:
+		keys = []
+		responses = {}
+		for index in range(11):
+			secret = f'{index + 1:064X}'
+			key = create_secret_lock_search_key(
+				bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(secret), 'hash160')
+			keys.append(key)
+			responses[_secret_search_path(SIGNER_ADDRESS, secret)] = {
+				'data': [create_secret_lock_item(
+					composite_hash=f'{index + 1:064X}', secret=secret)]}
+		connector = BoundedLockConnector(secret_responses=responses)
+		set_symbol_connector(self.puller, connector)
+
+		# Act:
+		entries = asyncio.run(self.puller._fetch_dirty_secret_locks(keys, 12))  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertLess(LOCK_FETCH_CONCURRENCY, len(keys))
+		self.assertEqual(LOCK_FETCH_CONCURRENCY, connector.max_in_flight_lock_requests)
+		self.assertEqual(11, len(entries))
+		self.assertEqual(11, len(connector.paths))
+
+	def test_fetch_secret_locks_preserves_non_sorted_first_encounter_key_order(self):
+		# Arrange:
+		secrets = [f'{3:064X}', f'{1:064X}', f'{11:064X}', f'{2:064X}']
+		keys = [
+			create_secret_lock_search_key(
+				bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(secret), 'hash160')
+			for secret in secrets
+		]
+		connector = LockConnector(secret_responses={
+			_secret_search_path(SIGNER_ADDRESS, secret): {
+				'data': [create_secret_lock_item(composite_hash=secret, secret=secret)]
+			}
+			for secret in secrets
+		})
+		set_symbol_connector(self.puller, connector)
+
+		# Act:
+		entries = asyncio.run(self.puller._fetch_dirty_secret_locks(keys, 12))  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual([
+			(bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(f'{3:064X}'), 'hash160'),
+			(bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(f'{1:064X}'), 'hash160'),
+			(bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(f'{11:064X}'), 'hash160'),
+			(bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(f'{2:064X}'), 'hash160')
+		], [entry['key'] for entry in entries])
+
+	def test_collect_dirty_lock_keys_uses_hash_lock_body_hash(self):
+		# Arrange:
+		transaction_row = self._create_lock_transaction_row(
+			TransactionType.HASH_LOCK.value, {'hash': LOCK_HASH_2})
+
+		# Act:
+		keys = self._collect_lock_keys([transaction_row])
+
+		# Assert:
+		self.assertEqual([bytes.fromhex(LOCK_HASH_2)], [key.hash for key in keys.hash_keys])
+		self.assertEqual([], keys.secret_keys)
+
+	def test_collect_dirty_lock_keys_uses_top_level_aggregate_bonded_hash(self):
+		# Arrange:
+		top_level = self._create_lock_transaction_row(
+			TransactionType.AGGREGATE_BONDED.value, {}, hash=bytes.fromhex(LOCK_HASH_2))
+
+		# Act:
+		keys = self._collect_lock_keys([top_level])
+
+		# Assert:
+		self.assertEqual([bytes.fromhex(LOCK_HASH_2)], [key.hash for key in keys.hash_keys])
+		self.assertEqual([], keys.secret_keys)
+
+	def test_collect_dirty_lock_keys_excludes_embedded_aggregate_bonded_hash(self):
+		# Arrange:
+		embedded = self._create_lock_transaction_row(
+			TransactionType.AGGREGATE_BONDED.value, {}, is_embedded=True, hash=bytes.fromhex(LOCK_HASH_2))
+
+		# Act:
+		keys = self._collect_lock_keys([embedded])
+
+		# Assert:
+		self.assertEqual([], keys.hash_keys)
+		self.assertEqual([], keys.secret_keys)
+
+	def test_collect_dirty_lock_keys_uses_resolved_secret_lock_recipient(self):
+		# Arrange:
+		transaction_row = self._create_lock_transaction_row(
+			TransactionType.SECRET_LOCK.value,
+			{'secret': SECRET, 'hashAlgorithm': 1, 'recipientAddress': '99065A28385EB5AE88000000000000000000000000000000'})
+
+		# Act:
+		keys = self._collect_lock_keys([transaction_row])
+
+		# Assert:
+		self.assertEqual([], keys.hash_keys)
+		self.assertEqual([(
+			bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160'
+		)], keys.secret_keys)
+
+	def test_collect_dirty_lock_keys_uses_secret_proof_with_unknown_owner(self):
+		# Arrange:
+		transaction_row = self._create_lock_transaction_row(
+			TransactionType.SECRET_PROOF.value, {'secret': SECRET, 'hashAlgorithm': 0})
+
+		# Act:
+		keys = self._collect_lock_keys([transaction_row])
+
+		# Assert:
+		self.assertEqual([], keys.hash_keys)
+		self.assertEqual([(None, bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'sha3_256')], keys.secret_keys)
+
+	def test_collect_dirty_lock_keys_ignores_unrelated_transaction_type(self):
+		# Arrange:
+		unrelated = self._create_lock_transaction_row(TransactionType.TRANSFER.value, {})
+
+		# Act:
+		keys = self._collect_lock_keys([unrelated])
+
+		# Assert:
+		self.assertEqual(([], []), (keys.hash_keys, keys.secret_keys))
+
+	def test_collect_dirty_lock_keys_accepts_empty_transaction_input(self):
+		# Arrange:
+		transaction_rows = []
+
+		# Act:
+		keys = self._collect_lock_keys(transaction_rows)
+
+		# Assert:
+		self.assertEqual(([], []), (keys.hash_keys, keys.secret_keys))
+
+	def test_collect_dirty_lock_keys_deduplicates_hash_keys_in_first_encounter_order(self):
+		# Arrange:
+		first = self._create_lock_transaction_row(TransactionType.HASH_LOCK.value, {'hash': LOCK_HASH_2})
+		second = self._create_lock_transaction_row(TransactionType.HASH_LOCK.value, {'hash': LOCK_HASH})
+		duplicate = self._create_lock_transaction_row(TransactionType.HASH_LOCK.value, {'hash': LOCK_HASH_2})
+
+		# Act:
+		keys = self._collect_lock_keys([first, second, duplicate])
+
+		# Assert:
+		self.assertEqual([bytes.fromhex(LOCK_HASH_2), bytes.fromhex(LOCK_HASH)], [key.hash for key in keys.hash_keys])
+
+	def test_collect_dirty_lock_keys_deduplicates_secret_keys_in_first_encounter_order(self):
+		# Arrange:
+		first = self._create_lock_transaction_row(TransactionType.SECRET_PROOF.value, {'secret': SECRET, 'hashAlgorithm': 0})
+		second = self._create_lock_transaction_row(TransactionType.SECRET_LOCK.value, {'secret': SECRET, 'hashAlgorithm': 1})
+		duplicate = self._create_lock_transaction_row(TransactionType.SECRET_PROOF.value, {'secret': SECRET, 'hashAlgorithm': 0})
+
+		# Act:
+		keys = self._collect_lock_keys([first, second, duplicate])
+
+		# Assert:
+		self.assertEqual([
+			(None, bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'sha3_256'),
+			(bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160')
+		], keys.secret_keys)
+
+	def test_collect_dirty_lock_keys_includes_hash_lock_expiry_key(self):
+		# Arrange:
+		self.puller.symbol_db.upsert_hash_lock(create_hash_lock_row(create_hash_lock_item(endHeight='10'), 1))
+
+		# Act:
+		keys = self._collect_lock_keys([])
+
+		# Assert:
+		self.assertEqual([bytes.fromhex(LOCK_HASH)], [key.hash for key in keys.hash_keys])
+		self.assertEqual([], keys.secret_keys)
+
+	def test_collect_dirty_lock_keys_includes_secret_lock_expiry_key(self):
+		# Arrange:
+		key = create_secret_lock_search_key(
+			bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160')
+		self.puller.symbol_db.replace_secret_locks(
+			key, [create_secret_lock_row(create_secret_lock_item(endHeight='10'), 1)])
+
+		# Act:
+		keys = self._collect_lock_keys([])
+
+		# Assert:
+		self.assertEqual([], keys.hash_keys)
+		self.assertEqual([key], keys.secret_keys)
+
+	def test_collect_dirty_lock_keys_deduplicates_transaction_and_expiry_hash_key(self):
+		# Arrange:
+		self.puller.symbol_db.upsert_hash_lock(create_hash_lock_row(create_hash_lock_item(endHeight='10'), 1))
+		transaction_row = self._create_lock_transaction_row(TransactionType.HASH_LOCK.value, {'hash': LOCK_HASH})
+
+		# Act:
+		keys = self._collect_lock_keys([transaction_row])
+
+		# Assert:
+		self.assertEqual([bytes.fromhex(LOCK_HASH)], [key.hash for key in keys.hash_keys])
+
+	def test_collect_dirty_lock_keys_deduplicates_transaction_and_expiry_secret_key(self):
+		# Arrange:
+		key = create_secret_lock_search_key(
+			bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160')
+		self.puller.symbol_db.replace_secret_locks(
+			key, [create_secret_lock_row(create_secret_lock_item(endHeight='10'), 1)])
+		transaction_row = self._create_lock_transaction_row(
+			TransactionType.SECRET_LOCK.value, {'secret': SECRET, 'hashAlgorithm': 1})
+
+		# Act:
+		keys = self._collect_lock_keys([transaction_row])
+
+		# Assert:
+		self.assertEqual([key], keys.secret_keys)
+
+	def test_collect_dirty_lock_keys_rejects_surviving_alias_recipient(self):
+		# Arrange:
+		alias_address = bytes.fromhex('99065A28385EB5AE88000000000000000000000000000000')
+		transaction_row = {
+			'type': TransactionType.SECRET_PROOF.value,
+			'is_embedded': False,
+			'hash': bytes.fromhex('01' * 32),
+			'signer_address': bytes.fromhex(SIGNER_ADDRESS),
+			'recipient_address': alias_address,
+			'body': {'secret': SECRET, 'hashAlgorithm': 0}
+		}
+
+		# Act / Assert:
+		with self.assertRaisesRegex(ValueError, 'recipient_address'):
+			self.puller._collect_dirty_lock_keys_for_batch(  # pylint: disable=protected-access
+				[{'height': 1}], {1: [transaction_row]})
+
+	@staticmethod
+	def _create_lock_sync_connector():
+		hash_transaction = create_node_transaction(
+			1,
+			transaction_hash='01' * 32,
+			type=TransactionType.HASH_LOCK.value,
+			hash=LOCK_HASH,
+			mosaicId=MOSAIC_ID,
+			amount='1234')
+		secret_transaction = create_node_transaction(
+			1,
+			transaction_hash='02' * 32,
+			type=TransactionType.SECRET_LOCK.value,
+			secret=SECRET,
+			hashAlgorithm=1,
+			mosaicId=MOSAIC_ID,
+			amount='1234')
+		return LockConnector(
+			1,
+			{0: [create_node_block(1)]},
+			hash_responses={'lock/hash/' + LOCK_HASH: create_hash_lock_item()},
+			secret_responses={_secret_search_path(SIGNER_ADDRESS, SECRET): {
+				'data': [create_secret_lock_item()]}},
+			transactions_by_path={transaction_path(1, 1): {'data': [hash_transaction, secret_transaction]}},
+			statement_pages={statement_path(1, 1): {'data': []}})
+
+	@staticmethod
+	def _expected_persisted_lock_state():
+		return ([{
+			'hash': bytes.fromhex(LOCK_HASH),
+			'owner_address': bytes.fromhex(SIGNER_ADDRESS),
+			'mosaic_id': MOSAIC_ID,
+			'amount': 1234,
+			'end_height': 100,
+			'status': 'unused',
+			'raw_payload': {
+				'lock': {
+					'hash': LOCK_HASH,
+					'ownerAddress': SIGNER_ADDRESS,
+					'mosaicId': MOSAIC_ID,
+					'amount': '1234',
+					'endHeight': '100',
+					'status': 0
+				},
+				'id': 'hash-lock'
+			},
+			'updated_at_height': 1
+		}], [{
+			'composite_hash': bytes.fromhex(COMPOSITE_HASH),
+			'owner_address': bytes.fromhex(SIGNER_ADDRESS),
+			'recipient_address': bytes.fromhex(RECIPIENT_ADDRESS),
+			'secret': bytes.fromhex(SECRET),
+			'hash_algorithm': 'hash160',
+			'mosaic_id': MOSAIC_ID,
+			'amount': 1234,
+			'end_height': 100,
+			'status': 'unused',
+			'raw_payload': {
+				'lock': {
+					'compositeHash': COMPOSITE_HASH,
+					'ownerAddress': SIGNER_ADDRESS,
+					'recipientAddress': RECIPIENT_ADDRESS,
+					'secret': SECRET,
+					'hashAlgorithm': 1,
+					'mosaicId': MOSAIC_ID,
+					'amount': '1234',
+					'endHeight': '100',
+					'status': 0
+				},
+				'id': 'secret-lock'
+			},
+			'updated_at_height': 1
+		}])
+
+	def _fetch_persisted_lock_state(self):
+		cursor = self.puller.symbol_db.connection.cursor()
+		cursor.execute(
+			'SELECT hash, owner_address, mosaic_id, amount, end_height, status, raw_payload, updated_at_height '
+			'FROM symbol_hash_locks ORDER BY hash')
+		hash_locks = [{
+			'hash': bytes(lock_hash),
+			'owner_address': bytes(owner_address),
+			'mosaic_id': mosaic_id,
+			'amount': amount,
+			'end_height': end_height,
+			'status': status,
+			'raw_payload': raw_payload,
+			'updated_at_height': updated_at_height
+		} for lock_hash, owner_address, mosaic_id, amount, end_height, status, raw_payload, updated_at_height
+			in cursor.fetchall()]
+		cursor.execute(
+			'SELECT composite_hash, owner_address, recipient_address, secret, hash_algorithm, mosaic_id, amount, end_height, '
+			'status, raw_payload, updated_at_height FROM symbol_secret_locks ORDER BY composite_hash')
+		secret_locks = [{
+			'composite_hash': bytes(composite_hash),
+			'owner_address': bytes(owner_address),
+			'recipient_address': bytes(recipient_address),
+			'secret': bytes(secret),
+			'hash_algorithm': hash_algorithm,
+			'mosaic_id': mosaic_id,
+			'amount': amount,
+			'end_height': end_height,
+			'status': status,
+			'raw_payload': raw_payload,
+			'updated_at_height': updated_at_height
+		} for composite_hash, owner_address, recipient_address, secret, hash_algorithm, mosaic_id, amount, end_height,
+			status, raw_payload, updated_at_height in cursor.fetchall()]
+		return hash_locks, secret_locks
+
+	def test_sync_block_headers_persists_hash_and_secret_locks(self):
+		# Arrange:
+		connector = self._create_lock_sync_connector()
+		expected_lock_state = self._expected_persisted_lock_state()
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual(expected_lock_state, self._fetch_persisted_lock_state())
+
+	def test_sync_block_headers_converges_hash_and_secret_locks_when_restarted_from_existing_blocks(self):
+		# Arrange:
+		connector = self._create_lock_sync_connector()
+		expected_lock_state = self._expected_persisted_lock_state()
+		self._sync_with_connector(connector)
+		cursor = self.puller.symbol_db.connection.cursor()
+		cursor.execute('DELETE FROM symbol_sync_state')
+		self.puller.symbol_db.connection.commit()
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual(expected_lock_state, self._fetch_persisted_lock_state())
+
+	def test_sync_block_headers_restores_a_deleted_hash_lock_from_rollback_transaction_key(self):
+		# Arrange:
+		self._seed_blocks(self.puller.symbol_db, [1, 2], {2: b'local mismatch'.hex()})
+		self.puller.symbol_db.upsert_sync_state(create_sync_state(
+			chain_height=2,
+			last_synced_height=2,
+			last_synced_block_hash=bytes.fromhex('02' * 32)))
+		transaction = create_transaction_entry(
+			2,
+			'rollback-hash-lock',
+			type=TransactionType.HASH_LOCK.value,
+			body={'hash': LOCK_HASH})
+		self.puller.symbol_db.upsert_transactions_for_height(2, [transaction])
+		self.puller.symbol_db.upsert_hash_lock(create_hash_lock_row(create_hash_lock_item(), 2))
+		self.puller.symbol_db.delete_hash_lock(create_hash_lock_key_from_hex(LOCK_HASH))
+		cursor = self.puller.symbol_db.connection.cursor()
+		cursor.execute('SELECT hash FROM symbol_hash_locks')
+		self.assertEqual([], cursor.fetchall())
+		connector = LockConnector(
+			2,
+			{1: [create_node_block(2)]},
+			{2: create_node_block(2)},
+			hash_responses={'lock/hash/' + LOCK_HASH: create_hash_lock_item(status=1)},
+			transactions_by_path={transaction_path(2, 2): {'data': []}},
+			statement_pages={statement_path(2, 2): {'data': []}})
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		cursor.execute('SELECT hash, status, updated_at_height FROM symbol_hash_locks')
+		lock_state = [
+			(bytes(lock_hash), status, updated_at_height)
+			for lock_hash, status, updated_at_height in cursor.fetchall()]
+		self.assertEqual([(bytes.fromhex(LOCK_HASH), 'used', 1)], lock_state)
+		self.assertEqual([1, 2], self._fetch_block_heights(self.puller.symbol_db))
+		cursor.execute('SELECT height, type FROM symbol_transactions WHERE height >= 2')
+		self.assertEqual([], cursor.fetchall())
+
+	def test_sync_block_headers_restores_a_deleted_secret_lock_from_rollback_transaction_key(self):
+		# Arrange:
+		self._seed_blocks(self.puller.symbol_db, [1, 2], {2: b'local mismatch'.hex()})
+		self.puller.symbol_db.upsert_sync_state(create_sync_state(
+			chain_height=2,
+			last_synced_height=2,
+			last_synced_block_hash=bytes.fromhex('02' * 32)))
+		transaction = create_transaction_entry(
+			2,
+			'rollback-secret-lock',
+			type=TransactionType.SECRET_LOCK.value,
+			signer_address=bytes.fromhex(SIGNER_ADDRESS),
+			recipient_address=bytes.fromhex(RECIPIENT_ADDRESS),
+			body={
+				'secret': SECRET,
+				'hashAlgorithm': 1,
+				'recipientAddress': '99065A28385EB5AE88000000000000000000000000000000'
+			})
+		self.puller.symbol_db.upsert_transactions_for_height(2, [transaction])
+		secret_key = create_secret_lock_search_key(
+			bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160')
+		self.puller.symbol_db.replace_secret_locks(
+			secret_key, [create_secret_lock_row(create_secret_lock_item(), 2)])
+		self.puller.symbol_db.replace_secret_locks(secret_key, [])
+		cursor = self.puller.symbol_db.connection.cursor()
+		cursor.execute('SELECT composite_hash FROM symbol_secret_locks')
+		self.assertEqual([], cursor.fetchall())
+		connector = LockConnector(
+			2,
+			{1: [create_node_block(2)]},
+			{2: create_node_block(2)},
+			secret_responses={_secret_search_path(SIGNER_ADDRESS, SECRET): {
+				'data': [create_secret_lock_item(status=1)]
+			}},
+			transactions_by_path={transaction_path(2, 2): {'data': []}},
+			statement_pages={statement_path(2, 2): {'data': []}})
+
+		# Act:
+		self._sync_with_connector(connector)
+
+		# Assert:
+		cursor.execute('SELECT composite_hash, status, updated_at_height FROM symbol_secret_locks')
+		self.assertEqual([
+			(bytes.fromhex(COMPOSITE_HASH), 'used', 1)
+		], [
+			(bytes(composite_hash), status, updated_at_height)
+			for composite_hash, status, updated_at_height in cursor.fetchall()
+		])
+		cursor.execute('SELECT height, type FROM symbol_transactions WHERE height >= 2')
+		self.assertEqual([], cursor.fetchall())
+
+	def test_sync_block_headers_keeps_rollback_state_unchanged_when_lock_replacement_fetch_fails(self):
+		# Arrange:
+		self._seed_blocks(self.puller.symbol_db, [1, 2], {2: b'local mismatch'.hex()})
+		original_sync_state = create_sync_state(
+			chain_height=2,
+			last_synced_height=2,
+			last_synced_block_hash=bytes.fromhex('02' * 32))
+		self.puller.symbol_db.upsert_sync_state(original_sync_state)
+		transaction = create_transaction_entry(
+			2,
+			'rollback-fetch-failure',
+			type=TransactionType.HASH_LOCK.value,
+			body={'hash': LOCK_HASH})
+		self.puller.symbol_db.upsert_transactions_for_height(2, [transaction])
+		self.puller.symbol_db.upsert_hash_lock(create_hash_lock_row(create_hash_lock_item(status=1), 2))
+		original_lock_state = self._fetch_lock_state()
+		original_sync_state = fetch_normalized_sync_state(self.puller.symbol_db)
+		connector = LockConnector(
+			2,
+			{1: [create_node_block(2)]},
+			{2: create_node_block(2)},
+			hash_responses={'lock/hash/' + LOCK_HASH: RuntimeError('rollback lock fetch failed')})
+
+		# Act / Assert:
+		with self.assertRaisesRegex(RuntimeError, '^rollback lock fetch failed$'):
+			self._sync_with_connector(connector)
+
+		# Assert:
+		cursor = self.puller.symbol_db.connection.cursor()
+		cursor.execute('SELECT height, type FROM symbol_transactions ORDER BY height, id')
+		self.assertEqual([(2, TransactionType.HASH_LOCK.value)], cursor.fetchall())
+		self.assertEqual([1, 2], self._fetch_block_heights(self.puller.symbol_db))
+		self.assertEqual(original_lock_state, self._fetch_lock_state())
+		self.assertEqual(original_sync_state, fetch_normalized_sync_state(self.puller.symbol_db))
+
+	def test_sync_block_headers_keeps_all_rollback_state_unchanged_when_secret_lock_replacement_fetch_fails(self):
+		# Arrange:
+		self._seed_blocks(self.puller.symbol_db, [1, 2], {2: b'local mismatch'.hex()})
+		self.puller.symbol_db.upsert_sync_state(create_sync_state(
+			chain_height=2,
+			last_synced_height=2,
+			last_synced_block_hash=bytes.fromhex('02' * 32)))
+		namespace_item = create_namespace_item(owner_address=SIGNER_ADDRESS)
+		seed_namespace(self.puller.symbol_db, namespace_item, {NAMESPACE_ROOT_ID: 'original'}, 1)
+		self.puller.symbol_db.upsert_mosaic(create_expected_mosaic_row(create_mosaic_item(supply='1234'), 1))
+		metadata_item = create_metadata_item(metadata_type=1, target_id=MOSAIC_ID)
+		self.puller.symbol_db.upsert_metadata(create_expected_metadata_row(
+			metadata_item, 1, bytes.fromhex('11' * 32), 'mosaic', MOSAIC_ID, 'hello'))
+		transaction = create_transaction_entry(
+			2,
+			'rollback-secret-fetch-failure',
+			type=TransactionType.SECRET_LOCK.value,
+			signer_address=bytes.fromhex(SIGNER_ADDRESS),
+			recipient_address=bytes.fromhex(RECIPIENT_ADDRESS),
+			body={'secret': SECRET, 'hashAlgorithm': 1})
+		self.puller.symbol_db.upsert_transactions_for_height(2, [transaction])
+		self.puller.symbol_db.upsert_hash_lock(create_hash_lock_row(create_hash_lock_item(status=1), 2))
+		secret_key = create_secret_lock_search_key(
+			bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160')
+		self.puller.symbol_db.replace_secret_locks(
+			secret_key, [create_secret_lock_row(create_secret_lock_item(status=1), 2)])
+		original_state = self._fetch_complete_rollback_state()
+		connector = LockConnector(
+			2,
+			{1: [create_node_block(2)]},
+			{2: create_node_block(2)},
+			hash_responses={'lock/hash/' + LOCK_HASH: create_hash_lock_item()},
+			secret_responses={_secret_search_path(SIGNER_ADDRESS, SECRET): RuntimeError('rollback secret lock fetch failed')})
+
+		# Act / Assert:
+		with self.assertRaisesRegex(RuntimeError, '^rollback secret lock fetch failed$'):
+			self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual(original_state, self._fetch_complete_rollback_state())
+
+	def test_sync_block_headers_preserves_the_approved_residual_window_for_pruned_unused_pre_fork_locks(self):
+		self._assert_residual_window_for_pruned_pre_fork_locks(0)
+
+	def test_sync_block_headers_preserves_the_approved_residual_window_for_pruned_used_pre_fork_locks(self):
+		self._assert_residual_window_for_pruned_pre_fork_locks(1)
+
+	def _assert_residual_window_for_pruned_pre_fork_locks(self, status_number):
+		# Arrange:
+		self._seed_blocks(self.puller.symbol_db, [1])
+		self.puller.symbol_db.upsert_sync_state(create_sync_state(
+			chain_height=1,
+			last_synced_height=1,
+			last_synced_block_hash=bytes.fromhex('01' * 32)))
+		self.puller.symbol_db.upsert_hash_lock(create_hash_lock_row(
+			create_hash_lock_item(status=status_number, endHeight='3'), 1))
+		secret_key = create_secret_lock_search_key(
+			bytes.fromhex(SIGNER_ADDRESS), bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'hash160')
+		self.puller.symbol_db.replace_secret_locks(
+			secret_key, [create_secret_lock_row(create_secret_lock_item(status=status_number, endHeight='3'), 1)])
+		orphaned_block_two_hash = 'DD' * 32
+		orphaned_block_three_hash = 'EE' * 32
+		orphaned_connector = LockConnector(
+			3,
+			{1: [
+				create_node_block(2, block_hash=orphaned_block_two_hash),
+				create_node_block(3, block_hash=orphaned_block_three_hash, previous_hash=orphaned_block_two_hash)
+			]},
+			hash_responses={'lock/hash/' + LOCK_HASH: {'code': 'ResourceNotFound', 'message': 'not found'}},
+			secret_responses={_secret_search_path(SIGNER_ADDRESS, SECRET): {'data': []}},
+			transactions_by_path={transaction_path(2, 3): {'data': []}},
+			statement_pages={statement_path(2, 3): {'data': []}})
+
+		# Act: orphaned branch reaches the absolute end height and prunes both rows.
+		self._sync_with_connector(orphaned_connector)
+
+		# Assert:
+		self.assertEqual(([], []), self._fetch_lock_state())
+		self.assertEqual([1, 2, 3], self._fetch_block_heights(self.puller.symbol_db))
+		orphaned_sync_state = self.puller.symbol_db.get_sync_state()
+		self.assertEqual(3, orphaned_sync_state['chain_height'])
+		self.assertEqual(3, orphaned_sync_state['last_synced_height'])
+		self.assertEqual(bytes.fromhex(orphaned_block_three_hash), bytes(orphaned_sync_state['last_synced_block_hash']))
+		self.assertEqual(bytes.fromhex(orphaned_block_three_hash), self._fetch_block_hash(self.puller.symbol_db, 3))
+		self.assertEqual([
+			'lock/hash/' + LOCK_HASH,
+			_secret_search_path(SIGNER_ADDRESS, SECRET)
+		], [path for path in orphaned_connector.paths if path.startswith('lock/')])
+
+		# Act: canonical branch rolls back below the absolute end height.
+		rollback_connector = LockConnector(
+			2,
+			{1: [create_node_block(2, block_hash='FF' * 32)]},
+			{2: create_node_block(2, block_hash='FF' * 32)},
+			transactions_by_path={transaction_path(2, 2): {'data': []}},
+			statement_pages={statement_path(2, 2): {'data': []}})
+		self._sync_with_connector(rollback_connector)
+
+		# Assert:
+		self.assertEqual(([], []), self._fetch_lock_state())
+		self.assertEqual([], [path for path in rollback_connector.paths if path.startswith('lock/')])
+		self.assertEqual([1, 2], self._fetch_block_heights(self.puller.symbol_db))
+		self.assertEqual(2, self.puller.symbol_db.get_sync_state()['last_synced_height'])
+		self.assertEqual(bytes.fromhex('FF' * 32), self._fetch_block_hash(self.puller.symbol_db, 2))
+
+		# Act: canonical branch reaches the same absolute end height.
+		canonical_end_height_connector = LockConnector(
+			3,
+			{2: [create_node_block(3)]},
+			{2: create_node_block(2, block_hash='FF' * 32)},
+			transactions_by_path={transaction_path(3, 3): {'data': []}},
+			statement_pages={statement_path(3, 3): {'data': []}})
+		self._sync_with_connector(canonical_end_height_connector)
+
+		# Assert:
+		self.assertEqual(([], []), self._fetch_lock_state())
+		self.assertEqual([1, 2, 3], self._fetch_block_heights(self.puller.symbol_db))
+		self.assertEqual(3, self.puller.symbol_db.get_sync_state()['last_synced_height'])
+		self.assertEqual([], [path for path in canonical_end_height_connector.paths if path.startswith('lock/')])
+
+	def _fetch_lock_state(self):
+		cursor = self.puller.symbol_db.connection.cursor()
+		cursor.execute('SELECT hash, status, updated_at_height FROM symbol_hash_locks ORDER BY hash')
+		hash_rows = [tuple([bytes(row[0]), *row[1:]]) for row in cursor.fetchall()]
+		cursor.execute('SELECT composite_hash, hash_algorithm, updated_at_height FROM symbol_secret_locks ORDER BY composite_hash')
+		secret_rows = [tuple([bytes(row[0]), *row[1:]]) for row in cursor.fetchall()]
+		return hash_rows, secret_rows
+
+	def test_sync_block_headers_does_not_partially_write_when_lock_fetch_fails(self):
+		# Arrange:
+		transaction = create_node_transaction(
+			1,
+			transaction_hash='01' * 32,
+			type=TransactionType.HASH_LOCK.value,
+			hash=LOCK_HASH,
+			mosaicId=MOSAIC_ID,
+			amount='1234')
+		connector = LockConnector(
+			1,
+			{0: [create_node_block(1)]},
+			hash_responses={'lock/hash/' + LOCK_HASH: RuntimeError('lock fetch failed')},
+			transactions_by_path={transaction_path(1, 1): {'data': [transaction]}},
+			statement_pages={statement_path(1, 1): {'data': []}})
+
+		# Act / Assert:
+		with self.assertRaisesRegex(RuntimeError, '^lock fetch failed$'):
+			self._sync_with_connector(connector)
+
+		# Assert:
+		cursor = self.puller.symbol_db.connection.cursor()
+		for table_name in ('symbol_blocks', 'symbol_transactions', 'symbol_receipts', 'symbol_hash_locks', 'symbol_secret_locks'):
+			cursor.execute(f'SELECT COUNT(*) FROM {table_name}')
+			self.assertEqual(0, cursor.fetchone()[0], table_name)
+		self.assertIsNone(self.puller.symbol_db.get_sync_state())
+
+	def test_sync_block_headers_does_not_partially_write_when_secret_lock_fetch_fails(self):
+		# Arrange:
+		transaction = create_node_transaction(
+			1,
+			transaction_hash='01' * 32,
+			type=TransactionType.SECRET_LOCK.value,
+			secret=SECRET,
+			hashAlgorithm=1,
+			mosaicId=MOSAIC_ID,
+			amount='1234')
+		path = _secret_search_path(SIGNER_ADDRESS, SECRET)
+		connector = LockConnector(
+			1,
+			{0: [create_node_block(1)]},
+			secret_responses={path: RuntimeError('secret lock fetch failed')},
+			transactions_by_path={transaction_path(1, 1): {'data': [transaction]}},
+			statement_pages={statement_path(1, 1): {'data': []}})
+
+		# Act / Assert:
+		with self.assertRaisesRegex(RuntimeError, '^secret lock fetch failed$'):
+			self._sync_with_connector(connector)
+
+		# Assert:
+		cursor = self.puller.symbol_db.connection.cursor()
+		for table_name in ('symbol_blocks', 'symbol_transactions', 'symbol_receipts', 'symbol_hash_locks', 'symbol_secret_locks'):
+			cursor.execute(f'SELECT COUNT(*) FROM {table_name}')
+			self.assertEqual(0, cursor.fetchone()[0], table_name)
+		self.assertIsNone(self.puller.symbol_db.get_sync_state())

--- a/explorer/puller/tests/facade/symbol/test_PullerLocks.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerLocks.py
@@ -13,6 +13,8 @@ from puller.model.symbol.Lock import (
 	create_secret_lock_search_key
 )
 from tests.test.SymbolDatabaseTestUtils import fetch_full_block_state, fetch_normalized_sync_state
+from tests.test.SymbolLockTestUtils import create_expected_secret_lock_row
+from tests.test.SymbolLockTestUtils import create_secret_lock_item as create_secret_lock_item_fixture
 from tests.test.SymbolMetadataTestUtils import create_expected_metadata_row, create_metadata_item, fetch_metadata_rows
 from tests.test.SymbolMosaicTestUtils import create_expected_mosaic_row, create_mosaic_item, fetch_mosaic_state
 from tests.test.SymbolNamespaceTestUtils import NAMESPACE_ROOT_ID, create_namespace_item, fetch_namespace_state, seed_namespace
@@ -57,19 +59,18 @@ def create_secret_lock_item(
 	secret=SECRET,
 	**overrides
 ):
-	lock = {
-		'compositeHash': composite_hash,
-		'ownerAddress': owner_address,
-		'recipientAddress': RECIPIENT_ADDRESS,
-		'secret': secret,
-		'hashAlgorithm': 1,
-		'mosaicId': MOSAIC_ID,
-		'amount': '1234',
-		'endHeight': '100',
-		'status': 0
-	}
-	lock.update(overrides)
-	return {'lock': lock, 'id': 'secret-lock'}
+	return create_secret_lock_item_fixture(
+		composite_hash=composite_hash,
+		owner_address=owner_address,
+		recipient_address=RECIPIENT_ADDRESS,
+		secret=secret,
+		hash_algorithm=1,
+		mosaic_id=MOSAIC_ID,
+		amount='1234',
+		end_height='100',
+		status=0,
+		item_id='secret-lock',
+		lock_overrides=overrides)
 
 
 class LockConnector(FakeConnector):
@@ -765,32 +766,18 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 				'id': 'hash-lock'
 			},
 			'updated_at_height': 1
-		}], [{
-			'composite_hash': bytes.fromhex(COMPOSITE_HASH),
-			'owner_address': bytes.fromhex(SIGNER_ADDRESS),
-			'recipient_address': bytes.fromhex(RECIPIENT_ADDRESS),
-			'secret': bytes.fromhex(SECRET),
-			'hash_algorithm': 'hash160',
-			'mosaic_id': MOSAIC_ID,
-			'amount': 1234,
-			'end_height': 100,
-			'status': 'unused',
-			'raw_payload': {
-				'lock': {
-					'compositeHash': COMPOSITE_HASH,
-					'ownerAddress': SIGNER_ADDRESS,
-					'recipientAddress': RECIPIENT_ADDRESS,
-					'secret': SECRET,
-					'hashAlgorithm': 1,
-					'mosaicId': MOSAIC_ID,
-					'amount': '1234',
-					'endHeight': '100',
-					'status': 0
-				},
-				'id': 'secret-lock'
-			},
-			'updated_at_height': 1
-		}])
+		}], [create_expected_secret_lock_row(
+			create_secret_lock_item(),
+			1,
+			composite_hash=bytes.fromhex(COMPOSITE_HASH),
+			owner_address=bytes.fromhex(SIGNER_ADDRESS),
+			recipient_address=bytes.fromhex(RECIPIENT_ADDRESS),
+			secret=bytes.fromhex(SECRET),
+			hash_algorithm='hash160',
+			mosaic_id=MOSAIC_ID,
+			amount=1234,
+			end_height=100,
+			status='unused')])
 
 	def _fetch_persisted_lock_state(self):
 		cursor = self.puller.symbol_db.connection.cursor()

--- a/explorer/puller/tests/facade/symbol/test_PullerSync.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerSync.py
@@ -36,6 +36,7 @@ from .puller_test_utils import (
 	SymbolPullerTestBase,
 	create_amount_statement_item,
 	create_artifact_expiry_statement,
+	create_complete_aggregate_pair,
 	create_embedded_node_transaction,
 	create_network_properties,
 	create_node_block,
@@ -225,24 +226,15 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):  # pylint: disable=too-many-pu
 		aggregate_hash = 'A' * 64
 		self._assert_alias_supply_change_refreshes_mosaic_state(
 			alias_mosaic_id,
-			[
-				create_node_transaction(
-					1,
-					transaction_hash=aggregate_hash,
-					block_index=0,
-					type=TransactionType.AGGREGATE_COMPLETE.value,
-					transactionsHash='9' * 64,
-					cosignatures=[]),
-				create_embedded_node_transaction(
-					1,
-					aggregate_hash,
-					0,
-					transaction_id='embedded-mosaic-supply-change',
-					type=TransactionType.MOSAIC_SUPPLY_CHANGE.value,
-					mosaicId=alias_mosaic_id,
-					delta=str(supply_delta),
-					action=MosaicSupplyChangeAction.INCREASE.value)
-			],
+			create_complete_aggregate_pair(
+				1,
+				aggregate_hash,
+				0,
+				transaction_id='embedded-mosaic-supply-change',
+				type=TransactionType.MOSAIC_SUPPLY_CHANGE.value,
+				mosaicId=alias_mosaic_id,
+				delta=str(supply_delta),
+				action=MosaicSupplyChangeAction.INCREASE.value),
 			[
 				# The (1, 0) entry proves the embedded transaction uses (1, 1), not its parent aggregate source.
 				{'source': {'primaryId': 1, 'secondaryId': 0}, 'resolved': mosaic_id_at_aggregate_source},

--- a/explorer/puller/tests/model/symbol/test_Lock.py
+++ b/explorer/puller/tests/model/symbol/test_Lock.py
@@ -13,6 +13,7 @@ from puller.model.symbol.Lock import (
 	lock_hash_algorithm_label,
 	lock_status_label
 )
+from tests.test.SymbolLockTestUtils import create_expected_secret_lock_row, create_secret_lock_item
 
 OWNER_ADDRESS = '98' + '11' * 23
 RECIPIENT_ADDRESS = '98' + '22' * 23
@@ -33,22 +34,6 @@ def create_hash_lock_item(**overrides):
 	}
 	lock.update(overrides)
 	return {'lock': lock, 'id': 'hash-item'}
-
-
-def create_secret_lock_item(**overrides):
-	lock = {
-		'compositeHash': COMPOSITE_HASH,
-		'ownerAddress': OWNER_ADDRESS,
-		'recipientAddress': RECIPIENT_ADDRESS,
-		'secret': SECRET,
-		'hashAlgorithm': 1,
-		'mosaicId': MOSAIC_ID,
-		'amount': '1234',
-		'endHeight': '5678',
-		'status': 1
-	}
-	lock.update(overrides)
-	return {'lock': lock, 'id': 'secret-item'}
 
 
 class LockTest(TestCase):
@@ -92,19 +77,7 @@ class LockTest(TestCase):
 		row = create_secret_lock_row(item, 123)
 
 		# Assert:
-		self.assertEqual({
-			'composite_hash': bytes.fromhex(COMPOSITE_HASH),
-			'owner_address': bytes.fromhex(OWNER_ADDRESS),
-			'recipient_address': bytes.fromhex(RECIPIENT_ADDRESS),
-			'secret': bytes.fromhex(SECRET),
-			'hash_algorithm': 'hash160',
-			'mosaic_id': MOSAIC_ID,
-			'amount': 1234,
-			'end_height': 5678,
-			'status': 'used',
-			'raw_payload': item,
-			'updated_at_height': 123
-		}, row)
+		self.assertEqual(create_expected_secret_lock_row(item, 123), row)
 
 	def test_create_hash_lock_key_requires_exactly_32_bytes(self):
 		# Arrange:

--- a/explorer/puller/tests/model/symbol/test_Lock.py
+++ b/explorer/puller/tests/model/symbol/test_Lock.py
@@ -1,0 +1,330 @@
+# pylint: disable=too-many-public-methods
+from unittest import TestCase
+
+from puller.model.symbol.Lock import (
+	LOCK_HASH_ALGORITHM_LABELS,
+	LOCK_STATUS_LABELS,
+	create_hash_lock_key,
+	create_hash_lock_key_from_hex,
+	create_hash_lock_row,
+	create_secret_lock_row,
+	create_secret_lock_search_key,
+	create_secret_lock_search_key_from_hex_secret,
+	lock_hash_algorithm_label,
+	lock_status_label
+)
+
+OWNER_ADDRESS = '98' + '11' * 23
+RECIPIENT_ADDRESS = '98' + '22' * 23
+HASH = 'AA' * 32
+COMPOSITE_HASH = 'BB' * 32
+SECRET = 'CC' * 32
+MOSAIC_ID = '72C0212E67A08BCE'
+
+
+def create_hash_lock_item(**overrides):
+	lock = {
+		'hash': HASH,
+		'ownerAddress': OWNER_ADDRESS,
+		'mosaicId': MOSAIC_ID,
+		'amount': '1234',
+		'endHeight': '5678',
+		'status': 0
+	}
+	lock.update(overrides)
+	return {'lock': lock, 'id': 'hash-item'}
+
+
+def create_secret_lock_item(**overrides):
+	lock = {
+		'compositeHash': COMPOSITE_HASH,
+		'ownerAddress': OWNER_ADDRESS,
+		'recipientAddress': RECIPIENT_ADDRESS,
+		'secret': SECRET,
+		'hashAlgorithm': 1,
+		'mosaicId': MOSAIC_ID,
+		'amount': '1234',
+		'endHeight': '5678',
+		'status': 1
+	}
+	lock.update(overrides)
+	return {'lock': lock, 'id': 'secret-item'}
+
+
+class LockTest(TestCase):
+	def test_lock_status_and_hash_algorithm_mappings_are_exact(self):
+		# Arrange:
+		expected_status_labels = {0: 'unused', 1: 'used'}
+		expected_algorithm_labels = {0: 'sha3_256', 1: 'hash160', 2: 'hash256'}
+
+		# Act:
+		status_labels = LOCK_STATUS_LABELS
+		algorithm_labels = LOCK_HASH_ALGORITHM_LABELS
+
+		# Assert:
+		self.assertEqual(expected_status_labels, status_labels)
+		self.assertEqual(expected_algorithm_labels, algorithm_labels)
+
+	def test_create_hash_lock_row_returns_the_complete_normalized_row(self):
+		# Arrange:
+		item = create_hash_lock_item()
+
+		# Act:
+		row = create_hash_lock_row(item, 123)
+
+		# Assert:
+		self.assertEqual({
+			'hash': bytes.fromhex(HASH),
+			'owner_address': bytes.fromhex(OWNER_ADDRESS),
+			'mosaic_id': MOSAIC_ID,
+			'amount': 1234,
+			'end_height': 5678,
+			'status': 'unused',
+			'raw_payload': item,
+			'updated_at_height': 123
+		}, row)
+
+	def test_create_secret_lock_row_returns_the_complete_normalized_row(self):
+		# Arrange:
+		item = create_secret_lock_item()
+
+		# Act:
+		row = create_secret_lock_row(item, 123)
+
+		# Assert:
+		self.assertEqual({
+			'composite_hash': bytes.fromhex(COMPOSITE_HASH),
+			'owner_address': bytes.fromhex(OWNER_ADDRESS),
+			'recipient_address': bytes.fromhex(RECIPIENT_ADDRESS),
+			'secret': bytes.fromhex(SECRET),
+			'hash_algorithm': 'hash160',
+			'mosaic_id': MOSAIC_ID,
+			'amount': 1234,
+			'end_height': 5678,
+			'status': 'used',
+			'raw_payload': item,
+			'updated_at_height': 123
+		}, row)
+
+	def test_create_hash_lock_key_requires_exactly_32_bytes(self):
+		# Arrange:
+		invalid_hash = b'not-a-hash'
+
+		# Act / Assert:
+		with self.assertRaisesRegex(ValueError, '^Invalid Symbol Hash Lock key$'):
+			create_hash_lock_key(invalid_hash)
+
+	def test_create_hash_lock_key_from_hex_rejects_non_hex_and_wrong_length(self):
+		# Arrange:
+		invalid_values = ('not-hex', 'AA' * 31, 'AA' * 33)
+
+		# Act / Assert:
+		for invalid_value in invalid_values:
+			with self.subTest(invalid_value=invalid_value):
+				with self.assertRaisesRegex(ValueError, '^Invalid Symbol Hash Lock key$'):
+					create_hash_lock_key_from_hex(invalid_value)
+
+	def test_create_hash_lock_key_from_hex_rejects_a_non_string(self):
+		# Arrange:
+		invalid_hash = None
+
+		# Act / Assert:
+		with self.assertRaisesRegex(ValueError, '^Invalid Symbol Hash Lock key$'):
+			create_hash_lock_key_from_hex(invalid_hash)
+
+	def test_create_secret_lock_search_key_supports_unknown_owner(self):
+		# Arrange:
+		recipient = bytes.fromhex(RECIPIENT_ADDRESS)
+		secret = bytes.fromhex(SECRET)
+
+		# Act:
+		key = create_secret_lock_search_key(None, recipient, secret, 'hash160')
+
+		# Assert:
+		self.assertEqual((None, recipient, secret, 'hash160'), key)
+
+	def test_create_secret_lock_search_key_from_hex_secret_returns_the_complete_key(self):
+		# Arrange:
+		owner = bytes.fromhex(OWNER_ADDRESS)
+		recipient = bytes.fromhex(RECIPIENT_ADDRESS)
+
+		# Act:
+		key = create_secret_lock_search_key_from_hex_secret(owner, recipient, SECRET, 'sha3_256')
+
+		# Assert:
+		self.assertEqual((owner, recipient, bytes.fromhex(SECRET), 'sha3_256'), key)
+
+	def test_mapping_helpers_reject_unsupported_values(self):
+		# Arrange:
+		invalid_status = 99
+		invalid_algorithm = 99
+
+		# Act / Assert:
+		with self.assertRaisesRegex(ValueError, '^Unsupported Symbol lock status type 99$'):
+			lock_status_label(invalid_status)
+		with self.assertRaisesRegex(ValueError, '^Unsupported Symbol lock hash algorithm type 99$'):
+			lock_hash_algorithm_label(invalid_algorithm)
+
+	def test_lock_status_label_rejects_non_integer_values(self):
+		# Arrange:
+		invalid_values = (True, False, 0.0, 1.0, '1')
+
+		# Act / Assert:
+		for invalid_value in invalid_values:
+			with self.subTest(invalid_value=invalid_value):
+				with self.assertRaisesRegex(ValueError, f'^Unsupported Symbol lock status type {invalid_value}$'):
+					lock_status_label(invalid_value)
+
+	def test_lock_hash_algorithm_label_rejects_non_integer_values(self):
+		# Arrange:
+		invalid_values = (True, False, 0.0, 1.0, '1')
+
+		# Act / Assert:
+		for invalid_value in invalid_values:
+			with self.subTest(invalid_value=invalid_value):
+				with self.assertRaisesRegex(
+					ValueError, f'^Unsupported Symbol lock hash algorithm type {invalid_value}$'):
+					lock_hash_algorithm_label(invalid_value)
+
+	def test_create_hash_lock_row_accepts_nonnegative_integer_and_decimal_integer_string_numeric_fields(self):
+		# Arrange:
+		hash_item = create_hash_lock_item(amount=1234, endHeight='5678')
+
+		# Act:
+		hash_row = create_hash_lock_row(hash_item, 123)
+
+		# Assert:
+		self.assertEqual((1234, 5678), (hash_row['amount'], hash_row['end_height']))
+
+	def test_create_secret_lock_row_accepts_nonnegative_integer_and_decimal_integer_string_numeric_fields(self):
+		# Arrange:
+		secret_item = create_secret_lock_item(amount='1234', endHeight=5678)
+
+		# Act:
+		secret_row = create_secret_lock_row(secret_item, 123)
+
+		# Assert:
+		self.assertEqual((1234, 5678), (secret_row['amount'], secret_row['end_height']))
+
+	def test_create_hash_lock_row_rejects_noncanonical_numeric_fields_with_deterministic_errors(self):
+		# Arrange:
+		invalid_values = (True, 1.0, 1.5, '1.5', '1e3', '', ' 1', '1 ', '-1', None)
+
+		# Act / Assert:
+		for field_name in ('amount', 'endHeight'):
+			for invalid_value in invalid_values:
+				with self.subTest(field_name=field_name, invalid_value=invalid_value):
+					with self.assertRaisesRegex(ValueError, f'^Invalid Symbol Hash Lock {field_name}$'):
+						create_hash_lock_row(create_hash_lock_item(**{field_name: invalid_value}), 123)
+
+	def test_create_secret_lock_row_rejects_noncanonical_numeric_fields_with_deterministic_errors(self):
+		# Arrange:
+		invalid_values = (True, 1.0, 1.5, '1.5', '1e3', '', ' 1', '1 ', '-1', None)
+
+		# Act / Assert:
+		for field_name in ('amount', 'endHeight'):
+			for invalid_value in invalid_values:
+				with self.subTest(field_name=field_name, invalid_value=invalid_value):
+					with self.assertRaisesRegex(ValueError, f'^Invalid Symbol Secret Lock {field_name}$'):
+						create_secret_lock_row(create_secret_lock_item(**{field_name: invalid_value}), 123)
+
+	def test_create_hash_lock_row_rejects_a_malformed_wrapper(self):
+		# Arrange:
+		invalid_item = {}
+
+		# Act / Assert:
+		with self.assertRaisesRegex(ValueError, '^Malformed Symbol Hash Lock response$'):
+			create_hash_lock_row(invalid_item, 123)
+
+	def test_create_hash_lock_row_rejects_each_invalid_field(self):
+		# Arrange:
+		invalid_fields = {
+			'hash': 'not-hex',
+			'ownerAddress': OWNER_ADDRESS[:-2],
+			'mosaicId': 'not-hex',
+			'amount': True,
+			'endHeight': 'not-number',
+			'status': 99
+		}
+
+		# Act / Assert:
+		for field_name, invalid_value in invalid_fields.items():
+			item = create_hash_lock_item(**{field_name: invalid_value})
+			with self.subTest(field_name=field_name):
+				with self.assertRaises(ValueError):
+					create_hash_lock_row(item, 123)
+
+	def test_create_secret_lock_row_rejects_each_invalid_field(self):
+		# Arrange:
+		invalid_fields = {
+			'compositeHash': 'not-hex',
+			'ownerAddress': OWNER_ADDRESS[:-2],
+			'recipientAddress': RECIPIENT_ADDRESS[:-2],
+			'secret': 'not-hex',
+			'hashAlgorithm': 99,
+			'mosaicId': 'not-hex',
+			'amount': True,
+			'endHeight': 'not-number',
+			'status': 99
+		}
+
+		# Act / Assert:
+		for field_name, invalid_value in invalid_fields.items():
+			item = create_secret_lock_item(**{field_name: invalid_value})
+			with self.subTest(field_name=field_name):
+				with self.assertRaises(ValueError):
+					create_secret_lock_row(item, 123)
+
+	def test_create_secret_lock_search_key_rejects_invalid_owner(self):
+		# Arrange:
+		invalid_owner = b'owner'
+
+		# Act / Assert:
+		with self.assertRaisesRegex(ValueError, '^Invalid Symbol Secret Lock owner address$'):
+			create_secret_lock_search_key(invalid_owner, bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'sha3_256')
+
+	def test_create_secret_lock_search_key_rejects_invalid_recipient_secret_and_algorithm(self):
+		# Arrange:
+		owner = bytes.fromhex(OWNER_ADDRESS)
+
+		# Act / Assert:
+		with self.assertRaisesRegex(ValueError, '^Invalid Symbol Secret Lock recipient address$'):
+			create_secret_lock_search_key(owner, b'recipient', bytes.fromhex(SECRET), 'sha3_256')
+		with self.assertRaisesRegex(ValueError, '^Invalid Symbol Secret Lock secret$'):
+			create_secret_lock_search_key(owner, bytes.fromhex(RECIPIENT_ADDRESS), b'secret', 'sha3_256')
+		with self.assertRaisesRegex(ValueError, '^Unsupported Symbol Secret Lock hash algorithm invalid$'):
+			create_secret_lock_search_key(owner, bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'invalid')
+
+	def test_create_secret_lock_search_key_from_hex_secret_rejects_non_hex_secret(self):
+		# Arrange:
+		owner = bytes.fromhex(OWNER_ADDRESS)
+		recipient = bytes.fromhex(RECIPIENT_ADDRESS)
+
+		# Act / Assert:
+		with self.assertRaisesRegex(ValueError, '^Invalid Symbol Secret Lock secret$'):
+			create_secret_lock_search_key_from_hex_secret(owner, recipient, 'not-hex', 'sha3_256')
+
+	def test_create_secret_lock_search_key_from_hex_secret_rejects_a_non_string_secret(self):
+		# Arrange:
+		owner = bytes.fromhex(OWNER_ADDRESS)
+		recipient = bytes.fromhex(RECIPIENT_ADDRESS)
+
+		# Act / Assert:
+		with self.assertRaisesRegex(ValueError, '^Invalid Symbol Secret Lock secret$'):
+			create_secret_lock_search_key_from_hex_secret(owner, recipient, None, 'sha3_256')
+
+	def test_create_hash_lock_row_rejects_invalid_hex_with_the_expected_field_length(self):
+		# Arrange:
+		item = create_hash_lock_item(hash='GG' * 32)
+
+		# Act / Assert:
+		with self.assertRaisesRegex(ValueError, '^Invalid Symbol Hash Lock hash$'):
+			create_hash_lock_row(item, 123)
+
+	def test_create_secret_lock_row_rejects_invalid_mosaic_hex_with_the_expected_field_length(self):
+		# Arrange:
+		item = create_secret_lock_item(mosaicId='GG' * 8)
+
+		# Act / Assert:
+		with self.assertRaisesRegex(ValueError, '^Invalid Symbol Secret Lock mosaicId$'):
+			create_secret_lock_row(item, 123)

--- a/explorer/puller/tests/model/symbol/test_Lock.py
+++ b/explorer/puller/tests/model/symbol/test_Lock.py
@@ -179,9 +179,61 @@ class LockTest(TestCase):
 		# Assert:
 		self.assertEqual((1234, 5678), (secret_row['amount'], secret_row['end_height']))
 
+	def test_create_hash_lock_row_preserves_zero_numeric_values(self):
+		# Arrange:
+		items = (
+			create_hash_lock_item(amount=0, endHeight='0'),
+			create_hash_lock_item(amount='0', endHeight=0)
+		)
+
+		# Act:
+		rows = [create_hash_lock_row(item, 123) for item in items]
+
+		# Assert:
+		self.assertEqual([(0, 0), (0, 0)], [
+			(row['amount'], row['end_height'])
+			for row in rows
+		])
+
+	def test_create_hash_lock_row_uppercases_a_lowercase_mosaic_id(self):
+		# Arrange:
+		item = create_hash_lock_item(mosaicId=MOSAIC_ID.lower())
+
+		# Act:
+		row = create_hash_lock_row(item, 123)
+
+		# Assert:
+		self.assertEqual(MOSAIC_ID, row['mosaic_id'])
+
+	def test_create_secret_lock_row_preserves_zero_numeric_values(self):
+		# Arrange:
+		items = (
+			create_secret_lock_item(amount=0, endHeight='0'),
+			create_secret_lock_item(amount='0', endHeight=0)
+		)
+
+		# Act:
+		rows = [create_secret_lock_row(item, 123) for item in items]
+
+		# Assert:
+		self.assertEqual([(0, 0), (0, 0)], [
+			(row['amount'], row['end_height'])
+			for row in rows
+		])
+
+	def test_create_secret_lock_row_uppercases_a_lowercase_mosaic_id(self):
+		# Arrange:
+		item = create_secret_lock_item(mosaicId=MOSAIC_ID.lower())
+
+		# Act:
+		row = create_secret_lock_row(item, 123)
+
+		# Assert:
+		self.assertEqual(MOSAIC_ID, row['mosaic_id'])
+
 	def test_create_hash_lock_row_rejects_noncanonical_numeric_fields_with_deterministic_errors(self):
 		# Arrange:
-		invalid_values = (True, 1.0, 1.5, '1.5', '1e3', '', ' 1', '1 ', '-1', None)
+		invalid_values = (True, 1.0, 1.5, '1.5', '1e3', '', ' 1', '1 ', '-1', '+1', '١', None)
 
 		# Act / Assert:
 		for field_name in ('amount', 'endHeight'):
@@ -192,7 +244,7 @@ class LockTest(TestCase):
 
 	def test_create_secret_lock_row_rejects_noncanonical_numeric_fields_with_deterministic_errors(self):
 		# Arrange:
-		invalid_values = (True, 1.0, 1.5, '1.5', '1e3', '', ' 1', '1 ', '-1', None)
+		invalid_values = (True, 1.0, 1.5, '1.5', '1e3', '', ' 1', '1 ', '-1', '+1', '١', None)
 
 		# Act / Assert:
 		for field_name in ('amount', 'endHeight'):

--- a/explorer/puller/tests/model/symbol/test_Lock.py
+++ b/explorer/puller/tests/model/symbol/test_Lock.py
@@ -5,7 +5,6 @@ from puller.model.symbol.Lock import (
 	LOCK_HASH_ALGORITHM_LABELS,
 	LOCK_STATUS_LABELS,
 	create_hash_lock_key,
-	create_hash_lock_key_from_hex,
 	create_hash_lock_row,
 	create_secret_lock_row,
 	create_secret_lock_search_key,
@@ -79,6 +78,16 @@ class LockTest(TestCase):
 		# Assert:
 		self.assertEqual(create_expected_secret_lock_row(item, 123), row)
 
+	def test_create_hash_lock_key_normalizes_supported_input_types_to_bytes(self):
+		# Arrange:
+		expected_key = (bytes.fromhex(HASH),)
+
+		# Act:
+		keys = [create_hash_lock_key(HASH), create_hash_lock_key(bytes.fromhex(HASH))]
+
+		# Assert:
+		self.assertEqual([expected_key, expected_key], keys)
+
 	def test_create_hash_lock_key_requires_exactly_32_bytes(self):
 		# Arrange:
 		invalid_hash = b'not-a-hash'
@@ -87,7 +96,7 @@ class LockTest(TestCase):
 		with self.assertRaisesRegex(ValueError, '^Invalid Symbol Hash Lock key$'):
 			create_hash_lock_key(invalid_hash)
 
-	def test_create_hash_lock_key_from_hex_rejects_non_hex_and_wrong_length(self):
+	def test_create_hash_lock_key_rejects_non_hex_and_wrong_length_text(self):
 		# Arrange:
 		invalid_values = ('not-hex', 'AA' * 31, 'AA' * 33)
 
@@ -95,15 +104,15 @@ class LockTest(TestCase):
 		for invalid_value in invalid_values:
 			with self.subTest(invalid_value=invalid_value):
 				with self.assertRaisesRegex(ValueError, '^Invalid Symbol Hash Lock key$'):
-					create_hash_lock_key_from_hex(invalid_value)
+					create_hash_lock_key(invalid_value)
 
-	def test_create_hash_lock_key_from_hex_rejects_a_non_string(self):
+	def test_create_hash_lock_key_rejects_an_unsupported_type(self):
 		# Arrange:
-		invalid_hash = None
+		invalid_hash = bytearray(32)
 
 		# Act / Assert:
 		with self.assertRaisesRegex(ValueError, '^Invalid Symbol Hash Lock key$'):
-			create_hash_lock_key_from_hex(invalid_hash)
+			create_hash_lock_key(invalid_hash)
 
 	def test_create_secret_lock_search_key_supports_unknown_owner(self):
 		# Arrange:
@@ -308,6 +317,24 @@ class LockTest(TestCase):
 		with self.assertRaisesRegex(ValueError, '^Invalid Symbol Secret Lock owner address$'):
 			create_secret_lock_search_key(invalid_owner, bytes.fromhex(RECIPIENT_ADDRESS), bytes.fromhex(SECRET), 'sha3_256')
 
+	def test_create_secret_lock_search_key_rejects_non_byte_addresses_and_secret(self):
+		# Arrange:
+		owner = bytes.fromhex(OWNER_ADDRESS)
+		recipient = bytes.fromhex(RECIPIENT_ADDRESS)
+		secret = bytes.fromhex(SECRET)
+		invalid_values = (
+			('owner address', 'owner', recipient, secret),
+			('recipient address', owner, 'recipient', secret),
+			('secret', owner, recipient, 'secret')
+		)
+
+		# Act / Assert:
+		for field_name, owner_value, recipient_value, secret_value in invalid_values:
+			with self.subTest(field_name=field_name):
+				with self.assertRaisesRegex(ValueError, f'^Invalid Symbol Secret Lock {field_name}$'):
+					create_secret_lock_search_key(
+						owner_value, recipient_value, secret_value, 'sha3_256')
+
 	def test_create_secret_lock_search_key_rejects_invalid_recipient_secret_and_algorithm(self):
 		# Arrange:
 		owner = bytes.fromhex(OWNER_ADDRESS)
@@ -344,6 +371,31 @@ class LockTest(TestCase):
 
 		# Act / Assert:
 		with self.assertRaisesRegex(ValueError, '^Invalid Symbol Hash Lock hash$'):
+			create_hash_lock_row(item, 123)
+
+	def test_create_lock_rows_reject_non_string_hash_fields_with_deterministic_errors(self):
+		# Arrange:
+		invalid_fields = (
+			('Hash Lock hash', create_hash_lock_row, create_hash_lock_item(hash=None),
+				'^Invalid Symbol Hash Lock hash$'),
+			('Secret Lock compositeHash', create_secret_lock_row, create_secret_lock_item(compositeHash=None),
+				'^Invalid Symbol Secret Lock compositeHash$'),
+			('Secret Lock secret', create_secret_lock_row, create_secret_lock_item(secret=None),
+				'^Invalid Symbol Secret Lock secret$')
+		)
+
+		# Act / Assert:
+		for field_name, create_row, item, expected_error in invalid_fields:
+			with self.subTest(field_name=field_name):
+				with self.assertRaisesRegex(ValueError, expected_error):
+					create_row(item, 123)
+
+	def test_create_hash_lock_row_rejects_a_non_string_owner_address(self):
+		# Arrange:
+		item = create_hash_lock_item(ownerAddress=None)
+
+		# Act / Assert:
+		with self.assertRaisesRegex(ValueError, '^Invalid Symbol Hash Lock ownerAddress$'):
 			create_hash_lock_row(item, 123)
 
 	def test_create_secret_lock_row_rejects_invalid_mosaic_hex_with_the_expected_field_length(self):

--- a/explorer/puller/tests/test/SymbolLockTestUtils.py
+++ b/explorer/puller/tests/test/SymbolLockTestUtils.py
@@ -1,0 +1,60 @@
+import copy
+
+
+def create_secret_lock_item(
+	composite_hash='BB' * 32,
+	owner_address='98' + '11' * 23,
+	recipient_address='98' + '22' * 23,
+	secret='CC' * 32,
+	hash_algorithm=1,
+	mosaic_id='72C0212E67A08BCE',
+	amount='1234',
+	end_height='5678',
+	status=1,
+	item_id='secret-item',
+	lock_overrides=None,
+	**overrides
+):  # pylint: disable=too-many-arguments,too-many-positional-arguments
+	lock = {
+		'compositeHash': composite_hash,
+		'ownerAddress': owner_address,
+		'recipientAddress': recipient_address,
+		'secret': secret,
+		'hashAlgorithm': hash_algorithm,
+		'mosaicId': mosaic_id,
+		'amount': amount,
+		'endHeight': end_height,
+		'status': status
+	}
+	if lock_overrides:
+		lock.update(lock_overrides)
+	lock.update(overrides)
+	return {'lock': lock, 'id': item_id}
+
+
+def create_expected_secret_lock_row(
+	secret_lock_item,
+	observed_height,
+	composite_hash=bytes.fromhex('BB' * 32),
+	owner_address=bytes.fromhex('98' + '11' * 23),
+	recipient_address=bytes.fromhex('98' + '22' * 23),
+	secret=bytes.fromhex('CC' * 32),
+	hash_algorithm='hash160',
+	mosaic_id='72C0212E67A08BCE',
+	amount=1234,
+	end_height=5678,
+	status='used'
+):  # pylint: disable=too-many-arguments,too-many-positional-arguments
+	return {
+		'raw_payload': copy.deepcopy(secret_lock_item),
+		'updated_at_height': observed_height,
+		'composite_hash': composite_hash,
+		'secret': secret,
+		'hash_algorithm': hash_algorithm,
+		'owner_address': owner_address,
+		'recipient_address': recipient_address,
+		'mosaic_id': mosaic_id,
+		'status': status,
+		'end_height': end_height,
+		'amount': amount
+	}

--- a/explorer/puller/tests/test/SymbolLockTestUtils.py
+++ b/explorer/puller/tests/test/SymbolLockTestUtils.py
@@ -12,7 +12,6 @@ def create_secret_lock_item(
 	end_height='5678',
 	status=1,
 	item_id='secret-item',
-	lock_overrides=None,
 	**overrides
 ):  # pylint: disable=too-many-arguments,too-many-positional-arguments
 	lock = {
@@ -26,8 +25,6 @@ def create_secret_lock_item(
 		'endHeight': end_height,
 		'status': status
 	}
-	if lock_overrides:
-		lock.update(lock_overrides)
 	lock.update(overrides)
 	return {'lock': lock, 'id': item_id}
 


### PR DESCRIPTION
This PR adds puller-only Symbol Hash Lock and Secret Lock synchronization.

## How have you changed the behavior?

- Added exact Hash Lock and Secret Lock current-state schemas, enums, and indexes.
- Collects affected Lock keys from transactions, expiry ranges, and rollback state.
- Fetches canonical Lock state from the node before writing, with bounded concurrency.
- Uses the node-provided Secret Lock `compositeHash` without calculating it locally.
- Validates and locally filters paginated Secret Lock responses, rejecting malformed or duplicate data.
- Applies Hash/Secret Lock updates after Metadata and restores affected state atomically during rollback.