### PR TITLE
[explorer/rest] fix: cache statistics endpoints

### DIFF
--- a/explorer/rest/rest/facade/NemRestFacade.py
+++ b/explorer/rest/rest/facade/NemRestFacade.py
@@ -6,12 +6,7 @@ from symbollightapi.model.Exceptions import NodeException
 
 from rest.db.NemDatabase import NemDatabase
 from rest.facade.TtlCache import TtlCache
-from rest.model.common import (
-	STATISTICS_CACHE_MAX_ENTRIES,
-	STATISTICS_CACHE_TTL_SECONDS,
-	STATISTICS_RANGE_CACHE_MAX_ENTRIES,
-	Pagination
-)
+from rest.model.common import STATISTICS_CACHE_MAX_ENTRIES, STATISTICS_CACHE_TTL_SECONDS, STATISTICS_RANGE_CACHE_MAX_ENTRIES, Pagination
 
 
 class NemRestFacade:

--- a/explorer/rest/rest/facade/NemRestFacade.py
+++ b/explorer/rest/rest/facade/NemRestFacade.py
@@ -5,7 +5,13 @@ from symbollightapi.connector.NemConnector import NemConnector
 from symbollightapi.model.Exceptions import NodeException
 
 from rest.db.NemDatabase import NemDatabase
-from rest.model.common import Pagination
+from rest.facade.TtlCache import TtlCache
+from rest.model.common import (
+	STATISTICS_CACHE_MAX_ENTRIES,
+	STATISTICS_CACHE_TTL_SECONDS,
+	STATISTICS_RANGE_CACHE_MAX_ENTRIES,
+	Pagination
+)
 
 
 class NemRestFacade:
@@ -18,6 +24,8 @@ class NemRestFacade:
 		self.nem_db = NemDatabase(db_config, self.network, rest_config.harvesting_active_window_days)
 		self.nem_connector = NemConnector(rest_config.node_url, self.network)
 		self.max_lag_blocks = rest_config.max_lag_blocks
+		self.statistics_cache = TtlCache(STATISTICS_CACHE_TTL_SECONDS, STATISTICS_CACHE_MAX_ENTRIES)
+		self.statistics_range_cache = TtlCache(STATISTICS_CACHE_TTL_SECONDS, STATISTICS_RANGE_CACHE_MAX_ENTRIES)
 
 	def get_block(self, height):
 		"""Gets block by height."""
@@ -57,9 +65,7 @@ class NemRestFacade:
 	def get_account_statistics(self):
 		"""Gets account statistics."""
 
-		account_statistics = self.nem_db.get_account_statistics()
-
-		return account_statistics.to_dict()
+		return self.statistics_cache.get_or_load('account', lambda: self.nem_db.get_account_statistics().to_dict())
 
 	async def get_health(self):
 		"""Gets health of the node."""
@@ -175,16 +181,22 @@ class NemRestFacade:
 	def get_transaction_statistics(self):
 		"""Gets transaction statistics."""
 
-		transaction_statistics = self.nem_db.get_transaction_statistics()
+		def _load():
+			transaction_statistics = self.nem_db.get_transaction_statistics()
 
-		return transaction_statistics.to_dict() if transaction_statistics else None
+			return transaction_statistics.to_dict() if transaction_statistics else None
+
+		return self.statistics_cache.get_or_load('transaction', _load)
 
 	def get_transaction_statistics_by_date_range(self, start_date, end_date, period_type):  # pylint: disable=invalid-name
 		"""Gets transaction statistics grouped by period type."""
 
-		transaction_statistics = self.nem_db.get_transaction_statistics_by_date_range(start_date, end_date, period_type)
+		def _load():
+			transaction_statistics = self.nem_db.get_transaction_statistics_by_date_range(start_date, end_date, period_type)
 
-		return transaction_statistics.to_dict() if transaction_statistics else None
+			return transaction_statistics.to_dict() if transaction_statistics else None
+
+		return self.statistics_range_cache.get_or_load((start_date, end_date, period_type), _load)
 
 	async def get_unconfirmed_transactions(self):
 		"""Gets unconfirmed transactions."""

--- a/explorer/rest/rest/facade/TtlCache.py
+++ b/explorer/rest/rest/facade/TtlCache.py
@@ -12,7 +12,7 @@ class TtlCache:
 		self.ttl_seconds = ttl_seconds
 		self.max_entries = max_entries
 		self._entries = OrderedDict()
