### PR TITLE
[explorer/backend] feat: add Symbol receipt REST APIs

### DIFF
--- a/explorer/common/symbol/NativeMosaic.py
+++ b/explorer/common/symbol/NativeMosaic.py
@@ -1,0 +1,67 @@
+import string
+from collections import namedtuple
+
+# Symbol mosaic divisibility is 0 through 6 inclusive.
+# Source: https://docs.symbol.dev/concepts/mosaic.html (verified 2026-08-05).
+MAX_NATIVE_MOSAIC_DIVISIBILITY = 6
+
+
+def normalize_native_mosaic_id(mosaic_id):
+	"""Normalizes a Symbol mosaic id to an uppercase 16-character hex string."""
+
+	if not isinstance(mosaic_id, str):
+		raise ValueError('Native mosaic id must be a string')
+
+	normalized_id = mosaic_id
+	if normalized_id[:2].lower() == '0x':
+		normalized_id = normalized_id[2:]
+	normalized_id = normalized_id.replace("'", '')
+	if len(normalized_id) != 16 or any(character not in string.hexdigits for character in normalized_id):
+		raise ValueError('Native mosaic id must be a 16-character hexadecimal string')
+
+	return normalized_id.upper()
+
+
+def normalize_native_mosaic_divisibility(divisibility):
+	"""Validates and normalizes a Symbol mosaic divisibility value."""
+
+	if isinstance(divisibility, bool) or not isinstance(divisibility, int):
+		raise ValueError('Native mosaic divisibility must be an integer')
+	if not 0 <= divisibility <= MAX_NATIVE_MOSAIC_DIVISIBILITY:
+		raise ValueError('Native mosaic divisibility must be between 0 and 6')
+
+	return divisibility
+
+
+def extract_native_mosaic_id(network_properties):
+	"""Extracts and normalizes chain.currencyMosaicId from Node network properties."""
+
+	try:
+		return normalize_native_mosaic_id(network_properties['chain']['currencyMosaicId'])
+	except (KeyError, TypeError) as error:
+		raise ValueError('Network properties must include chain.currencyMosaicId') from error
+
+
+class NativeMosaicInfo(namedtuple('NativeMosaicInfo', ['id', 'divisibility'])):
+	"""Immutable, validated native mosaic identity and divisibility."""
+
+	__slots__ = ()
+
+	def __new__(cls, id, divisibility):  # pylint: disable=invalid-name,redefined-builtin
+		return super().__new__(
+			cls,
+			normalize_native_mosaic_id(id),
+			normalize_native_mosaic_divisibility(divisibility)
+		)
+
+
+def create_native_mosaic_info(network_properties, mosaic_definition):
+	"""Builds native mosaic information from validated Node response shapes."""
+
+	native_mosaic_id = extract_native_mosaic_id(network_properties)
+	try:
+		divisibility = mosaic_definition['mosaic']['divisibility']
+	except (KeyError, TypeError) as error:
+		raise ValueError('Mosaic response must include mosaic.divisibility') from error
+
+	return NativeMosaicInfo(native_mosaic_id, divisibility)

--- a/explorer/common/symbol/Receipt.py
+++ b/explorer/common/symbol/Receipt.py
@@ -1,0 +1,56 @@
+from types import MappingProxyType
+
+from symbolchain.sc import ReceiptType
+
+BALANCE_CHANGE_RECEIPT_TYPES = (
+	ReceiptType.HARVEST_FEE,
+	ReceiptType.LOCK_HASH_CREATED,
+	ReceiptType.LOCK_HASH_COMPLETED,
+	ReceiptType.LOCK_HASH_EXPIRED,
+	ReceiptType.LOCK_SECRET_CREATED,
+	ReceiptType.LOCK_SECRET_COMPLETED,
+	ReceiptType.LOCK_SECRET_EXPIRED
+)
+BALANCE_TRANSFER_RECEIPT_TYPES = (
+	ReceiptType.MOSAIC_RENTAL_FEE,
+	ReceiptType.NAMESPACE_RENTAL_FEE
+)
+ARTIFACT_EXPIRY_RECEIPT_TYPES = (
+	ReceiptType.MOSAIC_EXPIRED,
+	ReceiptType.NAMESPACE_EXPIRED,
+	ReceiptType.NAMESPACE_DELETED
+)
+
+RECEIPT_TYPE_LABELS = MappingProxyType({
+	ReceiptType.MOSAIC_RENTAL_FEE.value: 'mosaicRentalFee',
+	ReceiptType.NAMESPACE_RENTAL_FEE.value: 'namespaceRentalFee',
+	ReceiptType.HARVEST_FEE.value: 'harvestFee',
+	ReceiptType.LOCK_HASH_COMPLETED.value: 'lockHashCompleted',
+	ReceiptType.LOCK_HASH_EXPIRED.value: 'lockHashExpired',
+	ReceiptType.LOCK_SECRET_COMPLETED.value: 'lockSecretCompleted',
+	ReceiptType.LOCK_SECRET_EXPIRED.value: 'lockSecretExpired',
+	ReceiptType.LOCK_HASH_CREATED.value: 'lockHashCreated',
+	ReceiptType.LOCK_SECRET_CREATED.value: 'lockSecretCreated',
+	ReceiptType.MOSAIC_EXPIRED.value: 'mosaicExpired',
+	ReceiptType.NAMESPACE_EXPIRED.value: 'namespaceExpired',
+	ReceiptType.NAMESPACE_DELETED.value: 'namespaceDeleted',
+	ReceiptType.INFLATION.value: 'inflation'
+})
+RECEIPT_TYPE_GROUPS = MappingProxyType({
+	**{receipt_type.value: 'balanceChange' for receipt_type in BALANCE_CHANGE_RECEIPT_TYPES},
+	**{receipt_type.value: 'balanceTransfer' for receipt_type in BALANCE_TRANSFER_RECEIPT_TYPES},
+	**{receipt_type.value: 'artifactExpiry' for receipt_type in ARTIFACT_EXPIRY_RECEIPT_TYPES},
+	ReceiptType.INFLATION.value: 'inflation'
+})
+
+assert set(RECEIPT_TYPE_LABELS) == set(RECEIPT_TYPE_GROUPS), \
+	'RECEIPT_TYPE_LABELS and RECEIPT_TYPE_GROUPS must cover the same receipt types'
+
+RECEIPT_TYPE_CODES = tuple(RECEIPT_TYPE_LABELS)
+RECEIPT_TYPE_VALUES = tuple(RECEIPT_TYPE_LABELS.values())
+RECEIPT_GROUP_VALUES = ('balanceChange', 'balanceTransfer', 'artifactExpiry', 'inflation')
+
+INFLATION_RECEIPT_TYPE = RECEIPT_TYPE_LABELS[ReceiptType.INFLATION.value]
+NAMESPACE_EXPIRED_RECEIPT_TYPE = RECEIPT_TYPE_LABELS[ReceiptType.NAMESPACE_EXPIRED.value]
+NAMESPACE_DELETED_RECEIPT_TYPE = RECEIPT_TYPE_LABELS[ReceiptType.NAMESPACE_DELETED.value]
+MOSAIC_EXPIRED_RECEIPT_TYPE = RECEIPT_TYPE_LABELS[ReceiptType.MOSAIC_EXPIRED.value]

--- a/explorer/common/tests/test_NativeMosaic.py
+++ b/explorer/common/tests/test_NativeMosaic.py
@@ -1,0 +1,117 @@
+import pytest
+from common.symbol.NativeMosaic import (
+	MAX_NATIVE_MOSAIC_DIVISIBILITY,
+	NativeMosaicInfo,
+	create_native_mosaic_info,
+	extract_native_mosaic_id,
+	normalize_native_mosaic_divisibility,
+	normalize_native_mosaic_id
+)
+
+NETWORK_PROPERTIES = {'chain': {'currencyMosaicId': "0x72C0'212E'67A0'8BCE"}}
+MOSAIC_DEFINITION = {'mosaic': {'divisibility': 6}}
+
+
+def test_factory_normalizes_native_id():
+	# Arrange / Act:
+	native_mosaic_info = create_native_mosaic_info(NETWORK_PROPERTIES, MOSAIC_DEFINITION)
+
+	# Assert:
+	assert NativeMosaicInfo('72c0212e67a08bce', 6) == native_mosaic_info
+	assert '72C0212E67A08BCE' == native_mosaic_info.id
+	assert 6 == native_mosaic_info.divisibility
+
+
+def test_info_constructs_positionally():
+	# Arrange / Act:
+	native_mosaic_info = NativeMosaicInfo('72c0212e67a08bce', 6)
+
+	# Assert:
+	assert ('id', 'divisibility') == native_mosaic_info._fields
+	assert '72C0212E67A08BCE' == native_mosaic_info.id
+	assert 6 == native_mosaic_info.divisibility
+
+
+def test_info_constructs_with_keywords():
+	# Arrange:
+	positional_info = NativeMosaicInfo('72c0212e67a08bce', 6)
+
+	# Act:
+	keyword_info = NativeMosaicInfo(id='72c0212e67a08bce', divisibility=6)
+
+	# Assert:
+	assert positional_info == keyword_info
+
+
+def test_native_id_normalizes_lowercase():
+	# Arrange / Act / Assert:
+	assert '72C0212E67A08BCE' == normalize_native_mosaic_id('72c0212e67a08bce')
+
+
+def test_native_id_normalizes_grouped():
+	# Arrange / Act / Assert:
+	assert '72C0212E67A08BCE' == normalize_native_mosaic_id("72c0'212e'67a0'8bce")
+
+
+@pytest.mark.parametrize('mosaic_id', [
+	'72C0212E67A08BC',
+	'72C0212E67A08BCE0',
+	'72C0212E67A08BCG',
+	72
+])
+def test_native_id_rejects_malformed(mosaic_id):
+	# Arrange / Act / Assert:
+	with pytest.raises(ValueError, match='Native mosaic id'):
+		normalize_native_mosaic_id(mosaic_id)
+
+
+def test_native_id_rejects_missing():
+	# Arrange / Act / Assert:
+	with pytest.raises(ValueError, match='chain.currencyMosaicId'):
+		extract_native_mosaic_id({'chain': {}})
+
+
+@pytest.mark.parametrize('divisibility', [None, 6.0, '6'])
+def test_divisibility_rejects_non_int(divisibility):
+	# Arrange / Act / Assert:
+	with pytest.raises(ValueError, match='must be an integer'):
+		normalize_native_mosaic_divisibility(divisibility)
+
+
+def test_divisibility_rejects_bool():
+	# Arrange / Act / Assert:
+	with pytest.raises(ValueError, match='must be an integer'):
+		normalize_native_mosaic_divisibility(True)
+
+
+@pytest.mark.parametrize('divisibility', [-1, MAX_NATIVE_MOSAIC_DIVISIBILITY + 1])
+def test_divisibility_rejects_range(divisibility):
+	# Arrange / Act / Assert:
+	with pytest.raises(ValueError, match='between 0 and 6'):
+		normalize_native_mosaic_divisibility(divisibility)
+
+
+def test_divisibility_accepts_limits():
+	# Arrange / Act / Assert:
+	assert 0 == normalize_native_mosaic_divisibility(0)
+	assert MAX_NATIVE_MOSAIC_DIVISIBILITY == normalize_native_mosaic_divisibility(MAX_NATIVE_MOSAIC_DIVISIBILITY)
+
+
+def test_info_is_immutable():
+	# Arrange:
+	native_mosaic_info = NativeMosaicInfo('72C0212E67A08BCE', 6)
+
+	# Act / Assert:
+	with pytest.raises(AttributeError):
+		native_mosaic_info.id = '0000000000000000'
+
+
+@pytest.mark.parametrize('response', [
+	{},
+	{'mosaic': {}},
+	{'mosaic': {'divisibility': None}}
+])
+def test_factory_rejects_bad_response(response):
+	# Arrange / Act / Assert:
+	with pytest.raises(ValueError, match='Mosaic response|divisibility'):
+		create_native_mosaic_info(NETWORK_PROPERTIES, response)

--- a/explorer/common/tests/test_Receipt.py
+++ b/explorer/common/tests/test_Receipt.py
@@ -1,0 +1,121 @@
+import pytest
+from common.symbol.Receipt import (
+	ARTIFACT_EXPIRY_RECEIPT_TYPES,
+	BALANCE_CHANGE_RECEIPT_TYPES,
+	BALANCE_TRANSFER_RECEIPT_TYPES,
+	INFLATION_RECEIPT_TYPE,
+	MOSAIC_EXPIRED_RECEIPT_TYPE,
+	NAMESPACE_DELETED_RECEIPT_TYPE,
+	NAMESPACE_EXPIRED_RECEIPT_TYPE,
+	RECEIPT_GROUP_VALUES,
+	RECEIPT_TYPE_CODES,
+	RECEIPT_TYPE_GROUPS,
+	RECEIPT_TYPE_LABELS,
+	RECEIPT_TYPE_VALUES
+)
+from symbolchain.sc import ReceiptType
+
+
+def test_receipt_contract_has_labels():
+	# Arrange:
+	expected_labels = {
+		4685: 'mosaicRentalFee',
+		4942: 'namespaceRentalFee',
+		8515: 'harvestFee',
+		8776: 'lockHashCompleted',
+		9032: 'lockHashExpired',
+		8786: 'lockSecretCompleted',
+		9042: 'lockSecretExpired',
+		12616: 'lockHashCreated',
+		12626: 'lockSecretCreated',
+		16717: 'mosaicExpired',
+		16718: 'namespaceExpired',
+		16974: 'namespaceDeleted',
+		20803: 'inflation'
+	}
+
+	# Act / Assert:
+	assert tuple(expected_labels) == RECEIPT_TYPE_CODES
+	assert expected_labels == RECEIPT_TYPE_LABELS
+	assert tuple(expected_labels.values()) == RECEIPT_TYPE_VALUES
+
+
+def test_receipt_contract_has_groups():
+	# Arrange:
+	expected_groups = {
+		4685: 'balanceTransfer',
+		4942: 'balanceTransfer',
+		8515: 'balanceChange',
+		8776: 'balanceChange',
+		9032: 'balanceChange',
+		8786: 'balanceChange',
+		9042: 'balanceChange',
+		12616: 'balanceChange',
+		12626: 'balanceChange',
+		16717: 'artifactExpiry',
+		16718: 'artifactExpiry',
+		16974: 'artifactExpiry',
+		20803: 'inflation'
+	}
+
+	# Act / Assert:
+	assert expected_groups == RECEIPT_TYPE_GROUPS
+	assert set(RECEIPT_TYPE_LABELS) == set(RECEIPT_TYPE_GROUPS)
+	assert ('balanceChange', 'balanceTransfer', 'artifactExpiry', 'inflation') == RECEIPT_GROUP_VALUES
+
+
+def test_contract_uses_sdk_codes():
+	# Arrange / Act:
+	expected_codes = tuple(receipt_type.value for receipt_type in (
+		ReceiptType.MOSAIC_RENTAL_FEE,
+		ReceiptType.NAMESPACE_RENTAL_FEE,
+		ReceiptType.HARVEST_FEE,
+		ReceiptType.LOCK_HASH_COMPLETED,
+		ReceiptType.LOCK_HASH_EXPIRED,
+		ReceiptType.LOCK_SECRET_COMPLETED,
+		ReceiptType.LOCK_SECRET_EXPIRED,
+		ReceiptType.LOCK_HASH_CREATED,
+		ReceiptType.LOCK_SECRET_CREATED,
+		ReceiptType.MOSAIC_EXPIRED,
+		ReceiptType.NAMESPACE_EXPIRED,
+		ReceiptType.NAMESPACE_DELETED,
+		ReceiptType.INFLATION
+	))
+
+	# Assert:
+	assert expected_codes == RECEIPT_TYPE_CODES
+	assert {receipt_type.value for receipt_type in BALANCE_CHANGE_RECEIPT_TYPES} == {
+		ReceiptType.HARVEST_FEE.value,
+		ReceiptType.LOCK_HASH_CREATED.value,
+		ReceiptType.LOCK_HASH_COMPLETED.value,
+		ReceiptType.LOCK_HASH_EXPIRED.value,
+		ReceiptType.LOCK_SECRET_CREATED.value,
+		ReceiptType.LOCK_SECRET_COMPLETED.value,
+		ReceiptType.LOCK_SECRET_EXPIRED.value
+	}
+	assert {receipt_type.value for receipt_type in BALANCE_TRANSFER_RECEIPT_TYPES} == {
+		ReceiptType.MOSAIC_RENTAL_FEE.value,
+		ReceiptType.NAMESPACE_RENTAL_FEE.value
+	}
+	assert {receipt_type.value for receipt_type in ARTIFACT_EXPIRY_RECEIPT_TYPES} == {
+		ReceiptType.MOSAIC_EXPIRED.value,
+		ReceiptType.NAMESPACE_EXPIRED.value,
+		ReceiptType.NAMESPACE_DELETED.value
+	}
+
+
+def test_receipt_has_derived_labels():
+	# Arrange / Act / Assert:
+	assert 'inflation' == INFLATION_RECEIPT_TYPE
+	assert 'mosaicExpired' == MOSAIC_EXPIRED_RECEIPT_TYPE
+	assert 'namespaceExpired' == NAMESPACE_EXPIRED_RECEIPT_TYPE
+	assert 'namespaceDeleted' == NAMESPACE_DELETED_RECEIPT_TYPE
+
+
+def test_receipt_maps_are_immutable():
+	# Arrange / Act / Assert:
+	with pytest.raises(TypeError):
+		RECEIPT_TYPE_LABELS[8515] = 'changed'
+
+	with pytest.raises(TypeError):
+		RECEIPT_TYPE_GROUPS[8515] = 'changed'

--- a/explorer/puller/puller/db/SymbolDatabase.py
+++ b/explorer/puller/puller/db/SymbolDatabase.py
@@ -41,7 +41,8 @@ SYNC_STATE_COLUMNS = [
 	'finalized_epoch',
 	'finalized_point',
 	'last_synced_height',
-	'last_synced_block_hash'
+	'last_synced_block_hash',
+	'chain_revision'
 ]
 
 SYMBOL_RECEIPT_TYPE_VALUES = RECEIPT_TYPE_VALUES
@@ -86,6 +87,7 @@ SYMBOL_SYNC_STATE_DEFINITIONS = [
 	'finalized_point int',
 	'last_synced_height int',
 	'last_synced_block_hash bytea',
+	'chain_revision bigint NOT NULL DEFAULT 0',
 	'updated_at timestamp DEFAULT CURRENT_TIMESTAMP',
 	'CONSTRAINT symbol_sync_state_singleton CHECK (id = 1)'
 ]
@@ -464,13 +466,17 @@ SYMBOL_RECEIPT_DEFINITIONS = [
 	'raw_payload jsonb NOT NULL'
 ]
 SYMBOL_RECEIPT_INDEXES = [
-	'CREATE INDEX IF NOT EXISTS idx_symbol_receipts_height_type ON symbol_receipts(height DESC, receipt_type)',
-	'CREATE INDEX IF NOT EXISTS idx_symbol_receipts_type_height ON symbol_receipts(receipt_type, height DESC)',
-	'CREATE INDEX IF NOT EXISTS idx_symbol_receipts_group_height ON symbol_receipts(receipt_group, height DESC)',
-	'CREATE INDEX IF NOT EXISTS idx_symbol_receipts_target ON symbol_receipts(target_address)',
-	'CREATE INDEX IF NOT EXISTS idx_symbol_receipts_target_group_height ON symbol_receipts(target_address, receipt_group, height DESC)',
-	'CREATE INDEX IF NOT EXISTS idx_symbol_receipts_target_type_height ON symbol_receipts(target_address, receipt_type, height DESC)',
-	'CREATE INDEX IF NOT EXISTS idx_symbol_receipts_sender_group_height ON symbol_receipts(sender_address, receipt_group, height DESC)',
+	'CREATE INDEX IF NOT EXISTS idx_symbol_receipts_height_id ON symbol_receipts(height DESC, id DESC)',
+	'CREATE INDEX IF NOT EXISTS idx_symbol_receipts_group_height_id ON symbol_receipts(receipt_group, height DESC, id DESC)',
+	'CREATE INDEX IF NOT EXISTS idx_symbol_receipts_type_height_id ON symbol_receipts(receipt_type, height DESC, id DESC)',
+	'CREATE INDEX IF NOT EXISTS idx_symbol_receipts_target_height_id ON symbol_receipts(target_address, height DESC, id DESC)',
+	'CREATE INDEX IF NOT EXISTS idx_symbol_receipts_sender_height_id ON symbol_receipts(sender_address, height DESC, id DESC)',
+	'CREATE INDEX IF NOT EXISTS idx_symbol_receipts_target_group_height_id '
+	'ON symbol_receipts(target_address, receipt_group, height DESC, id DESC)',
+	'CREATE INDEX IF NOT EXISTS idx_symbol_receipts_target_type_height_id '
+	'ON symbol_receipts(target_address, receipt_type, height DESC, id DESC)',
+	'CREATE INDEX IF NOT EXISTS idx_symbol_receipts_sender_group_height_id '
+	'ON symbol_receipts(sender_address, receipt_group, height DESC, id DESC)',
 	'CREATE INDEX IF NOT EXISTS idx_symbol_receipts_mosaic ON symbol_receipts(mosaic_id)'
 ]
 
@@ -1738,6 +1744,7 @@ class SymbolDatabase(DatabaseConnection):  # pylint: disable=too-many-public-met
 		with self._database_transaction() as cursor:
 			self._delete_rollback_affected_rows_from_height(cursor, height)
 			self._stale_mark_account_refresh_state_if_needed(cursor, height)
+			self._increment_chain_revision(cursor)
 
 	def repair_rollback_from_height(self, height, sync_state, refresh_entries):
 		"""Repairs rollbacked chain and refreshed current state in one transaction."""
@@ -1751,7 +1758,20 @@ class SymbolDatabase(DatabaseConnection):  # pylint: disable=too-many-public-met
 			self._execute_hash_lock_entries(cursor, refresh_entries.hash_lock_entries)
 			self._execute_secret_lock_entries(cursor, refresh_entries.secret_lock_entries)
 			self._execute_mosaic_restriction_entries(cursor, refresh_entries.mosaic_restriction_entries)
+			self._increment_chain_revision(cursor)
 			self._execute_upsert_sync_state(cursor, sync_state)
+
+	@staticmethod
+	def _increment_chain_revision(cursor):
+		cursor.execute(
+			'''
+			UPDATE symbol_sync_state
+			SET chain_revision = chain_revision + 1
+			WHERE id = 1
+			RETURNING chain_revision
+			''')
+		if cursor.rowcount != 1 or cursor.fetchone() is None:
+			raise RuntimeError('Symbol sync state singleton is missing')
 
 	@staticmethod
 	def _delete_rollback_affected_rows_from_height(cursor, height):

--- a/explorer/puller/puller/db/SymbolDatabase.py
+++ b/explorer/puller/puller/db/SymbolDatabase.py
@@ -2,6 +2,7 @@
 from collections import namedtuple
 from contextlib import contextmanager
 
+from common.symbol.Receipt import RECEIPT_GROUP_VALUES, RECEIPT_TYPE_VALUES
 from psycopg2.extras import Json
 
 from puller.model.symbol.Account import ACCOUNT_TYPE_VALUES
@@ -22,7 +23,6 @@ from puller.model.symbol.MosaicRestriction import (
 	mosaic_restriction_entry_type_label
 )
 from puller.model.symbol.Namespace import NAMESPACE_ALIAS_TYPE_LABELS, NAMESPACE_REGISTRATION_TYPE_LABELS
-from puller.model.symbol.Receipt import RECEIPT_TYPE_LABELS
 from puller.model.symbol.Transaction import MESSAGE_TYPE_LABELS, TRANSACTION_TYPE_LABELS
 
 from .DatabaseConnection import DatabaseConnection
@@ -44,8 +44,8 @@ SYNC_STATE_COLUMNS = [
 	'last_synced_block_hash'
 ]
 
