### PR TITLE
[explorer] fix: resolve account transactions through an aggregate hash column

### DIFF
--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -139,7 +139,7 @@ class NemDatabase(DatabaseConnection):
 			CREATE INDEX IF NOT EXISTS transactions_sender_address_height_idx
 				ON transactions(sender_address, height DESC, id DESC)
 				INCLUDE (aggregate_hash)
-				WHERE NOT (is_inner = false AND transaction_type = {TransactionType.MULTISIG.value})
+				WHERE transaction_type <> {TransactionType.MULTISIG.value}
 			'''
 		)
 
@@ -148,7 +148,7 @@ class NemDatabase(DatabaseConnection):
 			CREATE INDEX IF NOT EXISTS transactions_recipient_address_height_idx
 				ON transactions(recipient_address, height DESC, id DESC)
 				INCLUDE (aggregate_hash)
-				WHERE NOT (is_inner = false AND transaction_type = {TransactionType.MULTISIG.value})
+				WHERE transaction_type <> {TransactionType.MULTISIG.value}
 			'''
 		)
 

--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -2,6 +2,7 @@ import json
 from binascii import unhexlify
 from collections import namedtuple
 
+from symbolchain.nc import TransactionType
 from symbolchain.nem.Network import Address
 
 from .DatabaseConnection import DatabaseConnection
@@ -133,6 +134,24 @@ class NemDatabase(DatabaseConnection):
 			'''
 		)
 
+		cursor.execute(
+			f'''
+			CREATE INDEX IF NOT EXISTS transactions_sender_address_height_idx
+				ON transactions(sender_address, height DESC, id DESC)
+				INCLUDE (aggregate_hash)
+				WHERE NOT (is_inner = false AND transaction_type = {TransactionType.MULTISIG.value})
+			'''
+		)
+
+		cursor.execute(
+			f'''
+			CREATE INDEX IF NOT EXISTS transactions_recipient_address_height_idx
+				ON transactions(recipient_address, height DESC, id DESC)
+				INCLUDE (aggregate_hash)
+				WHERE NOT (is_inner = false AND transaction_type = {TransactionType.MULTISIG.value})
+			'''
+		)
+
 		# Create indexes for transactions_mosaic table
 		cursor.execute(
 			'''
@@ -250,6 +269,7 @@ class NemDatabase(DatabaseConnection):
 				deadline timestamp NOT NULL,
 				signature bytea,
 				is_inner boolean NOT NULL,
+				aggregate_hash bytea,
 				payload jsonb,
 				size int NOT NULL,
 				version int NOT NULL
@@ -681,11 +701,12 @@ class NemDatabase(DatabaseConnection):
 				deadline,
 				signature,
 				is_inner,
+				aggregate_hash,
 				payload,
 				size,
 				version
 			)
