### PR TITLE
[explorer] fix: avoid full table scan in account transaction query

### DIFF
--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -2,7 +2,6 @@ import json
 from binascii import unhexlify
 from collections import namedtuple
 
-from symbolchain.nc import TransactionType
 from symbolchain.nem.Network import Address
 
 from .DatabaseConnection import DatabaseConnection
@@ -99,14 +98,9 @@ class NemDatabase(DatabaseConnection):
 			'''
 		)
 
-		# The address indexes below let the account transaction query bitmap-or its three arms together
-		# (see rest NemDatabase._create_multisig_inner_filter). They are split by is_inner because an
-		# account reaches a wrapper through its own address columns but an inner transaction through the
-		# hash of its wrapper. Address alone is enough: a bitmap scan reads only the leading column, and
-		# where the planner wants height order it walks transactions_height_is_inner_false_idx instead.
 		cursor.execute(
 			'''
-			CREATE INDEX IF NOT EXISTS transactions_outer_sender_address_idx
+			CREATE INDEX IF NOT EXISTS transactions_sender_address_is_inner_false_idx
 				ON transactions(sender_address)
 				WHERE is_inner = false
 			'''
@@ -114,7 +108,7 @@ class NemDatabase(DatabaseConnection):
 
 		cursor.execute(
 			'''
-			CREATE INDEX IF NOT EXISTS transactions_outer_recipient_address_idx
+			CREATE INDEX IF NOT EXISTS transactions_recipient_address_is_inner_false_idx
 				ON transactions(recipient_address)
 				WHERE is_inner = false
 			'''
@@ -122,7 +116,7 @@ class NemDatabase(DatabaseConnection):
 
 		cursor.execute(
 			'''
-			CREATE INDEX IF NOT EXISTS transactions_inner_sender_address_idx
+			CREATE INDEX IF NOT EXISTS transactions_sender_address_is_inner_true_idx
 				ON transactions(sender_address)
 				WHERE is_inner = true
 			'''
@@ -130,17 +124,17 @@ class NemDatabase(DatabaseConnection):
 
 		cursor.execute(
 			'''
-			CREATE INDEX IF NOT EXISTS transactions_inner_recipient_address_idx
+			CREATE INDEX IF NOT EXISTS transactions_recipient_address_is_inner_true_idx
 				ON transactions(recipient_address)
 				WHERE is_inner = true
 			'''
 		)
 
 		cursor.execute(
-			f'''
+			'''
 			CREATE INDEX IF NOT EXISTS transactions_inner_hash_idx
 				ON transactions(inner_hash)
-				WHERE is_inner = false AND transaction_type = {TransactionType.MULTISIG.value}
+				WHERE inner_hash IS NOT NULL
 			'''
 		)
 
@@ -679,9 +673,6 @@ class NemDatabase(DatabaseConnection):
 	def insert_transaction(cursor, transaction):
 		"""Inserts transaction information."""
 
