### PR TITLE
[explorer/puller] feat: Capture rollback data

### DIFF
--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -2,11 +2,21 @@ import json
 from binascii import unhexlify
 from collections import namedtuple
 
+from symbolchain.CryptoTypes import PublicKey
 from symbolchain.nem.Network import Address
 
 from .DatabaseConnection import DatabaseConnection
 
 AccountRefreshRecord = namedtuple('AccountRefreshRecord', ['id', 'address'])
+RollbackBlockRecord = namedtuple('RollbackBlockRecord', ['beneficiary', 'signer'])
+RollbackTransactionRecord = namedtuple(
+	'RollbackTransactionRecord',
+	['transaction_type', 'sender_address', 'recipient_address', 'payload']
+)
+OrphanChainRecords = namedtuple(
+	'OrphanChainRecords',
+	['blocks', 'transactions', 'transfer_levy_recipients']
+)
 
 
 class NemDatabase(DatabaseConnection):
@@ -411,6 +421,88 @@ class NemDatabase(DatabaseConnection):
 		)
 		result = cursor.fetchone()
 		return result[0] if result else None
+
+	def get_orphan_chain_records(self, fork_height):
+		"""Gets block and transaction records above a confirmed fork height."""
+
+		cursor = self.connection.cursor()
+		cursor.execute(
+			'''
+			SELECT
+				beneficiary,
+				signer
+			FROM blocks
+			WHERE height > %s
+			ORDER BY height ASC
+			''',
+			(fork_height,)
+		)
+		results = cursor.fetchall()
+		blocks = [
+			RollbackBlockRecord(Address(bytes(record[0])), PublicKey(bytes(record[1])))
+			for record in results
+		]
+
+		cursor.execute(
+			'''
+			SELECT
+				transaction_type,
+				sender_address,
+				recipient_address,
+				payload
+			FROM transactions
+			WHERE height > %s
+			ORDER BY height ASC, id ASC
+			''',
+			(fork_height,)
+		)
+		results = cursor.fetchall()
+		transactions = [
+			RollbackTransactionRecord(
+				record[0],
+				Address(bytes(record[1])),
+				Address(bytes(record[2])) if record[2] else None,
+				record[3]
+			)
+			for record in results
+		]
+
+		cursor.execute(
+			'''
+			SELECT DISTINCT mosaics.levy_recipient
+			FROM transactions
+			INNER JOIN transactions_mosaic
+				ON transactions_mosaic.transaction_id = transactions.id
+			INNER JOIN mosaics
+				ON mosaics.namespace_name = transactions_mosaic.namespace_name
+			WHERE transactions.height > %s
+				AND mosaics.levy_recipient IS NOT NULL
+			''',
+			(fork_height,)
+		)
+		results = cursor.fetchall()
+		transfer_levy_recipients = {Address(bytes(record[0])) for record in results}
+
+		return OrphanChainRecords(blocks, transactions, transfer_levy_recipients)
+
+	def get_account_creation_heights(self, addresses):
+		"""Gets stored creation heights for affected accounts."""
+
+		if not addresses:
+			return {}
+
+		cursor = self.connection.cursor()
+		cursor.execute(
+			'''
+			SELECT address, height
+			FROM accounts
+			WHERE address = ANY(%s)
+			''',
+			([address.bytes for address in addresses],)
+		)
+		results = cursor.fetchall()
+
+		return {Address(bytes(record[0])): record[1] for record in results}
 
 	def get_accounts_for_refresh(self, limit, last_account_id):
 		"""Gets account addresses that should have vested balance and importance refreshed."""

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -20,7 +20,7 @@ NEM_MAX_ROLLBACK_DEPTH = 360
 
 
 class NemRollbackError(RuntimeError):
