### PR TITLE
[explorer/frontend] fix: use runtime configuration on error pages

### DIFF
--- a/explorer/frontend/config/index.js
+++ b/explorer/frontend/config/index.js
@@ -35,4 +35,4 @@ export const publicAppConfig = Object.fromEntries(Object.entries(serverAppConfig
 
 const isClientSide = typeof window !== 'undefined';
 
-export default isClientSide ? (window.appConfig ?? publicAppConfig) : serverAppConfig;
+export default isClientSide ? window.appConfig : serverAppConfig;

--- a/explorer/frontend/next.config.js
+++ b/explorer/frontend/next.config.js
@@ -20,6 +20,9 @@ const variantAlias = `./variants/${VARIANT}`;
 module.exports = {
 	output: 'standalone',
 	reactStrictMode: true,
+	// `/api/*` on a deployed origin is proxied to the REST backend, so the runtime config script is
+	// exposed outside that namespace.
+	rewrites: async () => [{ source: '/runtime-config.js', destination: '/api/config' }],
 	experimental: {
 		scrollRestoration: true
 	},

--- a/explorer/frontend/pages/_app.jsx
+++ b/explorer/frontend/pages/_app.jsx
@@ -45,7 +45,6 @@ const AppComponent = ({ Component, pageProps, appConfig }) => {
 			router.push(router.asPath, null, { locale: userLanguage });
 	}, [userLanguage, router.locale]);
 
-
 	// Fetch backend status
 	const [backendStatus, setBackendStatus] = useState(null);
 	const fetchBackendStatus = async () => {
@@ -59,6 +58,7 @@ const AppComponent = ({ Component, pageProps, appConfig }) => {
 
 	return (
 		<div className={styles.wrapper}>
+			{/* Baseline configuration; `/runtime-config.js` overrides it with the container's runtime values. */}
 			<script dangerouslySetInnerHTML={{ __html: `window.appConfig = ${JSON.stringify(appConfig).replace(/</g, '\\u003c')};` }} />
 			<ConfigProvider>
 				<Header backendStatus={backendStatus} />

--- a/explorer/frontend/pages/_document.jsx
+++ b/explorer/frontend/pages/_document.jsx
@@ -9,6 +9,10 @@ export default function Document() {
 			</Head>
 			<body>
 				<Main />
+				{/* Overrides the configuration `_app` inlined at render time with the container's runtime
+				    values. Must stay free of `defer`: every Next.js bundle is deferred, so this runs first
+				    and `window.appConfig` is correct before any application module reads it. */}
+				<script src="/runtime-config.js" />
 				<NextScript />
 			</body>
 		</Html>

--- a/explorer/frontend/pages/api/config.js
+++ b/explorer/frontend/pages/api/config.js
@@ -1,0 +1,12 @@
+import { publicAppConfig } from '@/app/config';
+
+// `pages/404` and `pages/500` are statically prerendered, so the configuration `_app` inlines into
+// them is whatever existed at image build time - not at container start (see README "Environment
+// Variables"). API routes are never statically optimized, so this reflects the runtime values.
+const handler = (request, response) => {
+	response.setHeader('Content-Type', 'application/javascript; charset=utf-8');
+	response.setHeader('Cache-Control', 'no-store');
+	response.status(200).send(`window.appConfig = ${JSON.stringify(publicAppConfig)};`);
+};
+
+export default handler;


### PR DESCRIPTION
Fixes #2469

## Problem

Using the header search bar on a 404 page sends requests to a malformed URL:

```
❌ https://nem.fyi/undefined/block/B411ECEB...
✅ https://nem.fyi/api/nem/block/B411ECEB...
```

The requests fail and the search bar silently returns no results.

## Root cause

Next.js requires `pages/404` and `pages/500` to be statically prerendered - it explicitly rejects `getServerSideProps` and `getInitialProps` on them. Their HTML, including the `window.appConfig` script that `_app` inlines, is therefore generated once, during `next build`.

`PUBLIC_*` variables are runtime configuration: the `Dockerfile` only passes `NEXT_PUBLIC_EXPLORER_VARIANT` as a build arg. At build time `process.env.PUBLIC_API_BASE_URL` is `undefined`, and `JSON.stringify` drops keys with `undefined` values entirely - so the key is simply missing from `window.appConfig` on those pages.

`createApiUrl` then interpolates it into a template literal:

```js
  `${undefined}/block/HASH`  // → "undefined/block/HASH"
```

Every other page is server-rendered per request, which is why they are unaffected.

## Solution

Serve the configuration from a route that is never statically optimized, and load it from a script tag that runs before the application does.

The inline script is deliberately retained: if `/runtime-config.js` ever fails to load, server-rendered pages keep working with their freshly inlined values instead of losing configuration entirely.

Because the fix works below the level of any individual request, it covers the search bar, the backend health check, and any request added in the future - no per-caller handling required.