-		# a multisig wrapper points at exactly one inner transaction; the hash is mirrored out of the
-		# payload into its own column so the link is an ordinary indexed join key rather than a json
-		# expression, which the query planner cannot gather statistics for
 		inner_hash = transaction.payload.get('inner_hash') if transaction.payload else None
 
 		cursor.execute(

--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -2,6 +2,7 @@ import json
 from binascii import unhexlify
 from collections import namedtuple
 
+from symbolchain.nc import TransactionType
 from symbolchain.nem.Network import Address
 
 from .DatabaseConnection import DatabaseConnection
@@ -85,13 +86,6 @@ class NemDatabase(DatabaseConnection):
 		# Create indexes for transactions table
 		cursor.execute(
 			'''
-			CREATE INDEX IF NOT EXISTS transactions_transaction_hash_idx
-				ON transactions (transaction_hash)
-			'''
-		)
-
-		cursor.execute(
-			'''
 			CREATE INDEX IF NOT EXISTS transactions_transaction_type_idx
 				ON transactions (transaction_type)
 			'''
@@ -105,24 +99,48 @@ class NemDatabase(DatabaseConnection):
 			'''
 		)
 
+		# The address indexes below let the account transaction query bitmap-or its three arms together
+		# (see rest NemDatabase._create_multisig_inner_filter). They are split by is_inner because an
+		# account reaches a wrapper through its own address columns but an inner transaction through the
+		# hash of its wrapper. Address alone is enough: a bitmap scan reads only the leading column, and
+		# where the planner wants height order it walks transactions_height_is_inner_false_idx instead.
 		cursor.execute(
 			'''
-			CREATE INDEX IF NOT EXISTS transactions_recipient_address_idx
-				ON transactions(recipient_address)
-			'''
-		)
-
-		cursor.execute(
-			'''
-			CREATE INDEX IF NOT EXISTS transactions_sender_address_idx
+			CREATE INDEX IF NOT EXISTS transactions_outer_sender_address_idx
 				ON transactions(sender_address)
+				WHERE is_inner = false
 			'''
 		)
 
 		cursor.execute(
 			'''
-			CREATE INDEX IF NOT EXISTS transactions_is_inner_idx
-				ON transactions(is_inner)
+			CREATE INDEX IF NOT EXISTS transactions_outer_recipient_address_idx
+				ON transactions(recipient_address)
+				WHERE is_inner = false
+			'''
+		)
+
+		cursor.execute(
+			'''
+			CREATE INDEX IF NOT EXISTS transactions_inner_sender_address_idx
+				ON transactions(sender_address)
+				WHERE is_inner = true
+			'''
+		)
+
+		cursor.execute(
+			'''
+			CREATE INDEX IF NOT EXISTS transactions_inner_recipient_address_idx
+				ON transactions(recipient_address)
+				WHERE is_inner = true
+			'''
+		)
+
+		cursor.execute(
+			f'''
+			CREATE INDEX IF NOT EXISTS transactions_inner_hash_idx
+				ON transactions(inner_hash)
+				WHERE is_inner = false AND transaction_type = {TransactionType.MULTISIG.value}
 			'''
 		)
 
@@ -245,7 +263,8 @@ class NemDatabase(DatabaseConnection):
 				is_inner boolean NOT NULL,
 				payload jsonb,
 				size int NOT NULL,
-				version int NOT NULL
+				version int NOT NULL,
+				inner_hash bytea
 			)
 			'''
 		)
@@ -660,6 +679,11 @@ class NemDatabase(DatabaseConnection):
 	def insert_transaction(cursor, transaction):
 		"""Inserts transaction information."""
 
+		# a multisig wrapper points at exactly one inner transaction; the hash is mirrored out of the
+		# payload into its own column so the link is an ordinary indexed join key rather than a json
+		# expression, which the query planner cannot gather statistics for
+		inner_hash = transaction.payload.get('inner_hash') if transaction.payload else None
+
 		cursor.execute(
 			'''
 			INSERT INTO transactions (
@@ -676,9 +700,10 @@ class NemDatabase(DatabaseConnection):
 				is_inner,
 				payload,
 				size,
-				version
+				version,
+				inner_hash
 			)
-			VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+			VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 			RETURNING id
 			''',
 			(
@@ -695,7 +720,8 @@ class NemDatabase(DatabaseConnection):
 				transaction.is_inner,
 				json.dumps(transaction.payload) if transaction.payload else None,
 				transaction.size,
-				transaction.version
+				transaction.version,
+				unhexlify(inner_hash) if inner_hash else None
 			)
 		)
 

--- a/explorer/puller/tests/db/test_NemDatabase.py
+++ b/explorer/puller/tests/db/test_NemDatabase.py
@@ -95,7 +95,7 @@ TRANSACTIONS = [
 		is_inner=False,
 		sender_address=Address('TCJLCZSOQ6RGWHTPSV2DW467WZSHK4NBSITND4OF'),
 		recipient_address=Address('TBZWVEKB2XMTO4F3RAOEIBWRBMPQ5N23G56ZJM4I'),
-		payload='{}',
+		payload={'message': None},
 		size=184,
 		version=1
 	)
@@ -1074,7 +1074,7 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			datetime.datetime(2015, 3, 29, 20, 34, 19),
 			TRANSACTIONS[0].signature,
 			False,
-			'{}',
+			{'message': None},
 			184,
 			1
 		))