-	"""Raised when a safe NEM rollback point cannot be found."""
+	"""Raised when a NEM rollback cannot safely proceed."""
 
 
 BlockRecord = namedtuple('BlockRecord', [
@@ -92,6 +92,25 @@ TransactionRecord = namedtuple('TransactionRecord', [
 	'payload',
 	'size',
 	'version'
+])
+RollbackPayloadAccounts = namedtuple('RollbackPayloadAccounts', [
+	'accounts',
+	'remote_link_accounts'
+])
+RollbackProjectionIdentifiers = namedtuple('RollbackProjectionIdentifiers', [
+	'namespace_roots',
+	'mosaic_names'
+])
+NemRollbackImpact = namedtuple('NemRollbackImpact', [
+	'fork_height',
+	'affected_accounts',
+	'account_creation_heights',
+	'orphan_created_accounts',
+	'surviving_affected_accounts',
+	'orphan_beneficiaries',
+	'affected_remote_link_accounts',
+	'affected_namespace_roots',
+	'affected_mosaic_names'
 ])
 DatabaseConfig = namedtuple('DatabaseConfig', ['database', 'user', 'password', 'host', 'port'])
 
@@ -172,6 +191,124 @@ class NemPuller:
 			f'No matching NEM block hash found within {NEM_MAX_ROLLBACK_DEPTH} blocks '
 			f'(database height: {db_height}, chain height: {chain_height}); '
 			'manual investigation is required'
+		)
+
+	def _extract_affected_payload_accounts(self, transaction):
+		"""Extracts account addresses stored only in an orphan transaction payload."""
+
+		affected_accounts = set()
+		affected_remote_link_accounts = set()
+
+		if TransactionType.ACCOUNT_KEY_LINK.value == transaction.transaction_type:
+			affected_remote_link_accounts.add(transaction.sender_address)
+			affected_accounts.add(
+				self._convert_public_key_to_address(transaction.payload['remote_account'])
+			)
+		elif TransactionType.MULTISIG_ACCOUNT_MODIFICATION.value == transaction.transaction_type:
+			for modification in transaction.payload['modifications']:
+				affected_accounts.add(
+					self._convert_public_key_to_address(modification['cosignatory_account'])
+				)
+		elif TransactionType.MULTISIG.value == transaction.transaction_type:
+			for signature in transaction.payload['signatures']:
+				affected_accounts.add(Address(signature['other_account']))
+				affected_accounts.add(self._convert_public_key_to_address(signature['sender']))
+		elif TransactionType.MOSAIC_DEFINITION.value == transaction.transaction_type:
+			levy = transaction.payload['levy']
+			if levy:
+				affected_accounts.add(Address(levy['recipient']))
+
+		return RollbackPayloadAccounts(affected_accounts, affected_remote_link_accounts)
+
+	@staticmethod
+	def _extract_affected_projection_identifiers(transaction):
+		"""Extracts projection identifiers changed by an orphan transaction."""
+
+		affected_namespace_roots = set()
+		affected_mosaic_names = set()
+
+		if TransactionType.NAMESPACE_REGISTRATION.value == transaction.transaction_type:
+			parent = transaction.payload['parent']
+			if parent:
+				affected_namespace_roots.add(parent.split('.')[0])
+			else:
+				affected_namespace_roots.add(transaction.payload['namespace'])
+		elif transaction.transaction_type in (
+			TransactionType.MOSAIC_DEFINITION.value,
+			TransactionType.MOSAIC_SUPPLY_CHANGE.value
+		):
+			affected_mosaic_names.add(transaction.payload['namespace_name'])
+
+		return RollbackProjectionIdentifiers(affected_namespace_roots, affected_mosaic_names)
+
+	@staticmethod
+	def _validate_account_creation_heights(affected_accounts, account_creation_heights):
+		"""Requires every affected account to have a stored creation height."""
+
+		missing_accounts = affected_accounts - set(account_creation_heights)
+		if missing_accounts:
+			raise NemRollbackError(
+				f'Missing creation heights for {len(missing_accounts)} affected NEM account(s)'
+			)
+
+	def capture_rollback_impact(self, fork_height):
+		"""Captures the complete local impact of blocks above a confirmed fork height."""
+
+		if fork_height < 1:
+			raise NemRollbackError(f'Invalid NEM fork height {fork_height}')
+
+		affected_accounts = set()
+		orphan_beneficiaries = set()
+		affected_remote_link_accounts = set()
+		affected_namespace_roots = set()
+		affected_mosaic_names = set()
+
+		orphan_records = self.nem_db.get_orphan_chain_records(fork_height)
+
+		for block in orphan_records.blocks:
+			orphan_beneficiaries.add(block.beneficiary)
+			affected_accounts.add(block.beneficiary)
+			affected_accounts.add(self._convert_public_key_to_address(block.signer))
+
+		for transaction in orphan_records.transactions:
+			affected_accounts.add(transaction.sender_address)
+			if transaction.recipient_address:
+				affected_accounts.add(transaction.recipient_address)
+
+			payload_accounts = self._extract_affected_payload_accounts(transaction)
+			affected_accounts.update(payload_accounts.accounts)
+			affected_remote_link_accounts.update(payload_accounts.remote_link_accounts)
+
+			projection_identifiers = self._extract_affected_projection_identifiers(transaction)
+			affected_namespace_roots.update(projection_identifiers.namespace_roots)
+			affected_mosaic_names.update(projection_identifiers.mosaic_names)
+
+		affected_accounts.update(orphan_records.transfer_levy_recipients)
+
+		account_creation_heights = self.nem_db.get_account_creation_heights(affected_accounts)
+		self._validate_account_creation_heights(affected_accounts, account_creation_heights)
+
+		orphan_created_accounts = {
+			address
+			for address, height in account_creation_heights.items()
+			if height > fork_height
+		}
+		surviving_affected_accounts = {
+			address
+			for address, height in account_creation_heights.items()
+			if height <= fork_height
+		}
+
+		return NemRollbackImpact(
+			fork_height,
+			affected_accounts,
+			account_creation_heights,
+			orphan_created_accounts,
+			surviving_affected_accounts,
+			orphan_beneficiaries,
+			affected_remote_link_accounts,
+			affected_namespace_roots,
+			affected_mosaic_names
 		)
 
 	async def _retry_get_account_info(self, address, retries=3, delay=2):

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -254,7 +254,7 @@ class NemPuller:
 				f'Missing creation heights for {len(missing_accounts)} affected NEM account(s)'
 			)
 