-		# the eviction path reads the size and then removes entries, which two threads cannot interleave safely
+		# a write reads the size and then removes an entry, which two threads cannot interleave safely
 		self._lock = threading.Lock()
 
 	def get_or_load(self, key, load):
@@ -32,17 +32,10 @@ class TtlCache:
 		with self._lock:
 			self._entries[key] = (time.monotonic(), value)
 			self._entries.move_to_end(key)
-			self._evict()
+
+			# a write adds at most one entry, so dropping one keeps the cache within its limit;
+			# stale entries need no sweep because get_or_load rechecks the lifetime before returning a value
+			if len(self._entries) > self.max_entries:
+				self._entries.popitem(last=False)
 
 		return value
-
-	def _evict(self):
-		"""Drops stale entries, then the least recently used ones, until the cache fits."""
-
-		now = time.monotonic()
-
-		for key in [key for key, (stored_at, _) in self._entries.items() if now - stored_at >= self.ttl_seconds]:
-			del self._entries[key]
-
-		while len(self._entries) > self.max_entries:
-			self._entries.popitem(last=False)

--- a/explorer/rest/rest/facade/TtlCache.py
+++ b/explorer/rest/rest/facade/TtlCache.py
@@ -1,0 +1,48 @@
+import threading
+import time
+from collections import OrderedDict
+
+
+class TtlCache:
+	"""Keeps values for a fixed time, discarding the least recently used ones once the cache is full."""
+
+	def __init__(self, ttl_seconds, max_entries):
+		"""Creates a cache holding at most max_entries values, each for the given number of seconds."""
+
+		self.ttl_seconds = ttl_seconds
+		self.max_entries = max_entries
+		self._entries = OrderedDict()
+		# the eviction path reads the size and then removes entries, which two threads cannot interleave safely
+		self._lock = threading.Lock()
+
+	def get_or_load(self, key, load):
+		"""Returns the value stored under a key, calling load when it is missing or too old."""
+
+		with self._lock:
+			stored_at, value = self._entries.get(key, (None, None))
+			if stored_at is not None and time.monotonic() - stored_at < self.ttl_seconds:
+				self._entries.move_to_end(key)
+
+				return value
+
+		# load runs outside the lock, so a slow query cannot block readers of other keys. Two threads arriving
+		# on the same expired key will both load, which is harmless because these reads have no side effects.
+		value = load()
+
+		with self._lock:
+			self._entries[key] = (time.monotonic(), value)
+			self._entries.move_to_end(key)
+			self._evict()
+
+		return value
+
+	def _evict(self):
+		"""Drops stale entries, then the least recently used ones, until the cache fits."""
+
+		now = time.monotonic()
+
+		for key in [key for key, (stored_at, _) in self._entries.items() if now - stored_at >= self.ttl_seconds]:
+			del self._entries[key]
+
+		while len(self._entries) > self.max_entries:
+			self._entries.popitem(last=False)

--- a/explorer/rest/rest/model/common.py
+++ b/explorer/rest/rest/model/common.py
@@ -2,6 +2,10 @@ from collections import namedtuple
 
 DEFAULT_HARVESTING_ACTIVE_WINDOW_DAYS = 60
 
+STATISTICS_CACHE_TTL_SECONDS = 900
+STATISTICS_CACHE_MAX_ENTRIES = 4
+STATISTICS_RANGE_CACHE_MAX_ENTRIES = 64
+
 DatabaseConfig = namedtuple('DatabaseConfig', ['database', 'user', 'password', 'host', 'port'])
 Pagination = namedtuple('Pagination', ['limit', 'offset'])
 Sorting = namedtuple('Sorting', ['field', 'order'])

--- a/explorer/rest/tests/facade/test_NemRestFacade.py
+++ b/explorer/rest/tests/facade/test_NemRestFacade.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, patch
 from symbollightapi.model.Exceptions import NodeException
 
 from rest.facade.NemRestFacade import NemRestFacade