--- a/explorer/rest/rest/db/NemDatabase.py
+++ b/explorer/rest/rest/db/NemDatabase.py
@@ -865,12 +865,11 @@ class NemDatabase(DatabaseConnectionPool):
 		return (
 			' OR ('
 			f' t.transaction_type = {TransactionType.MULTISIG.value}'
-			' AND EXISTS ('
-			' SELECT 1 FROM transactions it'
+			' AND t.inner_hash = ANY(ARRAY('
+			' SELECT it.transaction_hash FROM transactions it'
 			' WHERE it.is_inner = true'
-			" AND it.transaction_hash = decode(t.payload->>'inner_hash', 'hex')"
 			f' AND {address_condition}'
-			' )'
+			'))'
 			' )'
 		)
 
@@ -878,7 +877,7 @@ class NemDatabase(DatabaseConnectionPool):
 		"""Gets transactions pagination."""
 
 		where_condition = ' WHERE t.is_inner = False '
-		order_condition = f' ORDER BY t.height {sort}'
+		order_condition = f' ORDER BY t.height {sort}, t.id {sort}'
 		limit_condition = ' LIMIT %s OFFSET %s'
 
 		filter_params = []

--- a/explorer/rest/tests/db/test_NemDatabase.py
+++ b/explorer/rest/tests/db/test_NemDatabase.py
@@ -707,12 +707,12 @@ class NemDatabaseTest(DatabaseTestBase):  # pylint: disable=too-many-public-meth
 
 	def test_can_query_transactions_filtered_limit_offset_0(self):
 		self._assert_can_query_transactions_with_filter(
-			Pagination(1, 0), 'desc', self._make_transaction_query(), ('account_key_link', )
+			Pagination(1, 0), 'desc', self._make_transaction_query(), ('mosaic_supply_change', )
 		)
 
 	def test_can_query_transactions_filtered_limit_offset_1(self):
 		self._assert_can_query_transactions_with_filter(
-			Pagination(2, 1), 'desc', self._make_transaction_query(), ('account_key_link', 'multisig')
+			Pagination(2, 1), 'desc', self._make_transaction_query(), ('mosaic_definition', 'namespace_registration')
 		)
 
 	def test_can_query_transactions_sorted_by_height_asc(self):
@@ -723,13 +723,13 @@ class NemDatabaseTest(DatabaseTestBase):  # pylint: disable=too-many-public-meth
 	def test_can_query_transactions_sorted_by_height_desc(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(3, 0), 'desc', self._make_transaction_query(),
-			('multisig_account_modification', 'account_key_link', 'multisig')
+			('mosaic_supply_change', 'mosaic_definition', 'namespace_registration')
 		)
 
 	def test_can_query_transactions_filtered_by_height(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc', self._make_transaction_query(height=1),
-			('transfer', 'transfer_v2')
+			('transfer_v2', 'transfer')
 		)
 
 	def test_can_query_transactions_filtered_by_nonexistent_height(self):
@@ -742,7 +742,7 @@ class NemDatabaseTest(DatabaseTestBase):  # pylint: disable=too-many-public-meth
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc',
 			self._make_transaction_query(transaction_types=[257, 2049]),
-			('account_key_link', 'transfer', 'transfer_v2')
+			('account_key_link', 'transfer_v2', 'transfer')
 		)
 
 	def test_can_query_transactions_filtered_by_address_as_sender(self):
@@ -754,7 +754,7 @@ class NemDatabaseTest(DatabaseTestBase):  # pylint: disable=too-many-public-meth
 	def test_can_query_transactions_filtered_by_address_as_recipient(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc', self._make_transaction_query(address=TRANSACTIONS[0].recipient_address),
-			('multisig', 'namespace_registration', 'mosaic_definition', 'transfer', 'transfer_v2')
+			('mosaic_definition', 'namespace_registration', 'multisig', 'transfer_v2', 'transfer')
 		)
 
 	def test_can_query_transactions_filtered_by_sender_address(self):
@@ -766,7 +766,7 @@ class NemDatabaseTest(DatabaseTestBase):  # pylint: disable=too-many-public-meth
 	def test_can_query_transactions_filtered_by_recipient_address(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc', self._make_transaction_query(recipient_address=TRANSACTIONS[0].recipient_address),
-			('multisig', 'namespace_registration', 'mosaic_definition', 'transfer', 'transfer_v2')
+			('mosaic_definition', 'namespace_registration', 'multisig', 'transfer_v2', 'transfer')
 		)
 
 	def test_can_exclude_multisig_transaction_for_initiator_account_from_address_filter(self):