-	def capture_rollback_impact(self, fork_height):
+	def capture_rollback_impact(self, fork_height):  # pylint: disable=too-many-locals
 		"""Captures the complete local impact of blocks above a confirmed fork height."""
 
 		if fork_height < 1:

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -293,7 +293,6 @@ class NemPuller:
 		account_creation_heights = self.nem_db.get_account_creation_heights(affected_accounts)
 		self._validate_account_creation_heights(affected_accounts, account_creation_heights)
 
-
 		for address, height in account_creation_heights.items():
 			if height > fork_height:
 				orphan_created_accounts.add(address)

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -265,6 +265,8 @@ class NemPuller:
 		affected_remote_link_accounts = set()
 		affected_namespace_roots = set()
 		affected_mosaic_names = set()
+		orphan_created_accounts = set()
+		surviving_affected_accounts = set()
 
 		orphan_records = self.nem_db.get_orphan_chain_records(fork_height)
 
@@ -291,16 +293,12 @@ class NemPuller:
 		account_creation_heights = self.nem_db.get_account_creation_heights(affected_accounts)
 		self._validate_account_creation_heights(affected_accounts, account_creation_heights)
 
-		orphan_created_accounts = {
-			address
-			for address, height in account_creation_heights.items()
-			if height > fork_height
-		}
-		surviving_affected_accounts = {
-			address
-			for address, height in account_creation_heights.items()
-			if height <= fork_height
-		}
+
+		for address, height in account_creation_heights.items():
+			if height > fork_height:
+				orphan_created_accounts.add(address)
+			else:
+				surviving_affected_accounts.add(address)
 
 		return NemRollbackImpact(
 			fork_height,

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -210,8 +210,11 @@ class NemPuller:
 					self._convert_public_key_to_address(modification['cosignatory_account'])
 				)
 		elif TransactionType.MULTISIG.value == transaction.transaction_type:
-			for signature in transaction.payload['signatures']:
-				affected_accounts.add(Address(signature['other_account']))
+			signatures = transaction.payload['signatures']
+			if signatures:
+				affected_accounts.add(Address(signatures[0]['other_account']))
+
+			for signature in signatures:
 				affected_accounts.add(self._convert_public_key_to_address(signature['sender']))
 		elif TransactionType.MOSAIC_DEFINITION.value == transaction.transaction_type:
 			levy = transaction.payload['levy']

--- a/explorer/puller/tests/db/test_NemDatabase.py
+++ b/explorer/puller/tests/db/test_NemDatabase.py
@@ -1141,3 +1141,83 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			'nem.xem',
 			2000000
 		))