-from rest.model.common import Pagination, RestConfig, Sorting
+from rest.model.common import STATISTICS_RANGE_CACHE_MAX_ENTRIES, Pagination, RestConfig, Sorting
 
 from ..test.DatabaseTestUtils import (
 	ACCOUNT_STATISTIC_VIEW,
@@ -442,6 +442,48 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 	# endregion
 
 	# region transaction statistics
+
+	def test_can_tell_cached_date_ranges_apart(self):
+		# Arrange: the same dates asked for in both period types, so only the period type can tell them apart
+		# Act:
+		daily = self.nem_rest_facade.get_transaction_statistics_by_date_range('2015-03-01', '2015-03-31', 'DAY')
+		monthly = self.nem_rest_facade.get_transaction_statistics_by_date_range('2015-03-01', '2015-03-31', 'MONTH')
+		daily_again = self.nem_rest_facade.get_transaction_statistics_by_date_range('2015-03-01', '2015-03-31', 'DAY')
+
+		# Assert: the period type belongs to the cache key, otherwise the monthly read would answer both
+		self.assertNotEqual(daily, monthly)
+		self.assertEqual(daily, daily_again)
+
+	def test_can_keep_summaries_cached_while_date_ranges_churn(self):
+		# Arrange: warm the transaction summary, then flood the range cache past its capacity
+		self.nem_rest_facade.get_transaction_statistics()
+
+		for day in range(STATISTICS_RANGE_CACHE_MAX_ENTRIES + 8):
+			self.nem_rest_facade.get_transaction_statistics_by_date_range('2015-03-01', f'2015-03-{1 + day % 28:02}', 'DAY')
+
+		with patch.object(
+			self.nem_rest_facade.nem_db, 'get_transaction_statistics',
+			wraps=self.nem_rest_facade.nem_db.get_transaction_statistics
+		) as spy:
+			# Act:
+			self.nem_rest_facade.get_transaction_statistics()
+
+			# Assert: the summaries live in their own cache, so arbitrary ranges cannot evict them
+			self.assertEqual(0, spy.call_count)
+
+	def test_can_serve_repeated_statistics_reads_from_cache(self):
+		# Arrange: statistics summarise the whole chain and are expensive, so a repeated read must not hit the database
+		with patch.object(
+			self.nem_rest_facade.nem_db, 'get_transaction_statistics',
+			wraps=self.nem_rest_facade.nem_db.get_transaction_statistics
+		) as spy:
+			# Act:
+			first_statistics = self.nem_rest_facade.get_transaction_statistics()
+			second_statistics = self.nem_rest_facade.get_transaction_statistics()
+
+			# Assert:
+			self.assertEqual(first_statistics, second_statistics)
+			self.assertEqual(1, spy.call_count)
 
 	def test_can_retrieve_transaction_statistics(self):
 		# Act:

--- a/explorer/rest/tests/facade/test_TtlCache.py
+++ b/explorer/rest/tests/facade/test_TtlCache.py
@@ -1,0 +1,119 @@
+import unittest
+
+from rest.facade.TtlCache import TtlCache
+
+
+class TtlCacheTest(unittest.TestCase):
+
+	@staticmethod
+	def _counting_loader(values):
+		"""Creates a loader returning the next value on each call and recording how often it ran."""
+
+		calls = []
+
+		def load():
+			calls.append(len(calls))
+
+			return values[len(calls) - 1]
+
+		return load, calls
+
+	def test_can_load_value_on_first_read(self):
+		# Arrange:
+		cache = TtlCache(60, 8)
+		load, calls = self._counting_loader(['first'])
+
+		# Act:
+		value = cache.get_or_load('key', load)
+
+		# Assert:
+		self.assertEqual('first', value)
+		self.assertEqual(1, len(calls))
+
+	def test_can_reuse_value_within_ttl(self):
+		# Arrange:
+		cache = TtlCache(60, 8)
+		load, calls = self._counting_loader(['first', 'second'])
+
+		# Act:
+		first_value = cache.get_or_load('key', load)
+		second_value = cache.get_or_load('key', load)
+
+		# Assert: the second read is served from the cache, so the loader ran once
+		self.assertEqual('first', first_value)
+		self.assertEqual('first', second_value)
+		self.assertEqual(1, len(calls))
+
+	def test_can_reload_value_after_ttl_expires(self):
+		# Arrange: a zero lifetime makes every stored value immediately stale
+		cache = TtlCache(0, 8)
+		load, calls = self._counting_loader(['first', 'second'])
+
+		# Act:
+		first_value = cache.get_or_load('key', load)
+		second_value = cache.get_or_load('key', load)
+
+		# Assert:
+		self.assertEqual('first', first_value)
+		self.assertEqual('second', second_value)
+		self.assertEqual(2, len(calls))
+
+	def test_can_keep_values_of_different_keys_apart(self):
+		# Arrange:
+		cache = TtlCache(60, 8)
+		load, calls = self._counting_loader(['first', 'second'])
+
+		# Act:
+		first_value = cache.get_or_load('one', load)
+		second_value = cache.get_or_load('two', load)
+
+		# Assert:
+		self.assertEqual('first', first_value)
+		self.assertEqual('second', second_value)
+		self.assertEqual(2, len(calls))
+
+	def test_can_cache_none(self):
+		# Arrange:
+		cache = TtlCache(60, 8)
+		load, calls = self._counting_loader([None, 'second'])
+
+		# Act:
+		first_value = cache.get_or_load('key', load)
+		second_value = cache.get_or_load('key', load)
+
+		# Assert: a missing result is worth caching too, otherwise it is recomputed on every read
+		self.assertIsNone(first_value)
+		self.assertIsNone(second_value)
+		self.assertEqual(1, len(calls))
+
+	def test_can_drop_least_recently_used_entry_when_full(self):
+		# Arrange: a cache holding two entries at a time
+		cache = TtlCache(60, 2)
+		load, calls = self._counting_loader(['a1', 'b1', 'c1', 'b2'])
+		cache.get_or_load('a', load)
+		cache.get_or_load('b', load)
+
+		# Act: touch 'a' so 'b' becomes the least recently used, then add a third key
+		cache.get_or_load('a', load)
+		cache.get_or_load('c', load)
+
+		# Assert: 'a' is still cached, so reading it does not load
+		self.assertEqual('a1', cache.get_or_load('a', load))
+		self.assertEqual(3, len(calls))
+
+		# Assert: 'b' was evicted, so reading it loads again
+		self.assertEqual('b2', cache.get_or_load('b', load))
+		self.assertEqual(4, len(calls))
+
+	def test_can_avoid_accumulating_stale_entries(self):
+		# Arrange: a zero lifetime makes every stored value stale the moment it is written
+		cache = TtlCache(0, 8)
+		load, _ = self._counting_loader(['a1', 'b1', 'c1'])
+
+		# Act: three different keys, none of which can ever be fresh
+		cache.get_or_load('a', load)
+		cache.get_or_load('b', load)
+		cache.get_or_load('c', load)
+
+		# Assert: stale entries are dropped on write, so a stream of distinct keys cannot grow the cache
+		self.assertEqual(0, len(cache._entries))  # pylint: disable=protected-access

--- a/explorer/rest/tests/facade/test_TtlCache.py
+++ b/explorer/rest/tests/facade/test_TtlCache.py
@@ -9,31 +9,31 @@ class TtlCacheTest(unittest.TestCase):
 	def _counting_loader(values):
 		"""Creates a loader returning the next value on each call and recording how often it ran."""
 
-		calls = []
+		load_calls = []
 
 		def load():
-			calls.append(len(calls))
+			load_calls.append(len(load_calls))
 
-			return values[len(calls) - 1]
+			return values[len(load_calls) - 1]
 
-		return load, calls
+		return load, load_calls
 
 	def test_can_load_value_on_first_read(self):
 		# Arrange:
 		cache = TtlCache(60, 8)
-		load, calls = self._counting_loader(['first'])
+		load, load_calls = self._counting_loader(['first'])
 
 		# Act:
 		value = cache.get_or_load('key', load)
 
 		# Assert:
 		self.assertEqual('first', value)
-		self.assertEqual(1, len(calls))
+		self.assertEqual(1, len(load_calls))
 
 	def test_can_reuse_value_within_ttl(self):
 		# Arrange:
 		cache = TtlCache(60, 8)
-		load, calls = self._counting_loader(['first', 'second'])
+		load, load_calls = self._counting_loader(['first', 'second'])
 
 		# Act:
 		first_value = cache.get_or_load('key', load)
@@ -42,12 +42,12 @@ class TtlCacheTest(unittest.TestCase):
 		# Assert: the second read is served from the cache, so the loader ran once
 		self.assertEqual('first', first_value)
 		self.assertEqual('first', second_value)
-		self.assertEqual(1, len(calls))
+		self.assertEqual(1, len(load_calls))
 
 	def test_can_reload_value_after_ttl_expires(self):
 		# Arrange: a zero lifetime makes every stored value immediately stale
 		cache = TtlCache(0, 8)
-		load, calls = self._counting_loader(['first', 'second'])
+		load, load_calls = self._counting_loader(['first', 'second'])
 
 		# Act:
 		first_value = cache.get_or_load('key', load)
@@ -56,12 +56,12 @@ class TtlCacheTest(unittest.TestCase):
 		# Assert:
 		self.assertEqual('first', first_value)
 		self.assertEqual('second', second_value)
-		self.assertEqual(2, len(calls))
+		self.assertEqual(2, len(load_calls))
 
 	def test_can_keep_values_of_different_keys_apart(self):
 		# Arrange:
 		cache = TtlCache(60, 8)
-		load, calls = self._counting_loader(['first', 'second'])
+		load, load_calls = self._counting_loader(['first', 'second'])
 
 		# Act:
 		first_value = cache.get_or_load('one', load)
@@ -70,12 +70,12 @@ class TtlCacheTest(unittest.TestCase):
 		# Assert:
 		self.assertEqual('first', first_value)
 		self.assertEqual('second', second_value)
-		self.assertEqual(2, len(calls))
+		self.assertEqual(2, len(load_calls))
 
 	def test_can_cache_none(self):
 		# Arrange:
 		cache = TtlCache(60, 8)
-		load, calls = self._counting_loader([None, 'second'])
+		load, load_calls = self._counting_loader([None, 'second'])
 
 		# Act:
 		first_value = cache.get_or_load('key', load)
@@ -84,12 +84,12 @@ class TtlCacheTest(unittest.TestCase):
 		# Assert: a missing result is worth caching too, otherwise it is recomputed on every read
 		self.assertIsNone(first_value)
 		self.assertIsNone(second_value)
-		self.assertEqual(1, len(calls))
+		self.assertEqual(1, len(load_calls))
 
 	def test_can_drop_least_recently_used_entry_when_full(self):
 		# Arrange: a cache holding two entries at a time
 		cache = TtlCache(60, 2)
-		load, calls = self._counting_loader(['a1', 'b1', 'c1', 'b2'])
+		load, load_calls = self._counting_loader(['a1', 'b1', 'c1', 'b2'])
 		cache.get_or_load('a', load)
 		cache.get_or_load('b', load)
 
@@ -99,21 +99,22 @@ class TtlCacheTest(unittest.TestCase):
 
 		# Assert: 'a' is still cached, so reading it does not load
 		self.assertEqual('a1', cache.get_or_load('a', load))
-		self.assertEqual(3, len(calls))
+		self.assertEqual(3, len(load_calls))
 
 		# Assert: 'b' was evicted, so reading it loads again
 		self.assertEqual('b2', cache.get_or_load('b', load))
-		self.assertEqual(4, len(calls))
+		self.assertEqual(4, len(load_calls))
 
-	def test_can_avoid_accumulating_stale_entries(self):
+	def test_can_bound_size_when_entries_are_stale(self):
 		# Arrange: a zero lifetime makes every stored value stale the moment it is written
-		cache = TtlCache(0, 8)
-		load, _ = self._counting_loader(['a1', 'b1', 'c1'])
+		cache = TtlCache(0, 2)
+		load, _ = self._counting_loader(['a1', 'b1', 'c1', 'd1'])
 
-		# Act: three different keys, none of which can ever be fresh
+		# Act: four different keys, none of which can ever be fresh
 		cache.get_or_load('a', load)
 		cache.get_or_load('b', load)
 		cache.get_or_load('c', load)
+		cache.get_or_load('d', load)
 
-		# Assert: stale entries are dropped on write, so a stream of distinct keys cannot grow the cache
-		self.assertEqual(0, len(cache._entries))  # pylint: disable=protected-access
+		# Assert: a stream of distinct keys cannot grow the cache past its limit
+		self.assertEqual(2, len(cache._entries))  # pylint: disable=protected-access


### PR DESCRIPTION
## Problem

The three statistics endpoints recompute a summary of the entire chain on every request, and two
of them take no parameters at all - so every visitor pays for the same result.

Measured against a copy of production (11.5M transactions):

  | endpoint | buffer pages | median |
  |---|---|---|
  | `transaction/statistics` | 175 332 (~1.4 GB) | 843.5 ms |
  | `account/statistics` | 29 192 | 258.7 ms |
  | `transaction/statistics/range` (48 months) | - | 304.2 ms |
  | `transaction/statistics/range` (90 days) | - | 17.5 ms |

  On nem.fyi `transaction/statistics` takes **2.36 s**, because production reads those pages from
  disk rather than from a warm page cache. Concurrent callers make it worse: they queue on the same
  buffers (`IPC/BufferIo`) instead of sharing a result.

  The frontend calls these endpoints to render the home page, so this cost is on the first screen
  every visitor sees.

  ## Why caching is the right fix here

  These are the rare queries where a cache is not papering over a bad plan. The result is a handful
  of aggregates over the whole table, so there is no page to narrow down to and no index that makes
  a full aggregation cheap. The cost is inherent to the question.

  A 15 minute lifetime means a statistic can lag by at most one quarter hour - invisible against a
  figure that moves a couple of dozen times a day - and removes essentially all of the work.