@@ -787,13 +787,13 @@ class NemDatabaseTest(DatabaseTestBase):  # pylint: disable=too-many-public-meth
 	def test_can_query_multisig_transaction_filtered_by_inner_recipient_address(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc', self._make_transaction_query(recipient_address=TRANSACTIONS[5].recipient_address),
-			('multisig', 'namespace_registration', 'mosaic_definition', 'transfer', 'transfer_v2')
+			('mosaic_definition', 'namespace_registration', 'multisig', 'transfer_v2', 'transfer')
 		)
 
 	def test_can_query_transactions_filtered_by_mosaic_nem_xem(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc', self._make_transaction_query(mosaic='nem.xem'),
-			('transfer', 'transfer_v2')
+			('transfer_v2', 'transfer')
 		)
 
 	def test_can_query_transactions_filtered_by_mosaic_other(self):

--- a/explorer/rest/tests/facade/test_NemRestFacade.py
+++ b/explorer/rest/tests/facade/test_NemRestFacade.py
@@ -477,7 +477,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			pagination=Pagination(1, 0),
 			sort='DESC',
 			transaction_query=self._make_transaction_query(),
-			expected_transaction_names=('account_key_link', )
+			expected_transaction_names=('mosaic_supply_change', )
 		)
 
 	def test_can_retrieve_transactions_filtered_by_offset(self):
@@ -485,7 +485,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			pagination=Pagination(1, 1),
 			sort='DESC',
 			transaction_query=self._make_transaction_query(),
-			expected_transaction_names=('multisig_account_modification', )
+			expected_transaction_names=('mosaic_definition', )
 		)
 
 	def test_can_retrieve_transactions_filtered_by_height(self):
@@ -495,7 +495,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			transaction_query=self._make_transaction_query(
 				height=1
 			),
-			expected_transaction_names=('transfer', 'transfer_v2')
+			expected_transaction_names=('transfer_v2', 'transfer')
 		)
 
 	def test_can_retrieve_transactions_sorted_by_height_desc(self):
@@ -503,7 +503,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			pagination=Pagination(2, 0),
 			sort='DESC',
 			transaction_query=self._make_transaction_query(),
-			expected_transaction_names=('account_key_link', 'multisig_account_modification')
+			expected_transaction_names=('mosaic_supply_change', 'mosaic_definition')
 		)
 
 	def test_can_retrieve_transactions_sorted_by_height_asc(self):
@@ -511,7 +511,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			pagination=Pagination(2, 0),
 			sort='ASC',
 			transaction_query=self._make_transaction_query(),
-			expected_transaction_names=('transfer_v2', 'transfer')
+			expected_transaction_names=('transfer', 'transfer_v2')
 		)
 
 	def test_can_retrieve_transactions_filtered_by_sender_public_key(self):
@@ -549,7 +549,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			transaction_query=self._make_transaction_query(
 				recipient_address='NBFWZ4IVRHEIBRCGHLYDS62FSFTBM3VDFA7E6LSQ'
 			),
-			expected_transaction_names=('multisig', 'namespace_registration', 'mosaic_definition', 'transfer', 'transfer_v2')
+			expected_transaction_names=('mosaic_definition', 'namespace_registration', 'multisig', 'transfer_v2', 'transfer')
 		)
 
 	def test_can_retrieve_transactions_filtered_by_sender_address(self):
@@ -579,7 +579,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			transaction_query=self._make_transaction_query(
 				transaction_types=[257, 2049]
 			),
-			expected_transaction_names=('account_key_link', 'transfer', 'transfer_v2')
+			expected_transaction_names=('account_key_link', 'transfer_v2', 'transfer')
 		)
 
 	def test_can_retrieve_transactions_filtered_by_mosaic(self):

