### PR TITLE
[explorer/nodewatch]: minor fixes 

### DIFF
--- a/explorer/nodewatch/nodewatch/NetworkRepository.py
+++ b/explorer/nodewatch/nodewatch/NetworkRepository.py
@@ -174,7 +174,7 @@ class NetworkRepository:
 		log.info(f'loading nodes from {nodes_data_filepath}')
 
 		with open(nodes_data_filepath, 'rt', encoding='utf8') as infile:
-			self.node_descriptors = list(filter(None.__ne__, [
+			self.node_descriptors = list(filter(lambda obj: obj is not None, [
 				self._create_descriptor_from_json(json_node) for json_node in json.load(infile)
 			]))
 

--- a/explorer/nodewatch/nodewatch/templates/nem_summary.html
+++ b/explorer/nodewatch/nodewatch/templates/nem_summary.html
@@ -38,7 +38,7 @@ NEM Summary
   </span>
   <div id='node-count-chart' class='chart'></div>
 
-  <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+  <script src="https://cdn.plot.ly/plotly-3.7.0.min.js"></script>
   <script type="text/javascript">
     Plotly.setPlotConfig({responsive: true});
     Plotly.newPlot('height-chart', {{ height_chart_json | safe }});

--- a/explorer/nodewatch/nodewatch/templates/symbol_summary.html
+++ b/explorer/nodewatch/nodewatch/templates/symbol_summary.html
@@ -45,7 +45,7 @@ Symbol Summary
   </span>
   <div id='node-count-chart' class='chart'></div>
 
-  <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+  <script src="https://cdn.plot.ly/plotly-3.7.0.min.js"></script>
   <script type="text/javascript">
     Plotly.setPlotConfig({responsive: true});
     Plotly.newPlot('height-chart', {{ height_chart_json | safe }});

--- a/explorer/nodewatch/pytest.ini
+++ b/explorer/nodewatch/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+
+filterwarnings = ignore:The 'warn' method is deprecated:DeprecationWarning

--- a/explorer/nodewatch/requirements.txt
+++ b/explorer/nodewatch/requirements.txt
@@ -2,7 +2,7 @@ aiohttp==3.14.3
 APScheduler==3.11.3
 Flask==3.1.3
 pandas==3.0.5
-plotly==5.24.1
+plotly==6.9.0
 symbol-sdk-python==3.3.2
 zenlog==1.1
 flask_cors==6.0.5

--- a/explorer/nodewatch/tests/test_HeightChartBuilder.py
+++ b/explorer/nodewatch/tests/test_HeightChartBuilder.py
@@ -1,5 +1,6 @@
 import json
 import unittest
+from base64 import b64encode
 from collections import namedtuple
 
 from nodewatch.chart_utils import VersionCustomizations
@@ -52,16 +53,21 @@ class HeightChartBuilderTest(unittest.TestCase):
 		expected_color = {'0.0.3.3': '#008A00', '0.0.3.1': '#00B300', '0.0.2.0': '#FF1F1F'}[name_parts[0]]
 		expected_shape = {'height': 'circle', 'finalized height': 'diamond'}[name_parts[1].strip()]
 
+		def to_plotly_encoding_int(source, size):
+			values = source if isinstance(source, list) else [source]
+			buffer = bytes().join([value.to_bytes(size, 'little') for value in values])
+			return {'bdata': b64encode(buffer).decode('utf-8'), 'dtype': f'i{size}'}
+
 		self.assertEqual({
 			'color': expected_color,
 			'sizeref': 319999.99964444444,
-			'size': expected['size'],
+			'size': to_plotly_encoding_int(expected['size'], 4),
 			'sizemode': 'area',
 			'symbol': expected_shape
 		}, chart_scatterpoint['marker'])
 		self.assertEqual('scatter', chart_scatterpoint['type'])
-		self.assertEqual(expected['y'], chart_scatterpoint['y'])
-		self.assertEqual(expected['x'], chart_scatterpoint['x'])
+		self.assertEqual(to_plotly_encoding_int(expected['y'], 1), chart_scatterpoint['y'])
+		self.assertEqual(to_plotly_encoding_int(expected['x'], 2), chart_scatterpoint['x'])
 		self.assertEqual(expected['text'], chart_scatterpoint['text'])
 
 	def test_can_create_power_chart_without_min_cluster_size(self):

--- a/explorer/nodewatch/tests/test_VersionChartBuilder.py
+++ b/explorer/nodewatch/tests/test_VersionChartBuilder.py
@@ -1,5 +1,7 @@
 import json
+import struct
 import unittest
+from base64 import b64encode
 from collections import namedtuple
 
 from nodewatch.chart_utils import VersionCustomizations
@@ -48,13 +50,17 @@ class VersionChartBuilderTest(unittest.TestCase):
 		chart_bar_segment = next(chart_bar_segment for chart_bar_segment in chart_data if segment_name == chart_bar_segment['name'])
 		expected_color = {'0.0.3.3': '#008A00', '0.0.3.1': '#00B300', '0.0.3.0': '#00D600'}[segment_name]
 
+		def to_plotly_encoding_double(values):
+			buffer = bytes().join([struct.pack('d', value) for value in values])
+			return {'bdata': b64encode(buffer).decode('utf-8'), 'dtype': 'f8'}
+
 		self.assertEqual({
 			'color': expected_color,
 			'pattern': {'shape': ''}
 		}, chart_bar_segment['marker'])
 		self.assertEqual('bar', chart_bar_segment['type'])
 		self.assertEqual(expected['y'] if 'y' in expected else ['All', 'All Nodes', 'Ex All Nodes'], chart_bar_segment['y'])
-		self.assertEqual(expected['x'], chart_bar_segment['x'])
+		self.assertEqual(to_plotly_encoding_double(expected['x']), chart_bar_segment['x'])
 		self.assertEqual(expected['text'], chart_bar_segment['text'])
 
 	def _assert_threshold_line(self, annotation, expected_threshold):


### PR DESCRIPTION
    [explorer/nodewatch]: suppress zenlog.warn deprecation warnings
    
     problem: warnings are emitted during pytest
    solution: supress in pytest.ini

    [explorer/nodewatch]: replace None.__ne__ with lambda expression
    
     problem: None.__ne__ does not behave as expected in some python versions
              (see also https://github.com/python/cpython/issues/112125)
    solution: replace None.__ne__ with lambda expression
              (operator.is_not_none would work but is only available in python 3.14+)

    [explorer/nodewatch]: update plotly library
    
     problem: using old version of plotly from 2021
    solution: update to latest


