### PR TITLE
[explorer/frontend] fix: make header logo clickable

### DIFF
--- a/explorer/frontend/components/Header.jsx
+++ b/explorer/frontend/components/Header.jsx
@@ -170,9 +170,9 @@ const Header = ({ backendStatus }) => {
 	return (
 		<div className={styles.headerWrapper}>
 			<header className={styles.header}>
-				<div className={styles.headerLogo}>
+				<Link className={styles.headerLogo} href={createPageHref('home')}>
 					<Image src={createAssetURL('/images/logo.png')} fill alt="Logo" />
-				</div>
+				</Link>
 
 				<div className={styles.headerRightSection}>
 					<div className={styles.headerMenu}>{renderMenu()}</div>


### PR DESCRIPTION
Problem:
The logo in the top-left corner of the header was a plain <div> with no navigation behavior, so clicking it did nothing on every page.

Solution:
Wrap the logo in a Next.js Link pointing to the home route, matching the existing menu items which already use createPageHref('home').