--- a/explorer/rest/tests/routes/nem/test_routes.py
+++ b/explorer/rest/tests/routes/nem/test_routes.py
@@ -20,6 +20,7 @@ from ...test.DatabaseTestUtils import (
 	TRANSACTION_MONTH_STATISTIC_VIEW,
 	TRANSACTION_NAMES_FILTERED_BY_MULTISIG_INNER_SENDER,
 	TRANSACTION_NAMES_SORTED_BY_HEIGHT_ASC,
+	TRANSACTION_NAMES_SORTED_BY_HEIGHT_DESC,
 	TRANSACTION_STATISTIC_VIEW,
 	DatabaseConfig,
 	initialize_database,
@@ -765,32 +766,15 @@ def _assert_get_api_nem_transactions(client, expected_status_code, expected_resu
 
 
 def test_api_transactions_without_params(client):  # pylint: disable=redefined-outer-name
-	_assert_get_api_nem_transactions(client, 200, transaction_dicts(
-		'mosaic_supply_change',
-		'namespace_registration',
-		'mosaic_definition',
-		'account_key_link',
-		'multisig_account_modification',
-		'multisig',
-		'transfer_v2',
-		'transfer'
-	))
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts(*TRANSACTION_NAMES_SORTED_BY_HEIGHT_DESC))
 
 
 def test_api_transactions_applies_limit(client):  # pylint: disable=redefined-outer-name
-	_assert_get_api_nem_transactions(client, 200, transaction_dicts('account_key_link'), limit=1)
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts('mosaic_supply_change'), limit=1)
 
 
 def test_api_transactions_applies_offset(client):  # pylint: disable=redefined-outer-name
-	_assert_get_api_nem_transactions(client, 200, transaction_dicts(
-		'namespace_registration',
-		'mosaic_definition',
-		'account_key_link',
-		'multisig_account_modification',
-		'multisig',
-		'transfer_v2',
-		'transfer'
-	), offset=1)
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts(*TRANSACTION_NAMES_SORTED_BY_HEIGHT_DESC[1:]), offset=1)
 
 
 def test_api_transactions_applies_sorted_by_height_asc(client):  # pylint: disable=redefined-outer-name, invalid-name
@@ -798,27 +782,18 @@ def test_api_transactions_applies_sorted_by_height_asc(client):  # pylint: disab
 
 
 def test_api_transactions_applies_sorted_by_height_desc(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_transactions(client, 200, transaction_dicts(
-		'mosaic_supply_change',
-		'namespace_registration',
-		'mosaic_definition',
-		'account_key_link',
-		'multisig_account_modification',
-		'multisig',
-		'transfer_v2',
-		'transfer'
-	), sort='DESC')
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts(*TRANSACTION_NAMES_SORTED_BY_HEIGHT_DESC), sort='DESC')
 
 
 def test_api_transactions_applies_height(client):  # pylint: disable=redefined-outer-name
-	_assert_get_api_nem_transactions(client, 200, transaction_dicts('transfer', 'transfer_v2'), height=1)
+	_assert_get_api_nem_transactions(client, 200, transaction_dicts('transfer_v2', 'transfer'), height=1)
 
 
 def test_api_transactions_applies_transaction_types(client):  # pylint: disable=redefined-outer-name, invalid-name
 	_assert_get_api_nem_transactions(client, 200, transaction_dicts(
 		'account_key_link',
-		'transfer',
-		'transfer_v2'
+		'transfer_v2',
+		'transfer'
 	), transactionTypes='transfer,account_key_link')
 
 
@@ -856,11 +831,11 @@ def test_api_transactions_excludes_multisig_for_initiator_from_address_filter(cl
 
 def test_api_transactions_applies_recipient_address(client):  # pylint: disable=redefined-outer-name, invalid-name
 	_assert_get_api_nem_transactions(client, 200, transaction_dicts(
-		'multisig',
-		'namespace_registration',
 		'mosaic_definition',
-		'transfer',
-		'transfer_v2'
+		'namespace_registration',
+		'multisig',
+		'transfer_v2',
+		'transfer'
 	), recipientAddress='NBFWZ4IVRHEIBRCGHLYDS62FSFTBM3VDFA7E6LSQ')
 
 

--- a/explorer/rest/tests/test/DatabaseTestUtils.py
+++ b/explorer/rest/tests/test/DatabaseTestUtils.py
@@ -909,12 +909,23 @@ TRANSACTION_NAMES_SORTED_BY_HEIGHT_ASC = (
 	'mosaic_supply_change'
 )
 
-TRANSACTION_NAMES_FILTERED_BY_MULTISIG_INNER_SENDER = (
-	'multisig',
-	'mosaic_definition',
+TRANSACTION_NAMES_SORTED_BY_HEIGHT_DESC = (
 	'mosaic_supply_change',
-	'multisig_account_modification',
+	'mosaic_definition',
 	'namespace_registration',
+	'multisig',
+	'multisig_account_modification',
+	'account_key_link',
+	'transfer_v2',
+	'transfer'
+)
+
+TRANSACTION_NAMES_FILTERED_BY_MULTISIG_INNER_SENDER = (
+	'mosaic_supply_change',
+	'mosaic_definition',
+	'namespace_registration',
+	'multisig',
+	'multisig_account_modification',
 	'transfer_v2',
 	'transfer'
 )
@@ -1053,7 +1064,8 @@ def initialize_database(db_config, network_name):
 				is_inner boolean NOT NULL,
 				payload jsonb,
 				size int NOT NULL,
-				version int NOT NULL
+				version int NOT NULL,
+				inner_hash bytea
 			)
 			'''
 		)
@@ -1216,9 +1228,10 @@ def initialize_database(db_config, network_name):
 					is_inner,
 					payload,
 					size,
-					version
+					version,
+					inner_hash
 				)
-				VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+				VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 				''',
 				(
 					unhexlify(transaction.transaction_hash),
@@ -1234,7 +1247,8 @@ def initialize_database(db_config, network_name):
 					transaction.is_inner,
 					json.dumps(transaction.payload) if transaction.payload else None,
 					transaction.size,
-					transaction.version
+					transaction.version,
+					unhexlify(transaction.payload['inner_hash']) if (transaction.payload or {}).get('inner_hash') else None
 				)
 			)
 