-SYMBOL_RECEIPT_TYPE_VALUES = tuple(RECEIPT_TYPE_LABELS.values())
-SYMBOL_RECEIPT_GROUP_VALUES = ('balanceChange', 'balanceTransfer', 'artifactExpiry', 'inflation')
+SYMBOL_RECEIPT_TYPE_VALUES = RECEIPT_TYPE_VALUES
+SYMBOL_RECEIPT_GROUP_VALUES = RECEIPT_GROUP_VALUES
 SYNC_STATE_STATUS_VALUES = ('initialized', 'healthy', 'repairing', 'unhealthy')
 SYMBOL_TRANSACTION_TYPE_VALUES = tuple(TRANSACTION_TYPE_LABELS.values())
 SYMBOL_TRANSACTION_MOSAIC_ROLE_VALUES = (
@@ -471,7 +471,6 @@ SYMBOL_RECEIPT_INDEXES = [
 	'CREATE INDEX IF NOT EXISTS idx_symbol_receipts_target_group_height ON symbol_receipts(target_address, receipt_group, height DESC)',
 	'CREATE INDEX IF NOT EXISTS idx_symbol_receipts_target_type_height ON symbol_receipts(target_address, receipt_type, height DESC)',
 	'CREATE INDEX IF NOT EXISTS idx_symbol_receipts_sender_group_height ON symbol_receipts(sender_address, receipt_group, height DESC)',
-	'CREATE INDEX IF NOT EXISTS idx_symbol_receipts_recipient_group_height ON symbol_receipts(recipient_address, receipt_group, height DESC)',
 	'CREATE INDEX IF NOT EXISTS idx_symbol_receipts_mosaic ON symbol_receipts(mosaic_id)'
 ]
 

--- a/explorer/puller/puller/facade/SymbolPuller.py
+++ b/explorer/puller/puller/facade/SymbolPuller.py
@@ -7,7 +7,14 @@ from collections import defaultdict, namedtuple
 from datetime import datetime, timedelta, timezone
 from urllib.parse import urlparse
 
+from common.symbol.NativeMosaic import NativeMosaicInfo, create_native_mosaic_info, extract_native_mosaic_id
 from common.symbol.NodeConfiguration import SymbolNodeConfiguration
+from common.symbol.Receipt import (
+	INFLATION_RECEIPT_TYPE,
+	MOSAIC_EXPIRED_RECEIPT_TYPE,
+	NAMESPACE_DELETED_RECEIPT_TYPE,
+	NAMESPACE_EXPIRED_RECEIPT_TYPE
+)
 from symbolchain.facade.SymbolFacade import SymbolFacade
 from symbolchain.sc import TransactionType
 from symbolchain.symbol.Network import Address, Network
@@ -47,18 +54,11 @@ from puller.model.symbol.MosaicRestriction import (
 	mosaic_restriction_entry_type_to_enum_value
 )
 from puller.model.symbol.Namespace import create_alias_name_rows, create_namespace_row
-from puller.model.symbol.Receipt import (
-	INFLATION_RECEIPT_TYPE,
-	MOSAIC_EXPIRED_RECEIPT_TYPE,
-	NAMESPACE_DELETED_RECEIPT_TYPE,
-	NAMESPACE_EXPIRED_RECEIPT_TYPE,
-	create_receipt_rows
-)
+from puller.model.symbol.Receipt import create_receipt_rows
 from puller.model.symbol.Resolution import is_alias_mosaic_id, select_resolution_entry
 from puller.model.symbol.Transaction import create_transaction_row, unique_address_rows
 
 DatabaseConfiguration = namedtuple('DatabaseConfiguration', ['database', 'user', 'password', 'host', 'port'])
-NativeMosaicInfo = namedtuple('NativeMosaicInfo', ['id', 'divisibility'])
 TransactionSource = namedtuple('TransactionSource', ['primary_id', 'secondary_id'])
 ResolutionStatements = namedtuple('ResolutionStatements', ['address', 'mosaic'])
 ResolutionRequest = namedtuple('ResolutionRequest', ['height', 'kind'])
@@ -691,16 +691,16 @@ class SymbolPuller:
 
 		return self._network_properties
 
-	async def _get_native_mosaic_info(self):
+	async def _get_native_mosaic_info(self) -> NativeMosaicInfo:
 		"""Gets and memoizes the native mosaic id and divisibility for this puller instance."""
 
 		if self._native_mosaic_info:
 			return self._native_mosaic_info
 
 		network_properties = await self._get_network_properties()
-		native_mosaic_id = network_properties['chain']['currencyMosaicId'].replace('0x', '').replace("'", '').upper()
+		native_mosaic_id = extract_native_mosaic_id(network_properties)
 		mosaic_definition = await self.get_symbol_node(f'/mosaics/{native_mosaic_id}')
-		self._native_mosaic_info = NativeMosaicInfo(native_mosaic_id, int(mosaic_definition['mosaic']['divisibility']))
+		self._native_mosaic_info = create_native_mosaic_info(network_properties, mosaic_definition)
 
 		return self._native_mosaic_info
 

--- a/explorer/puller/puller/model/symbol/Receipt.py
+++ b/explorer/puller/puller/model/symbol/Receipt.py
@@ -1,51 +1,6 @@
-from symbolchain.sc import ReceiptType
+import common.symbol.Receipt as receipt_contract
 
 from puller.model.symbol.format import bytes_from_hex_or_none, str_or_none
-
-BALANCE_CHANGE_RECEIPT_TYPES = (
-	ReceiptType.HARVEST_FEE,
-	ReceiptType.LOCK_HASH_CREATED,
-	ReceiptType.LOCK_HASH_COMPLETED,
-	ReceiptType.LOCK_HASH_EXPIRED,
-	ReceiptType.LOCK_SECRET_CREATED,
-	ReceiptType.LOCK_SECRET_COMPLETED,
-	ReceiptType.LOCK_SECRET_EXPIRED
-)
-BALANCE_TRANSFER_RECEIPT_TYPES = (
-	ReceiptType.MOSAIC_RENTAL_FEE,
-	ReceiptType.NAMESPACE_RENTAL_FEE
-)
-ARTIFACT_EXPIRY_RECEIPT_TYPES = (
-	ReceiptType.MOSAIC_EXPIRED,
-	ReceiptType.NAMESPACE_EXPIRED,
-	ReceiptType.NAMESPACE_DELETED
-)
-RECEIPT_TYPE_LABELS = {
-	ReceiptType.MOSAIC_RENTAL_FEE.value: 'mosaicRentalFee',
-	ReceiptType.NAMESPACE_RENTAL_FEE.value: 'namespaceRentalFee',
-	ReceiptType.HARVEST_FEE.value: 'harvestFee',
-	ReceiptType.LOCK_HASH_COMPLETED.value: 'lockHashCompleted',
-	ReceiptType.LOCK_HASH_EXPIRED.value: 'lockHashExpired',
-	ReceiptType.LOCK_SECRET_COMPLETED.value: 'lockSecretCompleted',
-	ReceiptType.LOCK_SECRET_EXPIRED.value: 'lockSecretExpired',
-	ReceiptType.LOCK_HASH_CREATED.value: 'lockHashCreated',
-	ReceiptType.LOCK_SECRET_CREATED.value: 'lockSecretCreated',
-	ReceiptType.MOSAIC_EXPIRED.value: 'mosaicExpired',
-	ReceiptType.NAMESPACE_EXPIRED.value: 'namespaceExpired',
-	ReceiptType.NAMESPACE_DELETED.value: 'namespaceDeleted',
-	ReceiptType.INFLATION.value: 'inflation'
-}
-RECEIPT_TYPE_GROUPS = {
-	**{receipt_type.value: 'balanceChange' for receipt_type in BALANCE_CHANGE_RECEIPT_TYPES},
-	**{receipt_type.value: 'balanceTransfer' for receipt_type in BALANCE_TRANSFER_RECEIPT_TYPES},
-	**{receipt_type.value: 'artifactExpiry' for receipt_type in ARTIFACT_EXPIRY_RECEIPT_TYPES},
-	ReceiptType.INFLATION.value: 'inflation'
-}
-assert set(RECEIPT_TYPE_LABELS) == set(RECEIPT_TYPE_GROUPS), 'RECEIPT_TYPE_LABELS and RECEIPT_TYPE_GROUPS must cover the same receipt types'
-INFLATION_RECEIPT_TYPE = RECEIPT_TYPE_LABELS[ReceiptType.INFLATION.value]
-NAMESPACE_EXPIRED_RECEIPT_TYPE = RECEIPT_TYPE_LABELS[ReceiptType.NAMESPACE_EXPIRED.value]
-NAMESPACE_DELETED_RECEIPT_TYPE = RECEIPT_TYPE_LABELS[ReceiptType.NAMESPACE_DELETED.value]
-MOSAIC_EXPIRED_RECEIPT_TYPE = RECEIPT_TYPE_LABELS[ReceiptType.MOSAIC_EXPIRED.value]
 
 
 def _create_base_receipt_row(statement, source, receipt):
@@ -53,8 +8,8 @@ def _create_base_receipt_row(statement, source, receipt):
 
 	return {
 		'height': int(statement['height']),
-		'receipt_type': RECEIPT_TYPE_LABELS[receipt_type],
-		'receipt_group': RECEIPT_TYPE_GROUPS[receipt_type],
+		'receipt_type': receipt_contract.RECEIPT_TYPE_LABELS[receipt_type],
+		'receipt_group': receipt_contract.RECEIPT_TYPE_GROUPS[receipt_type],
 		'version': int(receipt['version']),
 		'source_primary_id': int(source['primaryId']),
 		'source_secondary_id': int(source['secondaryId']),
@@ -81,7 +36,7 @@ def create_receipt_rows(statement_item):
 	rows = []
 	for receipt in statement['receipts']:
 		receipt_type = int(receipt['type'])
-		if receipt_type not in RECEIPT_TYPE_GROUPS:
+		if receipt_type not in receipt_contract.RECEIPT_TYPE_GROUPS:
 			continue
 
 		row = _create_base_receipt_row(statement, source, receipt)

--- a/explorer/puller/tests/db/test_SymbolDatabase.py
+++ b/explorer/puller/tests/db/test_SymbolDatabase.py
@@ -177,11 +177,19 @@ def _create_sync_state(**overrides):
 		'finalized_epoch': 2,
 		'finalized_point': 3,
 		'last_synced_height': 10,
-		'last_synced_block_hash': b'last'
+		'last_synced_block_hash': b'last',
+		'chain_revision': 0
 	}
 	sync_state.update(overrides)
 
 	return sync_state
+
+
+def _upsert_sync_state_with_revision(database, chain_revision):
+	database.upsert_sync_state(_create_sync_state())
+	cursor = database.connection.cursor()
+	cursor.execute('UPDATE symbol_sync_state SET chain_revision = %s WHERE id = 1', (chain_revision,))
+	database.connection.commit()
 
 
 def _create_receipt(height, receipt_type='inflation', **overrides):
@@ -1693,6 +1701,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		# Arrange:
 		database = self._create_database()
 		database.upsert_blocks([_create_block(1), _create_block(2)])
+		database.upsert_sync_state(_create_sync_state(chain_revision=0))
 		namespace_row = _create_namespace_row(updated_at_height=2)
 		database.upsert_namespace(namespace_row, _create_alias_name_rows(namespace_row))
 
@@ -1711,11 +1720,13 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 			('mosaic', '72C0212E67A08BCE', 'root', 2),
 			('namespace', NAMESPACE_ROOT_ID, 'root', 2)
 		], cursor.fetchall())
+		self.assertEqual(1, database.get_sync_state()['chain_revision'])
 
 	def test_repair_rollback_from_height_leaves_mosaic_current_state_rows_in_place(self):
 		# Arrange:
 		database = self._create_database()
 		fork_height = 2
+		database.upsert_sync_state(_create_sync_state(chain_revision=0))
 		mosaic_row = create_expected_mosaic_row(
 			create_mosaic_item(mosaic_id='0000000000000001', supply='4321', item_id='fork-survivor'),
 			fork_height)
@@ -1730,12 +1741,13 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 
 		# Assert:
 		self.assertEqual(original_mosaic_state, fetch_mosaic_state(database))
+		self.assertEqual(1, database.get_sync_state()['chain_revision'])
 
 	def test_repair_rollback_from_height_applies_namespace_mosaic_and_metadata_changes_in_same_transaction(self):
 		# Arrange:
 		database = self._create_database()
 		database.upsert_blocks([_create_block(1), _create_block(2)])
-		database.upsert_sync_state(_create_sync_state())
+		database.upsert_sync_state(_create_sync_state(chain_revision=0))
 		refreshed_row = _create_namespace_row()
 		deleted_row = _create_namespace_row('B95F1F8A96159516', 'orphaned', 2)
 		database.upsert_namespace(refreshed_row, _create_alias_name_rows(refreshed_row))
@@ -1794,7 +1806,8 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		expected_sync_state = _create_sync_state(
 			status='repairing',
 			last_synced_height=1,
-			last_synced_block_hash=b'hash 1')
+			last_synced_block_hash=b'hash 1',
+			chain_revision=1)
 		expected_mosaic_row = refresh_entries.mosaic_entries[0]['row']
 		expected_mosaic_state = [create_persisted_mosaic_state(expected_mosaic_row, [])]
 		expected_namespace_state = (
@@ -1826,7 +1839,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		# Arrange:
 		database = self._create_database()
 		database.upsert_blocks([_create_block(1), _create_block(2)])
-		database.upsert_sync_state(_create_sync_state())
+		database.upsert_sync_state(_create_sync_state(chain_revision=0))
 		original_namespace_row = _create_namespace_row(observed_height=2)
 		deleted_namespace_row = _create_namespace_row('B95F1F8A96159516', 'gone', 2)
 		database.upsert_namespace(original_namespace_row, _create_alias_name_rows(original_namespace_row))
@@ -1895,6 +1908,54 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		self.assertEqual(original_state['namespace'], fetch_namespace_state(database.connection))
 		self.assertEqual(original_state['mosaic'], fetch_mosaic_state(database))
 		self.assertEqual(original_state['metadata'], fetch_metadata_rows(database))
+
+	def test_repair_failure_after_revision_increment_restores_receipts_and_chain_revision_atomically(self):
+		# Arrange:
+		database = self._create_database()
+		database.upsert_blocks([_create_block(1), _create_block(2)])
+		database.upsert_receipts_for_height(1, [_create_receipt(1)], 10)
+		database.upsert_receipts_for_height(2, [_create_receipt(2)], 20)
+		_upsert_sync_state_with_revision(database, 7)
+		database.upsert_account_current_state(*_create_account_row(ADDRESS1, observed_height=2))
+		database.upsert_account_refresh_state({
+			'status': 'healthy',
+			'last_successful_run_id': 'run-1',
+			'last_completed_height': 2
+		})
+		cursor = database.connection.cursor()
+		cursor.execute('SELECT height, amount FROM symbol_receipts ORDER BY height')
+		original_receipts = cursor.fetchall()
+		original_sync_state = database.get_sync_state()
+		original_blocks = fetch_full_block_state(database)
+		cursor.execute('SELECT address, last_seen_height FROM symbol_accounts ORDER BY address')
+		original_account_state = [(bytes(address), height) for address, height in cursor.fetchall()]
+		cursor.execute('SELECT address, mosaic_id, amount, updated_at_height FROM symbol_account_mosaics ORDER BY address, mosaic_id')
+		original_account_mosaic_state = [(bytes(address), mosaic_id, amount, height) for address, mosaic_id, amount, height in cursor.fetchall()]
+		original_refresh_state = database.get_account_refresh_state()
+		self.assertEqual(7, original_sync_state['chain_revision'])
+
+		# Act:
+		# PostgreSQL rejects the invalid status in _execute_upsert_sync_state after the revision increment.
+		with self.assertRaises(PsycopgError):
+			database.repair_rollback_from_height(
+				2,
+				_create_sync_state(status='invalid', last_synced_height=1, last_synced_block_hash=b'hash 1'),
+				RollbackRefreshEntries())
+
+		# Assert:
+		cursor.execute('SELECT height, amount FROM symbol_receipts ORDER BY height')
+		self.assertEqual(original_receipts, cursor.fetchall())
+		self.assertEqual(original_blocks, fetch_full_block_state(database))
+		cursor.execute('SELECT address, last_seen_height FROM symbol_accounts ORDER BY address')
+		self.assertEqual(original_account_state, [
+			(bytes(address), height) for address, height in cursor.fetchall()
+		])
+		cursor.execute('SELECT address, mosaic_id, amount, updated_at_height FROM symbol_account_mosaics ORDER BY address, mosaic_id')
+		self.assertEqual(original_account_mosaic_state, [
+			(bytes(address), mosaic_id, amount, height) for address, mosaic_id, amount, height in cursor.fetchall()
+		])
+		self.assertEqual(original_refresh_state, database.get_account_refresh_state())
+		self.assertEqual(original_sync_state, database.get_sync_state())
 
 	def test_repair_rollback_rolls_back_namespace_entries_and_chain_state_when_later_alias_insert_fails(self):
 		# Arrange:
@@ -2444,10 +2505,19 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 			('finalized_point', 'int4'),
 			('last_synced_height', 'int4'),
 			('last_synced_block_hash', 'bytea'),
+			('chain_revision', 'int8'),
 			('updated_at', 'timestamp')
 		], sync_state_columns)
 		self.assertEqual('symbol_sync_state_status', status_type)
 		self.assertIsNone(status_default)
+		cursor.execute(
+			'''
+			SELECT column_default
+			FROM information_schema.columns
+			WHERE table_name = 'symbol_sync_state'
+				AND column_name = 'chain_revision'
+			''')
+		self.assertEqual('0', cursor.fetchone()[0])
 
 	def test_create_tables_creates_enum_types(self):
 		# Arrange:
@@ -2546,38 +2616,43 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 
 		self.assertEqual([
 			(
-				'idx_symbol_receipts_group_height',
-				'CREATE INDEX idx_symbol_receipts_group_height ON public.symbol_receipts USING btree (receipt_group, height DESC)'
+				'idx_symbol_receipts_group_height_id',
+				'CREATE INDEX idx_symbol_receipts_group_height_id ON public.symbol_receipts USING btree (receipt_group, height DESC, id DESC)'
 			),
 			(
-				'idx_symbol_receipts_height_type',
-				'CREATE INDEX idx_symbol_receipts_height_type ON public.symbol_receipts USING btree (height DESC, receipt_type)'
+				'idx_symbol_receipts_height_id',
+				'CREATE INDEX idx_symbol_receipts_height_id ON public.symbol_receipts USING btree (height DESC, id DESC)'
 			),
 			(
 				'idx_symbol_receipts_mosaic',
 				'CREATE INDEX idx_symbol_receipts_mosaic ON public.symbol_receipts USING btree (mosaic_id)'
 			),
 			(
-				'idx_symbol_receipts_sender_group_height',
-				'CREATE INDEX idx_symbol_receipts_sender_group_height ON public.symbol_receipts '
-				'USING btree (sender_address, receipt_group, height DESC)'
+				'idx_symbol_receipts_sender_group_height_id',
+				'CREATE INDEX idx_symbol_receipts_sender_group_height_id ON public.symbol_receipts '
+				'USING btree (sender_address, receipt_group, height DESC, id DESC)'
 			),
 			(
-				'idx_symbol_receipts_target',
-				'CREATE INDEX idx_symbol_receipts_target ON public.symbol_receipts USING btree (target_address)'
+				'idx_symbol_receipts_sender_height_id',
+				'CREATE INDEX idx_symbol_receipts_sender_height_id ON public.symbol_receipts USING btree (sender_address, height DESC, id DESC)'
 			),
 			(
-				'idx_symbol_receipts_target_group_height',
-				'CREATE INDEX idx_symbol_receipts_target_group_height ON public.symbol_receipts '
-				'USING btree (target_address, receipt_group, height DESC)'
+				'idx_symbol_receipts_target_group_height_id',
+				'CREATE INDEX idx_symbol_receipts_target_group_height_id ON public.symbol_receipts '
+				'USING btree (target_address, receipt_group, height DESC, id DESC)'
 			),
 			(
-				'idx_symbol_receipts_target_type_height',
-				'CREATE INDEX idx_symbol_receipts_target_type_height ON public.symbol_receipts USING btree (target_address, receipt_type, height DESC)'
+				'idx_symbol_receipts_target_height_id',
+				'CREATE INDEX idx_symbol_receipts_target_height_id ON public.symbol_receipts USING btree (target_address, height DESC, id DESC)'
 			),
 			(
-				'idx_symbol_receipts_type_height',
-				'CREATE INDEX idx_symbol_receipts_type_height ON public.symbol_receipts USING btree (receipt_type, height DESC)'
+				'idx_symbol_receipts_target_type_height_id',
+				'CREATE INDEX idx_symbol_receipts_target_type_height_id ON public.symbol_receipts '
+				'USING btree (target_address, receipt_type, height DESC, id DESC)'
+			),
+			(
+				'idx_symbol_receipts_type_height_id',
+				'CREATE INDEX idx_symbol_receipts_type_height_id ON public.symbol_receipts USING btree (receipt_type, height DESC, id DESC)'
 			),
 			(
 				'symbol_receipts_pkey',
@@ -3019,7 +3094,8 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 				finalized_epoch,
 				finalized_point,
 				last_synced_height,
-				last_synced_block_hash
+				last_synced_block_hash,
+				chain_revision
 			FROM symbol_sync_state
 			WHERE id = 1
 			'''
@@ -3034,6 +3110,35 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		self.assertEqual(3, result[5])
 		self.assertEqual(10, result[6])
 		self.assertEqual(bytes(b'last'), bytes(result[7]))
+		self.assertEqual(0, result[8])
+
+	def test_normal_sync_state_upsert_preserves_chain_revision(self):
+		# Arrange:
+		database = self._create_database()
+		database.upsert_sync_state(_create_sync_state())
+		cursor = database.connection.cursor()
+		cursor.execute('UPDATE symbol_sync_state SET chain_revision = 7 WHERE id = 1')
+		database.connection.commit()
+
+		# Act:
+		database.upsert_sync_state(_create_sync_state(chain_height=11))
+
+		# Assert:
+		self.assertEqual(7, database.get_sync_state()['chain_revision'])
+
+	def test_normal_block_append_preserves_chain_revision(self):
+		# Arrange:
+		database = self._create_database()
+		database.upsert_sync_state(_create_sync_state())
+		cursor = database.connection.cursor()
+		cursor.execute('UPDATE symbol_sync_state SET chain_revision = 7 WHERE id = 1')
+		database.connection.commit()
+
+		# Act:
+		database.upsert_blocks([_create_block(1)])
+
+		# Assert:
+		self.assertEqual(7, database.get_sync_state()['chain_revision'])
 
 	def test_get_sync_state_returns_upserted_value(self):
 		# Arrange:
@@ -3579,6 +3684,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 	def test_repair_rollback_marks_account_refresh_state_stale_when_completed_height_is_rollbacked(self):
 		# Arrange:
 		database = self._create_database()
+		database.upsert_sync_state(_create_sync_state(chain_revision=0))
 		database.upsert_account_refresh_state({
 			'status': 'healthy',
 			'last_successful_run_id': 'run-1',
@@ -3591,10 +3697,12 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 
 		# Assert:
 		self.assertEqual('stale', database.get_account_refresh_state()['status'])
+		self.assertEqual(1, database.get_sync_state()['chain_revision'])
 
 	def test_repair_rollback_leaves_account_refresh_state_when_completed_height_is_before_rollback(self):
 		# Arrange:
 		database = self._create_database()
+		database.upsert_sync_state(_create_sync_state(chain_revision=0))
 		database.upsert_account_refresh_state({
 			'status': 'healthy',
 			'last_successful_run_id': 'run-1',
@@ -3607,6 +3715,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 
 		# Assert:
 		self.assertEqual('healthy', database.get_account_refresh_state()['status'])
+		self.assertEqual(1, database.get_sync_state()['chain_revision'])
 
 	def test_repair_rollback_from_height_rolls_back_when_sync_state_table_is_missing(self):
 		# Arrange:
@@ -3666,9 +3775,54 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		self.assertEqual(original_namespace_state, fetch_namespace_state(database.connection))
 		self.assertEqual(original_mosaic_state, fetch_mosaic_state(database))
 
+	def test_repair_rollback_fails_without_sync_state_singleton(self):
+		# Arrange:
+		database = self._create_database()
+		database.upsert_blocks([_create_block(1), _create_block(2)])
+		database.upsert_receipts_for_height(1, [_create_receipt(1)], 10)
+		database.upsert_receipts_for_height(2, [_create_receipt(2)], 20)
+		database.upsert_account_current_state(*_create_account_row(ADDRESS1, observed_height=2))
+		database.upsert_account_refresh_state({
+			'status': 'healthy',
+			'last_successful_run_id': 'run-1',
+			'last_completed_height': 2
+		})
+		cursor = database.connection.cursor()
+		cursor.execute('DELETE FROM symbol_sync_state')
+		database.connection.commit()
+		original_blocks = fetch_full_block_state(database)
+		cursor.execute('SELECT height, amount FROM symbol_receipts ORDER BY height')
+		original_receipts = cursor.fetchall()
+		cursor.execute('SELECT address, last_seen_height FROM symbol_accounts ORDER BY address')
+		original_account_state = [(bytes(address), height) for address, height in cursor.fetchall()]
+		cursor.execute('SELECT address, mosaic_id, amount, updated_at_height FROM symbol_account_mosaics ORDER BY address, mosaic_id')
+		original_account_mosaic_state = [(bytes(address), mosaic_id, amount, height) for address, mosaic_id, amount, height in cursor.fetchall()]
+		original_refresh_state = database.get_account_refresh_state()
+
+		# Act:
+		with self.assertRaisesRegex(RuntimeError, 'Symbol sync state singleton is missing'):
+			database.repair_rollback_from_height(
+				2, _create_sync_state(status='repairing', last_synced_height=1), RollbackRefreshEntries())
+
+		# Assert:
+		self.assertEqual(original_blocks, fetch_full_block_state(database))
+		cursor.execute('SELECT height, amount FROM symbol_receipts ORDER BY height')
+		self.assertEqual(original_receipts, cursor.fetchall())
+		cursor.execute('SELECT address, last_seen_height FROM symbol_accounts ORDER BY address')
+		self.assertEqual(original_account_state, [
+			(bytes(address), height) for address, height in cursor.fetchall()
+		])
+		cursor.execute('SELECT address, mosaic_id, amount, updated_at_height FROM symbol_account_mosaics ORDER BY address, mosaic_id')
+		self.assertEqual(original_account_mosaic_state, [
+			(bytes(address), mosaic_id, amount, height) for address, mosaic_id, amount, height in cursor.fetchall()
+		])
+		self.assertEqual(original_refresh_state, database.get_account_refresh_state())
+		self.assertIsNone(database.get_sync_state())
+
 	def test_repair_rollback_deletes_current_state_but_preserves_account_refresh_rows(self):
 		# Arrange:
 		database = self._create_database()
+		database.upsert_sync_state(_create_sync_state(chain_revision=0))
 		account_row, mosaic_rows = _create_account_row()
 		database.upsert_account_current_state(account_row, mosaic_rows)
 		database.upsert_multisig(bytes.fromhex(ADDRESS1), {
@@ -3720,6 +3874,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		self.assertEqual([(0, expected_address)], self._fetch_rank_addresses(database, 'ID'))
 		self.assertEqual([(0, expected_address)], self._fetch_rank_addresses(database, 'IMPORTANCE'))
 		self.assertEqual([(0, expected_address)], self._fetch_rank_addresses(database, f'BALANCE:{NATIVE_MOSAIC_ID}'))
+		self.assertEqual(1, database.get_sync_state()['chain_revision'])
 
 	def test_rejects_invalid_block_type(self):
 		# Arrange:
@@ -3939,6 +4094,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 			_create_block(2),
 			_create_block(3)
 		])
+		_upsert_sync_state_with_revision(database, 7)
 		database.upsert_receipts_for_height(2, [_create_receipt(2)], 100)
 		database.upsert_receipts_for_height(3, [_create_receipt(3)], 100)
 
@@ -3954,6 +4110,49 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 
 		self.assertEqual([(1,)], block_results)
 		self.assertEqual([], receipt_results)
+		self.assertEqual(8, database.get_sync_state()['chain_revision'])
+
+	def test_delete_blocks_from_height_fails_without_sync_state_singleton(self):
+		# Arrange:
+		database = self._create_database()
+		database.upsert_blocks([_create_block(1), _create_block(2)])
+		database.upsert_receipts_for_height(2, [_create_receipt(2)], 20)
+		database.upsert_account_current_state(*_create_account_row(ADDRESS1, observed_height=2))
+		database.upsert_account_refresh_state({
+			'status': 'healthy',
+			'last_successful_run_id': 'run-1',
+			'last_completed_height': 2
+		})
+		cursor = database.connection.cursor()
+		cursor.execute('DELETE FROM symbol_sync_state')
+		database.connection.commit()
+		original_blocks = fetch_full_block_state(database)
+		cursor.execute('SELECT height, amount FROM symbol_receipts ORDER BY height')
+		original_receipts = cursor.fetchall()
+		cursor.execute('SELECT address, last_seen_height FROM symbol_accounts ORDER BY address')
+		original_account_state = [(bytes(address), height) for address, height in cursor.fetchall()]
+		cursor.execute('SELECT address, mosaic_id, amount, updated_at_height FROM symbol_account_mosaics ORDER BY address, mosaic_id')
+		original_account_mosaic_state = [(bytes(address), mosaic_id, amount, height) for address, mosaic_id, amount, height in cursor.fetchall()]
+		original_refresh_state = database.get_account_refresh_state()
+
+		# Act:
+		with self.assertRaisesRegex(RuntimeError, 'Symbol sync state singleton is missing'):
+			database.delete_blocks_from_height(2)
+
+		# Assert:
+		self.assertEqual(original_blocks, fetch_full_block_state(database))
+		cursor.execute('SELECT height, amount FROM symbol_receipts ORDER BY height')
+		self.assertEqual(original_receipts, cursor.fetchall())
+		cursor.execute('SELECT address, last_seen_height FROM symbol_accounts ORDER BY address')
+		self.assertEqual(original_account_state, [
+			(bytes(address), height) for address, height in cursor.fetchall()
+		])
+		cursor.execute('SELECT address, mosaic_id, amount, updated_at_height FROM symbol_account_mosaics ORDER BY address, mosaic_id')
+		self.assertEqual(original_account_mosaic_state, [
+			(bytes(address), mosaic_id, amount, height) for address, mosaic_id, amount, height in cursor.fetchall()
+		])
+		self.assertEqual(original_refresh_state, database.get_account_refresh_state())
+		self.assertIsNone(database.get_sync_state())
 
 	def test_upsert_transactions_for_height_computes_effective_fee(self):
 		# Arrange:
@@ -4148,6 +4347,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		database = self._create_database()
 		cursor = database.connection.cursor()
 		database.upsert_blocks([_create_block(1), _create_block(2), _create_block(3)])
+		database.upsert_sync_state(_create_sync_state(chain_revision=0))
 		database.upsert_transactions_for_height(1, [create_transaction_entry(1, 'kept')])
 		database.upsert_transactions_for_height(2, [create_transaction_entry(
 			2,
@@ -4173,12 +4373,14 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		self.assertEqual(0, mosaic_count)
 		self.assertEqual(0, address_count)
 		self.assertEqual([(1,)], block_results)
+		self.assertEqual(1, database.get_sync_state()['chain_revision'])
 
 	def test_delete_blocks_from_height_deletes_account_family_rows(self):
 		# Arrange:
 		database = self._create_database()
 		cursor = database.connection.cursor()
 		database.upsert_blocks([_create_block(1), _create_block(2), _create_block(3)])
+		database.upsert_sync_state(_create_sync_state(chain_revision=0))
 		kept_account_row, kept_mosaic_rows = _create_account_row(ADDRESS1, observed_height=1)
 		rollbacked_account_row, rollbacked_mosaic_rows = _create_account_row(RECIPIENT_ADDRESS, observed_height=2)
 		after_fork_account_row, after_fork_mosaic_rows = _create_account_row(ADDRESS4, observed_height=3)
@@ -4207,6 +4409,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		self.assertEqual([(ADDRESS1.lower(), 1)], account_results)
 		self.assertEqual([(ADDRESS1.lower(), NATIVE_MOSAIC_ID, 1)], mosaic_results)
 		self.assertEqual([(ADDRESS1.lower(), 1)], multisig_results)
+		self.assertEqual(1, database.get_sync_state()['chain_revision'])
 
 	def test_can_repair_rollback_from_height_in_one_transaction(self):
 		# Arrange:
@@ -4231,6 +4434,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		database.upsert_receipts_for_height(1, [_create_receipt(1)], 100)
 		database.upsert_receipts_for_height(2, [_create_receipt(2)], 100)
 		database.upsert_receipts_for_height(3, [_create_receipt(3)], 100)
+		_upsert_sync_state_with_revision(database, 7)
 		database.upsert_account_current_state(*_create_account_row(ADDRESS1, observed_height=1))
 		database.upsert_account_current_state(*_create_account_row(RECIPIENT_ADDRESS, observed_height=2))
 		database.upsert_multisig(bytes.fromhex(ADDRESS1), _create_multisig_row(ADDRESS1, 1))
@@ -4281,6 +4485,9 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 			bytes(b'hash 1'),
 			bytes(sync_state['last_synced_block_hash'])
 		)
+		self.assertEqual(8, sync_state['chain_revision'])
+		database.upsert_sync_state(_create_sync_state(status='healthy', last_synced_height=1))
+		self.assertEqual(8, database.get_sync_state()['chain_revision'])
 
 	def test_create_tables_creates_exact_hash_lock_columns_types_and_nullability(self):
 		# Arrange:
@@ -4830,6 +5037,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 	def test_repair_rollback_deletes_lock_rows_at_fork_and_applies_replacements_atomically(self):
 		# Arrange:
 		database = self._create_database()
+		database.upsert_sync_state(_create_sync_state(chain_revision=0))
 		kept_hash_row = _create_hash_lock_row(observed_height=1, lock_hash=LOCK_HASH)
 		orphaned_hash_row = _create_hash_lock_row(observed_height=2, lock_hash=LOCK_HASH_2)
 		kept_secret_row = _create_secret_lock_row(observed_height=1)
@@ -4874,10 +5082,12 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 			for composite_hash, status, updated_at_height in cursor.fetchall()])
 		self.assertEqual('repairing', database.get_sync_state()['status'])
 		self.assertEqual(1, database.get_sync_state()['last_synced_height'])
+		self.assertEqual(1, database.get_sync_state()['chain_revision'])
 
 	def test_repair_rollback_applies_hash_lock_delete_entries(self):
 		# Arrange:
 		database = self._create_database()
+		database.upsert_sync_state(_create_sync_state(chain_revision=0))
 		database.upsert_hash_lock(_create_hash_lock_row(observed_height=1))
 
 		# Act:
@@ -4892,10 +5102,12 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		cursor = database.connection.cursor()
 		cursor.execute('SELECT hash FROM symbol_hash_locks')
 		self.assertEqual([], cursor.fetchall())
+		self.assertEqual(1, database.get_sync_state()['chain_revision'])
 
 	def test_repair_rollback_applies_empty_secret_lock_replacement_and_preserves_siblings(self):
 		# Arrange:
 		database = self._create_database()
+		database.upsert_sync_state(_create_sync_state(chain_revision=0))
 		target_key = create_secret_lock_search_key(LOCK_OWNER, LOCK_RECIPIENT, LOCK_SECRET, 'hash160')
 		sibling_key = create_secret_lock_search_key(LOCK_OWNER_2, LOCK_RECIPIENT, LOCK_SECRET, 'hash160')
 		database.replace_secret_locks(target_key, [_create_secret_lock_row()])
@@ -4919,6 +5131,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 			[(LOCK_COMPOSITE_HASH_2, LOCK_OWNER_2)],
 			[(bytes(composite_hash), bytes(owner_address)) for composite_hash, owner_address in cursor.fetchall()])
 		self.assertEqual('repairing', database.get_sync_state()['status'])
+		self.assertEqual(1, database.get_sync_state()['chain_revision'])
 
 	def test_repair_rollback_restores_chain_and_lock_state_when_later_secret_lock_write_fails(self):  # pylint: disable=too-many-locals
 		# Arrange:
@@ -5506,6 +5719,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 	def test_repair_rollback_applies_mosaic_restriction_replacement(self):
 		# Arrange:
 		database = self._create_database()
+		database.upsert_sync_state(_create_sync_state(chain_revision=0))
 		key = MosaicRestrictionKey(MosaicRestrictionEntryType.GLOBAL, RESTRICTION_MOSAIC_ID, None)
 		row = _create_mosaic_restriction_row(entry_type=MosaicRestrictionEntryType.GLOBAL, target_address=None)
 

--- a/explorer/puller/tests/db/test_SymbolDatabase.py
+++ b/explorer/puller/tests/db/test_SymbolDatabase.py
@@ -2558,11 +2558,6 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 				'CREATE INDEX idx_symbol_receipts_mosaic ON public.symbol_receipts USING btree (mosaic_id)'
 			),
 			(
-				'idx_symbol_receipts_recipient_group_height',
-				'CREATE INDEX idx_symbol_receipts_recipient_group_height ON public.symbol_receipts '
-				'USING btree (recipient_address, receipt_group, height DESC)'
-			),
-			(
 				'idx_symbol_receipts_sender_group_height',
 				'CREATE INDEX idx_symbol_receipts_sender_group_height ON public.symbol_receipts '
 				'USING btree (sender_address, receipt_group, height DESC)'

--- a/explorer/puller/tests/facade/symbol/puller_test_utils.py
+++ b/explorer/puller/tests/facade/symbol/puller_test_utils.py
@@ -324,7 +324,8 @@ def create_sync_state(**overrides):
 		'finalized_epoch': 1,
 		'finalized_point': 1,
 		'last_synced_height': 3,
-		'last_synced_block_hash': bytes.fromhex(f'{3:064X}')
+		'last_synced_block_hash': bytes.fromhex(f'{3:064X}'),
+		'chain_revision': 0
 	}
 	sync_state.update(overrides)
 

--- a/explorer/puller/tests/facade/symbol/test_Puller.py
+++ b/explorer/puller/tests/facade/symbol/test_Puller.py
@@ -3,11 +3,11 @@ import tempfile
 from unittest import TestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from common.symbol.Receipt import MOSAIC_EXPIRED_RECEIPT_TYPE, NAMESPACE_EXPIRED_RECEIPT_TYPE
 from symbolchain.sc import AliasAction, TransactionType
 from symbollightapi.model.Exceptions import NodeException
 
 from puller.facade.SymbolPuller import SymbolPuller
-from puller.model.symbol.Receipt import MOSAIC_EXPIRED_RECEIPT_TYPE, NAMESPACE_EXPIRED_RECEIPT_TYPE
 from tests.test.SymbolMosaicTestUtils import MOSAIC_ID, create_expected_mosaic_row, create_mosaic_item
 
 from .puller_test_utils import NODE_URL, ResponseConnector, create_db_config, create_symbol_puller, temporary_symbol_puller

--- a/explorer/puller/tests/facade/symbol/test_PullerAccounts.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerAccounts.py
@@ -27,6 +27,7 @@ from .puller_test_utils import (
 	create_node_block,
 	create_node_transaction,
 	create_resolution_statement,
+	create_sync_state,
 	set_symbol_connector,
 	statement_path,
 	transaction_path
@@ -829,6 +830,14 @@ class SymbolPullerAccountsTest(SymbolPullerTestBase):  # pylint: disable=too-man
 	def test_rollback_re_raises_database_error(self):
 		# Arrange:
 		database = self.exit_stack.enter_context(SymbolDatabase(self.db_config))
+		database.upsert_sync_state(create_sync_state(
+			chain_height=1,
+			finalized_height=0,
+			finalized_hash=b'finalized',
+			finalized_epoch=0,
+			finalized_point=0,
+			last_synced_height=0,
+			last_synced_block_hash=b'last'))
 		sync_state = self._create_rollback_sync_state(status='invalid')
 
 		# Act:

--- a/explorer/puller/tests/facade/symbol/test_PullerAccounts.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerAccounts.py
@@ -15,12 +15,15 @@ from puller.model.symbol.Block import create_block_row
 
 from .puller_test_utils import (
 	BENEFICIARY_ADDRESS,
+	NATIVE_MOSAIC_DIVISIBILITY,
 	NATIVE_MOSAIC_ID,
 	RECIPIENT_ADDRESS,
 	FakeConnector,
+	ResponseConnector,
 	SymbolPullerTestBase,
 	create_account_item,
 	create_amount_statement_item,
+	create_chain_info,
 	create_node_block,
 	create_node_transaction,
 	create_resolution_statement,
@@ -131,6 +134,17 @@ class SymbolPullerAccountsTest(SymbolPullerTestBase):  # pylint: disable=too-man
 			(bytes.fromhex(address_hex),))
 
 		return cursor.fetchone()[0]
+
+	def _fetch_account_mosaics(self):
+		cursor = self.puller.symbol_db.connection.cursor()
+		cursor.execute(
+			'''
+			SELECT address, mosaic_id, amount
+			FROM symbol_account_mosaics
+			ORDER BY address, mosaic_id
+			''')
+
+		return [(bytes(address), mosaic_id, amount) for address, mosaic_id, amount in cursor.fetchall()]
 
 	@staticmethod
 	def _create_rollback_sync_state(status='repairing'):
@@ -535,7 +549,7 @@ class SymbolPullerAccountsTest(SymbolPullerTestBase):  # pylint: disable=too-man
 		self.assertEqual([], self._fetch_block_heights(self.puller.symbol_db))
 		self.assertEqual(0, self._fetch_account_count())
 
-	def test_get_native_mosaic_info_is_memoized(self):
+	def test_sync_memoizes_native_info(self):
 		# Arrange:
 		connector = FakeConnector(1, {0: [self._create_block(1)]})
 
@@ -544,8 +558,38 @@ class SymbolPullerAccountsTest(SymbolPullerTestBase):  # pylint: disable=too-man
 		self._sync_with_connector(connector)
 
 		# Assert:
-		self.assertEqual(1, connector.paths.count('network/properties'))
-		self.assertEqual(1, connector.paths.count(f'mosaics/{NATIVE_MOSAIC_ID}'))
+		native_paths = [
+			path for path in connector.paths
+			if path in ('network/properties', f'mosaics/{NATIVE_MOSAIC_ID}')
+		]
+		self.assertEqual(['network/properties', f'mosaics/{NATIVE_MOSAIC_ID}'], native_paths)
+		self.assertEqual(
+			[(bytes.fromhex(BENEFICIARY_ADDRESS), NATIVE_MOSAIC_ID, 20_000 * 10 ** NATIVE_MOSAIC_DIVISIBILITY)],
+			self._fetch_account_mosaics())
+		self.assertTrue(self._fetch_account_current_state()[3])
+
+	def test_sync_rejects_bad_mosaic_response(self):
+		# Arrange:
+		connector = ResponseConnector({
+			'chain/info': create_chain_info(),
+			'network/properties': {
+				'network': {'epochAdjustment': '100s'},
+				'chain': {'currencyMosaicId': "0x72C0'212E'67A0'8BCE"}
+			},
+			f'mosaics/{NATIVE_MOSAIC_ID}': {'mosaic': {}}
+		})
+
+		# Act / Assert:
+		self._assert_sync_rejects_node_response(
+			connector,
+			ValueError,
+			'Mosaic response must include mosaic.divisibility')
+
+		self.assertEqual(
+			['chain/info', 'network/properties', f'mosaics/{NATIVE_MOSAIC_ID}'],
+			connector.paths)
+		self.assertEqual(0, self._fetch_account_count())
+		self.assertIsNone(self.puller.symbol_db.get_account_refresh_state())
 
 	def test_refresh_accounts_pages_all_accounts_and_assigns_search_order_across_pages(self):
 		# Arrange:

--- a/explorer/puller/tests/facade/symbol/test_PullerLocks.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerLocks.py
@@ -1773,7 +1773,8 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			finalized_epoch=4,
 			finalized_point=5,
 			last_synced_height=2,
-			last_synced_block_hash=bytes.fromhex(f'{2:064X}')),
+			last_synced_block_hash=bytes.fromhex(f'{2:064X}'),
+			chain_revision=1),
 			fetch_normalized_sync_state(self.puller.symbol_db))
 		self.assertEqual(['lock/hash/' + LOCK_HASH], [
 			path for path in connector.paths if path.startswith('lock/')
@@ -1826,7 +1827,8 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			finalized_epoch=4,
 			finalized_point=5,
 			last_synced_height=2,
-			last_synced_block_hash=bytes.fromhex(f'{2:064X}')),
+			last_synced_block_hash=bytes.fromhex(f'{2:064X}'),
+			chain_revision=1),
 			fetch_normalized_sync_state(self.puller.symbol_db))
 		self.assertEqual([path], [path for path in connector.paths if path.startswith('lock/')])
 
@@ -1899,7 +1901,8 @@ class SymbolPullerLocksTest(SymbolPullerTestBase):
 			finalized_epoch=4,
 			finalized_point=5,
 			last_synced_height=2,
-			last_synced_block_hash=bytes.fromhex(f'{2:064X}')),
+			last_synced_block_hash=bytes.fromhex(f'{2:064X}'),
+			chain_revision=1),
 			fetch_normalized_sync_state(self.puller.symbol_db))
 
 	def test_sync_block_headers_keeps_all_rollback_state_unchanged_when_hash_lock_replacement_fetch_fails(self):

--- a/explorer/puller/tests/model/symbol/test_Receipt.py
+++ b/explorer/puller/tests/model/symbol/test_Receipt.py
@@ -3,15 +3,7 @@ from unittest import TestCase
 
 from symbolchain.sc import ReceiptType
 
-from puller.model.symbol.Receipt import (
-	INFLATION_RECEIPT_TYPE,
-	MOSAIC_EXPIRED_RECEIPT_TYPE,
-	NAMESPACE_DELETED_RECEIPT_TYPE,
-	NAMESPACE_EXPIRED_RECEIPT_TYPE,
-	RECEIPT_TYPE_GROUPS,
-	RECEIPT_TYPE_LABELS,
-	create_receipt_rows
-)
+from puller.model.symbol.Receipt import create_receipt_rows
 
 TARGET_ADDRESS = '98' * 24
 SENDER_ADDRESS = '99' * 24
@@ -30,46 +22,6 @@ def _create_statement_item(receipts, **overrides):
 
 
 class ReceiptTest(TestCase):
-
-	def test_receipt_type_groups_maps_supported_types_to_documented_groups(self):
-		# Arrange / Act / Assert:
-		self.assertEqual({
-			ReceiptType.HARVEST_FEE.value: 'balanceChange',
-			ReceiptType.LOCK_HASH_CREATED.value: 'balanceChange',
-			ReceiptType.LOCK_HASH_COMPLETED.value: 'balanceChange',
-			ReceiptType.LOCK_HASH_EXPIRED.value: 'balanceChange',
-			ReceiptType.LOCK_SECRET_CREATED.value: 'balanceChange',
-			ReceiptType.LOCK_SECRET_COMPLETED.value: 'balanceChange',
-			ReceiptType.LOCK_SECRET_EXPIRED.value: 'balanceChange',
-			ReceiptType.MOSAIC_RENTAL_FEE.value: 'balanceTransfer',
-			ReceiptType.NAMESPACE_RENTAL_FEE.value: 'balanceTransfer',
-			ReceiptType.MOSAIC_EXPIRED.value: 'artifactExpiry',
-			ReceiptType.NAMESPACE_EXPIRED.value: 'artifactExpiry',
-			ReceiptType.NAMESPACE_DELETED.value: 'artifactExpiry',
-			ReceiptType.INFLATION.value: 'inflation'
-		}, RECEIPT_TYPE_GROUPS)
-
-	def test_receipt_type_labels_maps_supported_types_to_documented_labels(self):
-		# Arrange / Act / Assert:
-		self.assertEqual({
-			ReceiptType.MOSAIC_RENTAL_FEE.value: 'mosaicRentalFee',
-			ReceiptType.NAMESPACE_RENTAL_FEE.value: 'namespaceRentalFee',
-			ReceiptType.HARVEST_FEE.value: 'harvestFee',
-			ReceiptType.LOCK_HASH_COMPLETED.value: 'lockHashCompleted',
-			ReceiptType.LOCK_HASH_EXPIRED.value: 'lockHashExpired',
-			ReceiptType.LOCK_SECRET_COMPLETED.value: 'lockSecretCompleted',
-			ReceiptType.LOCK_SECRET_EXPIRED.value: 'lockSecretExpired',
-			ReceiptType.LOCK_HASH_CREATED.value: 'lockHashCreated',
-			ReceiptType.LOCK_SECRET_CREATED.value: 'lockSecretCreated',
-			ReceiptType.MOSAIC_EXPIRED.value: 'mosaicExpired',
-			ReceiptType.NAMESPACE_EXPIRED.value: 'namespaceExpired',
-			ReceiptType.NAMESPACE_DELETED.value: 'namespaceDeleted',
-			ReceiptType.INFLATION.value: 'inflation'
-		}, RECEIPT_TYPE_LABELS)
-		self.assertEqual('inflation', INFLATION_RECEIPT_TYPE)
-		self.assertEqual('namespaceExpired', NAMESPACE_EXPIRED_RECEIPT_TYPE)
-		self.assertEqual('namespaceDeleted', NAMESPACE_DELETED_RECEIPT_TYPE)
-		self.assertEqual('mosaicExpired', MOSAIC_EXPIRED_RECEIPT_TYPE)
 
 	def test_create_receipt_rows_populates_balance_change_fields(self):
 		# Arrange:

--- a/explorer/rest/rest/db/DatabaseConnection.py
+++ b/explorer/rest/rest/db/DatabaseConnection.py
@@ -1,4 +1,5 @@
 from psycopg2 import pool
+from zenlog import log
 
 
 class DatabaseConnectionPool:
@@ -40,15 +41,31 @@ class PooledConnection:
 
 		self._pool = connection_pool
 		self.connection = None
+		self._discard_requested = False
 
 	def __enter__(self):
 		"""Acquire a database connection from the pool upon entering the context of a `with` statement."""
 
+		self._discard_requested = False
 		self.connection = self._pool.getconn()
 		return self.connection
+
+	def mark_for_discard(self):
+		"""Marks the acquired connection to be discarded when the context exits."""
+
+		self._discard_requested = True
 
 	def __exit__(self, exc_type, exc_value, traceback):
 		"""Ensure the connection is returned to the pool upon exiting the context of a `with` statement."""
 
 		if self.connection:
-			self._pool.putconn(self.connection)
+			try:
+				if self._discard_requested:
+					self._pool.putconn(self.connection, close=True)
+				else:
+					self._pool.putconn(self.connection)
+			except BaseException as cleanup_error:
+				log.error(f'Failed to return database connection: {cleanup_error}')
+				if exc_type is None:
+					raise
+		return False

--- a/explorer/rest/rest/db/SymbolDatabase.py
+++ b/explorer/rest/rest/db/SymbolDatabase.py
@@ -1,6 +1,12 @@
+from collections import namedtuple
+from contextlib import contextmanager
 from enum import Enum
 
+from zenlog import log
+
 from rest.model.symbol.Block import SymbolBlockView
+from rest.model.symbol.format import format_address
+from rest.model.symbol.Receipt import ReceiptPage, ReceiptPosition
 
 from .DatabaseConnection import DatabaseConnectionPool
 
@@ -30,8 +36,38 @@ BLOCK_COLUMNS = '''
 	voting_eligible_accounts_count,
 	harvesting_eligible_accounts_count,
 	total_voting_balance,
-	previous_importance_block_hash
+	previous_importance_block_hash,
+	block_reward
 '''
+
+RECEIPT_COLUMNS = '''
+	receipts.id,
+	receipts.height,
+	receipts.receipt_type,
+	receipts.receipt_group,
+	receipts.version,
+	receipts.sender_address,
+	receipts.recipient_address,
+	receipts.target_address,
+	receipts.mosaic_id,
+	receipts.amount,
+	receipts.artifact_id,
+	mosaics.divisibility AS mosaic_divisibility
+'''
+RECEIPT_RESULT_COLUMNS = (
+	'id',
+	'height',
+	'receipt_type',
+	'receipt_group',
+	'version',
+	'sender_address',
+	'recipient_address',
+	'target_address',
+	'mosaic_id',
+	'amount',
+	'artifact_id',
+	'mosaic_divisibility'
+)
 
 SYNC_STATE_COLUMNS = [
 	'status',
@@ -42,9 +78,35 @@ SYNC_STATE_COLUMNS = [
 	'finalized_point',
 	'last_synced_height',
 	'last_synced_block_hash',
+	'chain_revision',
 	'updated_at'
 ]
 READABLE_BLOCK_STATUSES = frozenset(['healthy', 'repairing'])
+RECEIPT_READABLE_STATUS = 'healthy'
+
+ReceiptQuery = namedtuple('ReceiptQuery', [
+	'limit',
+	'cursor',
+	'height',
+	'receipt_group',
+	'receipt_type',
+	'included_receipt_types',
+	'target_address',
+	'sender_address'
+])
+
+
+class ReceiptDataUnavailableError(RuntimeError):
+	"""Raised when the Symbol receipt snapshot is not readable."""
+
+
+class ReceiptCursorStaleError(RuntimeError):
+	"""Raised when a receipt cursor belongs to an older chain revision."""
+
+	MESSAGE = 'Receipt cursor is stale'
+
+	def __init__(self):
+		super().__init__(self.MESSAGE)
 
 
 class SortOrder(str, Enum):
@@ -56,11 +118,6 @@ def _bytes_or_none(value):
 	return bytes(value) if value else None
 
 
-def _address(value):
-	from symbolchain.symbol.Network import Address  # pylint: disable=import-outside-toplevel
-	return str(Address(bytes(value)))
-
-
 def _is_block_data_readable(sync_state):
 	return bool(sync_state and sync_state.get('status') in READABLE_BLOCK_STATUSES and sync_state.get('last_synced_height'))
 
@@ -70,6 +127,13 @@ def _create_sync_state(columns, result):
 		return None
 
 	return dict(zip(columns, result))
+
+
+def _mark_broken_receipt_connection(connection_owner, message, error):
+	"""Marks a receipt connection for discard and logs the cleanup failure."""
+
+	connection_owner.mark_for_discard()
+	log.error(f'{message}: {error}')
 
 
 class SymbolDatabase(DatabaseConnectionPool):
@@ -113,6 +177,88 @@ class SymbolDatabase(DatabaseConnectionPool):
 			return None
 
 		return sync_state['last_synced_height']
+
+	def get_receipts(self, query):
+		"""Gets a readable Symbol receipt page from one consistent DB snapshot."""
+
+		connection_owner = self.connection()
+		with connection_owner as connection:
+			with self._receipt_read_transaction(connection, connection_owner):
+				with connection.cursor() as cursor:
+					cursor.execute('''
+						SELECT status, last_synced_height, chain_revision
+						FROM symbol_sync_state
+						WHERE id = 1
+					''')
+					sync_state = cursor.fetchone()
+					if not sync_state or sync_state[0] != RECEIPT_READABLE_STATUS or sync_state[1] is None:
+						raise ReceiptDataUnavailableError('Symbol backend data is unavailable')
+
+					chain_revision = sync_state[2]
+					if query.cursor and query.cursor.revision != chain_revision:
+						raise ReceiptCursorStaleError()
+
+					predicates = ['receipts.height <= %s']
+					parameters = [sync_state[1]]
+					if query.height is not None:
+						predicates.append('receipts.height = %s')
+						parameters.append(query.height)
+					if query.receipt_group is not None:
+						predicates.append('receipts.receipt_group = %s')
+						parameters.append(query.receipt_group)
+					if query.receipt_type is not None:
+						predicates.append('receipts.receipt_type = %s')
+						parameters.append(query.receipt_type)
+					if query.included_receipt_types:
+						predicates.append('receipts.receipt_type = ANY(%s::symbol_receipt_type[])')
+						parameters.append(list(query.included_receipt_types))
+					if query.target_address is not None:
+						predicates.append('receipts.target_address = %s')
+						parameters.append(query.target_address)
+					if query.sender_address is not None:
+						predicates.append('receipts.sender_address = %s')
+						parameters.append(query.sender_address)
+					if query.cursor:
+						predicates.append('(receipts.height, receipts.id) < (%s, %s)')
+						parameters.extend([query.cursor.height, query.cursor.id])
+
+					parameters.append(query.limit + 1)
+					cursor.execute(
+						f'''
+						SELECT {RECEIPT_COLUMNS}
+						FROM symbol_receipts receipts
+						LEFT JOIN symbol_mosaics mosaics ON mosaics.mosaic_id = receipts.mosaic_id
+						WHERE {' AND '.join(predicates)}
+						ORDER BY receipts.height DESC, receipts.id DESC
+						LIMIT %s
+						''',
+						parameters)
+					rows = [dict(zip(RECEIPT_RESULT_COLUMNS, row)) for row in cursor.fetchall()]
+					has_next_page = len(rows) > query.limit
+					items = tuple(rows[:query.limit])
+					next_position = ReceiptPosition(items[-1]['height'], items[-1]['id']) if has_next_page else None
+					return ReceiptPage(items, next_position, chain_revision)
+
+	@staticmethod
+	@contextmanager
+	def _receipt_read_transaction(connection, connection_owner):
+		"""Owns the transaction-local receipt snapshot and failure cleanup."""
+
+		try:
+			with connection.cursor() as cursor:
+				cursor.execute('SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY')
+			yield
+		except BaseException:
+			try:
+				connection.rollback()
+			except BaseException as cleanup_error:
+				_mark_broken_receipt_connection(connection_owner, 'Failed to rollback receipt transaction', cleanup_error)
+			raise
+		try:
+			connection.commit()
+		except BaseException as cleanup_error:
+			_mark_broken_receipt_connection(connection_owner, 'Failed to commit receipt transaction', cleanup_error)
+			raise
 
 	def get_blocks(self, from_height, limit, sort):
 		"""Gets Symbol blocks using fromHeight cursor pagination."""
@@ -179,8 +325,8 @@ class SymbolDatabase(DatabaseConnectionPool):
 			difficulty=result[8],
 			fee_multiplier=result[9],
 			block_type=result[10],
-			harvester=_address(result[11]),
-			beneficiary_address=_address(result[12]),
+			harvester=format_address(result[11]),
+			beneficiary_address=format_address(result[12]),
 			signature=_bytes_or_none(result[13]),
 			size=result[14],
 			proof_gamma=_bytes_or_none(result[15]),
@@ -194,5 +340,6 @@ class SymbolDatabase(DatabaseConnectionPool):
 			harvesting_eligible_accounts_count=result[23],
 			total_voting_balance=result[24],
 			previous_importance_block_hash=_bytes_or_none(result[25]),
+			block_reward=result[26],
 			is_finalized=bool(finalized_height and result[0] <= finalized_height)
 		)

--- a/explorer/rest/rest/facade/SymbolRestFacade.py
+++ b/explorer/rest/rest/facade/SymbolRestFacade.py
@@ -1,7 +1,9 @@
+from common.symbol.NativeMosaic import NativeMosaicInfo
 from psycopg2 import Error as PsycopgError
 from zenlog import log
 
 from rest.db.SymbolDatabase import SymbolDatabase
+from rest.model.symbol.Receipt import ReceiptPage, SymbolReceiptView
 
 DATABASE_UNAVAILABLE_MESSAGE = 'Symbol database is unavailable'
 
@@ -9,13 +11,15 @@ DATABASE_UNAVAILABLE_MESSAGE = 'Symbol database is unavailable'
 class SymbolRestFacade:
 	"""Symbol Rest Facade."""
 
-	def __init__(self, db_config, node_config):
+	def __init__(self, db_config, node_config, native_mosaic_info):
 		"""Creates a Symbol facade object."""
 
 		if db_config is None:
 			raise ValueError('Symbol database configuration is required')
 		if node_config is None:
 			raise ValueError('Symbol node configuration is required')
+		if not isinstance(native_mosaic_info, NativeMosaicInfo):
+			raise ValueError('Native mosaic information is required')
 
 		self.symbol_db = None
 		self.db_error = None
@@ -26,6 +30,7 @@ class SymbolRestFacade:
 			self.db_error = DATABASE_UNAVAILABLE_MESSAGE
 
 		self.node_config = node_config
+		self.native_mosaic_info = native_mosaic_info
 
 	def is_configured(self):
 		"""Returns whether Symbol REST dependencies are configured."""
@@ -51,11 +56,7 @@ class SymbolRestFacade:
 		if not self.is_database_available():
 			return False
 
-		try:
-			return self.symbol_db.get_block_head_height() is not None
-		except PsycopgError:
-			log.error('Failed to check Symbol block data availability')
-			return False
+		return self.symbol_db.get_block_head_height() is not None
 
 	def get_health(self):
 		"""Gets health of the Symbol backend core foundation."""
@@ -142,7 +143,7 @@ class SymbolRestFacade:
 		if blocks is None:
 			return None
 
-		return [block.to_dict() for block in blocks]
+		return [block.to_dict(self.native_mosaic_info) for block in blocks]
 
 	def get_block(self, height):
 		"""Gets a Symbol block by height."""
@@ -152,4 +153,20 @@ class SymbolRestFacade:
 
 		block = self.symbol_db.get_block(height)
 
-		return block.to_detail_dict() if block else None
+		return block.to_detail_dict(self.native_mosaic_info) if block else None
+
+	def get_receipts(self, query):
+		"""Gets Symbol receipts for a validated query."""
+
+		if not self.is_database_available():
+			return None
+
+		page = self.symbol_db.get_receipts(query)
+		if page is None:
+			return None
+
+		return ReceiptPage(
+			tuple(SymbolReceiptView(receipt, self.native_mosaic_info).to_dict() for receipt in page.items),
+			page.next_position,
+			page.chain_revision
+		)

--- a/explorer/rest/rest/model/symbol/Block.py
+++ b/explorer/rest/rest/model/symbol/Block.py
@@ -1,4 +1,4 @@
-from rest.model.symbol.format import format_timestamp, format_xym_amount, str_or_none, to_hex, to_hex_or_none
+from rest.model.symbol.format import format_amount, format_timestamp, str_or_none, to_hex, to_hex_or_none
 
 
 class SymbolBlockView:  # pylint: disable=too-many-instance-attributes
@@ -31,9 +31,10 @@ class SymbolBlockView:  # pylint: disable=too-many-instance-attributes
 		self.harvesting_eligible_accounts_count = kwargs['harvesting_eligible_accounts_count']
 		self.total_voting_balance = kwargs['total_voting_balance']
 		self.previous_importance_block_hash = kwargs['previous_importance_block_hash']
+		self.block_reward = kwargs['block_reward']
 		self.is_finalized = kwargs['is_finalized']
 
-	def to_dict(self):
+	def to_dict(self, native_mosaic_info):
 		"""Formats the block info as a dictionary."""
 
 		return {
@@ -44,20 +45,22 @@ class SymbolBlockView:  # pylint: disable=too-many-instance-attributes
 			'networkTimestamp': self.network_timestamp,
 			'harvester': self.harvester,
 			'beneficiaryAddress': self.beneficiary_address,
-			'totalFee': format_xym_amount(self.total_fee),
+			'totalFee': format_amount(self.total_fee, native_mosaic_info.divisibility),
 			'transactionCount': self.transaction_count,
 			'statementCount': self.statement_count,
-			# Receipts Core will populate block rewards when receipt data is available.
-			'blockReward': None,
+			'blockReward': (
+				None if self.block_reward is None
+				else format_amount(self.block_reward, native_mosaic_info.divisibility)
+			),
 			'isFinalized': self.is_finalized,
 			'difficulty': str(self.difficulty)
 		}
 
-	def to_detail_dict(self):
+	def to_detail_dict(self, native_mosaic_info):
 		"""Formats the block info as a block-detail dictionary."""
 
 		return {
-			**self.to_dict(),
+			**self.to_dict(native_mosaic_info),
 			'signature': to_hex(self.signature),
 			'size': self.size,
 			'feeMultiplier': self.fee_multiplier,

--- a/explorer/rest/rest/model/symbol/Receipt.py
+++ b/explorer/rest/rest/model/symbol/Receipt.py
@@ -1,0 +1,42 @@
+from collections import namedtuple
+
+from rest.model.symbol.format import format_address, format_amount, format_hex_id
+
+ReceiptPosition = namedtuple('ReceiptPosition', ['height', 'id'])
+ReceiptPage = namedtuple('ReceiptPage', ['items', 'next_position', 'chain_revision'])
+
+
+class SymbolReceiptView:
+	"""Formats a database receipt row for the Symbol Explorer API."""
+
+	def __init__(self, row, native_mosaic_info):
+		self.row = row
+		self.native_mosaic_info = native_mosaic_info
+
+	def to_dict(self):
+		"""Serializes the receipt using the injected native mosaic contract."""
+
+		mosaic_id = format_hex_id(self.row['mosaic_id'])
+		mosaics = []
+		if mosaic_id is not None:
+			is_native = mosaic_id == self.native_mosaic_info.id
+			divisibility = self.native_mosaic_info.divisibility if is_native else self.row['mosaic_divisibility']
+			amount = self.row['amount'] if divisibility is None else format_amount(self.row['amount'], divisibility)
+			mosaics = [{
+				'id': mosaic_id,
+				'name': mosaic_id,
+				'amount': amount,
+				'isNative': is_native
+			}]
+
+		return {
+			'version': self.row['version'],
+			'height': self.row['height'],
+			'type': self.row['receipt_type'],
+			'group': self.row['receipt_group'],
+			'targetAddress': format_address(self.row['target_address']),
+			'sender': format_address(self.row['sender_address']),
+			'to': format_address(self.row['recipient_address']),
+			'artifactId': format_hex_id(self.row['artifact_id']),
+			'mosaics': mosaics
+		}

--- a/explorer/rest/rest/model/symbol/ReceiptCursor.py
+++ b/explorer/rest/rest/model/symbol/ReceiptCursor.py
@@ -1,0 +1,87 @@
+import base64
+import binascii
+import json
+import re
+from collections import namedtuple
+
+RECEIPT_CURSOR_VERSION = 1
+MAX_RECEIPT_CURSOR_LENGTH = 2048
+MAX_SIGNED_BIGINT = 9223372036854775807
+BASE64URL_PATTERN = re.compile(r'^[A-Za-z0-9_-]+$')
+DECIMAL_PATTERN = re.compile(r'^(0|[1-9][0-9]*)$')
+FILTER_HASH_PATTERN = re.compile(r'^[0-9a-f]{64}$')
+CURSOR_KEYS = frozenset(['v', 'scope', 'network', 'revision', 'height', 'id', 'filterHash'])
+CURSOR_SCOPES = frozenset(['receipts', 'blockReceipts'])
+CURSOR_NETWORKS = frozenset(['mainnet', 'testnet'])
+
+ReceiptCursor = namedtuple('ReceiptCursor', ['version', 'scope', 'network', 'revision', 'height', 'id', 'filter_hash'])
+
+
+class ReceiptCursorError(ValueError):
+	"""Raised when a receipt cursor is not a valid opaque token."""
+
+
+def encode_receipt_cursor(cursor):
+	"""Encodes a validated receipt cursor as unpadded Base64URL JSON."""
+
+	payload = {
+		'v': cursor.version,
+		'scope': cursor.scope,
+		'network': cursor.network,
+		'revision': str(cursor.revision),
+		'height': str(cursor.height),
+		'id': str(cursor.id),
+		'filterHash': cursor.filter_hash
+	}
+	serialized = json.dumps(payload, ensure_ascii=True, sort_keys=True, separators=(',', ':')).encode('utf-8')
+	return base64.urlsafe_b64encode(serialized).decode('ascii').rstrip('=')
+
+
+def decode_receipt_cursor(token):
+	"""Decodes and strictly validates a receipt cursor token."""
+
+	if not isinstance(token, str) or not token or len(token) > MAX_RECEIPT_CURSOR_LENGTH:
+		raise ReceiptCursorError('Invalid receipt cursor')
+	if not BASE64URL_PATTERN.fullmatch(token) or len(token) % 4 == 1:
+		raise ReceiptCursorError('Invalid receipt cursor')
+
+	try:
+		padding = '=' * (-len(token) % 4)
+		decoded = base64.urlsafe_b64decode((token + padding).encode('ascii'))
+		if base64.urlsafe_b64encode(decoded).decode('ascii').rstrip('=') != token:
+			raise ReceiptCursorError('Invalid receipt cursor')
+		payload = json.loads(decoded.decode('utf-8'))
+	except (ReceiptCursorError, ValueError, UnicodeDecodeError, binascii.Error) as error:
+		raise ReceiptCursorError('Invalid receipt cursor') from error
+
+	if not isinstance(payload, dict) or frozenset(payload) != CURSOR_KEYS:
+		raise ReceiptCursorError('Invalid receipt cursor')
+	if isinstance(payload['v'], bool) or payload['v'] != RECEIPT_CURSOR_VERSION:
+		raise ReceiptCursorError('Invalid receipt cursor')
+	if not isinstance(payload['scope'], str) or not isinstance(payload['network'], str):
+		raise ReceiptCursorError('Invalid receipt cursor')
+	if payload['scope'] not in CURSOR_SCOPES or payload['network'] not in CURSOR_NETWORKS:
+		raise ReceiptCursorError('Invalid receipt cursor')
+
+	values = {}
+	for field, minimum in [('revision', 0), ('height', 1), ('id', 1)]:
+		value = payload[field]
+		if not isinstance(value, str) or not DECIMAL_PATTERN.fullmatch(value):
+			raise ReceiptCursorError('Invalid receipt cursor')
+		parsed = int(value)
+		if parsed < minimum or parsed > MAX_SIGNED_BIGINT:
+			raise ReceiptCursorError('Invalid receipt cursor')
+		values[field] = parsed
+
+	if not isinstance(payload['filterHash'], str) or not FILTER_HASH_PATTERN.fullmatch(payload['filterHash']):
+		raise ReceiptCursorError('Invalid receipt cursor')
+
+	return ReceiptCursor(
+		RECEIPT_CURSOR_VERSION,
+		payload['scope'],
+		payload['network'],
+		values['revision'],
+		values['height'],
+		values['id'],
+		payload['filterHash']
+	)

--- a/explorer/rest/rest/model/symbol/format.py
+++ b/explorer/rest/rest/model/symbol/format.py
@@ -1,6 +1,6 @@
 from decimal import Decimal
 
-XYM_DIVISIBILITY = 6
+from symbolchain.symbol.Network import Address
 
 
 def format_timestamp(timestamp):
@@ -19,5 +19,25 @@ def str_or_none(value):
 	return str(value) if value is not None else None
 
 
-def format_xym_amount(total_fee):
-	return float(Decimal(total_fee) / (Decimal(10) ** XYM_DIVISIBILITY))
+def format_amount(amount, divisibility):
+	"""Formats an absolute amount using the supplied mosaic divisibility."""
+
+	return float(Decimal(amount) / (Decimal(10) ** divisibility))
+
+
+def format_address(address):
+	"""Formats a persisted Symbol address byte sequence as canonical text."""
+
+	if address is None:
+		return None
+
+	return str(Address(bytes(address)))
+
+
+def format_hex_id(identifier):
+	"""Formats a persisted or textual Symbol identifier as uppercase hexadecimal."""
+
+	if identifier is None:
+		return None
+
+	return identifier.upper()

--- a/explorer/rest/rest/routes/symbol.py
+++ b/explorer/rest/rest/routes/symbol.py
@@ -67,8 +67,8 @@ def setup_symbol_routes(app, symbol_api_facade):  # pylint: disable=too-many-sta
 			if availability_check and not availability_check():
 				return _service_unavailable('Symbol backend data is unavailable'), None
 			return None, query_fn()
-		except ReceiptCursorStaleError as error:
-			return _conflict(str(error)), None
+		except ReceiptCursorStaleError:
+			return _conflict(ReceiptCursorStaleError.MESSAGE), None
 		except ReceiptDataUnavailableError:
 			return _service_unavailable('Symbol backend data is unavailable'), None
 		except PsycopgError:

--- a/explorer/rest/rest/routes/symbol.py
+++ b/explorer/rest/rest/routes/symbol.py
@@ -1,19 +1,41 @@
 import configparser
+import hashlib
+import json
 from pathlib import Path
 
+import common.symbol.Receipt as receipt_contract
 from common.symbol.NodeConfiguration import SymbolNodeConfiguration
 from flask import abort, jsonify, request
 from psycopg2 import Error as PsycopgError
+from symbolchain.Network import NetworkLocator
+from symbolchain.symbol.Network import Network
 from zenlog import log
 
-from rest.db.SymbolDatabase import SortOrder
+from rest.db.SymbolDatabase import ReceiptCursorStaleError, ReceiptDataUnavailableError, ReceiptQuery, SortOrder
 from rest.facade.SymbolRestFacade import SymbolRestFacade
 from rest.model.common import DatabaseConfig
+from rest.model.symbol.ReceiptCursor import ReceiptCursor, decode_receipt_cursor, encode_receipt_cursor
+from rest.symbol_node import fetch_native_mosaic_info
 
 BLOCK_LIST_QUERY_PARAMETERS = frozenset(['limit', 'fromHeight', 'sort'])
+RECEIPT_QUERY_PARAMETERS = frozenset([
+	'limit',
+	'cursor',
+	'group',
+	'receiptType',
+	'includedReceiptTypes',
+	'targetAddress',
+	'senderAddress'
+])
+BLOCK_RECEIPT_QUERY_PARAMETERS = frozenset(['limit', 'cursor'])
 
 
-def setup_symbol_facade(app):
+def setup_symbol_facade(app, native_mosaic_info_fetcher=fetch_native_mosaic_info):
+	"""Creates the Symbol facade after setup-time native mosaic validation.
+
+	The fetcher is injected at the Symbol setup boundary for deterministic tests;
+	production uses the Node-backed default and fetches once before serving requests.
+	"""
 	config = configparser.ConfigParser()
 	db_path = Path(app.config.get('DATABASE_CONFIG_FILEPATH'))
 
@@ -31,16 +53,24 @@ def setup_symbol_facade(app):
 	)
 	node_config = SymbolNodeConfiguration.from_app_config(app.config)
 	node_config.assert_request_allowed(node_config.base_url)
+	native_mosaic_info = native_mosaic_info_fetcher(node_config)
 
-	return SymbolRestFacade(db_params, node_config)
+	return SymbolRestFacade(db_params, node_config, native_mosaic_info)
 
 
-def setup_symbol_routes(app, symbol_api_facade):
-	def _run_block_query(query_fn, error_log):
-		if not symbol_api_facade.is_block_data_available():
-			return _service_unavailable('Symbol backend data is unavailable'), None
+def setup_symbol_routes(app, symbol_api_facade):  # pylint: disable=too-many-statements
+	network_name = app.config.get('NETWORK_NAME', 'mainnet').lower()
+	network = NetworkLocator.find_by_name(Network.NETWORKS, network_name)
+
+	def _run_symbol_query(query_fn, error_log, availability_check=None):
 		try:
+			if availability_check and not availability_check():
+				return _service_unavailable('Symbol backend data is unavailable'), None
 			return None, query_fn()
+		except ReceiptCursorStaleError as error:
+			return _conflict(str(error)), None
+		except ReceiptDataUnavailableError:
+			return _service_unavailable('Symbol backend data is unavailable'), None
 		except PsycopgError:
 			log.error(error_log)
 			return _service_unavailable('Symbol backend data is unavailable'), None
@@ -67,9 +97,10 @@ def setup_symbol_routes(app, symbol_api_facade):
 		except ValueError as error:
 			abort(400, error)
 
-		error, result = _run_block_query(
+		error, result = _run_symbol_query(
 			lambda: symbol_api_facade.get_blocks(from_height, limit, SortOrder(sort)),
-			'Failed to get Symbol blocks')
+			'Failed to get Symbol blocks',
+			symbol_api_facade.is_block_data_available)
 		if error:
 			return error
 
@@ -85,9 +116,10 @@ def setup_symbol_routes(app, symbol_api_facade):
 		except ValueError as error:
 			abort(400, error)
 
-		error, result = _run_block_query(
+		error, result = _run_symbol_query(
 			lambda: symbol_api_facade.get_block(height),
-			'Failed to get Symbol block')
+			'Failed to get Symbol block',
+			symbol_api_facade.is_block_data_available)
 		if error:
 			return error
 
@@ -95,6 +127,50 @@ def setup_symbol_routes(app, symbol_api_facade):
 			abort(404)
 
 		return jsonify(result)
+
+	@app.route('/api/symbol/receipts')
+	def api_get_symbol_receipts():
+		_validate_allowed_query_parameters(RECEIPT_QUERY_PARAMETERS)
+		try:
+			query = _parse_receipt_query(network, network_name, height=None, scope='receipts')
+		except ValueError as error:
+			abort(400, error)
+
+		error, result = _run_symbol_query(
+			lambda: symbol_api_facade.get_receipts(query),
+			'Failed to get Symbol receipts')
+		if error:
+			return error
+
+		if result is None:
+			return _service_unavailable('Symbol backend data is unavailable')
+
+		return jsonify(_serialize_receipt_page(result, query, network_name, 'receipts'))
+
+	@app.route('/api/symbol/block/<height>/receipts')
+	def api_get_symbol_block_receipts(height):
+		_validate_allowed_query_parameters(BLOCK_RECEIPT_QUERY_PARAMETERS)
+		try:
+			validated_height = _parse_block_height(height)
+			query = _parse_receipt_query(
+				network,
+				network_name,
+				height=validated_height,
+				scope='blockReceipts',
+				block_route=True)
+		except ValueError as error:
+			abort(400, error)
+
+		error, result = _run_symbol_query(
+			lambda: symbol_api_facade.get_receipts(query),
+			'Failed to get Symbol block receipts')
+		if error:
+			return error
+
+		if result is None:
+			return _service_unavailable('Symbol backend data is unavailable')
+
+		return jsonify(_serialize_receipt_page(result, query, network_name, 'blockReceipts'))
 
 
 def _validate_allowed_query_parameters(allowed_parameters):
@@ -111,8 +187,181 @@ def _parse_block_height(raw_height):
 	return height
 
 
+def _parse_receipt_query(network, network_name, height, scope, block_route=False):
+	limit = _parse_bounded_integer('limit', 10, 1, 100)
+	raw_cursor = _get_scalar('cursor')
+	cursor = decode_receipt_cursor(raw_cursor) if raw_cursor is not None else None
+	if block_route:
+		query = ReceiptQuery(limit, cursor, height, None, None, (), None, None)
+		_filter_cursor(query, cursor, network_name, scope, height)
+		return query
+
+	group = _parse_group()
+	receipt_type = _parse_scalar_receipt_type()
+	included_receipt_types = _parse_included_receipt_types()
+	if receipt_type is not None and included_receipt_types:
+		raise ValueError('receiptType and includedReceiptTypes cannot be combined')
+
+	if group and receipt_type and _receipt_group_for_label(receipt_type) != group:
+		raise ValueError('receiptType does not belong to group')
+	if group and any(_receipt_group_for_label(receipt_type) != group for receipt_type in included_receipt_types):
+		raise ValueError('includedReceiptTypes contains a receipt from another group')
+
+	target_address = _parse_address('targetAddress', network)
+	sender_address = _parse_address('senderAddress', network)
+	query = ReceiptQuery(
+		limit,
+		cursor,
+		height,
+		group,
+		receipt_type,
+		included_receipt_types,
+		target_address,
+		sender_address
+	)
+	_filter_cursor(query, cursor, network_name, scope, height)
+	return query
+
+
+def _parse_bounded_integer(name, default, minimum, maximum):
+	raw_value = _get_scalar(name)
+	if raw_value is None:
+		return default
+
+	try:
+		value = int(raw_value)
+	except (TypeError, ValueError) as error:
+		raise ValueError(f'{name} must be an integer') from error
+
+	if value < minimum or value > maximum:
+		raise ValueError(f'{name} must be between {minimum} and {maximum}')
+
+	return value
+
+
+def _parse_group():
+	group = _get_scalar('group')
+	if group is not None and group not in receipt_contract.RECEIPT_GROUP_VALUES:
+		raise ValueError('group is invalid')
+
+	return group
+
+
+def _parse_scalar_receipt_type():
+	raw_value = _get_scalar('receiptType')
+	if raw_value is None:
+		return None
+
+	try:
+		code = int(raw_value)
+	except (TypeError, ValueError) as error:
+		raise ValueError('receiptType must be a valid numeric code') from error
+
+	if code not in receipt_contract.RECEIPT_TYPE_LABELS:
+		raise ValueError('receiptType is not supported')
+
+	return receipt_contract.RECEIPT_TYPE_LABELS[code]
+
+
+def _parse_included_receipt_types():
+	values = request.args.getlist('includedReceiptTypes')
+	parsed_values = []
+	for raw_value in values:
+		if ',' in raw_value:
+			raise ValueError('includedReceiptTypes must use repeated query parameters')
+		try:
+			code = int(raw_value)
+		except (TypeError, ValueError) as error:
+			raise ValueError('includedReceiptTypes must contain numeric codes') from error
+		if code not in receipt_contract.RECEIPT_TYPE_LABELS:
+			raise ValueError('includedReceiptTypes contains an unsupported receipt type')
+		parsed_values.append(receipt_contract.RECEIPT_TYPE_LABELS[code])
+
+	return tuple(sorted(set(parsed_values)))
+
+
+def _receipt_group_for_label(label):
+	code = next(code for code, candidate in receipt_contract.RECEIPT_TYPE_LABELS.items() if candidate == label)
+	return receipt_contract.RECEIPT_TYPE_GROUPS[code]
+
+
+def _parse_address(name, network):
+	raw_value = _get_scalar(name)
+	if raw_value is None:
+		return None
+
+	if not network.is_valid_address_string(raw_value):
+		raise ValueError(f'{name} is invalid')
+
+	return network.address_class(raw_value).bytes
+
+
+def _get_scalar(name):
+	values = request.args.getlist(name)
+	if len(values) > 1:
+		raise ValueError(f'{name} must not be repeated')
+
+	return values[0] if values else None
+
+
 def _service_unavailable(message):
 	return jsonify({
 		'status': 503,
 		'message': message
 	}), 503
+
+
+def _receipt_filter_hash(query, scope):
+	filter_payload = {
+		'blockHeight': query.height,
+		'group': query.receipt_group,
+		'includedReceiptTypes': list(query.included_receipt_types),
+		'receiptType': query.receipt_type,
+		'scope': scope,
+		'senderAddress': query.sender_address.hex() if query.sender_address is not None else None,
+		'targetAddress': query.target_address.hex() if query.target_address is not None else None
+	}
+	canonical_filter = json.dumps(filter_payload, sort_keys=True, separators=(',', ':')).encode('utf-8')
+	return hashlib.sha256(canonical_filter).hexdigest()
+
+
+def _filter_cursor(query, cursor, network_name, scope, height):
+	if cursor is None:
+		return
+	if cursor.scope != scope:
+		raise ValueError('Receipt cursor scope mismatch')
+	if cursor.network != network_name:
+		raise ValueError('Receipt cursor network mismatch')
+	if scope == 'blockReceipts' and cursor.height != height:
+		raise ValueError('Receipt cursor block height mismatch')
+	if cursor.filter_hash != _receipt_filter_hash(query, scope):
+		raise ValueError('Receipt cursor filter mismatch')
+
+
+def _serialize_receipt_page(page, query, network_name, scope):
+	next_cursor = None
+	if page.next_position is not None:
+		receipt_cursor = ReceiptCursor(
+			1,
+			scope,
+			network_name,
+			page.chain_revision,
+			page.next_position.height,
+			page.next_position.id,
+			_receipt_filter_hash(query, scope)
+		)
+		next_cursor = encode_receipt_cursor(receipt_cursor)
+
+	return {
+		'data': page.items,
+		'pagination': {
+			'nextCursor': next_cursor
+		}
+	}
+
+
+def _conflict(message):
+	return jsonify({
+		'status': 409,
+		'message': message
+	}), 409

--- a/explorer/rest/rest/symbol_node.py
+++ b/explorer/rest/rest/symbol_node.py
@@ -1,0 +1,20 @@
+import asyncio
+
+from common.symbol.NativeMosaic import create_native_mosaic_info, extract_native_mosaic_id
+from symbollightapi.connector.SymbolConnector import SymbolConnector
+
+
+async def _fetch_native_mosaic_info(connector):
+	network_properties = await connector.get('network/properties')
+	native_mosaic_id = extract_native_mosaic_id(network_properties)
+	mosaic_definition = await connector.get(f'mosaics/{native_mosaic_id}')
+	return create_native_mosaic_info(network_properties, mosaic_definition)
+
+
+def fetch_native_mosaic_info(node_config, connector_factory=SymbolConnector):
+	"""Fetches and validates native mosaic information during REST setup."""
+
+	endpoint = node_config.assert_request_allowed(node_config.base_url)
+	connector = connector_factory(endpoint)
+	connector.timeout_seconds = node_config.timeout_seconds
+	return asyncio.run(_fetch_native_mosaic_info(connector))

--- a/explorer/rest/tests/db/test_DatabaseConnection.py
+++ b/explorer/rest/tests/db/test_DatabaseConnection.py
@@ -1,43 +1,192 @@
 import unittest
 
 import psycopg2
-import testing.postgresql
+from common.tests.PostgresTestUtils import PostgresTestDatabase
 
-from rest.db.DatabaseConnection import DatabaseConnectionPool
+from rest.db.DatabaseConnection import DatabaseConnectionPool, PooledConnection
 
-from ..test.DatabaseTestUtils import DatabaseConfig
+
+class RecordingConnection:
+	"""Connection identity used to observe the pool lifecycle."""
+
+	def __init__(self, name):
+		self.name = name
+
+
+class RecordingConnectionPool:
+	"""Minimal pool that models available versus explicitly discarded connections."""
+
+	def __init__(self, connections=None, putconn_error=None):
+		self.available = connections or [RecordingConnection('connection')]
+		self.connection = self.available[0]
+		self.returned = []
+		self.discarded = []
+		self.putconn_error = putconn_error
+
+	def getconn(self):
+		if not self.available:
+			raise RuntimeError('pool exhausted')
+		return self.available.pop(0)
+
+	def putconn(self, connection, close=False):
+		self.returned.append((connection, close))
+		if self.putconn_error:
+			error = self.putconn_error
+			self.putconn_error = None
+			raise error
+		if close:
+			self.discarded.append(connection)
+		else:
+			self.available.append(connection)
 
 
 class TestDatabaseConnectionPool(unittest.TestCase):
-
-	def setUp(self):
-		self.postgresql = testing.postgresql.Postgresql()
-		self.db_config = DatabaseConfig(**self.postgresql.dsn(), password='')
-
-	def tearDown(self):
-		self.postgresql.stop()
-
 	def test_can_acquire_connection(self):
 		# Arrange:
-		database_connection_pool = DatabaseConnectionPool(self.db_config)
+		with PostgresTestDatabase() as db_config:
+			database_connection_pool = DatabaseConnectionPool(db_config)
 
-		# Act:
-		with database_connection_pool.connection() as connection:
-			# Assert:
-			self.assertIsNotNone(connection)
-			self.assertIsInstance(connection, psycopg2.extensions.connection)
+			# Act:
+			with database_connection_pool.connection() as connection:
+				# Assert:
+				self.assertIsNotNone(connection)
+				self.assertIsInstance(connection, psycopg2.extensions.connection)
 
 	def test_can_release_connection(self):
 		# Arrange:
-		database_connection_pool = DatabaseConnectionPool(self.db_config, min_connections=1, max_connections=2)
+		with PostgresTestDatabase() as db_config:
+			database_connection_pool = DatabaseConnectionPool(db_config, min_connections=1, max_connections=2)
 
-		# Act & Assert:
-		with database_connection_pool.connection() as connection1:
+			# Act & Assert:
+			with database_connection_pool.connection() as connection1:
+				with database_connection_pool.connection() as connection2:
+					self.assertNotEqual(connection1, connection2)
+
+			with database_connection_pool.connection() as connection1:
+				pass
+
 			with database_connection_pool.connection() as connection2:
-				self.assertNotEqual(connection1, connection2)
+				self.assertEqual(connection1, connection2)
 
-		with database_connection_pool.connection() as connection1:
+
+class PooledConnectionTest(unittest.TestCase):
+	def test_normal_exit_returns_connection_without_discard(self):
+		# Arrange:
+		pool = RecordingConnectionPool()
+		pooled_connection = PooledConnection(pool)
+
+		# Act:
+		with pooled_connection as connection:
 			pass
 
-		with database_connection_pool.connection() as connection2:
-			self.assertEqual(connection1, connection2)
+		# Assert:
+		self.assertEqual([(connection, False)], pool.returned)
+		self.assertEqual([connection], pool.available)
+		self.assertEqual([], pool.discarded)
+
+	def test_operation_failure_preserves_exception_with_default_return(self):
+		# Arrange:
+		pool = RecordingConnectionPool()
+		pooled_connection = PooledConnection(pool)
+
+		# Act:
+		with self.assertRaisesRegex(RuntimeError, '^operation failed$'):
+			with pooled_connection:
+				raise RuntimeError('operation failed')
+
+		# Assert:
+		self.assertEqual([(pool.connection, False)], pool.returned)
+		self.assertEqual([pool.connection], pool.available)
+
+	def test_normal_return_keeps_primary(self):
+		# Arrange:
+		pool = RecordingConnectionPool(putconn_error=RuntimeError('putconn cleanup failed'))
+		pooled_connection = PooledConnection(pool)
+
+		# Act:
+		with self.assertRaisesRegex(ValueError, '^primary operation failed$'):
+			with pooled_connection:
+				raise ValueError('primary operation failed')
+
+		# Assert:
+		self.assertEqual([(pool.connection, False)], pool.returned)
+		self.assertEqual([], pool.available)
+		self.assertEqual([], pool.discarded)
+
+	def test_normal_return_propagates_cleanup(self):
+		# Arrange:
+		pool = RecordingConnectionPool(putconn_error=RuntimeError('putconn cleanup failed'))
+		pooled_connection = PooledConnection(pool)
+
+		# Act:
+		with self.assertRaisesRegex(RuntimeError, '^putconn cleanup failed$'):
+			with pooled_connection:
+				pass
+
+		# Assert:
+		self.assertEqual([(pool.connection, False)], pool.returned)
+		self.assertEqual([], pool.available)
+
+	def test_reused_context_resets_discard(self):
+		# Arrange:
+		connection_a = RecordingConnection('A')
+		connection_b = RecordingConnection('B')
+		pool = RecordingConnectionPool([connection_a, connection_b])
+		pooled_connection = PooledConnection(pool)
+
+		# Act:
+		with pooled_connection:
+			pooled_connection.mark_for_discard()
+		with pooled_connection:
+			pass
+
+		# Assert:
+		self.assertEqual([(connection_a, True), (connection_b, False)], pool.returned)
+		self.assertEqual([connection_b], pool.available)
+		self.assertEqual([connection_a], pool.discarded)
+
+	def test_discard_requests_explicit_pool_close_and_removes_connection(self):
+		# Arrange:
+		pool = RecordingConnectionPool()
+		pooled_connection = PooledConnection(pool)
+
+		# Act:
+		with pooled_connection:
+			pooled_connection.mark_for_discard()
+
+		# Assert:
+		self.assertEqual([(pool.connection, True)], pool.returned)
+		self.assertEqual([], pool.available)
+		self.assertEqual([pool.connection], pool.discarded)
+		with self.assertRaisesRegex(RuntimeError, '^pool exhausted$'):
+			pool.getconn()
+
+	def test_primary_exception_survives_discard_failure(self):
+		# Arrange:
+		pool = RecordingConnectionPool(putconn_error=RuntimeError('discard failed'))
+		pooled_connection = PooledConnection(pool)
+
+		# Act:
+		with self.assertRaisesRegex(RuntimeError, '^operation failed$'):
+			with pooled_connection:
+				pooled_connection.mark_for_discard()
+				raise RuntimeError('operation failed')
+
+		# Assert:
+		self.assertEqual([(pool.connection, True)], pool.returned)
+		self.assertEqual([], pool.available)
+		self.assertEqual([], pool.discarded)
+
+	def test_discard_failure_propagates_without_primary_exception(self):
+		# Arrange:
+		pool = RecordingConnectionPool(putconn_error=RuntimeError('cleanup failed'))
+		pooled_connection = PooledConnection(pool)
+
+		# Act:
+		with self.assertRaisesRegex(RuntimeError, '^cleanup failed$'):
+			with pooled_connection:
+				pooled_connection.mark_for_discard()
+
+		# Assert:
+		self.assertEqual([(pool.connection, True)], pool.returned)
+		self.assertEqual([], pool.available)

--- a/explorer/rest/tests/db/test_SymbolReceiptDatabase.py
+++ b/explorer/rest/tests/db/test_SymbolReceiptDatabase.py
@@ -1,0 +1,727 @@
+from collections import defaultdict
+
+import pytest
+from common.tests.PostgresTestUtils import PostgresTestDatabase, drop_symbol_block_tables_if_present
+from puller.db.SymbolDatabase import SymbolDatabase as PullerSymbolDatabase
+
+from rest.db.SymbolDatabase import ReceiptCursorStaleError, ReceiptDataUnavailableError, ReceiptQuery, SortOrder, SymbolDatabase
+from rest.model.symbol.Receipt import ReceiptPosition
+from rest.model.symbol.ReceiptCursor import ReceiptCursor
+from tests.test.SymbolBlockTestUtils import create_symbol_block, create_symbol_sync_state
+
+NATIVE_MOSAIC_ID = '72C0212E67A08BCE'
+TARGET_ADDRESS = bytes.fromhex('9889432DE263BB8FE88444A4DA28D3609BD8BB8FAE18AE95')
+SENDER_ADDRESS = bytes.fromhex('98' + '11' * 23)
+OTHER_ADDRESS = bytes.fromhex('98' + '22' * 23)
+
+
+@pytest.fixture(scope='module', name='symbol_database_config')
+def fixture_symbol_database_config():
+	with PostgresTestDatabase() as db_config:
+		yield db_config
+
+
+def _create_receipt(height, receipt_type='inflation', receipt_group='inflation', **overrides):
+	receipt = {
+		'height': height,
+		'receipt_type': receipt_type,
+		'receipt_group': receipt_group,
+		'version': 1,
+		'source_primary_id': 0,
+		'source_secondary_id': 0,
+		'sender_address': None,
+		'recipient_address': None,
+		'target_address': None,
+		'mosaic_id': None,
+		'amount': 100,
+		'artifact_id': None,
+		'raw_payload': {'type': receipt_type}
+	}
+	receipt.update(overrides)
+	return receipt
+
+
+def _reset_database(database_config, sync_height=4, block_count=None):
+	with PullerSymbolDatabase(database_config) as database:
+		drop_symbol_block_tables_if_present(database)
+		database.create_tables()
+		database.upsert_sync_state(create_symbol_sync_state(sync_height, sync_height))
+		block_count = block_count or sync_height
+		database.upsert_blocks([create_symbol_block(height) for height in range(1, block_count + 1)])
+
+
+def _seed_receipts(database_config, receipts, sync_height=4, mosaics=(), block_count=None):
+	_reset_database(database_config, sync_height, block_count)
+	by_height = defaultdict(list)
+	for receipt in receipts:
+		by_height[receipt['height']].append(receipt)
+
+	with PullerSymbolDatabase(database_config) as database:
+		for mosaic in mosaics:
+			database.upsert_mosaic(mosaic)
+		for height, rows in by_height.items():
+			database.upsert_receipts_for_height(height, rows, 0)
+
+
+def _create_rest_database(database_config):
+	return SymbolDatabase(database_config)
+
+
+class LifecycleReceiptCursor:
+	def __init__(self, connection):
+		self.connection = connection
+		self.result = []
+
+	def __enter__(self):
+		return self
+
+	def __exit__(self, _exc_type, _exc_value, _traceback):
+		return False
+
+	def execute(self, statement, _parameters=None):
+		self.connection.statements.append(statement.strip())
+		self.result = []
+		if 'FROM symbol_sync_state' in statement:
+			self.result = (
+				self.connection.status,
+				self.connection.last_synced_height,
+				self.connection.chain_revision
+			)
+
+	def fetchone(self):
+		return self.result
+
+	def fetchall(self):
+		return self.result
+
+
+class LifecycleReceiptConnection:
+	def __init__(self, rollback_error=None, commit_error=None, close_error=None):
+		self.status = 'healthy'
+		self.last_synced_height = 1
+		self.chain_revision = 0
+		self.rollback_error = rollback_error
+		self.commit_error = commit_error
+		self.close_error = close_error
+		self.closed = False
+		self.statements = []
+
+	def cursor(self):
+		return LifecycleReceiptCursor(self)
+
+	def rollback(self):
+		if self.rollback_error:
+			error = self.rollback_error
+			self.rollback_error = None
+			raise error
+
+	def commit(self):
+		if self.commit_error:
+			error = self.commit_error
+			self.commit_error = None
+			raise error
+
+	def close(self):
+		if self.close_error:
+			error = self.close_error
+			self.close_error = None
+			raise error
+		self.closed = True
+
+
+class LifecycleReceiptPool:
+	def __init__(self, connections):
+		self.connections = list(connections)
+		self.acquired = []
+		self.returned = []
+		self.discarded = []
+		self.discard_attempts = []
+
+	def getconn(self):
+		connection = self.connections.pop(0)
+		self.acquired.append(connection)
+		return connection
+
+	def putconn(self, connection, close=False):
+		self.returned.append((connection, close))
+		if close:
+			self.discard_attempts.append(connection)
+			connection.close()
+			self.discarded.append(connection)
+		elif connection.closed:
+			self.discarded.append(connection)
+		else:
+			self.connections.append(connection)
+
+
+class NormalReturnFailureReceiptPool(LifecycleReceiptPool):
+	def __init__(self, connections):
+		super().__init__(connections)
+		self.failure_injected = False
+
+	def putconn(self, connection, close=False):
+		if not close and not self.failure_injected:
+			self.failure_injected = True
+			self.returned.append((connection, close))
+			raise RuntimeError('putconn cleanup failed')
+
+		super().putconn(connection, close)
+
+
+class LifecycleSymbolDatabase(SymbolDatabase):  # pylint: disable=super-init-not-called
+	def __init__(self, connection_pool):  # pylint: disable=super-init-not-called
+		self._pool = connection_pool
+
+
+def _create_lifecycle_database(*connections):
+	pool = LifecycleReceiptPool(connections)
+	return LifecycleSymbolDatabase(pool), pool
+
+
+def test_get_receipts_filters_by_group(symbol_database_config):
+	# Arrange:
+	_seed_receipts(symbol_database_config, [
+		_create_receipt(1),
+		_create_receipt(2, 'harvestFee', 'balanceChange')
+	])
+	database = _create_rest_database(symbol_database_config)
+
+	# Act:
+	result = database.get_receipts(ReceiptQuery(10, None, None, 'balanceChange', None, (), None, None))
+
+	# Assert:
+	assert ['harvestFee'] == [row['receipt_type'] for row in result.items]
+
+
+def test_get_receipts_filters_by_type(symbol_database_config):
+	# Arrange:
+	_seed_receipts(symbol_database_config, [
+		_create_receipt(1, 'inflation', 'inflation'),
+		_create_receipt(2, 'mosaicExpired', 'artifactExpiry')
+	])
+	database = _create_rest_database(symbol_database_config)
+
+	# Act:
+	result = database.get_receipts(ReceiptQuery(10, None, None, None, 'mosaicExpired', (), None, None))
+
+	# Assert:
+	assert ['mosaicExpired'] == [row['receipt_type'] for row in result.items]
+
+
+def test_receipts_fail_when_unreadable(symbol_database_config):
+	# Arrange:
+	_reset_database(symbol_database_config, sync_height=1)
+	with PullerSymbolDatabase(symbol_database_config) as database:
+		with database.connection.cursor() as cursor:
+			cursor.execute("UPDATE symbol_sync_state SET status = 'unhealthy' WHERE id = 1")
+			database.connection.commit()
+	rest_database = _create_rest_database(symbol_database_config)
+
+	# Act:
+	with pytest.raises(ReceiptDataUnavailableError):
+		rest_database.get_receipts(ReceiptQuery(10, None, None, None, None, (), None, None))
+
+
+def test_receipts_fail_when_repairing(symbol_database_config):
+	# Arrange:
+	_reset_database(symbol_database_config, sync_height=1)
+	with PullerSymbolDatabase(symbol_database_config) as database:
+		with database.connection.cursor() as cursor:
+			cursor.execute("UPDATE symbol_sync_state SET status = 'repairing' WHERE id = 1")
+			database.connection.commit()
+	rest_database = _create_rest_database(symbol_database_config)
+
+	# Act / Assert:
+	with pytest.raises(ReceiptDataUnavailableError):
+		rest_database.get_receipts(ReceiptQuery(10, None, None, None, None, (), None, None))
+
+
+def test_receipts_fail_state_missing(symbol_database_config):
+	# Arrange:
+	_reset_database(symbol_database_config, sync_height=1)
+	with PullerSymbolDatabase(symbol_database_config) as database:
+		with database.connection.cursor() as cursor:
+			cursor.execute('DELETE FROM symbol_sync_state WHERE id = 1')
+			database.connection.commit()
+	rest_database = _create_rest_database(symbol_database_config)
+
+	# Act / Assert:
+	with pytest.raises(ReceiptDataUnavailableError):
+		rest_database.get_receipts(ReceiptQuery(10, None, None, None, None, (), None, None))
+
+
+def test_receipts_reuse_unavailable(symbol_database_config):
+	# Arrange:
+	_seed_receipts(symbol_database_config, [_create_receipt(1, amount=101)])
+	with PullerSymbolDatabase(symbol_database_config) as database:
+		with database.connection.cursor() as cursor:
+			cursor.execute("UPDATE symbol_sync_state SET status = 'unhealthy' WHERE id = 1")
+			database.connection.commit()
+	rest_database = _create_rest_database(symbol_database_config)
+
+	# Act:
+	with pytest.raises(ReceiptDataUnavailableError):
+		rest_database.get_receipts(ReceiptQuery(10, None, None, None, None, (), None, None))
+	with PullerSymbolDatabase(symbol_database_config) as database:
+		with database.connection.cursor() as cursor:
+			cursor.execute("UPDATE symbol_sync_state SET status = 'healthy' WHERE id = 1")
+			database.connection.commit()
+	result = rest_database.get_receipts(ReceiptQuery(10, None, None, None, None, (), None, None))
+
+	# Assert:
+	assert [(1, 101)] == [(row['height'], row['amount']) for row in result.items]
+
+
+def test_receipts_reuse_stale(symbol_database_config):
+	# Arrange:
+	_seed_receipts(symbol_database_config, [_create_receipt(1, amount=101)])
+	rest_database = _create_rest_database(symbol_database_config)
+	stale_cursor = ReceiptCursor(1, 'receipts', 'mainnet', 1, 1, 1, '0' * 64)
+
+	# Act:
+	with pytest.raises(ReceiptCursorStaleError):
+		rest_database.get_receipts(ReceiptQuery(10, stale_cursor, None, None, None, (), None, None))
+	result = rest_database.get_receipts(ReceiptQuery(10, None, None, None, None, (), None, None))
+
+	# Assert:
+	assert [(1, 101)] == [(row['height'], row['amount']) for row in result.items]
+
+
+def test_receipts_preserve_stale_error():
+	# Arrange:
+	broken = LifecycleReceiptConnection(rollback_error=RuntimeError('rollback failed'))
+	healthy = LifecycleReceiptConnection()
+	database, pool = _create_lifecycle_database(broken, healthy)
+	stale_cursor = ReceiptCursor(1, 'receipts', 'mainnet', 1, 1, 1, '0' * 64)
+
+	# Act:
+	with pytest.raises(ReceiptCursorStaleError) as error:
+		database.get_receipts(ReceiptQuery(10, stale_cursor, None, None, None, (), None, None))
+	result = database.get_receipts(ReceiptQuery(10, None, None, None, None, (), None, None))
+
+	# Assert:
+	assert 'Receipt cursor is stale' == str(error.value)
+	assert [broken] == pool.discarded
+	assert [broken, healthy] == pool.acquired
+	assert () == result.items
+
+
+def test_receipts_stale_return_failure():
+	# Arrange:
+	broken = LifecycleReceiptConnection()
+	healthy = LifecycleReceiptConnection()
+	pool = NormalReturnFailureReceiptPool((broken, healthy))
+	database = LifecycleSymbolDatabase(pool)
+	stale_cursor = ReceiptCursor(1, 'receipts', 'mainnet', 1, 1, 1, '0' * 64)
+
+	# Act:
+	with pytest.raises(ReceiptCursorStaleError) as error:
+		database.get_receipts(ReceiptQuery(10, stale_cursor, None, None, None, (), None, None))
+	result = database.get_receipts(ReceiptQuery(10, None, None, None, None, (), None, None))
+
+	# Assert:
+	assert 'Receipt cursor is stale' == str(error.value)
+	assert [(broken, False), (healthy, False)] == pool.returned
+	assert [healthy] == pool.connections
+	assert [broken, healthy] == pool.acquired
+	assert () == result.items
+
+
+def test_receipts_preserve_close_failure():
+	# Arrange:
+	broken = LifecycleReceiptConnection(
+		rollback_error=RuntimeError('rollback failed'),
+		close_error=RuntimeError('close failed'))
+	healthy = LifecycleReceiptConnection()
+	database, pool = _create_lifecycle_database(broken, healthy)
+	stale_cursor = ReceiptCursor(1, 'receipts', 'mainnet', 1, 1, 1, '0' * 64)
+
+	# Act:
+	with pytest.raises(ReceiptCursorStaleError) as error:
+		database.get_receipts(ReceiptQuery(10, stale_cursor, None, None, None, (), None, None))
+	first_result = database.get_receipts(ReceiptQuery(10, None, None, None, None, (), None, None))
+	second_result = database.get_receipts(ReceiptQuery(10, None, None, None, None, (), None, None))
+
+	# Assert:
+	assert 'Receipt cursor is stale' == str(error.value)
+	assert False is broken.closed
+	assert [broken] == pool.discard_attempts
+	assert 0 == len(pool.discarded)
+	assert [healthy] == pool.connections
+	assert [broken, healthy, healthy] == pool.acquired
+	assert () == first_result.items
+	assert () == second_result.items
+
+
+def test_receipts_discard_commit_failure():
+	# Arrange:
+	broken = LifecycleReceiptConnection(commit_error=RuntimeError('commit failed'))
+	healthy = LifecycleReceiptConnection()
+	database, pool = _create_lifecycle_database(broken, healthy)
+
+	# Act:
+	with pytest.raises(RuntimeError) as error:
+		database.get_receipts(ReceiptQuery(10, None, None, None, None, (), None, None))
+	result = database.get_receipts(ReceiptQuery(10, None, None, None, None, (), None, None))
+
+	# Assert:
+	assert 'commit failed' == str(error.value)
+	assert [broken] == pool.discarded
+	assert [broken, healthy] == pool.acquired
+	assert () == result.items
+
+
+def test_receipts_commit_close_failure():
+	# Arrange:
+	broken = LifecycleReceiptConnection(
+		commit_error=RuntimeError('commit failed'),
+		close_error=RuntimeError('close failed'))
+	healthy = LifecycleReceiptConnection()
+	database, pool = _create_lifecycle_database(broken, healthy)
+
+	# Act:
+	with pytest.raises(RuntimeError) as error:
+		database.get_receipts(ReceiptQuery(10, None, None, None, None, (), None, None))
+	first_result = database.get_receipts(ReceiptQuery(10, None, None, None, None, (), None, None))
+	second_result = database.get_receipts(ReceiptQuery(10, None, None, None, None, (), None, None))
+
+	# Assert:
+	assert 'commit failed' == str(error.value)
+	assert False is broken.closed
+	assert [broken] == pool.discard_attempts
+	assert 0 == len(pool.discarded)
+	assert [healthy] == pool.connections
+	assert [broken, healthy, healthy] == pool.acquired
+	assert () == first_result.items
+	assert () == second_result.items
+
+
+def test_receipts_filter_included_array(symbol_database_config):
+	# Arrange:
+	_seed_receipts(symbol_database_config, [
+		_create_receipt(1, 'harvestFee', 'balanceChange'),
+		_create_receipt(2, 'lockHashCreated', 'balanceChange'),
+		_create_receipt(3, 'inflation', 'inflation')
+	])
+	database = _create_rest_database(symbol_database_config)
+
+	# Act:
+	result = database.get_receipts(ReceiptQuery(
+		10, None, None, None, None, ('harvestFee', 'lockHashCreated'), None, None))
+
+	# Assert:
+	assert ['lockHashCreated', 'harvestFee'] == [row['receipt_type'] for row in result.items]
+
+
+def test_get_receipts_filters_by_height(symbol_database_config):
+	# Arrange:
+	_seed_receipts(symbol_database_config, [
+		_create_receipt(1),
+		_create_receipt(2)
+	])
+	database = _create_rest_database(symbol_database_config)
+
+	# Act:
+	result = database.get_receipts(ReceiptQuery(10, None, 1, None, None, (), None, None))
+
+	# Assert:
+	assert [1] == [row['height'] for row in result.items]
+
+
+def test_receipts_filter_target(symbol_database_config):
+	# Arrange:
+	_seed_receipts(symbol_database_config, [
+		_create_receipt(1, 'harvestFee', 'balanceChange', target_address=TARGET_ADDRESS),
+		_create_receipt(2, 'harvestFee', 'balanceChange', target_address=OTHER_ADDRESS)
+	])
+	database = _create_rest_database(symbol_database_config)
+
+	# Act:
+	result = database.get_receipts(ReceiptQuery(10, None, None, None, None, (), TARGET_ADDRESS, None))
+
+	# Assert:
+	assert [TARGET_ADDRESS] == [bytes(row['target_address']) for row in result.items]
+
+
+def test_receipts_filter_sender(symbol_database_config):
+	# Arrange:
+	_seed_receipts(symbol_database_config, [
+		_create_receipt(1, 'mosaicRentalFee', 'balanceTransfer', sender_address=SENDER_ADDRESS),
+		_create_receipt(2, 'mosaicRentalFee', 'balanceTransfer', sender_address=OTHER_ADDRESS)
+	])
+	database = _create_rest_database(symbol_database_config)
+
+	# Act:
+	result = database.get_receipts(ReceiptQuery(10, None, None, None, None, (), None, SENDER_ADDRESS))
+
+	# Assert:
+	assert [SENDER_ADDRESS] == [bytes(row['sender_address']) for row in result.items]
+
+
+def test_receipts_combined_watermark(symbol_database_config):
+	# Arrange:
+	_seed_receipts(symbol_database_config, [
+		_create_receipt(1, 'harvestFee', 'balanceChange', target_address=TARGET_ADDRESS),
+		_create_receipt(2, 'lockHashCreated', 'balanceChange', target_address=TARGET_ADDRESS),
+		_create_receipt(3, 'harvestFee', 'balanceChange', target_address=OTHER_ADDRESS),
+		_create_receipt(4, 'harvestFee', 'balanceChange', target_address=TARGET_ADDRESS)
+	], sync_height=3, block_count=4)
+	database = _create_rest_database(symbol_database_config)
+
+	# Act:
+	result = database.get_receipts(ReceiptQuery(
+		10, None, None, 'balanceChange', 'harvestFee', (), TARGET_ADDRESS, None))
+
+	# Assert:
+	assert [1] == [row['height'] for row in result.items]
+
+
+def test_receipts_order_height_id(symbol_database_config):
+	# Arrange:
+	_seed_receipts(symbol_database_config, [
+		_create_receipt(1, 'harvestFee', 'balanceChange'),
+		_create_receipt(2, 'harvestFee', 'balanceChange'),
+		_create_receipt(2, 'lockHashCreated', 'balanceChange')
+	])
+	database = _create_rest_database(symbol_database_config)
+
+	# Act:
+	result = database.get_receipts(ReceiptQuery(10, None, None, 'balanceChange', None, (), None, None))
+
+	# Assert:
+	assert [(2, 'lockHashCreated'), (2, 'harvestFee'), (1, 'harvestFee')] == [
+		(row['height'], row['receipt_type']) for row in result.items]
+
+
+def test_receipts_paginates_ordered_rows(symbol_database_config):
+	# Arrange:
+	_seed_receipts(symbol_database_config, [
+		_create_receipt(1, 'harvestFee', 'balanceChange', amount=101),
+		_create_receipt(2, 'harvestFee', 'balanceChange', amount=201),
+		_create_receipt(2, 'lockHashCreated', 'balanceChange', amount=202),
+		_create_receipt(3, 'lockHashCompleted', 'balanceChange', amount=301),
+		_create_receipt(3, 'lockSecretCreated', 'balanceChange', amount=302)
+	])
+	database = _create_rest_database(symbol_database_config)
+
+	# Act:
+	first_page = database.get_receipts(ReceiptQuery(2, None, None, 'balanceChange', None, (), None, None))
+	cursor = ReceiptCursor(
+		1,
+		'receipts',
+		'mainnet',
+		first_page.chain_revision,
+		first_page.next_position.height,
+		first_page.next_position.id,
+		'0' * 64)
+	result = database.get_receipts(ReceiptQuery(2, cursor, None, 'balanceChange', None, (), None, None))
+
+	# Assert:
+	assert [(2, 'lockHashCreated', 202), (2, 'harvestFee', 201)] == [
+		(row['height'], row['receipt_type'], row['amount']) for row in result.items]
+
+
+def test_receipts_no_cursor_exact_limit(symbol_database_config):
+	# Arrange:
+	_seed_receipts(symbol_database_config, [
+		_create_receipt(1, amount=101),
+		_create_receipt(2, amount=201)
+	])
+	database = _create_rest_database(symbol_database_config)
+
+	# Act:
+	result = database.get_receipts(ReceiptQuery(2, None, None, None, None, (), None, None))
+
+	# Assert:
+	assert 2 == len(result.items)
+	assert result.next_position is None
+
+
+def test_receipts_cursor_uses_last_item(symbol_database_config):
+	# Arrange:
+	_seed_receipts(symbol_database_config, [
+		_create_receipt(1, 'harvestFee', 'balanceChange', amount=101),
+		_create_receipt(1, 'lockHashCreated', 'balanceChange', amount=102),
+		_create_receipt(1, 'lockHashCompleted', 'balanceChange', amount=103)
+	])
+	database = _create_rest_database(symbol_database_config)
+
+	# Act:
+	result = database.get_receipts(ReceiptQuery(2, None, None, 'balanceChange', None, (), None, None))
+
+	# Assert:
+	assert [3, 2] == [row['id'] for row in result.items]
+	assert ReceiptPosition(1, 2) == result.next_position
+
+
+def test_receipts_pages_no_duplicates(symbol_database_config):
+	# Arrange:
+	_seed_receipts(symbol_database_config, [
+		_create_receipt(1, amount=101),
+		_create_receipt(2, amount=201),
+		_create_receipt(2, 'lockHashCreated', 'balanceChange', amount=202),
+		_create_receipt(3, amount=301),
+		_create_receipt(3, 'lockHashCreated', 'balanceChange', amount=302)
+	])
+	database = _create_rest_database(symbol_database_config)
+	query_cursor = None
+	rows = []
+
+	# Act:
+	while True:
+		page = database.get_receipts(ReceiptQuery(2, query_cursor, None, None, None, (), None, None))
+		rows.extend((row['height'], row['amount']) for row in page.items)
+		if page.next_position is None:
+			break
+		query_cursor = ReceiptCursor(
+			1,
+			'receipts',
+			'mainnet',
+			page.chain_revision,
+			page.next_position.height,
+			page.next_position.id,
+			'0' * 64)
+
+	# Assert:
+	assert [(3, 302), (3, 301), (2, 202), (2, 201), (1, 101)] == rows
+
+
+def test_receipts_cursor_excludes_newer(symbol_database_config):
+	# Arrange:
+	_seed_receipts(
+		symbol_database_config,
+		[_create_receipt(2, amount=201), _create_receipt(1, amount=101)],
+		sync_height=3)
+	database = _create_rest_database(symbol_database_config)
+	first_page = database.get_receipts(ReceiptQuery(1, None, None, None, None, (), None, None))
+	query_cursor = ReceiptCursor(
+		1,
+		'receipts',
+		'mainnet',
+		first_page.chain_revision,
+		first_page.next_position.height,
+		first_page.next_position.id,
+		'0' * 64)
+	with PullerSymbolDatabase(symbol_database_config) as puller_database:
+		puller_database.upsert_receipts_for_height(3, [_create_receipt(3, amount=301)], 0)
+
+	# Act:
+	result = database.get_receipts(ReceiptQuery(1, query_cursor, None, None, None, (), None, None))
+
+	# Assert:
+	assert [(1, 101)] == [(row['height'], row['amount']) for row in result.items]
+
+
+def test_block_cursor_keeps_height(symbol_database_config):
+	# Arrange:
+	_seed_receipts(symbol_database_config, [
+		_create_receipt(2, amount=201),
+		_create_receipt(2, 'lockHashCreated', 'balanceChange', amount=202),
+		_create_receipt(2, 'lockHashCompleted', 'balanceChange', amount=203),
+		_create_receipt(1, amount=101)
+	])
+	database = _create_rest_database(symbol_database_config)
+	first_page = database.get_receipts(ReceiptQuery(2, None, 2, None, None, (), None, None))
+	query_cursor = ReceiptCursor(
+		1,
+		'blockReceipts',
+		'mainnet',
+		first_page.chain_revision,
+		first_page.next_position.height,
+		first_page.next_position.id,
+		'0' * 64)
+
+	# Act:
+	second_page = database.get_receipts(ReceiptQuery(2, query_cursor, 2, None, None, (), None, None))
+
+	# Assert:
+	assert [(2, 201)] == [(row['height'], row['amount']) for row in second_page.items]
+
+
+def test_receipts_empty_result(symbol_database_config):
+	# Arrange:
+	_seed_receipts(symbol_database_config, [])
+	database = _create_rest_database(symbol_database_config)
+
+	# Act:
+	result = database.get_receipts(ReceiptQuery(10, None, None, None, None, (), None, None))
+
+	# Assert:
+	assert () == result.items
+	assert result.next_position is None
+
+
+def test_receipts_metadata_join(symbol_database_config):
+	# Arrange:
+	mosaic = {
+		'mosaic_id': 'ABCDEF0123456789',
+		'owner_address': OTHER_ADDRESS,
+		'start_height': 1,
+		'duration': 0,
+		'expiration_height': None,
+		'supply': 1,
+		'divisibility': 3,
+		'flags': 0,
+		'supply_mutable': False,
+		'transferable': True,
+		'restrictable': False,
+		'revokable': False,
+		'raw_payload': {},
+		'updated_at_height': 1
+	}
+	_seed_receipts(symbol_database_config, [
+		_create_receipt(1, 'harvestFee', 'balanceChange', mosaic_id=mosaic['mosaic_id'])
+	], mosaics=[mosaic])
+	database = _create_rest_database(symbol_database_config)
+
+	# Act:
+	result = database.get_receipts(ReceiptQuery(10, None, None, None, None, (), None, None))
+
+	# Assert:
+	assert 3 == result.items[0]['mosaic_divisibility']
+
+
+def test_receipts_missing_metadata(symbol_database_config):
+	# Arrange:
+	_seed_receipts(symbol_database_config, [
+		_create_receipt(1, 'harvestFee', 'balanceChange', mosaic_id='ABCDEF0123456789')
+	])
+	database = _create_rest_database(symbol_database_config)
+
+	# Act:
+	result = database.get_receipts(ReceiptQuery(10, None, None, None, None, (), None, None))
+
+	# Assert:
+	assert result.items[0]['mosaic_divisibility'] is None
+
+
+def test_get_blocks_reads_block_reward(symbol_database_config):
+	# Arrange:
+	_reset_database(symbol_database_config, sync_height=2)
+	with PullerSymbolDatabase(symbol_database_config) as database:
+		with database.connection.cursor() as cursor:
+			cursor.execute('UPDATE symbol_blocks SET block_reward = 123 WHERE height = 2')
+			database.connection.commit()
+	rest_database = _create_rest_database(symbol_database_config)
+
+	# Act:
+	result = rest_database.get_blocks(None, 2, SortOrder.DESC)
+
+	# Assert:
+	assert [123, None] == [block.block_reward for block in result]
+
+
+def test_get_block_reads_block_reward(symbol_database_config):
+	# Arrange:
+	_reset_database(symbol_database_config, sync_height=2)
+	with PullerSymbolDatabase(symbol_database_config) as database:
+		with database.connection.cursor() as cursor:
+			cursor.execute('UPDATE symbol_blocks SET block_reward = 456 WHERE height = 2')
+			database.connection.commit()
+	rest_database = _create_rest_database(symbol_database_config)
+
+	# Act:
+	result = rest_database.get_block(2)
+
+	# Assert:
+	assert 456 == result.block_reward

--- a/explorer/rest/tests/facade/test_SymbolRestFacade.py
+++ b/explorer/rest/tests/facade/test_SymbolRestFacade.py
@@ -1,16 +1,19 @@
 from unittest import TestCase
 
+from common.symbol.NativeMosaic import NativeMosaicInfo
 from common.symbol.NodeConfiguration import SymbolNodeConfiguration
 from common.tests.PostgresTestUtils import create_unreachable_db_configuration
 from psycopg2 import Error as PsycopgError
 from psycopg2 import OperationalError
 
-from rest.db.SymbolDatabase import SortOrder
+from rest.db.SymbolDatabase import ReceiptQuery, SortOrder
 from rest.facade.SymbolRestFacade import SymbolRestFacade
+from rest.model.symbol.Receipt import ReceiptPage, ReceiptPosition
 
 from ..test.SymbolHealthTestUtils import create_symbol_health
 
 NODE_URL = 'http://127.0.0.1:3000'
+NATIVE_MOSAIC_INFO = NativeMosaicInfo('72C0212E67A08BCE', 6)
 
 
 def _create_node_config():
@@ -115,11 +118,11 @@ class SyncStateFailingSymbolDatabase:
 
 class BlockView:
 	@staticmethod
-	def to_dict():
+	def to_dict(_native_mosaic_info):
 		return {'height': 1}
 
 	@staticmethod
-	def to_detail_dict():
+	def to_detail_dict(_native_mosaic_info):
 		return {'height': 1, 'detail': True}
 
 
@@ -149,10 +152,27 @@ class BlockSymbolDatabase:
 		return BlockView() if 1 == height else None
 
 
+class ReceiptSymbolDatabase:
+	def __init__(self, receipts=None):
+		self.receipts = [] if receipts is None else receipts
+		self.query = None
+
+	def get_receipts(self, query):
+		self.query = query
+		return ReceiptPage(tuple(self.receipts), ReceiptPosition(12, 99), 7)
+
+
+class MissingReceiptSymbolDatabase:
+	@staticmethod
+	def get_receipts(_query):
+		return None
+
+
 def _create_configured_facade():
 	facade = SymbolRestFacade(
 		create_unreachable_db_configuration(),
-		_create_node_config())
+		_create_node_config(),
+		NATIVE_MOSAIC_INFO)
 	facade.symbol_db = HealthySymbolDatabase()
 	facade.db_error = None
 	return facade
@@ -161,7 +181,8 @@ def _create_configured_facade():
 def _create_facade_with_database(symbol_db):
 	facade = SymbolRestFacade(
 		create_unreachable_db_configuration(),
-		_create_node_config())
+		_create_node_config(),
+		NATIVE_MOSAIC_INFO)
 	facade.symbol_db = symbol_db
 	facade.db_error = None
 	return facade
@@ -177,7 +198,7 @@ class SymbolRestFacadeTest(TestCase):  # pylint: disable=too-many-public-methods
 			ValueError,
 			'Symbol database configuration is required'
 		):
-			SymbolRestFacade(None, node_config)
+			SymbolRestFacade(None, node_config, NATIVE_MOSAIC_INFO)
 
 	def test_rejects_missing_node_config(self):
 		# Act + Assert:
@@ -185,7 +206,15 @@ class SymbolRestFacadeTest(TestCase):  # pylint: disable=too-many-public-methods
 			ValueError,
 			'Symbol node configuration is required'
 		):
-			SymbolRestFacade(create_unreachable_db_configuration(), None)
+			SymbolRestFacade(create_unreachable_db_configuration(), None, NATIVE_MOSAIC_INFO)
+
+	def test_rejects_missing_native_mosaic_info(self):
+		# Act + Assert:
+		with self.assertRaisesRegex(
+			ValueError,
+			'Native mosaic information is required'
+		):
+			SymbolRestFacade(create_unreachable_db_configuration(), _create_node_config(), None)
 
 	def test_reports_configured_when_dependencies_are_available(self):
 		# Arrange:
@@ -285,7 +314,8 @@ class SymbolRestFacadeTest(TestCase):  # pylint: disable=too-many-public-methods
 		# Act:
 		facade = SymbolRestFacade(
 			db_config=create_unreachable_db_configuration(),
-			node_config=node_config)
+			node_config=node_config,
+			native_mosaic_info=NATIVE_MOSAIC_INFO)
 
 		# Assert:
 		self.assertFalse(facade.is_configured())
@@ -295,7 +325,8 @@ class SymbolRestFacadeTest(TestCase):  # pylint: disable=too-many-public-methods
 		node_config = _create_node_config()
 		facade = SymbolRestFacade(
 			db_config=create_unreachable_db_configuration(),
-			node_config=node_config)
+			node_config=node_config,
+			native_mosaic_info=NATIVE_MOSAIC_INFO)
 
 		# Act:
 		result = facade.get_health()
@@ -373,7 +404,8 @@ class SymbolRestFacadeTest(TestCase):  # pylint: disable=too-many-public-methods
 		# Arrange:
 		facade = SymbolRestFacade(
 			create_unreachable_db_configuration(),
-			_create_node_config())
+			_create_node_config(),
+			NATIVE_MOSAIC_INFO)
 
 		# Act + Assert:
 		self.assertFalse(facade.is_database_available())
@@ -421,7 +453,8 @@ class SymbolRestFacadeTest(TestCase):  # pylint: disable=too-many-public-methods
 		# Arrange:
 		facade = SymbolRestFacade(
 			create_unreachable_db_configuration(),
-			_create_node_config())
+			_create_node_config(),
+			NATIVE_MOSAIC_INFO)
 
 		# Act + Assert:
 		self.assertIsNone(facade.get_block(1))
@@ -430,3 +463,66 @@ class SymbolRestFacadeTest(TestCase):  # pylint: disable=too-many-public-methods
 		# Act + Assert:
 		with self.assertRaises(PsycopgError):
 			_create_facade_with_database(BlockReadErrorSymbolDatabase()).get_block(1)
+
+	def test_get_receipts_orchestrates_database_and_view(self):
+		# Arrange:
+		symbol_db = ReceiptSymbolDatabase([{
+			'height': 12,
+			'receipt_type': 'inflation',
+			'receipt_group': 'inflation',
+			'version': 1,
+			'sender_address': None,
+			'recipient_address': None,
+			'target_address': None,
+			'mosaic_id': '72c0212e67a08bce',
+			'amount': 1000000,
+			'artifact_id': None,
+			'mosaic_divisibility': None
+		}])
+		facade = _create_facade_with_database(symbol_db)
+		query = ReceiptQuery(10, None, None, 'inflation', None, (), None, None)
+
+		# Act:
+		result = facade.get_receipts(query)
+
+		# Assert:
+		self.assertEqual(ReceiptPage(({
+			'version': 1,
+			'height': 12,
+			'type': 'inflation',
+			'group': 'inflation',
+			'targetAddress': None,
+			'sender': None,
+			'to': None,
+			'artifactId': None,
+			'mosaics': [{
+				'id': '72C0212E67A08BCE',
+				'name': '72C0212E67A08BCE',
+				'amount': 1.0,
+				'isNative': True
+			}]
+		},), ReceiptPosition(12, 99), 7), result)
+		self.assertIs(query, symbol_db.query)
+
+	def test_get_receipts_returns_none(self):
+		# Arrange:
+		facade = _create_facade_with_database(MissingReceiptSymbolDatabase())
+
+		# Act:
+		result = facade.get_receipts(ReceiptQuery(10, None, None, None, None, (), None, None))
+
+		# Assert:
+		self.assertIsNone(result)
+
+	def test_get_receipts_returns_none_without_database(self):
+		# Arrange:
+		facade = SymbolRestFacade(
+			create_unreachable_db_configuration(),
+			_create_node_config(),
+			NATIVE_MOSAIC_INFO)
+
+		# Act:
+		result = facade.get_receipts(ReceiptQuery(10, None, None, None, None, (), None, None))
+
+		# Assert:
+		self.assertIsNone(result)

--- a/explorer/rest/tests/model/symbol/test_Block.py
+++ b/explorer/rest/tests/model/symbol/test_Block.py
@@ -2,7 +2,11 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from unittest import TestCase
 
+from common.symbol.NativeMosaic import NativeMosaicInfo
+
 from rest.model.symbol.Block import SymbolBlockView
+
+NATIVE_MOSAIC_INFO = NativeMosaicInfo('72C0212E67A08BCE', 6)
 
 
 def _expected_list_dict():
@@ -53,6 +57,7 @@ class SymbolBlockViewTest(TestCase):
 			harvesting_eligible_accounts_count=17,
 			total_voting_balance=Decimal('19000235663367'),
 			previous_importance_block_hash=b'\x0A',
+			block_reward=None,
 			is_finalized=True
 		)
 
@@ -61,7 +66,7 @@ class SymbolBlockViewTest(TestCase):
 		block_view = self._create_block_view()
 
 		# Act:
-		result = block_view.to_dict()
+		result = block_view.to_dict(NATIVE_MOSAIC_INFO)
 
 		# Assert:
 		self.assertEqual(_expected_list_dict(), result)
@@ -71,7 +76,7 @@ class SymbolBlockViewTest(TestCase):
 		block_view = self._create_block_view()
 
 		# Act:
-		result = block_view.to_detail_dict()
+		result = block_view.to_detail_dict(NATIVE_MOSAIC_INFO)
 
 		# Assert:
 		self.assertEqual({
@@ -99,7 +104,7 @@ class SymbolBlockViewTest(TestCase):
 		block_view.state_hash_sub_cache_roots = []
 
 		# Act:
-		result = block_view.to_detail_dict()
+		result = block_view.to_detail_dict(NATIVE_MOSAIC_INFO)
 
 		# Assert:
 		self.assertEqual([], result['stateHashSubCacheMerkleRoots'])
@@ -110,7 +115,35 @@ class SymbolBlockViewTest(TestCase):
 		block_view.timestamp = datetime(2026, 1, 2, 3, 4, 5)
 
 		# Act:
-		result = block_view.to_dict()
+		result = block_view.to_dict(NATIVE_MOSAIC_INFO)
 
 		# Assert:
 		self.assertEqual('2026-01-02T03:04:05Z', result['timestamp'])
+
+	def test_formats_zero_block_reward(self):
+		# Arrange:
+		block_view = self._create_block_view()
+		block_view.block_reward = 0
+
+		# Act:
+		result = block_view.to_dict(NATIVE_MOSAIC_INFO)
+
+		# Assert:
+		expected = _expected_list_dict()
+		expected['blockReward'] = 0.0
+		self.assertEqual(expected, result)
+
+	def test_formats_positive_block_reward_with_native_divisibility(self):
+		# Arrange:
+		block_view = self._create_block_view()
+		block_view.total_fee = 12345
+		block_view.block_reward = 678
+		native_mosaic_info = NATIVE_MOSAIC_INFO._replace(divisibility=3)
+
+		# Act:
+		result = block_view.to_dict(native_mosaic_info)
+
+		# Assert:
+		expected = _expected_list_dict()
+		expected.update({'totalFee': 12.345, 'blockReward': 0.678})
+		self.assertEqual(expected, result)

--- a/explorer/rest/tests/model/symbol/test_Receipt.py
+++ b/explorer/rest/tests/model/symbol/test_Receipt.py
@@ -1,0 +1,120 @@
+from unittest import TestCase
+
+from common.symbol.NativeMosaic import NativeMosaicInfo
+
+from rest.model.symbol.Receipt import SymbolReceiptView
+
+NATIVE_MOSAIC_INFO = NativeMosaicInfo('72C0212E67A08BCE', 6)
+TARGET_ADDRESS = bytes.fromhex('9889432DE263BB8FE88444A4DA28D3609BD8BB8FAE18AE95')
+SENDER_ADDRESS = bytes.fromhex('98' + '11' * 23)
+RECIPIENT_ADDRESS = bytes.fromhex('98' + '22' * 23)
+
+
+def _create_row(**overrides):
+	row = {
+		'height': 1234,
+		'receipt_type': 'lockHashCreated',
+		'receipt_group': 'balanceChange',
+		'version': 1,
+		'sender_address': None,
+		'recipient_address': None,
+		'target_address': None,
+		'mosaic_id': None,
+		'amount': 10,
+		'artifact_id': None,
+		'mosaic_divisibility': None
+	}
+	row.update(overrides)
+	return row
+
+
+def _expected_receipt(mosaics, target_address=None, sender=None, recipient=None, artifact_id=None):
+	return {
+		'version': 1,
+		'height': 1234,
+		'type': 'lockHashCreated',
+		'group': 'balanceChange',
+		'targetAddress': target_address,
+		'sender': sender,
+		'to': recipient,
+		'artifactId': artifact_id,
+		'mosaics': mosaics
+	}
+
+
+class SymbolReceiptViewTest(TestCase):
+	def test_serializes_receipt_without_mosaic(self):
+		# Arrange:
+		view = SymbolReceiptView(_create_row(), NATIVE_MOSAIC_INFO)
+
+		# Act:
+		result = view.to_dict()
+
+		# Assert:
+		self.assertEqual(_expected_receipt([]), result)
+
+	def test_formats_native_amount_without_metadata(self):
+		# Arrange:
+		view = SymbolReceiptView(_create_row(mosaic_id='72c0212e67a08bce', amount=1000000), NATIVE_MOSAIC_INFO)
+
+		# Act:
+		result = view.to_dict()
+
+		# Assert:
+		self.assertEqual(_expected_receipt([{
+			'id': '72C0212E67A08BCE',
+			'name': '72C0212E67A08BCE',
+			'amount': 1.0,
+			'isNative': True
+		}]), result)
+
+	def test_formats_non_native_amount_with_metadata(self):
+		# Arrange:
+		view = SymbolReceiptView(_create_row(
+			mosaic_id='abcdef0123456789', amount=12345, mosaic_divisibility=3),
+			NATIVE_MOSAIC_INFO)
+
+		# Act:
+		result = view.to_dict()
+
+		# Assert:
+		self.assertEqual(_expected_receipt([{
+			'id': 'ABCDEF0123456789',
+			'name': 'ABCDEF0123456789',
+			'amount': 12.345,
+			'isNative': False
+		}]), result)
+
+	def test_keeps_non_native_absolute_amount_without_metadata(self):
+		# Arrange:
+		view = SymbolReceiptView(_create_row(mosaic_id='abcdef0123456789', amount=12345), NATIVE_MOSAIC_INFO)
+
+		# Act:
+		result = view.to_dict()
+
+		# Assert:
+		self.assertEqual(_expected_receipt([{
+			'id': 'ABCDEF0123456789',
+			'name': 'ABCDEF0123456789',
+			'amount': 12345,
+			'isNative': False
+		}]), result)
+
+	def test_formats_addresses_and_artifact_id(self):
+		# Arrange:
+		view = SymbolReceiptView(_create_row(
+			target_address=TARGET_ADDRESS,
+			sender_address=SENDER_ADDRESS,
+			recipient_address=RECIPIENT_ADDRESS,
+			artifact_id='abcdef0123456789'), NATIVE_MOSAIC_INFO)
+
+		# Act:
+		result = view.to_dict()
+
+		# Assert:
+		self.assertEqual(_expected_receipt(
+			[],
+			target_address='TCEUGLPCMO5Y72EEISSNUKGTMCN5RO4PVYMK5FI',
+			sender='TAIRCEIRCEIRCEIRCEIRCEIRCEIRCEIRCEIRCEI',
+			recipient='TARCEIRCEIRCEIRCEIRCEIRCEIRCEIRCEIRCEIQ',
+			artifact_id='ABCDEF0123456789'), result)

--- a/explorer/rest/tests/model/symbol/test_ReceiptCursor.py
+++ b/explorer/rest/tests/model/symbol/test_ReceiptCursor.py
@@ -1,0 +1,82 @@
+import base64
+import json
+
+import pytest
+
+from rest.model.symbol.ReceiptCursor import ReceiptCursor, ReceiptCursorError, decode_receipt_cursor, encode_receipt_cursor
+
+
+def _cursor(**overrides):
+	values = {
+		'version': 1,
+		'scope': 'receipts',
+		'network': 'mainnet',
+		'revision': 3,
+		'height': 5660900,
+		'id': 28471002,
+		'filter_hash': '64' * 32
+	}
+	values.update(overrides)
+	return ReceiptCursor(**values)
+
+
+def _payload(**overrides):
+	values = {
+		'v': 1,
+		'scope': 'receipts',
+		'network': 'mainnet',
+		'revision': '3',
+		'height': '5660900',
+		'id': '28471002',
+		'filterHash': '64' * 32
+	}
+	values.update(overrides)
+	return values
+
+
+def _encode_payload(payload):
+	return base64.urlsafe_b64encode(json.dumps(payload, sort_keys=True, separators=(',', ':')).encode('utf-8')).decode('ascii').rstrip('=')
+
+
+def test_encode_is_deterministic():
+	# Arrange / Act:
+	result = encode_receipt_cursor(_cursor())
+
+	# Assert:
+	assert result == _encode_payload(_payload())
+
+
+def test_round_trip_and_unpadded_output():
+	# Arrange:
+	cursor = _cursor(revision=0, height=1, id=1)
+
+	# Act:
+	encoded = encode_receipt_cursor(cursor)
+
+	# Assert:
+	assert '=' not in encoded
+	assert cursor == decode_receipt_cursor(encoded)
+
+
+@pytest.mark.parametrize('payload', [
+	_payload(v=True),
+	_payload(v=2),
+	_payload(extra=1),
+	_payload(scope='other'),
+	_payload(network='other'),
+	_payload(revision='-1'),
+	_payload(height='0'),
+	_payload(id='9223372036854775808'),
+	_payload(filterHash='A' * 64)
+])
+def test_decode_rejects_invalid_payload(payload):
+	# Act / Assert:
+	with pytest.raises(ReceiptCursorError, match='Invalid receipt cursor'):
+		decode_receipt_cursor(_encode_payload(payload))
+
+
+@pytest.mark.parametrize('token', ['', 'bad.token', 'A', base64.urlsafe_b64encode(b'\xff').decode('ascii').rstrip('=')])
+def test_decode_rejects_malformed_tokens(token):
+	# Act / Assert:
+	with pytest.raises(ReceiptCursorError, match='Invalid receipt cursor'):
+		decode_receipt_cursor(token)

--- a/explorer/rest/tests/model/symbol/test_format.py
+++ b/explorer/rest/tests/model/symbol/test_format.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from unittest import TestCase
 
-from rest.model.symbol.format import format_timestamp, format_xym_amount, str_or_none, to_hex, to_hex_or_none
+from rest.model.symbol.format import format_address, format_amount, format_hex_id, format_timestamp, str_or_none, to_hex, to_hex_or_none
 
 
 class SymbolFormatTest(TestCase):
@@ -17,6 +17,24 @@ class SymbolFormatTest(TestCase):
 		# Act + Assert:
 		self.assertEqual('0A0B', to_hex(bytes.fromhex('0a0b')))
 
+	def test_can_format_text_id(self):
+		# Act + Assert:
+		self.assertEqual('ABCDEF0123456789', format_hex_id('abcdef0123456789'))
+
+	def test_can_format_optional_id(self):
+		# Act + Assert:
+		self.assertIsNone(format_hex_id(None))
+
+	def test_can_format_address(self):
+		# Act + Assert:
+		self.assertEqual(
+			'TCEUGLPCMO5Y72EEISSNUKGTMCN5RO4PVYMK5FI',
+			format_address(bytes.fromhex('9889432DE263BB8FE88444A4DA28D3609BD8BB8FAE18AE95')))
+
+	def test_can_format_optional_address(self):
+		# Act + Assert:
+		self.assertIsNone(format_address(None))
+
 	def test_can_format_optional_hex(self):
 		# Act + Assert:
 		self.assertEqual('0A0B', to_hex_or_none(bytes.fromhex('0a0b')))
@@ -27,6 +45,10 @@ class SymbolFormatTest(TestCase):
 		self.assertEqual('123', str_or_none(123))
 		self.assertIsNone(str_or_none(None))
 
-	def test_can_format_xym_amount(self):
+	def test_can_format_amount_with_divisibility(self):
 		# Act + Assert:
-		self.assertEqual(1.234567, format_xym_amount(Decimal('1234567')))
+		self.assertEqual(1.234567, format_amount(Decimal('1234567'), 6))
+
+	def test_can_format_amount_with_non_default_divisibility(self):
+		# Act + Assert:
+		self.assertEqual(12.345, format_amount(Decimal('12345'), 3))

--- a/explorer/rest/tests/routes/symbol/test_receipt_routes.py
+++ b/explorer/rest/tests/routes/symbol/test_receipt_routes.py
@@ -1,0 +1,816 @@
+import base64
+import json
+
+import pytest
+from flask import Flask
+from psycopg2 import OperationalError
+from symbolchain.symbol.Network import Network
+
+from rest import setup_error_handlers
+from rest.db.SymbolDatabase import ReceiptCursorStaleError, ReceiptDataUnavailableError, ReceiptQuery
+from rest.model.symbol.Receipt import ReceiptPage, ReceiptPosition
+from rest.model.symbol.ReceiptCursor import MAX_RECEIPT_CURSOR_LENGTH, decode_receipt_cursor
+from rest.routes.symbol import setup_symbol_routes
+
+TEST_ADDRESS = str(Network.TESTNET.address_class(bytes.fromhex('9889432DE263BB8FE88444A4DA28D3609BD8BB8FAE18AE95')))
+
+
+class ReceiptFacade:
+	def __init__(self):
+		self.receipts_result = ReceiptPage((), None, 0)
+		self.receipt_query = None
+		self.receipts_error = None
+
+	@staticmethod
+	def get_health():
+		return {'isHealthy': True, 'errors': []}
+
+	@staticmethod
+	def is_block_data_available():
+		return False
+
+	@staticmethod
+	def get_blocks(_from_height, _limit, _sort):
+		return []
+
+	@staticmethod
+	def get_block(_height):
+		return None
+
+	def get_receipts(self, query):
+		self.receipt_query = query
+		if self.receipts_error:
+			raise self.receipts_error
+		return self.receipts_result
+
+
+def _create_client(facade):
+	app = Flask(__name__)
+	app.config['NETWORK_NAME'] = 'testnet'
+	setup_error_handlers(app)
+	setup_symbol_routes(app, facade)
+	return app.test_client()
+
+
+def _assert_bad_request(response, message):
+	assert 400 == response.status_code
+	assert {'status': 400, 'message': message} == response.json
+
+
+def test_receipts_builds_default_query():
+	# Arrange:
+	facade = ReceiptFacade()
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts')
+
+	# Assert:
+	assert 200 == response.status_code
+	assert {'data': [], 'pagination': {'nextCursor': None}} == response.json
+	assert ReceiptQuery(10, None, None, None, None, (), None, None) == facade.receipt_query
+
+
+def test_receipts_normalizes_filters():
+	# Arrange:
+	facade = ReceiptFacade()
+	url = (
+		f'/api/symbol/receipts?limit=25&group=balanceChange&'
+		f'receiptType=8515&targetAddress={TEST_ADDRESS}'
+	)
+
+	# Act:
+	response = _create_client(facade).get(url)
+
+	# Assert:
+	assert 200 == response.status_code
+	assert ReceiptQuery(
+		25,
+		None,
+		None,
+		'balanceChange',
+		'harvestFee',
+		(),
+		bytes.fromhex('9889432DE263BB8FE88444A4DA28D3609BD8BB8FAE18AE95'),
+		None
+	) == facade.receipt_query
+
+
+def test_receipts_rejects_offset():
+	# Arrange:
+	facade = ReceiptFacade()
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts?offset=1')
+
+	# Assert:
+	_assert_bad_request(response, 'Unsupported query parameter: offset')
+	assert facade.receipt_query is None
+
+
+def test_receipts_rejects_page_number():
+	# Arrange:
+	facade = ReceiptFacade()
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts?pageNumber=2')
+
+	# Assert:
+	_assert_bad_request(response, 'Unsupported query parameter: pageNumber')
+	assert facade.receipt_query is None
+
+
+def test_receipts_rejects_bad_limit():
+	# Arrange:
+	facade = ReceiptFacade()
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts?limit=invalid')
+
+	# Assert:
+	_assert_bad_request(response, 'limit must be an integer')
+	assert facade.receipt_query is None
+
+
+@pytest.mark.parametrize('query_parameter, message', [
+	('limit=0', 'limit must be between 1 and 100'),
+	('limit=-1', 'limit must be between 1 and 100'),
+	('limit=101', 'limit must be between 1 and 100'),
+])
+def test_receipts_invalid_pagination(query_parameter, message):
+	# Arrange:
+	facade = ReceiptFacade()
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts?' + query_parameter)
+
+	# Assert:
+	_assert_bad_request(response, message)
+	assert facade.receipt_query is None
+
+
+def test_receipts_rejects_bad_group():
+	# Arrange:
+	facade = ReceiptFacade()
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts?group=unknown')
+
+	# Assert:
+	_assert_bad_request(response, 'group is invalid')
+	assert facade.receipt_query is None
+
+
+def test_receipts_rejects_bad_type_code():
+	# Arrange:
+	facade = ReceiptFacade()
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts?receiptType=invalid')
+
+	# Assert:
+	_assert_bad_request(response, 'receiptType must be a valid numeric code')
+	assert facade.receipt_query is None
+
+
+def test_receipts_unknown_type_code():
+	# Arrange:
+	facade = ReceiptFacade()
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts?receiptType=1')
+
+	# Assert:
+	_assert_bad_request(response, 'receiptType is not supported')
+	assert facade.receipt_query is None
+
+
+def test_receipts_normalizes_includes():
+	# Arrange:
+	facade = ReceiptFacade()
+
+	# Act:
+	response = _create_client(facade).get(
+		'/api/symbol/receipts?includedReceiptTypes=8776&includedReceiptTypes=12616&'
+		'includedReceiptTypes=8776&group=balanceChange')
+
+	# Assert:
+	assert 200 == response.status_code
+	assert {'data': [], 'pagination': {'nextCursor': None}} == response.json
+	assert ReceiptQuery(
+		10, None, None, 'balanceChange', None,
+		('lockHashCompleted', 'lockHashCreated'), None, None
+	) == facade.receipt_query
+
+
+def test_receipts_included_mismatch():
+	# Arrange:
+	facade = ReceiptFacade()
+
+	# Act:
+	response = _create_client(facade).get(
+		'/api/symbol/receipts?group=inflation&includedReceiptTypes=8515')
+
+	# Assert:
+	_assert_bad_request(response, 'includedReceiptTypes contains a receipt from another group')
+	assert facade.receipt_query is None
+
+
+def test_receipts_bad_included_type():
+	# Arrange:
+	facade = ReceiptFacade()
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts?includedReceiptTypes=invalid')
+
+	# Assert:
+	_assert_bad_request(response, 'includedReceiptTypes must contain numeric codes')
+	assert facade.receipt_query is None
+
+
+def test_receipts_unknown_included_type():
+	# Arrange:
+	facade = ReceiptFacade()
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts?includedReceiptTypes=1')
+
+	# Assert:
+	_assert_bad_request(response, 'includedReceiptTypes contains an unsupported receipt type')
+	assert facade.receipt_query is None
+
+
+def test_block_receipts_path_height():
+	# Arrange:
+	facade = ReceiptFacade()
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/block/1234/receipts?limit=7')
+
+	# Assert:
+	assert 200 == response.status_code
+	assert ReceiptQuery(7, None, 1234, None, None, (), None, None) == facade.receipt_query
+
+
+@pytest.mark.parametrize('query_parameter, parameter_name', [
+	('group=inflation', 'group'),
+	('receiptType=8515', 'receiptType'),
+	('includedReceiptTypes=8515', 'includedReceiptTypes'),
+	('excludedReceiptTypes=8515', 'excludedReceiptTypes'),
+	('targetAddress=' + TEST_ADDRESS, 'targetAddress'),
+	('senderAddress=' + TEST_ADDRESS, 'senderAddress'),
+	('height=1234', 'height'),
+	('recipientAddress=' + TEST_ADDRESS, 'recipientAddress')
+])
+def test_block_rejects_filter(query_parameter, parameter_name):
+	# Arrange:
+	facade = ReceiptFacade()
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/block/1234/receipts?' + query_parameter)
+
+	# Assert:
+	_assert_bad_request(response, 'Unsupported query parameter: ' + parameter_name)
+	assert facade.receipt_query is None
+
+
+def test_block_receipts_bad_height():
+	# Arrange:
+	facade = ReceiptFacade()
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/block/0/receipts')
+
+	# Assert:
+	_assert_bad_request(response, 'Height must be greater than or equal to 1')
+	assert facade.receipt_query is None
+
+
+@pytest.mark.parametrize('query_parameter, parameter_name', [
+	('height=1234', 'height'),
+	('excludedReceiptTypes=8515', 'excludedReceiptTypes'),
+	('recipientAddress=' + TEST_ADDRESS, 'recipientAddress')
+])
+def test_receipts_rejects_prohibited(query_parameter, parameter_name):
+	# Arrange:
+	facade = ReceiptFacade()
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts?' + query_parameter)
+
+	# Assert:
+	_assert_bad_request(response, 'Unsupported query parameter: ' + parameter_name)
+	assert facade.receipt_query is None
+
+
+def test_receipts_repeated_scalar():
+	# Arrange:
+	facade = ReceiptFacade()
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts?limit=1&limit=2')
+
+	# Assert:
+	_assert_bad_request(response, 'limit must not be repeated')
+	assert facade.receipt_query is None
+
+
+def test_receipts_rejects_comma_types():
+	# Arrange:
+	facade = ReceiptFacade()
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts?includedReceiptTypes=12616,8776')
+
+	# Assert:
+	_assert_bad_request(response, 'includedReceiptTypes must use repeated query parameters')
+	assert facade.receipt_query is None
+
+
+def test_receipts_conflicting_types():
+	# Arrange:
+	facade = ReceiptFacade()
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts?receiptType=8515&includedReceiptTypes=8515')
+
+	# Assert:
+	_assert_bad_request(response, 'receiptType and includedReceiptTypes cannot be combined')
+	assert facade.receipt_query is None
+
+
+def test_receipts_group_mismatch():
+	# Arrange:
+	facade = ReceiptFacade()
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts?group=inflation&receiptType=8515')
+
+	# Assert:
+	_assert_bad_request(response, 'receiptType does not belong to group')
+	assert facade.receipt_query is None
+
+
+def test_receipts_bad_address():
+	# Arrange:
+	facade = ReceiptFacade()
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts?targetAddress=invalid')
+
+	# Assert:
+	_assert_bad_request(response, 'targetAddress is invalid')
+	assert facade.receipt_query is None
+
+
+def test_receipts_bad_address_length():
+	# Arrange:
+	facade = ReceiptFacade()
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts?targetAddress=' + TEST_ADDRESS[:-1])
+
+	# Assert:
+	_assert_bad_request(response, 'targetAddress is invalid')
+	assert facade.receipt_query is None
+
+
+def test_receipts_bad_address_checksum():
+	# Arrange:
+	facade = ReceiptFacade()
+	last_character = 'A' if TEST_ADDRESS[-1] != 'A' else 'B'
+	bad_address = TEST_ADDRESS[:-1] + last_character
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts?targetAddress=' + bad_address)
+
+	# Assert:
+	_assert_bad_request(response, 'targetAddress is invalid')
+	assert facade.receipt_query is None
+
+
+def test_receipts_sender_bytes():
+	# Arrange:
+	facade = ReceiptFacade()
+
+	# Act:
+	response = _create_client(facade).get(
+		'/api/symbol/receipts?targetAddress=' + TEST_ADDRESS + '&senderAddress=' + TEST_ADDRESS)
+
+	# Assert:
+	assert 200 == response.status_code
+	assert ReceiptQuery(
+		10,
+		None,
+		None,
+		None,
+		None,
+		(),
+		bytes.fromhex('9889432DE263BB8FE88444A4DA28D3609BD8BB8FAE18AE95'),
+		bytes.fromhex('9889432DE263BB8FE88444A4DA28D3609BD8BB8FAE18AE95')
+	) == facade.receipt_query
+
+
+def test_block_receipts_rejects_offset():
+	# Arrange:
+	facade = ReceiptFacade()
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/block/1234/receipts?offset=1')
+
+	# Assert:
+	_assert_bad_request(response, 'Unsupported query parameter: offset')
+	assert facade.receipt_query is None
+
+
+def test_receipts_returns_empty_page():
+	# Arrange:
+	facade = ReceiptFacade()
+	facade.receipts_result = ReceiptPage((), None, 0)
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts')
+
+	# Assert:
+	assert 200 == response.status_code
+	assert {'data': [], 'pagination': {'nextCursor': None}} == response.json
+
+
+def test_receipts_503_missing_result():
+	# Arrange:
+	facade = ReceiptFacade()
+	facade.receipts_result = None
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts')
+
+	# Assert:
+	assert 503 == response.status_code
+	assert {'status': 503, 'message': 'Symbol backend data is unavailable'} == response.json
+
+
+def test_receipts_503_unavailable():
+	# Arrange:
+	facade = ReceiptFacade()
+	facade.receipts_error = ReceiptDataUnavailableError()
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts')
+
+	# Assert:
+	assert 503 == response.status_code
+	assert {'status': 503, 'message': 'Symbol backend data is unavailable'} == response.json
+
+
+def test_block_receipts_503_unavailable():
+	# Arrange:
+	facade = ReceiptFacade()
+	facade.receipts_error = ReceiptDataUnavailableError()
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/block/1234/receipts')
+
+	# Assert:
+	assert 503 == response.status_code
+	assert {'status': 503, 'message': 'Symbol backend data is unavailable'} == response.json
+
+
+def test_block_receipts_missing_result():
+	# Arrange:
+	facade = ReceiptFacade()
+	facade.receipts_result = None
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/block/1234/receipts')
+
+	# Assert:
+	assert 503 == response.status_code
+	assert {'status': 503, 'message': 'Symbol backend data is unavailable'} == response.json
+
+
+def test_receipts_maps_database_error():
+	# Arrange:
+	facade = ReceiptFacade()
+	facade.receipts_error = OperationalError('database unavailable')
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts')
+
+	# Assert:
+	assert 503 == response.status_code
+	assert {'status': 503, 'message': 'Symbol backend data is unavailable'} == response.json
+
+
+def _encode_payload(payload):
+	return base64.urlsafe_b64encode(json.dumps(payload, sort_keys=True, separators=(',', ':')).encode('utf-8')).decode('ascii').rstrip('=')
+
+
+def _valid_cursor_for_default_query(facade, path='/api/symbol/receipts'):
+	facade.receipts_result = ReceiptPage(({'height': 2},), ReceiptPosition(2, 9), 3)
+	response = _create_client(facade).get(path + '?limit=1')
+	assert response.status_code == 200
+	facade.receipt_query = None
+	return response.json['pagination']['nextCursor']
+
+
+def test_receipts_page_has_cursor():
+	# Arrange:
+	facade = ReceiptFacade()
+	facade.receipts_result = ReceiptPage(({'height': 5},), ReceiptPosition(5, 44), 3)
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts?limit=1')
+
+	# Assert:
+	assert 200 == response.status_code
+	assert response.json == {
+		'data': [{'height': 5}],
+		'pagination': {'nextCursor': response.json['pagination']['nextCursor']}
+	}
+	assert response.json['pagination']['nextCursor']
+	assert '=' not in response.json['pagination']['nextCursor']
+
+
+def test_receipts_cursor_ignores_limit():
+	# Arrange:
+	facade = ReceiptFacade()
+	cursor = _valid_cursor_for_default_query(facade)
+	facade.receipts_result = ReceiptPage((), None, 3)
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts?limit=5&cursor=' + cursor)
+
+	# Assert:
+	assert 200 == response.status_code
+	assert {'data': [], 'pagination': {'nextCursor': None}} == response.json
+	assert facade.receipt_query.limit == 5
+	assert facade.receipt_query.cursor.revision == 3
+	assert facade.receipt_query.cursor.height == 2
+	assert facade.receipt_query.cursor.id == 9
+
+
+def test_receipts_cursor_reordered():
+	# Arrange:
+	facade = ReceiptFacade()
+	facade.receipts_result = ReceiptPage(({'height': 2},), ReceiptPosition(2, 9), 3)
+	client = _create_client(facade)
+	first_response = client.get(
+		'/api/symbol/receipts?limit=1&group=balanceChange&'
+		'includedReceiptTypes=8776&includedReceiptTypes=12616&includedReceiptTypes=8776')
+	cursor = first_response.json['pagination']['nextCursor']
+	facade.receipt_query = None
+	facade.receipts_result = ReceiptPage((), None, 3)
+
+	# Act:
+	response = client.get(
+		'/api/symbol/receipts?limit=5&cursor=' + cursor + '&group=balanceChange&'
+		'includedReceiptTypes=12616&includedReceiptTypes=8776&includedReceiptTypes=12616')
+
+	# Assert:
+	assert 200 == first_response.status_code
+	assert {'data': [{'height': 2}], 'pagination': {'nextCursor': cursor}} == first_response.json
+	assert 200 == response.status_code
+	assert {'data': [], 'pagination': {'nextCursor': None}} == response.json
+	assert ReceiptQuery(
+		5,
+		decode_receipt_cursor(cursor),
+		None,
+		'balanceChange',
+		None,
+		('lockHashCompleted', 'lockHashCreated'),
+		None,
+		None
+	) == facade.receipt_query
+
+
+@pytest.mark.parametrize('parameter', ['pageSize=1', 'sort=desc', 'unknown=value'])
+def test_receipts_rejects_unknown_query(parameter):
+	# Arrange:
+	facade = ReceiptFacade()
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts?' + parameter)
+
+	# Assert:
+	_assert_bad_request(response, 'Unsupported query parameter: ' + parameter.split('=', 1)[0])
+	assert facade.receipt_query is None
+
+
+def test_receipts_rejects_duplicate():
+	# Arrange:
+	facade = ReceiptFacade()
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts?cursor=a&cursor=b')
+
+	# Assert:
+	_assert_bad_request(response, 'cursor must not be repeated')
+	assert facade.receipt_query is None
+
+
+@pytest.mark.parametrize('cursor', ['', 'not-base64', 'A'])
+def test_receipts_rejects_bad_base64(cursor):
+	# Arrange:
+	facade = ReceiptFacade()
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts?cursor=' + cursor)
+
+	# Assert:
+	_assert_bad_request(response, 'Invalid receipt cursor')
+	assert facade.receipt_query is None
+
+
+@pytest.mark.parametrize('cursor', [
+	base64.urlsafe_b64encode(b'\xff').decode('ascii').rstrip('='),
+	_encode_payload({'v': 1}),
+	_encode_payload({'v': 2, 'scope': 'receipts', 'network': 'testnet', 'revision': '0', 'height': '1', 'id': '1', 'filterHash': '0' * 64})
+])
+def test_receipts_rejects_bad_payload(cursor):
+	# Arrange:
+	facade = ReceiptFacade()
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts?cursor=' + cursor)
+
+	# Assert:
+	_assert_bad_request(response, 'Invalid receipt cursor')
+	assert facade.receipt_query is None
+
+
+@pytest.mark.parametrize('field, value', [
+	('scope', []),
+	('scope', {}),
+	('network', []),
+	('network', {})
+])
+def test_receipts_rejects_container(field, value):
+	# Arrange:
+	facade = ReceiptFacade()
+	payload = {
+		'v': 1, 'scope': 'receipts', 'network': 'testnet', 'revision': '0', 'height': '1', 'id': '1',
+		'filterHash': '0' * 64
+	}
+	payload[field] = value
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts?cursor=' + _encode_payload(payload))
+
+	# Assert:
+	_assert_bad_request(response, 'Invalid receipt cursor')
+	assert facade.receipt_query is None
+
+
+def test_receipts_rejects_long_cursor():
+	# Arrange:
+	facade = ReceiptFacade()
+	cursor = 'A' * (MAX_RECEIPT_CURSOR_LENGTH + 1)
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts?cursor=' + cursor)
+
+	# Assert:
+	_assert_bad_request(response, 'Invalid receipt cursor')
+	assert facade.receipt_query is None
+
+
+def test_receipts_rejects_extra_key():
+	# Arrange:
+	facade = ReceiptFacade()
+	payload = {
+		'v': 1, 'scope': 'receipts', 'network': 'testnet', 'revision': '0', 'height': '1', 'id': '1',
+		'filterHash': '0' * 64, 'extra': 1
+	}
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts?cursor=' + _encode_payload(payload))
+
+	# Assert:
+	_assert_bad_request(response, 'Invalid receipt cursor')
+	assert facade.receipt_query is None
+
+
+@pytest.mark.parametrize('field_value', ['x', '-1', '9223372036854775808'])
+def test_receipts_rejects_bad_revision(field_value):
+	# Arrange:
+	facade = ReceiptFacade()
+	payload = {
+		'v': 1, 'scope': 'receipts', 'network': 'testnet', 'revision': field_value, 'height': '1', 'id': '1',
+		'filterHash': '0' * 64
+	}
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts?cursor=' + _encode_payload(payload))
+
+	# Assert:
+	_assert_bad_request(response, 'Invalid receipt cursor')
+	assert facade.receipt_query is None
+
+
+@pytest.mark.parametrize('field, value', [
+	('height', '0'), ('height', '-1'), ('height', '9223372036854775808'),
+	('id', '0'), ('id', '-1'), ('id', '9223372036854775808')
+])
+def test_receipts_rejects_bad_position(field, value):
+	# Arrange:
+	facade = ReceiptFacade()
+	payload = {'v': 1, 'scope': 'receipts', 'network': 'testnet', 'revision': '0', 'height': '1', 'id': '1', 'filterHash': '0' * 64}
+	payload[field] = value
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts?cursor=' + _encode_payload(payload))
+
+	# Assert:
+	_assert_bad_request(response, 'Invalid receipt cursor')
+	assert facade.receipt_query is None
+
+
+@pytest.mark.parametrize('field_hash', ['A' * 64, '0' * 63, 'g' * 64])
+def test_receipts_rejects_bad_filter(field_hash):
+	# Arrange:
+	facade = ReceiptFacade()
+	payload = {'v': 1, 'scope': 'receipts', 'network': 'testnet', 'revision': '0', 'height': '1', 'id': '1', 'filterHash': field_hash}
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts?cursor=' + _encode_payload(payload))
+
+	# Assert:
+	_assert_bad_request(response, 'Invalid receipt cursor')
+	assert facade.receipt_query is None
+
+
+def test_receipts_rejects_bool_version():
+	# Arrange:
+	facade = ReceiptFacade()
+	payload = {'v': True, 'scope': 'receipts', 'network': 'testnet', 'revision': '0', 'height': '1', 'id': '1', 'filterHash': '0' * 64}
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts?cursor=' + _encode_payload(payload))
+
+	# Assert:
+	_assert_bad_request(response, 'Invalid receipt cursor')
+	assert facade.receipt_query is None
+
+
+def test_receipts_rejects_scope_mismatch():
+	# Arrange:
+	facade = ReceiptFacade()
+	block_cursor = _valid_cursor_for_default_query(facade, '/api/symbol/block/2/receipts')
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts?cursor=' + block_cursor)
+
+	# Assert:
+	_assert_bad_request(response, 'Receipt cursor scope mismatch')
+	assert facade.receipt_query is None
+
+
+def test_receipts_filter_mismatch():
+	# Arrange:
+	facade = ReceiptFacade()
+	valid_cursor = _valid_cursor_for_default_query(facade)
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts?cursor=' + valid_cursor + '&group=inflation')
+
+	# Assert:
+	_assert_bad_request(response, 'Receipt cursor filter mismatch')
+	assert facade.receipt_query is None
+
+
+def test_receipts_network_mismatch():
+	# Arrange:
+	facade = ReceiptFacade()
+	payload = {'v': 1, 'scope': 'receipts', 'network': 'mainnet', 'revision': '0', 'height': '1', 'id': '1', 'filterHash': '0' * 64}
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts?cursor=' + _encode_payload(payload))
+
+	# Assert:
+	_assert_bad_request(response, 'Receipt cursor network mismatch')
+	assert facade.receipt_query is None
+
+
+def test_block_cursor_rejects_path():
+	# Arrange:
+	facade = ReceiptFacade()
+	cursor = _valid_cursor_for_default_query(facade, '/api/symbol/block/2/receipts')
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/block/3/receipts?cursor=' + cursor)
+
+	# Assert:
+	_assert_bad_request(response, 'Receipt cursor block height mismatch')
+	assert facade.receipt_query is None
+
+
+def test_receipts_maps_stale_cursor():
+	# Arrange:
+	facade = ReceiptFacade()
+	facade.receipts_error = ReceiptCursorStaleError()
+
+	# Act:
+	response = _create_client(facade).get('/api/symbol/receipts')
+
+	# Assert:
+	assert 409 == response.status_code
+	assert {'status': 409, 'message': 'Receipt cursor is stale'} == response.json

--- a/explorer/rest/tests/routes/symbol/test_receipt_routes.py
+++ b/explorer/rest/tests/routes/symbol/test_receipt_routes.py
@@ -803,10 +803,12 @@ def test_block_cursor_rejects_path():
 	assert facade.receipt_query is None
 
 
-def test_receipts_maps_stale_cursor():
+def test_receipts_hides_internal_details():
 	# Arrange:
 	facade = ReceiptFacade()
-	facade.receipts_error = ReceiptCursorStaleError()
+	stale_error = ReceiptCursorStaleError()
+	stale_error.args = ('internal cursor details',)
+	facade.receipts_error = stale_error
 
 	# Act:
 	response = _create_client(facade).get('/api/symbol/receipts')

--- a/explorer/rest/tests/test_symbol_core_routes.py
+++ b/explorer/rest/tests/test_symbol_core_routes.py
@@ -2,18 +2,66 @@ import tempfile
 from pathlib import Path
 
 import pytest
+from common.symbol.NativeMosaic import NativeMosaicInfo
 from common.symbol.NodeConfiguration import SymbolNodeConfigurationError
 from common.tests.PostgresTestUtils import PostgresTestDatabase, create_unreachable_db_configuration, drop_symbol_block_tables_if_present
 from flask import Flask
 from puller.db.SymbolDatabase import SymbolDatabase as PullerSymbolDatabase
+from symbolchain.symbol.Network import Network
 
 from rest import create_app, setup_symbol_facade
 from rest.facade.SymbolRestFacade import SymbolRestFacade
 from rest.model.common import DatabaseConfig
+from rest.routes.symbol import setup_symbol_routes
+from rest.symbol_node import fetch_native_mosaic_info
 
 from .test.EnvTestUtils import rest_settings_env
 from .test.SymbolBlockTestUtils import create_symbol_block, create_symbol_importance_block, create_symbol_sync_state
 from .test.SymbolHealthTestUtils import create_symbol_health
+
+NATIVE_MOSAIC_INFO = NativeMosaicInfo('72C0212E67A08BCE', 6)
+TARGET_ADDRESS = bytes.fromhex('9889432DE263BB8FE88444A4DA28D3609BD8BB8FAE18AE95')
+SENDER_ADDRESS = bytes.fromhex('98' + '11' * 23)
+RECIPIENT_ADDRESS = bytes.fromhex('98' + '22' * 23)
+
+
+class SetupConnector:
+	def __init__(self, _endpoint):
+		self.responses = {
+			'network/properties': {'chain': {'currencyMosaicId': "0x72C0'212E'67A0'8BCE"}},
+			'mosaics/72C0212E67A08BCE': {'mosaic': {'divisibility': 3}}
+		}
+
+	async def get(self, path):
+		return self.responses[path]
+
+
+class BadSetupConnector(SetupConnector):
+	def __init__(self, endpoint):
+		super().__init__(endpoint)
+		self.responses['mosaics/72C0212E67A08BCE'] = {'mosaic': {}}
+
+
+def _create_symbol_app():
+	return create_app(rest_chain_handlers={
+		'symbol': (_setup_test_symbol_facade, setup_symbol_routes)
+	})
+
+
+def _fetch_test_native_mosaic_info(_node_config):
+	return NATIVE_MOSAIC_INFO
+
+
+def _setup_test_symbol_facade(app):
+	return setup_symbol_facade(app, native_mosaic_info_fetcher=_fetch_test_native_mosaic_info)
+
+
+def _fetch_setup_native_mosaic_info(node_config):
+	return fetch_native_mosaic_info(node_config, SetupConnector)
+
+
+def _fetch_bad_native_mosaic_info(node_config):
+	return fetch_native_mosaic_info(node_config, BadSetupConnector)
 
 
 def _create_config_file(
@@ -84,6 +132,25 @@ def _seed_symbol_block_tables(database_config, sync_state, blocks):
 		database.upsert_blocks(blocks)
 
 
+def _update_block_reward(database_config, height, reward):
+	with PullerSymbolDatabase(database_config) as database:
+		with database.connection.cursor() as cursor:
+			cursor.execute(
+				'UPDATE symbol_blocks SET block_reward = %s WHERE height = %s',
+				(reward, height))
+			database.connection.commit()
+
+
+def _seed_symbol_receipts(database_config, sync_state, blocks, receipts):
+	_seed_symbol_block_tables(database_config, sync_state, blocks)
+	with PullerSymbolDatabase(database_config) as database:
+		by_height = {}
+		for receipt in receipts:
+			by_height.setdefault(receipt['height'], []).append(receipt)
+		for height, rows in by_height.items():
+			database.upsert_receipts_for_height(height, rows, 0)
+
+
 def _expected_block_list_item(height, is_finalized):
 	return {
 		'height': height,
@@ -143,7 +210,7 @@ def test_symbol_health_with_database(symbol_database_config):
 			[])
 		with rest_settings_env(app_config_path):
 			# Act:
-			response = create_app().test_client().get('/api/symbol/health')
+			response = _create_symbol_app().test_client().get('/api/symbol/health')
 
 	# Assert:
 	assert 200 == response.status_code
@@ -171,7 +238,7 @@ def test_symbol_health_reports_db_error(symbol_database_config):
 		_drop_symbol_block_tables_if_present(symbol_database_config)
 		with rest_settings_env(app_config_path):
 			# Act:
-			response = create_app().test_client().get('/api/symbol/health')
+			response = _create_symbol_app().test_client().get('/api/symbol/health')
 
 	# Assert:
 	assert 200 == response.status_code
@@ -199,7 +266,7 @@ def test_symbol_blocks_reads_db(symbol_database_config):
 			[create_symbol_block(height) for height in range(1, 4)])
 		with rest_settings_env(app_config_path):
 			# Act:
-			response = create_app().test_client().get(
+			response = _create_symbol_app().test_client().get(
 				'/api/symbol/blocks?limit=2&fromHeight=3&sort=desc')
 
 	# Assert:
@@ -224,7 +291,7 @@ def test_symbol_block_reads_db(symbol_database_config):
 			[create_symbol_block(2)])
 		with rest_settings_env(app_config_path):
 			# Act:
-			response = create_app().test_client().get('/api/symbol/block/2')
+			response = _create_symbol_app().test_client().get('/api/symbol/block/2')
 
 	# Assert:
 	assert 200 == response.status_code
@@ -245,7 +312,7 @@ def test_symbol_importance_reads_db(symbol_database_config):
 			[create_symbol_importance_block(2)])
 		with rest_settings_env(app_config_path):
 			# Act:
-			response = create_app().test_client().get('/api/symbol/block/2')
+			response = _create_symbol_app().test_client().get('/api/symbol/block/2')
 
 	# Assert:
 	assert 200 == response.status_code
@@ -255,6 +322,108 @@ def test_symbol_importance_reads_db(symbol_database_config):
 		'harvestingEligibleAccountsCount': '17',
 		'totalVotingBalance': '19000235663367',
 		'previousImportanceBlockHash': '86' * 32
+	} == response.json
+
+
+def test_symbol_block_list_reward(symbol_database_config):
+	# Arrange:
+	with tempfile.TemporaryDirectory() as temp_directory:
+		db_config_path = _create_config_file(
+			temp_directory,
+			database_config=symbol_database_config)
+		app_config_path = _create_app_config(temp_directory, db_config_path)
+
+		_seed_symbol_block_tables(
+			symbol_database_config,
+			create_symbol_sync_state(last_synced_height=2, finalized_height=2),
+			[create_symbol_block(2)])
+		_update_block_reward(symbol_database_config, 2, 1234567)
+		with rest_settings_env(app_config_path):
+			# Act:
+			response = _create_symbol_app().test_client().get('/api/symbol/blocks?limit=1')
+
+	# Assert:
+	expected = _expected_block_list_item(2, is_finalized=True)
+	expected['blockReward'] = 1.234567
+	assert 200 == response.status_code
+	assert [expected] == response.json
+
+
+def test_symbol_block_detail_reward(symbol_database_config):
+	# Arrange:
+	with tempfile.TemporaryDirectory() as temp_directory:
+		db_config_path = _create_config_file(
+			temp_directory,
+			database_config=symbol_database_config)
+		app_config_path = _create_app_config(temp_directory, db_config_path)
+
+		_seed_symbol_block_tables(
+			symbol_database_config,
+			create_symbol_sync_state(last_synced_height=2, finalized_height=2),
+			[create_symbol_block(2)])
+		_update_block_reward(symbol_database_config, 2, 2000000)
+		with rest_settings_env(app_config_path):
+			# Act:
+			response = _create_symbol_app().test_client().get('/api/symbol/block/2')
+
+	# Assert:
+	expected = _expected_block_detail(2, is_finalized=True)
+	expected['blockReward'] = 2.0
+	assert 200 == response.status_code
+	assert expected == response.json
+
+
+def test_symbol_receipts_read_db(symbol_database_config):
+	# Arrange:
+	with tempfile.TemporaryDirectory() as temp_directory:
+		db_config_path = _create_config_file(
+			temp_directory,
+			database_config=symbol_database_config)
+		app_config_path = _create_app_config(temp_directory, db_config_path)
+		receipt = {
+			'height': 2,
+			'receipt_type': 'harvestFee',
+			'receipt_group': 'balanceChange',
+			'version': 1,
+			'source_primary_id': 0,
+			'source_secondary_id': 0,
+			'sender_address': SENDER_ADDRESS,
+			'recipient_address': RECIPIENT_ADDRESS,
+			'target_address': TARGET_ADDRESS,
+			'mosaic_id': '72C0212E67A08BCE',
+			'amount': 1234567,
+			'artifact_id': None,
+			'raw_payload': {'type': 'harvestFee'}
+		}
+		_seed_symbol_receipts(
+			symbol_database_config,
+			create_symbol_sync_state(last_synced_height=2, finalized_height=2),
+			[create_symbol_block(2)],
+			[receipt])
+		with rest_settings_env(app_config_path):
+			# Act:
+			response = _create_symbol_app().test_client().get('/api/symbol/receipts')
+
+	# Assert:
+	assert 200 == response.status_code
+	assert {
+		'data': [{
+			'version': 1,
+			'height': 2,
+			'type': 'harvestFee',
+			'group': 'balanceChange',
+			'targetAddress': str(Network.MAINNET.address_class(TARGET_ADDRESS)),
+			'sender': str(Network.MAINNET.address_class(SENDER_ADDRESS)),
+			'to': str(Network.MAINNET.address_class(RECIPIENT_ADDRESS)),
+			'artifactId': None,
+			'mosaics': [{
+				'id': NATIVE_MOSAIC_INFO.id,
+				'name': NATIVE_MOSAIC_INFO.id,
+				'amount': 1.234567,
+				'isNative': True
+			}]
+		}],
+		'pagination': {'nextCursor': None}
 	} == response.json
 
 
@@ -282,7 +451,7 @@ def test_health_reports_db_error():
 
 		with rest_settings_env(app_config_path):
 			# Act:
-			response = create_app().test_client().get('/api/symbol/health')
+			response = _create_symbol_app().test_client().get('/api/symbol/health')
 
 	# Assert:
 	assert 200 == response.status_code
@@ -341,12 +510,58 @@ def test_symbol_facade_config(symbol_database_config):
 		app.config.from_pyfile(app_config_path)
 
 		# Act:
-		facade = setup_symbol_facade(app)
+		facade = setup_symbol_facade(app, native_mosaic_info_fetcher=_fetch_test_native_mosaic_info)
 
 	# Assert:
 	assert isinstance(facade, SymbolRestFacade)
 	assert facade.is_configured()
 	assert 'http://localhost:3000' == facade.node_config.base_url
+
+
+def test_setup_uses_connector_factory():
+	# Arrange:
+	with tempfile.TemporaryDirectory() as temp_directory:
+		db_config_path = _create_config_file(temp_directory)
+		app_config_path = _create_app_config(temp_directory, db_config_path)
+		app = Flask(__name__)
+		app.config.from_pyfile(app_config_path)
+
+		# Act:
+		facade = setup_symbol_facade(app, native_mosaic_info_fetcher=_fetch_setup_native_mosaic_info)
+
+	# Assert:
+	assert NativeMosaicInfo('72C0212E67A08BCE', 3) == facade.native_mosaic_info
+
+
+def test_setup_rejects_bad_native_info():
+	# Arrange:
+	with tempfile.TemporaryDirectory() as temp_directory:
+		db_config_path = _create_config_file(temp_directory)
+		app_config_path = _create_app_config(temp_directory, db_config_path)
+		app = Flask(__name__)
+		app.config.from_pyfile(app_config_path)
+
+		# Act + Assert:
+		with pytest.raises(ValueError, match='Mosaic response must include mosaic.divisibility'):
+			setup_symbol_facade(app, native_mosaic_info_fetcher=_fetch_bad_native_mosaic_info)
+
+
+def test_setup_uses_native_fetcher():
+	# Arrange:
+	with tempfile.TemporaryDirectory() as temp_directory:
+		db_config_path = _create_config_file(temp_directory)
+		app_config_path = _create_app_config(temp_directory, db_config_path)
+		app = Flask(__name__)
+		app.config.from_pyfile(app_config_path)
+
+		def native_fetcher(_node_config):
+			return NativeMosaicInfo('ABCDEF0123456789', 2)
+
+		# Act:
+		facade = setup_symbol_facade(app, native_mosaic_info_fetcher=native_fetcher)
+
+	# Assert:
+	assert NativeMosaicInfo('ABCDEF0123456789', 2) == facade.native_mosaic_info
 
 
 def test_symbol_facade_requires_db():
@@ -378,7 +593,7 @@ def test_symbol_facade_db_error():
 		app.config.from_pyfile(app_config_path)
 
 		# Act:
-		facade = setup_symbol_facade(app)
+		facade = setup_symbol_facade(app, native_mosaic_info_fetcher=_fetch_test_native_mosaic_info)
 
 	# Assert:
 	health = facade.get_health()

--- a/explorer/rest/tests/test_symbol_node.py
+++ b/explorer/rest/tests/test_symbol_node.py
@@ -1,0 +1,78 @@
+import pytest
+from common.symbol.NativeMosaic import NativeMosaicInfo
+from common.symbol.NodeConfiguration import SymbolNodeConfiguration
+
+from rest.symbol_node import fetch_native_mosaic_info
+
+NODE_URL = 'http://localhost:3000'
+
+
+def _create_network_properties():
+	return {'chain': {'currencyMosaicId': "0x72C0'212E'67A0'8BCE"}}
+
+
+def _create_mosaic_definition(divisibility=3):
+	return {'mosaic': {'divisibility': divisibility}}
+
+
+class RecordingConnector:
+	def __init__(self, endpoint, responses):
+		self.endpoint = endpoint
+		self.responses = responses
+		self.timeout_seconds = None
+		self.paths = []
+
+	async def get(self, path):
+		self.paths.append(path)
+		return self.responses[path]
+
+
+def _create_node_config():
+	return SymbolNodeConfiguration.from_url(NODE_URL, allow_loopback=True)
+
+
+def test_fetches_native_mosaic_in_order():
+	# Arrange:
+	responses = {
+		'network/properties': _create_network_properties(),
+		'mosaics/72C0212E67A08BCE': _create_mosaic_definition()
+	}
+	connector = None
+
+	def connector_factory(endpoint):
+		nonlocal connector
+		connector = RecordingConnector(endpoint, responses)
+		return connector
+
+	# Act:
+	result = fetch_native_mosaic_info(_create_node_config(), connector_factory)
+
+	# Assert:
+	assert NativeMosaicInfo('72C0212E67A08BCE', 3) == result
+	assert NODE_URL == connector.endpoint
+	assert ['network/properties', 'mosaics/72C0212E67A08BCE'] == connector.paths
+	assert 2 == len(connector.paths)
+	assert 10 == connector.timeout_seconds
+
+
+def test_rejects_bad_mosaic_response():
+	# Arrange:
+	responses = {
+		'network/properties': _create_network_properties(),
+		'mosaics/72C0212E67A08BCE': {'mosaic': {}}
+	}
+	connector = None
+
+	def connector_factory(endpoint):
+		nonlocal connector
+		connector = RecordingConnector(endpoint, responses)
+		return connector
+
+	# Act + Assert:
+	with pytest.raises(ValueError, match='Mosaic response must include mosaic.divisibility'):
+		fetch_native_mosaic_info(_create_node_config(), connector_factory)
+
+	# Assert:
+	assert NODE_URL == connector.endpoint
+	assert ['network/properties', 'mosaics/72C0212E67A08BCE'] == connector.paths
+	assert 2 == len(connector.paths)


### PR DESCRIPTION
## Summary

- Added shared Symbol receipt contracts for the 13 supported receipt types and their public groups.
- Added a validated `NativeMosaicInfo` contract shared by Puller and REST.
- Added `symbol_sync_state.chain_revision` and receipt indexes required for deterministic keyset pagination.
- Incremented the chain revision atomically during rollback repair so stale cursors can be rejected.
- Added:
  - `GET /api/symbol/receipts`
  - `GET /api/symbol/block/<height>/receipts`
- Added opaque cursor pagination using deterministic `height DESC, id DESC` ordering.
- Bound receipt cursors to the network, route scope, normalized filters, and chain revision.
- Added exhaustive query allowlists, receipt type/group validation, and Symbol address validation.
- Added 400 responses for malformed or mismatched cursors, 409 for stale cursors, and 503 for unavailable receipt state.
- Added receipt DTO serialization with native and non-native mosaic amount formatting.
- Exposed persisted `blockReward` values in Symbol block list and detail responses.
- Added setup-time native mosaic discovery from Symbol node network properties and mosaic metadata.
- Preserved existing NEM routes and implementation boundaries.