+
+	def test_can_read_orphan_chain_records(self):
+		# Arrange:
+		surviving_account = ACCOUNTS[0]
+		orphan_account = ACCOUNTS[0]._replace(
+			address=Address('TALICE6XEEEOBFJVY3ZCENZ7WBG6LB4KB7P7KMQX'),
+			height=2
+		)
+		surviving_transaction = TRANSACTIONS[0]._replace(
+			transaction_hash='11' * 32,
+			height=1,
+			payload={'source': 'surviving'}
+		)
+		orphan_transaction = TRANSACTIONS[0]._replace(
+			transaction_hash='22' * 32,
+			height=2,
+			payload={'source': 'outer'}
+		)
+		orphan_inner_transaction = TRANSACTIONS[0]._replace(
+			transaction_hash='33' * 32,
+			height=2,
+			sender_address=orphan_account.address,
+			is_inner=True,
+			payload={'source': 'inner'}
+		)
+		levy_mosaic = MOSAICS[0]._replace(
+			root_namespace='foo',
+			namespace_name='foo.token',
+			levy_recipient=orphan_account.address
+		)
+
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+			cursor = nem_database.connection.cursor()
+
+			for block in BLOCKS:
+				nem_database.insert_block(cursor, block)
+
+			nem_database.upsert_account(cursor, surviving_account)
+			nem_database.upsert_account(cursor, orphan_account)
+			nem_database.upsert_mosaic(cursor, levy_mosaic)
+			nem_database.insert_transaction(cursor, surviving_transaction)
+			orphan_transaction_id = nem_database.insert_transaction(cursor, orphan_transaction)
+			nem_database.insert_transaction(cursor, orphan_inner_transaction)
+			nem_database.insert_transaction_mosaic(
+				cursor,
+				orphan_transaction_id,
+				Mosaic('foo.token', 100)
+			)
+			nem_database.connection.commit()
+
+			# Act:
+			orphan_blocks, orphan_transactions, orphan_transfer_levy_recipients = nem_database.get_orphan_chain_records(1)
+			account_heights = nem_database.get_account_creation_heights({
+				surviving_account.address,
+				orphan_account.address
+			})
+
+		# Assert:
+		self.assertEqual(1, len(orphan_blocks))
+		self.assertEqual(str(BLOCKS[1].beneficiary), str(orphan_blocks[0].beneficiary))
+		self.assertEqual(str(BLOCKS[1].signer), str(orphan_blocks[0].signer))
+
+		self.assertEqual(2, len(orphan_transactions))
+		self.assertEqual(['outer', 'inner'], [
+			transaction.payload['source']
+			for transaction in orphan_transactions
+		])
+		self.assertEqual(str(orphan_account.address), str(orphan_transactions[1].sender_address))
+
+		self.assertEqual(
+			{str(orphan_account.address)},
+			{str(address) for address in orphan_transfer_levy_recipients}
+		)
+		self.assertEqual({
+			str(surviving_account.address): 1,
+			str(orphan_account.address): 2
+		}, {
+			str(address): height for address, height in account_heights.items()
+		})

--- a/explorer/puller/tests/db/test_NemDatabase.py
+++ b/explorer/puller/tests/db/test_NemDatabase.py
@@ -1213,11 +1213,19 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 
 		self.assertEqual(
 			{orphan_account.address},
-			{address for address in orphan_transfer_levy_recipients}
+			orphan_transfer_levy_recipients
 		)
 		self.assertEqual({
 			surviving_account.address: 1,
 			orphan_account.address: 2
-		}, {
-			address: height for address, height in account_heights.items()
-		})
+		}, account_heights)
+
+	def test_returns_empty_account_creation_heights_when_addresses_are_empty(self):
+		# Arrange:
+		nem_database = NemDatabase(self.db_config)
+
+		# Act:
+		account_heights = nem_database.get_account_creation_heights(set())
+
+		# Assert:
+		self.assertEqual({}, account_heights)

--- a/explorer/puller/tests/db/test_NemDatabase.py
+++ b/explorer/puller/tests/db/test_NemDatabase.py
@@ -1201,23 +1201,23 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 
 		# Assert:
 		self.assertEqual(1, len(orphan_blocks))