### PR DESCRIPTION
## Problem

  Account pages on the NEM explorer take seconds to load, and often fail outright — the
  frontend's 15s request timeout turns into an HTTP 500. Measured against production
  (`nem.fyi`, 11.5M transactions):

  | Account | Offset | Response |
  |---|---|---|
  | 4 transactions | 0 (first page) | 4 842 ms |
  | 27 transactions (multisig) | 20 | 4 022 ms |
  | 34k transactions | 20 | 36 ms |

  This is not an edge case. **87.2% of accounts** (835 750 of 958 187) hold fewer
  transactions than one page, and every one of them hits the slow path on first view.

  Because the REST connection pool holds 10 connections, a handful of these queries
  saturate it and everything else queues behind them — including unrelated homepage
  requests, which is why the whole site felt slow.

  ## Root cause

  `get_transactions` built a single filter:

  ```sql
  WHERE t.is_inner = False
    AND ( (t.transaction_type != 4100 AND t.sender_address = %s)
       OR  t.recipient_address = %s
       OR (t.transaction_type = 4100 AND EXISTS (
             SELECT 1 FROM transactions it
              WHERE it.is_inner = true
                AND it.transaction_hash = decode(t.payload->>'inner_hash', 'hex')
                AND (it.sender_address = %s OR it.recipient_address = %s))))
  ORDER BY t.height DESC LIMIT %s OFFSET %s
  ```
A multisig wrapper carries no address of its own — the account is only reachable through
  the inner transaction the wrapper points at. That third arm is a **correlated** `EXISTS`:
  it reads `t.payload` of the current row, so there is no value to look up in an index.

  PostgreSQL can combine OR arms into a `BitmapOr` only when *every* arm is independently
  indexable. One non-indexable arm disqualifies the whole condition, leaving a single
  possible plan: walk `transactions_height_is_inner_false_idx` and evaluate the filter per
  row. `LIMIT` cannot cut it short — proving no further matches exist requires reaching the
  end of the table.

  ```
  Index Scan using transactions_height_is_inner_false_idx
    Rows Removed by Filter: 11062746        <- the entire table
  Execution Time: 5447 ms
  ```

  Adding indexes does **not** help. Verified by ablation: with the full new index set in
  place but the query unchanged, pathological cases stay at 3.9–5.8s (occasionally slower,
  since the extra indexes only give the planner more options it cannot use).

  | Case | Original | + indexes only | Full change |
  |---|---|---|---|
  | 4 tx, offset 0 | 4 842 ms | 3 907 ms | **0.7 ms** |
  | 4 tx, offset 20 | 3 819 ms | 4 224 ms | **0.5 ms** |
  | 27 tx multisig, offset 20 | 4 022 ms | 5 792 ms | **0.7 ms** |
  | 34k tx, offset 20 | 36 ms | 1.0 ms | **0.9 ms** |
  | 34k tx, offset 1000 | 57 ms | 24 ms | **35 ms** |




