### PR TITLE
[explorer] Fix slow namespace listing

### DIFF
--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -82,6 +82,13 @@ class NemDatabase(DatabaseConnection):
 			'''
 		)
 
+		cursor.execute(
+			'''
+			CREATE INDEX IF NOT EXISTS mosaics_root_namespace_idx
+				ON mosaics (root_namespace)
+			'''
+		)
+
 		# Create indexes for transactions table
 		cursor.execute(
 			'''

--- a/explorer/rest/rest/db/NemDatabase.py
+++ b/explorer/rest/rest/db/NemDatabase.py
@@ -369,14 +369,19 @@ class NemDatabase(DatabaseConnectionPool):
 
 		return f'''
 			SELECT
-				root_namespace,
-				owner,
-				registered_height,
+				n.root_namespace,
+				n.owner,
+				n.registered_height,
 				b.timestamp AS registered_timestamp,
-				expiration_height ,
-				sub_namespaces,
+				n.expiration_height,
+				n.sub_namespaces,
 				COALESCE(m.mosaics, '[]'::json) AS mosaics
-			FROM namespaces n
+			FROM (
+				SELECT * FROM namespaces n
+				{where_condition}
+				{order_condition}
+				{limit_condition}
+			) n
 			LEFT JOIN blocks b
 				on n.registered_height = b.height
 			LEFT JOIN LATERAL (
@@ -392,9 +397,7 @@ class NemDatabase(DatabaseConnectionPool):
 					ON ms.registered_height = mb.height
 				WHERE ms.root_namespace = n.root_namespace
 			) m ON true
-			{where_condition}
 			{order_condition}
-			{limit_condition}
 		'''
 
 	@staticmethod
@@ -605,7 +608,7 @@ class NemDatabase(DatabaseConnectionPool):
 	def get_namespaces(self, pagination, sort):
 		"""Gets namespaces pagination in database."""
 
-		order_condition = f' ORDER BY registered_height {sort}'
+		order_condition = f' ORDER BY registered_height {sort}, root_namespace ASC'
 		limit_condition = ' LIMIT %s OFFSET %s'
 
 		sql = self._generate_namespace_query(


### PR DESCRIPTION
# Problem

`GET /api/nem/namespaces` is slow out of proportion to the data it returns. The tables
are tiny - 3178 namespaces and 3619 mosaics - yet a ten-row page reads **324 683 buffer
pages, about 2.5 GB**.

The listing joins a lateral subquery that aggregates each namespace's mosaics into JSON.
That lateral sits above `ORDER BY` and `LIMIT`, so it is evaluated for **every**
namespace and only then are all but ten rows discarded:

```
Limit  (actual time=1293.454..1293.461 rows=10)
  Buffers: shared hit=324683
  ->  Sort  (actual time=1048.183..1048.188 rows=10)
        Sort Key: n.registered_height DESC
        ->  Nested Loop Left Join  (actual time=0.618..1044.535 rows=3178)
              Buffers: shared hit=324680
```

1044 ms of the 1293 ms is spent in that join. `mosaics` also has no index on
`root_namespace` - only on `namespace_name` - so each of the 3178 lateral evaluations
scans the whole mosaics table.

# Fix

Two changes, both small.

**Select the page before aggregating.** The row selection (`WHERE` / `ORDER BY` /
`LIMIT`) moves into a subquery, so the lateral runs for the rows the query actually
returns rather than for the whole table.

**Add the missing index.**
                            
```sql
CREATE INDEX CONCURRENTLY IF NOT EXISTS mosaics_root_namespace_idx ON mosaics (root_namespace);
```

# Measurements

  Against a copy of production, `limit=10`, median of five runs:

  | | buffer pages | ms |
  |---|---|---|
  | current | 324 683 | 480 |
  | page selected before the lateral | 1 715 | 3.7 |
  | index only | 34 140 | 67 |
  | **both** | **807** | **2.0** |

  Through the REST API locally: `namespaces?limit=10` **5.0 ms**, `offset=100` 3.0 ms,
  `namespace/nem` 2.4 ms. For reference, `/api/nem/namespaces?limit=10` on production
  currently answers in 1.79 s.

  The restructure is the larger of the two effects; the index roughly halves what is left.