-		self.assertEqual(str(BLOCKS[1].beneficiary), str(orphan_blocks[0].beneficiary))
-		self.assertEqual(str(BLOCKS[1].signer), str(orphan_blocks[0].signer))
+		self.assertEqual(BLOCKS[1].beneficiary, orphan_blocks[0].beneficiary)
+		self.assertEqual(BLOCKS[1].signer, orphan_blocks[0].signer)
 
 		self.assertEqual(2, len(orphan_transactions))
 		self.assertEqual(['outer', 'inner'], [
 			transaction.payload['source']
 			for transaction in orphan_transactions
 		])
-		self.assertEqual(str(orphan_account.address), str(orphan_transactions[1].sender_address))
+		self.assertEqual(orphan_account.address, orphan_transactions[1].sender_address)
 
 		self.assertEqual(
-			{str(orphan_account.address)},
-			{str(address) for address in orphan_transfer_levy_recipients}
+			{orphan_account.address},
+			{address for address in orphan_transfer_levy_recipients}
 		)
 		self.assertEqual({
-			str(surviving_account.address): 1,
-			str(orphan_account.address): 2
+			surviving_account.address: 1,
+			orphan_account.address: 2
 		}, {
-			str(address): height for address, height in account_heights.items()
+			address: height for address, height in account_heights.items()
 		})

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -1644,6 +1644,45 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			1
 		)
 
+	def test_extracts_multisig_account_and_all_signature_senders(self):
+		# Arrange:
+		multisig_account = Address('TAWUGAUSWSVB35T5QE44ICIK2WE3AUOTSGZBO5O4')
+		first_signature_sender = PublicKey(
+			'f94e8702eb1943b23570b1b83be1b81536df35538978820e98bfce8f999e2d37'
+		)
+		second_signature_sender = PublicKey(
+			'1fbdbdde28daf828245e4533765726f0b7790e0b7146e2ce205df3e86366980b'
+		)
+		transaction = self._create_rollback_transaction(
+			1,
+			TransactionType.MULTISIG.value,
+			11,
+			Address('TCJLCZSOQ6RGWHTPSV2DW467WZSHK4NBSITND4OF'),
+			payload={'signatures': [
+				{
+					'other_account': str(multisig_account),
+					'sender': str(first_signature_sender)
+				},
+				{
+					'other_account': str(multisig_account),
+					'sender': str(second_signature_sender)
+				}
+			]}
+		)
+
+		# Act:
+		accounts = self.puller._extract_affected_payload_accounts(  # pylint: disable=protected-access
+			transaction
+		)
+
+		# Assert:
+		expected_accounts = RollbackPayloadAccounts({
+			multisig_account,
+			Address('TANIBAXPVLBP37YXSGREVD77NXIFZML5FANIVEXX'),
+			Address('TADMEHCFJD45GPTDL4HZP2LJLZVAZRLYWY2K4OOH')
+		}, set())
+		self.assertEqual(expected_accounts, accounts)
+
 	def test_can_capture_all_data_affected_by_rollback(self):  # pylint: disable=too-many-locals
 		# Arrange:
 		fork_height = 10

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -39,6 +39,7 @@ from puller.facade.NemPuller import (
 	NamespaceRecord,
 	NemPuller,
 	NemRollbackError,
+	RollbackPayloadAccounts,
 	TransactionRecord
 )
 
@@ -1788,6 +1789,10 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			definition_levy_recipient,
 			transfer_levy_recipient
 		}
+		expected_account_creation_heights = {
+			address: orphan_height if recipient == address else fork_height
+			for address in expected_accounts
+		}
 
 		with self.puller.nem_db as database:
 			database.create_tables()
@@ -1828,13 +1833,10 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 				transfer_transaction_id,
 				Mosaic('levy.token', 1)
 			)
-			for address in expected_accounts:
+			for address, height in expected_account_creation_heights.items():
 				database.upsert_account(
 					cursor,
-					self._create_rollback_account(
-						address,
-						orphan_height if recipient == address else fork_height
-					)
+					self._create_rollback_account(address, height)
 				)
 			database.connection.commit()
 
@@ -1850,7 +1852,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		self.assertEqual({sender}, capture.affected_remote_link_accounts)
 		self.assertEqual({'root'}, capture.affected_namespace_roots)
 		self.assertEqual({'root.token', 'root.supply'}, capture.affected_mosaic_names)