-			VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+			VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 			RETURNING id
 			''',
 			(
@@ -700,6 +721,7 @@ class NemDatabase(DatabaseConnection):
 				transaction.deadline,
 				unhexlify(transaction.signature) if transaction.signature else None,
 				transaction.is_inner,
+				unhexlify(transaction.aggregate_hash) if transaction.aggregate_hash else None,
 				json.dumps(transaction.payload) if transaction.payload else None,
 				transaction.size,
 				transaction.version

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -85,8 +85,9 @@ TransactionRecord = namedtuple('TransactionRecord', [
 	'recipient_address',
 	'payload',
 	'size',
-	'version'
-])
+	'version',
+	'aggregate_hash'
+], defaults=[None])
 DatabaseConfig = namedtuple('DatabaseConfig', ['database', 'user', 'password', 'host', 'port'])
 
 
@@ -442,7 +443,7 @@ class NemPuller:
 		adjustment = transaction.delta if transaction.supply_type == 1 else -transaction.delta
 		self.nem_db.update_mosaic_total_supply(cursor, transaction.namespace_name, adjustment)
 
-	def _build_transaction_record(self, transaction, is_inner):
+	def _build_transaction_record(self, transaction, is_inner, aggregate_hash=None):
 		"""Create TransactionRecord from transaction data."""
 
 		payload = None
@@ -531,6 +532,7 @@ class NemPuller:
 			signature=transaction.signature,
 			transaction_type=transaction.transaction_type,
 			is_inner=is_inner,
+			aggregate_hash=aggregate_hash,
 			sender_address=self._convert_public_key_to_address(transaction.sender),
 			recipient_address=recipient_address,
 			payload=payload,
@@ -538,11 +540,11 @@ class NemPuller:
 			version=transaction.version
 		)
 
-	def _process_transaction(self, cursor, transaction, block_height, is_inner):
+	def _process_transaction(self, cursor, transaction, block_height, is_inner, aggregate_hash=None):
 		# pylint: disable=too-many-arguments,too-many-positional-arguments
 		"""Process a single transaction."""
 
-		transaction_record = self._build_transaction_record(transaction, is_inner)
+		transaction_record = self._build_transaction_record(transaction, is_inner, aggregate_hash)
 		transaction_id = self.nem_db.insert_transaction(cursor, transaction_record)
 
 		if transaction.transaction_type == TransactionType.TRANSFER.value:
@@ -582,7 +584,13 @@ class NemPuller:
 				# For inner transactions, we set the transaction hash to the inner hash
 				transaction.other_transaction.transaction_hash = transaction.inner_hash
 				transaction.other_transaction.height = transaction.height
-				self._process_transaction(cursor, transaction=transaction.other_transaction, block_height=height, is_inner=True)
+				self._process_transaction(
+					cursor,
+					transaction=transaction.other_transaction,
+					block_height=height,
+					is_inner=True,
+					aggregate_hash=transaction.transaction_hash
+				)
 
 			self._process_transaction(
 				cursor,

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -1531,12 +1531,13 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		self.assertEqual(block.transactions[0].other_transaction.height, block.transactions[0].height)
 		self.assertEqual(block.transactions[0].other_transaction.transaction_hash, block.transactions[0].inner_hash)
 
-		# first call is inner transaction
+		# first call is inner transaction, pointing back at the aggregate that owns it
 		self.assertEqual(process_transaction_calls[0][0], (cursor,))
 		self.assertEqual(process_transaction_calls[0][1], {
 			'transaction': block.transactions[0].other_transaction,
 			'block_height': 3,
-			'is_inner': True
+			'is_inner': True,
+			'aggregate_hash': block.transactions[0].transaction_hash
 		})
 
 		# second call is outer transaction

--- a/explorer/rest/rest/db/NemDatabase.py
+++ b/explorer/rest/rest/db/NemDatabase.py
@@ -862,75 +862,108 @@ class NemDatabase(DatabaseConnectionPool):
 		)
 
 	@staticmethod
-	def _create_multisig_inner_filter(address_condition):
-		"""Creates a filter for multisig inner transactions."""
+	def _create_transaction_filters(transaction_query, transaction_type_column):
+		"""Creates the optional listing filters, reading the transaction type from the given column."""
 
+		condition = ''
+		params = []
+
+		if transaction_query.height:
+			condition += ' AND t.height = %s'
+			params.append(transaction_query.height)
+
+		if transaction_query.transaction_types:
+			condition += f' AND {transaction_type_column} IN %s'
+			params.append(tuple(transaction_query.transaction_types))
+
+		if transaction_query.mosaic:
+			condition += (
+				' AND t.transaction_type = %s'
+				' AND EXISTS (SELECT 1 FROM transactions_mosaic tm'
+				' WHERE tm.transaction_id = t.id AND tm.namespace_name = %s)'
+			)
+			params.extend([TransactionType.TRANSFER.value, transaction_query.mosaic])
+
+		return condition, params
+
+	@staticmethod
+	def _create_address_branches(transaction_query):
+		"""Creates one branch per address role being searched; a sender and recipient pair narrows a single branch."""
+
+		if transaction_query.address:
+			address = transaction_query.address.bytes
+
+			return [('sender_address', '', [address]), ('recipient_address', '', [address])]
+
+		if transaction_query.sender_address and transaction_query.recipient_address:
+			return [(
+				'sender_address',
+				' AND t.recipient_address = %s',
+				[transaction_query.sender_address.bytes, transaction_query.recipient_address.bytes]
+			)]
+
+		if transaction_query.sender_address:
+			return [('sender_address', '', [transaction_query.sender_address.bytes])]
+
+		if transaction_query.recipient_address:
+			return [('recipient_address', '', [transaction_query.recipient_address.bytes])]
+
+		return []
+
+	@staticmethod
+	def _create_address_page_condition(branches, sort, filters, pagination):
+		"""Restricts the listing to one page of ids, chosen by index ordered branches before any row is hydrated."""
+
+		filter_condition, filter_params = filters
+		page_size = pagination.limit + pagination.offset
+		branch_sql = []
+		params = []
+
+		for column, extra_condition, address_params in branches:
+			branch_sql.append(
+				' (SELECT COALESCE(o.id, t.id) AS id, t.height'
+				' FROM transactions t'
+				' LEFT JOIN transactions o ON o.transaction_hash = t.aggregate_hash'
+				f' WHERE t.{column} = %s{extra_condition}'
+				f' AND NOT (t.is_inner = false AND t.transaction_type = {TransactionType.MULTISIG.value})'
+				f'{filter_condition}'
+				f' ORDER BY t.height {sort}, t.id {sort}'
+				' LIMIT %s)'
+			)
+			params.extend(address_params + filter_params + [page_size])
+
+		# a branch resolves an inner row to its owner, so only an unlinked one could reach here; listing it would
+		# expose a row that carries no signature, so the listing states outright that it holds top level transactions
 		return (
-			' OR ('
-			f' t.transaction_type = {TransactionType.MULTISIG.value}'
-			' AND EXISTS ('
-			' SELECT 1 FROM transactions it'
-			' WHERE it.is_inner = true'
-			" AND it.transaction_hash = decode(t.payload->>'inner_hash', 'hex')"
-			f' AND {address_condition}'
-			' )'
-			' )'
+			' WHERE t.is_inner = false AND t.id IN (SELECT id FROM ('
+			f' SELECT DISTINCT id, height FROM ({" UNION ALL ".join(branch_sql)}) page'
+			f' ORDER BY height {sort}, id {sort}'
+			' LIMIT %s OFFSET %s) page_ids)',
+			params + [pagination.limit, pagination.offset]
 		)
 
 	def get_transactions(self, pagination, sort, transaction_query):
 		"""Gets transactions pagination."""
 
-		where_condition = ' WHERE t.is_inner = False '
 		order_condition = f' ORDER BY t.height {sort}'
-		limit_condition = ' LIMIT %s OFFSET %s'
+		branches = self._create_address_branches(transaction_query)
 
-		filter_params = []
-
-		if transaction_query.height:
-			where_condition += ' AND t.height = %s'
-			filter_params.append(transaction_query.height)
-
-		if transaction_query.transaction_types:
-			where_condition += ' AND t.transaction_type IN %s'
-			filter_params.append(tuple(transaction_query.transaction_types))
-
-		# Exclude multisig wrappers when matching by initiator.
-		non_multisig_sender_filter = f'(t.transaction_type != {TransactionType.MULTISIG.value} AND t.sender_address = %s)'
-
-		if transaction_query.address:
-			multisig_inner_filter = self._create_multisig_inner_filter('(it.sender_address = %s OR it.recipient_address = %s)')
-			where_condition += (
-				f' AND ({non_multisig_sender_filter}'
-				' OR t.recipient_address = %s'
-				f'{multisig_inner_filter})'
+		if branches:
+			# the page is chosen by the branches, so the outer query has nothing left to limit
+			limit_condition = ''
+			# ties are broken the same way the branches order them, otherwise the page and its rows disagree
+			order_condition += f', t.id {sort}'
+			where_condition, params = self._create_address_page_condition(
+				branches,
+				sort,
+				self._create_transaction_filters(transaction_query, 'COALESCE(o.transaction_type, t.transaction_type)'),
+				pagination
 			)
-			filter_params.extend([transaction_query.address.bytes] * 4)
 		else:
-			if transaction_query.sender_address:
-				multisig_inner_filter = self._create_multisig_inner_filter('it.sender_address = %s')
-				where_condition += (
-					f' AND ({non_multisig_sender_filter}'
-					f'{multisig_inner_filter})'
-				)
-				filter_params.extend([transaction_query.sender_address.bytes] * 2)
-
-			if transaction_query.recipient_address:
-				multisig_inner_filter = self._create_multisig_inner_filter('it.recipient_address = %s')
-				where_condition += (
-					' AND (t.recipient_address = %s'
-					f'{multisig_inner_filter})'
-				)
-				filter_params.extend([transaction_query.recipient_address.bytes] * 2)
-
-		if transaction_query.mosaic:
-			where_condition += (
-				' AND t.transaction_type = %s'
-				' AND EXISTS (SELECT 1 FROM transactions_mosaic tm WHERE tm.transaction_id = t.id AND tm.namespace_name = %s) '
-			)
-
-			filter_params.extend([TransactionType.TRANSFER.value, transaction_query.mosaic])
-
-		params = filter_params + [pagination.limit, pagination.offset]
+			limit_condition = ' LIMIT %s OFFSET %s'
+			filter_condition, filter_params = self._create_transaction_filters(transaction_query, 't.transaction_type')
+			where_condition = ' WHERE t.is_inner = False ' + filter_condition
+			params = filter_params + [pagination.limit, pagination.offset]
 
 		transactions = self._get_transactions(
 			params,

--- a/explorer/rest/rest/db/NemDatabase.py
+++ b/explorer/rest/rest/db/NemDatabase.py
@@ -925,7 +925,7 @@ class NemDatabase(DatabaseConnectionPool):
 				' FROM transactions t'
 				' LEFT JOIN transactions o ON o.transaction_hash = t.aggregate_hash'
 				f' WHERE t.{column} = %s{extra_condition}'
-				f' AND NOT (t.is_inner = false AND t.transaction_type = {TransactionType.MULTISIG.value})'
+				f' AND t.transaction_type <> {TransactionType.MULTISIG.value}'
 				f'{filter_condition}'
 				f' ORDER BY t.height {sort}, t.id {sort}'
 				' LIMIT %s)'

--- a/explorer/rest/tests/db/test_NemDatabase.py
+++ b/explorer/rest/tests/db/test_NemDatabase.py
@@ -754,7 +754,7 @@ class NemDatabaseTest(DatabaseTestBase):  # pylint: disable=too-many-public-meth
 	def test_can_query_transactions_filtered_by_address_as_recipient(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc', self._make_transaction_query(address=TRANSACTIONS[0].recipient_address),
-			('multisig', 'namespace_registration', 'mosaic_definition', 'transfer', 'transfer_v2')
+			('mosaic_definition', 'namespace_registration', 'multisig', 'transfer_v2', 'transfer')
 		)
 
 	def test_can_query_transactions_filtered_by_sender_address(self):
@@ -766,7 +766,7 @@ class NemDatabaseTest(DatabaseTestBase):  # pylint: disable=too-many-public-meth
 	def test_can_query_transactions_filtered_by_recipient_address(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc', self._make_transaction_query(recipient_address=TRANSACTIONS[0].recipient_address),
-			('multisig', 'namespace_registration', 'mosaic_definition', 'transfer', 'transfer_v2')
+			('mosaic_definition', 'namespace_registration', 'multisig', 'transfer_v2', 'transfer')
 		)
 
 	def test_can_exclude_multisig_transaction_for_initiator_account_from_address_filter(self):
@@ -787,7 +787,7 @@ class NemDatabaseTest(DatabaseTestBase):  # pylint: disable=too-many-public-meth
 	def test_can_query_multisig_transaction_filtered_by_inner_recipient_address(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc', self._make_transaction_query(recipient_address=TRANSACTIONS[5].recipient_address),
-			('multisig', 'namespace_registration', 'mosaic_definition', 'transfer', 'transfer_v2')
+			('mosaic_definition', 'namespace_registration', 'multisig', 'transfer_v2', 'transfer')
 		)
 
 	def test_can_query_transactions_filtered_by_mosaic_nem_xem(self):

--- a/explorer/rest/tests/facade/test_NemRestFacade.py
+++ b/explorer/rest/tests/facade/test_NemRestFacade.py
@@ -591,7 +591,7 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 			transaction_query=self._make_transaction_query(
 				recipient_address='NBFWZ4IVRHEIBRCGHLYDS62FSFTBM3VDFA7E6LSQ'
 			),
-			expected_transaction_names=('multisig', 'namespace_registration', 'mosaic_definition', 'transfer', 'transfer_v2')
+			expected_transaction_names=('mosaic_definition', 'namespace_registration', 'multisig', 'transfer_v2', 'transfer')
 		)
 
 	def test_can_retrieve_transactions_filtered_by_sender_address(self):

--- a/explorer/rest/tests/routes/nem/test_routes.py
+++ b/explorer/rest/tests/routes/nem/test_routes.py
@@ -856,11 +856,11 @@ def test_api_transactions_excludes_multisig_for_initiator_from_address_filter(cl
 
 def test_api_transactions_applies_recipient_address(client):  # pylint: disable=redefined-outer-name, invalid-name
 	_assert_get_api_nem_transactions(client, 200, transaction_dicts(
-		'multisig',
-		'namespace_registration',
 		'mosaic_definition',
-		'transfer',
-		'transfer_v2'
+		'namespace_registration',
+		'multisig',
+		'transfer_v2',
+		'transfer'
 	), recipientAddress='NBFWZ4IVRHEIBRCGHLYDS62FSFTBM3VDFA7E6LSQ')
 
 

--- a/explorer/rest/tests/test/DatabaseTestUtils.py
+++ b/explorer/rest/tests/test/DatabaseTestUtils.py
@@ -90,8 +90,9 @@ Transaction = namedtuple('Transaction', [
 	'recipient_address',
 	'payload',
 	'size',
-	'version'
-])
+	'version',
+	'aggregate_hash'
+], defaults=[None])
 TransactionMosaic = namedtuple('Transaction_Mosaic', [
 	'transaction_id',
 	'namespace_name',
@@ -376,7 +377,8 @@ TRANSACTIONS = [
 			'message': None
 		},
 		size=184,
-		version=1
+		version=1,
+		aggregate_hash='0' * 63 + '5'
 	),
 	Transaction(  # Namespace registration
 		transaction_hash='0' * 63 + '7',
@@ -910,11 +912,11 @@ TRANSACTION_NAMES_SORTED_BY_HEIGHT_ASC = (
 )
 
 TRANSACTION_NAMES_FILTERED_BY_MULTISIG_INNER_SENDER = (
-	'multisig',
-	'mosaic_definition',
 	'mosaic_supply_change',
-	'multisig_account_modification',
+	'mosaic_definition',
 	'namespace_registration',
+	'multisig',
+	'multisig_account_modification',
 	'transfer_v2',
 	'transfer'
 )
@@ -1051,6 +1053,7 @@ def initialize_database(db_config, network_name):
 				deadline timestamp NOT NULL,
 				signature bytea,
 				is_inner boolean NOT NULL,
+				aggregate_hash bytea,
 				payload jsonb,
 				size int NOT NULL,
 				version int NOT NULL
@@ -1214,11 +1217,12 @@ def initialize_database(db_config, network_name):
 					deadline,
 					signature,
 					is_inner,
+					aggregate_hash,
 					payload,
 					size,
 					version
 				)
-				VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+				VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 				''',
 				(
 					unhexlify(transaction.transaction_hash),
@@ -1232,6 +1236,7 @@ def initialize_database(db_config, network_name):
 					transaction.deadline,
 					unhexlify(transaction.signature) if transaction.signature else None,
 					transaction.is_inner,
+					unhexlify(transaction.aggregate_hash) if transaction.aggregate_hash else None,
 					json.dumps(transaction.payload) if transaction.payload else None,
 					transaction.size,
 					transaction.version


### PR DESCRIPTION
## The problem

`/api/nem/transactions?address=…` times out on nem.fyi. Measured against a copy of production
(11.5M transactions), a single page of ten rows costs:

| account | buffer pages | time |
|---|---|---|
| dormant, 2 transactions | 10 262 395 | 80 s cold, 7–10 s warm |
| multisig, 339k transactions | 124 778 | 1.5 s |
| heaviest, 2.25M transactions | 2 031 867 | 2.3 s |

The dormant account being the worst looks backwards until you see the mechanism. `LIMIT 10` can
only stop a scan once ten rows have been found. An account with two transactions never finds them,
so the whole table has to be read to prove no more exist. **86.7% of accounts hold fewer than ten
transactions** (834 649 of 962 477), which means most of the address space falls into the full scan
rather than a rare corner of it.

Sample address: `NAAANAABDBG526XNAVTXD5I4IF3N6EIVOHIB3U7E`.

### The query before

```sql
SELECT
    t.transaction_hash, t.transaction_type, t.sender_address AS from_address, t.fee, t.height,
    t.timestamp, t.deadline, t.signature, t.recipient_address AS to_address, t.payload,
    COALESCE(m.mosaics, '[]'::json) AS mosaics, t.size, t.version
FROM transactions t
LEFT JOIN LATERAL (
    SELECT json_agg(json_build_object(
        'namespace_name', tm.namespace_name,
        'quantity',       tm.quantity,
        'divisibility',   mo.divisibility)) AS mosaics
    FROM transactions_mosaic tm
    LEFT JOIN mosaics mo ON mo.namespace_name = tm.namespace_name
    WHERE tm.transaction_id = t.id
) m ON true
WHERE t.is_inner = False
  AND ( (t.transaction_type != 4100 AND t.sender_address = $1)
     OR t.recipient_address = $1
     OR ( t.transaction_type = 4100 AND EXISTS (
            SELECT 1 FROM transactions it
             WHERE it.is_inner = true
               AND it.transaction_hash = decode(t.payload->>'inner_hash', 'hex')
               AND (it.sender_address = $1 OR it.recipient_address = $1) ) ) )
ORDER BY t.height DESC
LIMIT 10 OFFSET 0
```

### Why it was slow

Two independent reasons, and removing only one of them does not help.

**The correlated subquery.** The third arm reaches multisig inner transactions through
`decode(t.payload->>'inner_hash','hex')`. Being correlated, it is evaluated per candidate row. That
rules out any bitmap plan and leaves a walk of `transactions_height_is_inner_false_idx` with a
filter attached:

```
Index Scan using transactions_height_is_inner_false_idx on transactions t
  Rows Removed by Filter: 11 062 748
```

**The disjunction.** Even with the correlated arm gone, `sender_address = X OR recipient_address =
X` remains. A btree is sorted along one axis, so no single index can return that combined set in
height order. PostgreSQL either uses `BitmapOr`, which yields rows in heap order and destroys the
ordering, or abandons the indexes entirely. Either way every match must be sorted before `LIMIT`
can take ten.

Measured on identical data and indexes, changing only `OR` into `UNION ALL`:

| form | pages | plan | sort |
|---|---|---|---|
| `OR` | 1 144 026 | `Parallel Seq Scan`, 2 247 738 rows | `external merge` 19 MB × 3 workers |
| `UNION ALL` | 25 | 2 × `Index Only Scan` | `quicksort` 25 kB in memory |

##  The fix

### `aggregate_hash` on inner rows

Inner rows now carry `aggregate_hash`, pointing at the transaction that owns them, mirroring
`symbol_transactions.aggregate_hash` (`SymbolDatabase.py:409`).

The direction is what matters. NEM's existing link lives in the wrapper's payload and points
*down*; this one points *up*, from child to parent. That lets the column ride along in the address
index as an `INCLUDE` payload, so a branch never visits the heap to learn the owner, and the join
runs against the existing `transaction_hash` unique index.

The puller sets it when inserting the inner row, where the wrapper's hash is already in scope
(`NemPuller.py:582`).

### Indexes

```sql
CREATE INDEX transactions_sender_address_height_idx
    ON transactions (sender_address, height DESC, id DESC)
    INCLUDE (aggregate_hash)
    WHERE NOT (is_inner = false AND transaction_type = 4100);
```

and the same for `recipient_address`.

The partial predicate is not only about size. It proves to the planner that the condition already
holds for every entry, so it disappears from the plan. Without it the condition returns as a
runtime `Filter` needing `is_inner` and `transaction_type`, which are not in the index, so every
candidate visits the heap and the scan stops being index-only.

### The query after

```sql
SELECT
    t.transaction_hash, t.transaction_type, t.sender_address AS from_address, t.fee, t.height,
    t.timestamp, t.deadline, t.signature, t.recipient_address AS to_address, t.payload,
    COALESCE(m.mosaics, '[]'::json) AS mosaics, t.size, t.version
FROM transactions t
LEFT JOIN LATERAL (
    SELECT json_agg(json_build_object(
        'namespace_name', tm.namespace_name,
        'quantity',       tm.quantity,
        'divisibility',   mo.divisibility)) AS mosaics
    FROM transactions_mosaic tm
    LEFT JOIN mosaics mo ON mo.namespace_name = tm.namespace_name
    WHERE tm.transaction_id = t.id
) m ON true
WHERE t.is_inner = false AND t.id IN (
    SELECT id FROM (
        SELECT DISTINCT id, height FROM (
            (SELECT COALESCE(o.id, t.id) AS id, t.height
               FROM transactions t
               LEFT JOIN transactions o ON o.transaction_hash = t.aggregate_hash
              WHERE t.sender_address = $1
                AND t.transaction_type <> 4100
              ORDER BY t.height DESC, t.id DESC
              LIMIT 10)
          UNION ALL
            (SELECT COALESCE(o.id, t.id) AS id, t.height
               FROM transactions t
               LEFT JOIN transactions o ON o.transaction_hash = t.aggregate_hash
              WHERE t.recipient_address = $1
                AND t.transaction_type <> 4100
              ORDER BY t.height DESC, t.id DESC
              LIMIT 10)
        ) page
        ORDER BY height DESC, id DESC
        LIMIT 10 OFFSET 0
    ) page_ids
)
ORDER BY t.height DESC, t.id DESC
```

Reading it in order:

- Each branch matches the address **directly on inner rows** and resolves the owner by joining up,
  so the correlated subquery is gone.
- Each branch walks its own index in the order it already stores, and stops after `limit + offset`
  entries. Truncating is safe: the ten newest rows of the union must each be among the ten newest
  of the branch they came from, so nothing that belongs on the page can be discarded.
- The `LATERAL` runs only for the ten rows that survived, not for every match.
- `DISTINCT` is required because a self-transfer matches both branches.

`address` uses both branches, `senderAddress` the first, `recipientAddress` the second. A sender
and recipient pair narrows a **single** branch instead of producing two, because that combination
is a conjunction — unioning it would return everything sent by one plus everything received by the
other. This is not an edge case: the frontend rewrites `address` into the opposite role whenever
From or To is used on an account page (`transactions.js:29-35`).

Correctness rests on inner and outer rows sharing a height, so ordering by the inner row's height
is sound. Verified: 509 834 / 509 834 pairs.

### Results

| account | page | before | after |
|---|---|---|---|
| dormant, 2 tx | 10/0 | 10 262 395 | **35** |
| dormant, 2 tx | 50/500 | 10 262 395 | **13** |
| multisig, 339k | 10/0 | 124 778 | **39** |
| multisig, 339k | 50/500 | 140 290 | **183** |
| heaviest, 2.25M | 10/0 | 2 031 867 | **138** |
| heaviest, 2.25M | 50/500 | 2 036 316 | **1 652** |

Cost no longer tracks account activity. Through the REST code against the full database every
address variant answers in 1.6–9.9 ms.

Development timings understate the gain: the table fits in this machine's page cache, so the
"before" figures are served from RAM. Production reads the same pages from disk, which is why the
first measurement above took 80 s cold and 7 s once warm — the page counts are the honest metric.

## Deployment

The column and its backfill must be in place **before** this code runs:

```sql
ALTER TABLE transactions ADD COLUMN IF NOT EXISTS aggregate_hash bytea;

UPDATE transactions i
   SET aggregate_hash = o.transaction_hash
  FROM transactions o
 WHERE o.is_inner = false
   AND o.transaction_type = 4100
   AND decode(o.payload->>'inner_hash', 'hex') = i.transaction_hash
   AND i.is_inner
   AND i.aggregate_hash IS NULL;

CREATE INDEX CONCURRENTLY IF NOT EXISTS transactions_sender_address_height_idx
    ON transactions (sender_address, height DESC, id DESC)
    INCLUDE (aggregate_hash)
    WHERE transaction_type <> 4100;

CREATE INDEX CONCURRENTLY IF NOT EXISTS transactions_recipient_address_height_idx
    ON transactions (recipient_address, height DESC, id DESC)
    INCLUDE (aggregate_hash)
    WHERE transaction_type <> 4100;

```

Then both indexes `CONCURRENTLY`, then `VACUUM (ANALYZE) transactions` — the backfill rewrites
509 834 rows, and without refreshing the visibility map the branches make heap fetches they do not
need. Allow about 1.7 GB of permanent growth plus headroom during the build.

Order: SQL, then the puller, then **rerun the backfill** for anything that arrived in between (the
statement is idempotent), then this gate, then the REST service.

```sql
SELECT count(*) FILTER (WHERE is_inner) AS inner_rows,
       count(*) FILTER (WHERE is_inner AND aggregate_hash IS NOT NULL) AS linked
FROM transactions;
```

Both numbers must match. 