-		self.assertEqual(expected_accounts, set(capture.account_creation_heights))
+		self.assertEqual(expected_account_creation_heights, capture.account_creation_heights)
 
 	def test_rejects_invalid_fork_height_before_reading_database(self):
 		with patch.object(self.puller.nem_db, 'get_orphan_chain_records') as mock_get_orphan_chain_records:

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import testing.postgresql
 from symbolchain.CryptoTypes import PublicKey
+from symbolchain.nc import TransactionType
 from symbolchain.nem.Network import Address
 from symbollightapi.connector.NemConnector import AccountMosaic, NemAccountInfo
 from symbollightapi.model.Block import Block
@@ -32,6 +33,7 @@ from puller.facade.NemPuller import (
 	NEM_MAX_ROLLBACK_DEPTH,
 	AccountRecord,
 	AccountVestedBalanceRecord,
+	BlockRecord,
 	DatabaseConfig,
 	MosaicRecord,
 	NamespaceRecord,
@@ -1610,3 +1612,290 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			self._run_detect_rollback_test({}, {}, db_height, db_height)
 
 		self.assertEqual(expected_message, str(context.exception))
+
+	@staticmethod
+	def _create_rollback_account(address, height):
+		return AccountRecord(address, height, None, None, 0, 0, 0, [], 0, 'INACTIVE', None, [], [])
+
+	@staticmethod
+	def _create_rollback_transaction(
+		transaction_id,
+		transaction_type,
+		height,
+		sender_address,
+		recipient_address=None,
+		payload=None,
+		is_inner=False
+	):  # pylint: disable=too-many-arguments,too-many-positional-arguments
+		return TransactionRecord(
+			f'{transaction_id:064X}',
+			height,
+			PublicKey('11' * 32),
+			0,
+			'2015-03-29 00:00:00+00:00',
+			'2015-03-29 01:00:00+00:00',
+			None,
+			transaction_type,
+			is_inner,
+			sender_address,
+			recipient_address,
+			payload,
+			100,
+			1
+		)
+
+	def test_can_capture_all_data_affected_by_rollback(self):  # pylint: disable=too-many-locals
+		# Arrange:
+		fork_height = 10
+		orphan_height = fork_height + 1
+		beneficiary = Address('TBZWVEKB2XMTO4F3RAOEIBWRBMPQ5N23G56ZJM4I')
+		signer = PublicKey('8d07f90fb4bbe7715fa327c926770166a11be2e494a970605f2e12557f66c9b9')
+		signer_address = self.puller._convert_public_key_to_address(signer)  # pylint: disable=protected-access
+		sender = Address('TCJLCZSOQ6RGWHTPSV2DW467WZSHK4NBSITND4OF')
+		inner_sender = Address('TBKQWJJGPOHL462DBVMTYOAERXGG2BOS5XRFO2P6')
+		recipient = Address('TALICE6XEEEOBFJVY3ZCENZ7WBG6LB4KB7P7KMQX')
+		remote_key = PublicKey('7195f4d7a40ad7e31958ae96c4afed002962229675a4cae8dc8a18e290618981')
+		remote_address = self.puller._convert_public_key_to_address(remote_key)  # pylint: disable=protected-access
+		cosignatory_key = PublicKey('1fbdbdde28daf828245e4533765726f0b7790e0b7146e2ce205df3e86366980b')
+		cosignatory_address = self.puller._convert_public_key_to_address(cosignatory_key)  # pylint: disable=protected-access
+		signature_sender_key = PublicKey(
+			'f94e8702eb1943b23570b1b83be1b81536df35538978820e98bfce8f999e2d37'
+		)
+		signature_sender_address = self.puller._convert_public_key_to_address(  # pylint: disable=protected-access
+			signature_sender_key
+		)
+		multisig_account = Address('TAWUGAUSWSVB35T5QE44ICIK2WE3AUOTSGZBO5O4')
+		rental_fee_recipient = Address('TAMESPACEWH4MKFMBCVFERDPOOP4FK7MTDJEYP35')
+		creation_fee_recipient = Address('TBMOSAICOD4F54EE5CDMR23CCBGOAM2XSJBR5OLC')
+		definition_levy_recipient = Address('NBRYCNWZINEVNITUESKUMFIENWKYCRUGNFZV25AV')
+		transfer_levy_recipient = Address('TBEM6SFOHU5PORIGAVG3NNJIMCG73R2TWH35O2VF')
+
+		transactions = [
+			self._create_rollback_transaction(
+				1, TransactionType.TRANSFER.value, orphan_height, sender, recipient
+			),
+			self._create_rollback_transaction(
+				2,
+				TransactionType.ACCOUNT_KEY_LINK.value,
+				orphan_height,
+				sender,
+				payload={'mode': 1, 'remote_account': str(remote_key)}
+			),
+			self._create_rollback_transaction(
+				3,
+				TransactionType.MULTISIG_ACCOUNT_MODIFICATION.value,
+				orphan_height,
+				sender,
+				payload={'modifications': [{'cosignatory_account': str(cosignatory_key)}]}
+			),
+			self._create_rollback_transaction(
+				4,
+				TransactionType.MULTISIG.value,
+				orphan_height,
+				sender,
+				payload={'signatures': [{
+					'other_account': str(multisig_account),
+					'sender': str(signature_sender_key)
+				}]}
+			),
+			self._create_rollback_transaction(
+				5,
+				TransactionType.NAMESPACE_REGISTRATION.value,
+				orphan_height,
+				sender,
+				rental_fee_recipient,
+				{'parent': None, 'namespace': 'root'}
+			),
+			self._create_rollback_transaction(
+				6,
+				TransactionType.NAMESPACE_REGISTRATION.value,
+				orphan_height,
+				sender,
+				rental_fee_recipient,
+				{'parent': 'root.child', 'namespace': 'grandchild'}
+			),
+			self._create_rollback_transaction(
+				7,
+				TransactionType.MOSAIC_DEFINITION.value,
+				orphan_height,
+				sender,
+				creation_fee_recipient,
+				{
+					'namespace_name': 'root.token',
+					'levy': {'recipient': str(definition_levy_recipient)}
+				}
+			),
+			self._create_rollback_transaction(
+				8,
+				TransactionType.MOSAIC_SUPPLY_CHANGE.value,
+				orphan_height,
+				inner_sender,
+				payload={'namespace_name': 'root.supply'},
+				is_inner=True
+			)
+		]
+		expected_accounts = {
+			beneficiary,
+			signer_address,
+			sender,
+			inner_sender,
+			recipient,
+			remote_address,
+			cosignatory_address,
+			multisig_account,
+			signature_sender_address,
+			rental_fee_recipient,
+			creation_fee_recipient,
+			definition_levy_recipient,
+			transfer_levy_recipient
+		}
+
+		with self.puller.nem_db as database:
+			database.create_tables()
+			cursor = database.connection.cursor()
+			database.insert_block(cursor, BlockRecord(
+				orphan_height,
+				'2015-03-29 00:00:00+00:00',
+				0,
+				len(transactions),
+				1,
+				'AA' * 32,
+				beneficiary,
+				signer,
+				'BB' * 64,
+				100
+			))
+			database.upsert_mosaic(cursor, MosaicRecord(
+				'levy',
+				'levy.token',
+				'levy mosaic',
+				signer,
+				fork_height,
+				1,
+				1,
+				0,
+				True,
+				True,
+				1,
+				'nem.xem',
+				1,
+				transfer_levy_recipient
+			))
+			transfer_transaction_id = database.insert_transaction(cursor, transactions[0])
+			for transaction in transactions[1:]:
+				database.insert_transaction(cursor, transaction)
+			database.insert_transaction_mosaic(
+				cursor,
+				transfer_transaction_id,
+				Mosaic('levy.token', 1)
+			)
+			for address in expected_accounts:
+				database.upsert_account(
+					cursor,
+					self._create_rollback_account(
+						address,
+						orphan_height if recipient == address else fork_height
+					)
+				)
+			database.connection.commit()
+
+			# Act:
+			capture = self.puller.capture_rollback_impact(fork_height)
+
+		# Assert:
+		self.assertEqual(fork_height, capture.fork_height)
+		self.assertEqual(expected_accounts, capture.affected_accounts)
+		self.assertEqual({recipient}, capture.orphan_created_accounts)
+		self.assertEqual(expected_accounts - {recipient}, capture.surviving_affected_accounts)
+		self.assertEqual({beneficiary}, capture.orphan_beneficiaries)
+		self.assertEqual({sender}, capture.affected_remote_link_accounts)
+		self.assertEqual({'root'}, capture.affected_namespace_roots)
+		self.assertEqual({'root.token', 'root.supply'}, capture.affected_mosaic_names)
+		self.assertEqual(expected_accounts, set(capture.account_creation_heights))
+
+	def test_rejects_invalid_fork_height_before_reading_database(self):
+		with patch.object(self.puller.nem_db, 'get_orphan_chain_records') as mock_get_orphan_chain_records:
+			# Act:
+			with self.assertRaisesRegex(NemRollbackError, 'Invalid NEM fork height 0'):
+				self.puller.capture_rollback_impact(0)
+
+			# Assert:
+			mock_get_orphan_chain_records.assert_not_called()
+
+	def test_accepts_empty_multisig_collections(self):
+		# Arrange:
+		fork_height = 10
+		orphan_height = fork_height + 1
+		multisig_account = Address('TCJLCZSOQ6RGWHTPSV2DW467WZSHK4NBSITND4OF')
+		cosigner = Address('TALICE6XEEEOBFJVY3ZCENZ7WBG6LB4KB7P7KMQX')
+		transactions = [
+			self._create_rollback_transaction(
+				9,
+				TransactionType.MULTISIG_ACCOUNT_MODIFICATION.value,
+				orphan_height,
+				multisig_account,
+				payload={'modifications': []}
+			),
+			self._create_rollback_transaction(
+				10,
+				TransactionType.MULTISIG.value,
+				orphan_height,
+				cosigner,
+				payload={'signatures': []}
+			)
+		]
+
+		with self.puller.nem_db as database:
+			database.create_tables()
+			cursor = database.connection.cursor()
+			for transaction in transactions:
+				database.insert_transaction(cursor, transaction)
+			for address in (multisig_account, cosigner):
+				database.upsert_account(cursor, self._create_rollback_account(address, fork_height))
+			database.connection.commit()
+
+			# Act:
+			impact = self.puller.capture_rollback_impact(fork_height)
+
+		# Assert:
+		expected_accounts = {multisig_account, cosigner}
+		self.assertEqual(fork_height, impact.fork_height)
+		self.assertEqual(expected_accounts, impact.affected_accounts)
+		self.assertEqual({
+			multisig_account: fork_height,
+			cosigner: fork_height
+		}, impact.account_creation_heights)
+		self.assertEqual(set(), impact.orphan_created_accounts)
+		self.assertEqual(expected_accounts, impact.surviving_affected_accounts)
+		self.assertEqual(set(), impact.orphan_beneficiaries)
+		self.assertEqual(set(), impact.affected_remote_link_accounts)
+		self.assertEqual(set(), impact.affected_namespace_roots)
+		self.assertEqual(set(), impact.affected_mosaic_names)
+
+	def test_rejects_affected_account_without_creation_height(self):
+		# Arrange:
+		fork_height = 10
+		beneficiary = Address('TBZWVEKB2XMTO4F3RAOEIBWRBMPQ5N23G56ZJM4I')
+		signer = PublicKey('8d07f90fb4bbe7715fa327c926770166a11be2e494a970605f2e12557f66c9b9')
+
+		with self.puller.nem_db as database:
+			database.create_tables()
+			cursor = database.connection.cursor()
+			database.insert_block(cursor, BlockRecord(
+				fork_height + 1,
+				'2015-03-29 00:00:00+00:00',
+				0,
+				0,
+				1,
+				'CC' * 32,
+				beneficiary,
+				signer,
+				'DD' * 64,
+				100
+			))
+			database.connection.commit()
+
+			# Act + Assert:
+			expected_message = 'Missing creation heights for 2 affected NEM account'
+			with self.assertRaisesRegex(NemRollbackError, expected_message):
+				self.puller.capture_rollback_impact(fork_height)


### PR DESCRIPTION
Problem: Fork-height detection was previously implemented, but the data required to safely repair an orphaned chain was not captured before rollback.

Solution:
- Capture orphan block and transaction data above the confirmed fork height before deleting anything.
- Include block beneficiaries and signers, direct and inner transaction accounts, remote-link accounts, fee and levy recipients.
- Extract affected namespace roots and mosaic identifiers from transaction payloads for later projection reconstruction.
- Read account creation heights to separate orphan-created accounts from surviving affected accounts.
- Preserve surviving affected accounts for later node-state refresh and remove orphan-created accounts during repair.
