### PR TITLE
[explorer/rest] fix: select the listing page before joining

### DIFF
--- a/explorer/rest/rest/db/NemDatabase.py
+++ b/explorer/rest/rest/db/NemDatabase.py
@@ -322,7 +322,12 @@ class NemDatabase(DatabaseConnectionPool):
 				cosignatory_of,
 				cosignatories,
 				ar.remark
-			FROM accounts a
+			FROM (
+				SELECT * FROM accounts a
+				{where_condition}
+				{order_condition}
+				{limit_condition}
+			) a
 			LEFT JOIN account_remark ar
 				ON ar.address = a.address
 			LEFT JOIN LATERAL (
@@ -336,9 +341,7 @@ class NemDatabase(DatabaseConnectionPool):
 				LEFT JOIN mosaics m
 					ON m.namespace_name = mosaic.item->>'namespace_name'
 			) am ON true
-			{where_condition}
 			{order_condition}
-			{limit_condition}
 		'''
 
 	@staticmethod
@@ -427,7 +430,12 @@ class NemDatabase(DatabaseConnectionPool):
 				ns.registered_height AS root_namespace_registered_height,
 				ns_block.timestamp AS root_namespace_registered_timestamp,
 				ns.expiration_height AS root_namespace_expiration_height
-			FROM mosaics m
+			FROM (
+				SELECT * FROM mosaics m
+				{where_condition}
+				{order_condition}
+				{limit_condition}
+			) m
 			LEFT JOIN mosaics levy
 				ON levy.namespace_name = m.levy_namespace_name
 			LEFT JOIN namespaces ns
@@ -436,9 +444,7 @@ class NemDatabase(DatabaseConnectionPool):
 				ON ns_block.height = ns.registered_height
 			LEFT JOIN blocks m_block
 				ON m_block.height = m.registered_height
-			{where_condition}
 			{order_condition}
-			{limit_condition}
 		'''
 
 	@staticmethod
@@ -460,7 +466,12 @@ class NemDatabase(DatabaseConnectionPool):
 				COALESCE(m.mosaics, '[]'::json) AS mosaics,
 				t.size,
 				t.version
-			FROM transactions t
+			FROM (
+				SELECT * FROM transactions t
+				{where_condition}
+				{order_condition}
+				{limit_condition}
+			) t
 			LEFT JOIN LATERAL (
 				SELECT json_agg(json_build_object(
 				'namespace_name', tm.namespace_name,
@@ -471,9 +482,7 @@ class NemDatabase(DatabaseConnectionPool):
 				ON mo.namespace_name = tm.namespace_name
 			WHERE tm.transaction_id = t.id
 			) m ON true
-			{where_condition}
 			{order_condition}
-			{limit_condition}
 		'''
 
 	def _read_harvesting_active_cutoff_height(self, cursor):
@@ -642,7 +651,7 @@ class NemDatabase(DatabaseConnectionPool):
 	def get_mosaics(self, pagination, sort):
 		"""Gets mosaics pagination in database."""
 
-		order_condition = f' ORDER BY m.registered_height {sort}'
+		order_condition = f' ORDER BY m.registered_height {sort}, m.namespace_name'
 		limit_condition = ' LIMIT %s OFFSET %s'
 
 		sql = self._generate_mosaic_query(order_condition=order_condition, limit_condition=limit_condition)

--- a/explorer/rest/tests/db/test_NemDatabase.py
+++ b/explorer/rest/tests/db/test_NemDatabase.py
@@ -552,23 +552,23 @@ class NemDatabaseTest(DatabaseTestBase):  # pylint: disable=too-many-public-meth
 		self.assertEqual(expected_mosaics, mosaics_view)
 
 	def test_can_query_mosaics_filtered_limit_offset_0(self):
-		self._assert_can_query_mosaics_with_filter(Pagination(1, 0), 'desc', [EXPECTED_MOSAIC_VIEW_2])
+		self._assert_can_query_mosaics_with_filter(Pagination(1, 0), 'desc', [EXPECTED_MOSAIC_VIEW_3])
 
 	def test_can_query_mosaics_filtered_offset_1(self):
-		self._assert_can_query_mosaics_with_filter(Pagination(1, 1), 'desc', [EXPECTED_MOSAIC_VIEW_3])
+		self._assert_can_query_mosaics_with_filter(Pagination(1, 1), 'desc', [EXPECTED_MOSAIC_VIEW_2])
 
 	def test_can_query_mosaics_sorted_by_registered_height_asc(self):
 		self._assert_can_query_mosaics_with_filter(
 			Pagination(10, 0),
 			'asc',
-			[EXPECTED_MOSAIC_VIEW_1, EXPECTED_MOSAIC_VIEW_2, EXPECTED_MOSAIC_VIEW_3]
+			[EXPECTED_MOSAIC_VIEW_1, EXPECTED_MOSAIC_VIEW_3, EXPECTED_MOSAIC_VIEW_2]
 		)
 
 	def test_can_query_mosaics_sorted_by_registered_height_desc(self):
 		self._assert_can_query_mosaics_with_filter(
 			Pagination(10, 0),
 			'desc',
-			[EXPECTED_MOSAIC_VIEW_2, EXPECTED_MOSAIC_VIEW_3, EXPECTED_MOSAIC_VIEW_1]
+			[EXPECTED_MOSAIC_VIEW_3, EXPECTED_MOSAIC_VIEW_2, EXPECTED_MOSAIC_VIEW_1]
 		)
 
 	# endregion

--- a/explorer/rest/tests/facade/test_NemRestFacade.py
+++ b/explorer/rest/tests/facade/test_NemRestFacade.py
@@ -353,28 +353,28 @@ class TestNemRestFacade(DatabaseTestBase):  # pylint: disable=too-many-public-me
 		self._assert_can_retrieve_mosaics(
 			pagination=Pagination(1, 0),
 			sort='DESC',
-			expected_mosaics=[EXPECTED_MOSAIC_2]
+			expected_mosaics=[EXPECTED_MOSAIC_3]
 		)
 
 	def test_can_retrieve_mosaics_filtered_by_offset(self):
 		self._assert_can_retrieve_mosaics(
 			pagination=Pagination(1, 1),
 			sort='DESC',
-			expected_mosaics=[EXPECTED_MOSAIC_3]
+			expected_mosaics=[EXPECTED_MOSAIC_2]
 		)
 
 	def test_can_retrieve_mosaics_sorted_by_registered_height_asc(self):
 		self._assert_can_retrieve_mosaics(
 			pagination=Pagination(10, 0),
 			sort='ASC',
-			expected_mosaics=[EXPECTED_MOSAIC_1, EXPECTED_MOSAIC_2, EXPECTED_MOSAIC_3]
+			expected_mosaics=[EXPECTED_MOSAIC_1, EXPECTED_MOSAIC_3, EXPECTED_MOSAIC_2]
 		)
 
 	def test_can_retrieve_mosaics_sorted_by_registered_height_desc(self):
 		self._assert_can_retrieve_mosaics(
 			pagination=Pagination(10, 0),
 			sort='DESC',
-			expected_mosaics=[EXPECTED_MOSAIC_2, EXPECTED_MOSAIC_3, EXPECTED_MOSAIC_1]
+			expected_mosaics=[EXPECTED_MOSAIC_3, EXPECTED_MOSAIC_2, EXPECTED_MOSAIC_1]
 		)
 
 	# endregion

--- a/explorer/rest/tests/routes/nem/test_routes.py
+++ b/explorer/rest/tests/routes/nem/test_routes.py
@@ -557,30 +557,30 @@ def _assert_get_api_nem_mosaics(client, expected_status_code, expected_result, *
 
 
 def test_api_mosaics_without_params(client):  # pylint: disable=redefined-outer-name
-	_assert_get_api_nem_mosaics(client, 200, [MOSAIC_VIEWS[1].to_dict(), MOSAIC_VIEWS[2].to_dict(), MOSAIC_VIEWS[0].to_dict()])
+	_assert_get_api_nem_mosaics(client, 200, [MOSAIC_VIEWS[2].to_dict(), MOSAIC_VIEWS[1].to_dict(), MOSAIC_VIEWS[0].to_dict()])
 
 
 def test_api_mosaics_applies_limit(client):  # pylint: disable=redefined-outer-name
-	_assert_get_api_nem_mosaics(client, 200, [MOSAIC_VIEWS[1].to_dict()], limit=1)
+	_assert_get_api_nem_mosaics(client, 200, [MOSAIC_VIEWS[2].to_dict()], limit=1)
 
 
 def test_api_mosaics_applies_offset(client):  # pylint: disable=redefined-outer-name
-	_assert_get_api_nem_mosaics(client, 200, [MOSAIC_VIEWS[2].to_dict(), MOSAIC_VIEWS[0].to_dict()], offset=1)
+	_assert_get_api_nem_mosaics(client, 200, [MOSAIC_VIEWS[1].to_dict(), MOSAIC_VIEWS[0].to_dict()], offset=1)
 
 
 def test_api_mosaics_applies_sorted_by_registered_height_asc(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_mosaics(client, 200, [MOSAIC_VIEWS[0].to_dict(), MOSAIC_VIEWS[1].to_dict(), MOSAIC_VIEWS[2].to_dict()], sort='ASC')
+	_assert_get_api_nem_mosaics(client, 200, [MOSAIC_VIEWS[0].to_dict(), MOSAIC_VIEWS[2].to_dict(), MOSAIC_VIEWS[1].to_dict()], sort='ASC')
 
 
 def test_api_mosaics_applies_sorted_by_registered_height_desc(client):  # pylint: disable=redefined-outer-name, invalid-name
-	_assert_get_api_nem_mosaics(client, 200, [MOSAIC_VIEWS[1].to_dict(), MOSAIC_VIEWS[2].to_dict(), MOSAIC_VIEWS[0].to_dict()], sort='DESC')
+	_assert_get_api_nem_mosaics(client, 200, [MOSAIC_VIEWS[2].to_dict(), MOSAIC_VIEWS[1].to_dict(), MOSAIC_VIEWS[0].to_dict()], sort='DESC')
 
 
 def test_api_mosaics_with_all_params(client):  # pylint: disable=redefined-outer-name
 	_assert_get_api_nem_mosaics(
 		client,
 		200,
-		[MOSAIC_VIEWS[2].to_dict()],
+		[MOSAIC_VIEWS[1].to_dict()],
 		limit=1,
 		offset=1,
 		sort='DESC'


### PR DESCRIPTION
## Problem
Three listings did their expensive work for the whole table and only then applied `ORDER BY` and `LIMIT`:

  ```sql
  FROM accounts a
  LEFT JOIN account_remark ar ON ar.address = a.address
  LEFT JOIN LATERAL ( ...jsonb_array_elements(a.mosaics)... ) am ON true
  {where_condition}
  {order_condition}
  {limit_condition}
  ```

For a page of ten rows at `offset=100000`, that `LATERAL` expands a jsonb array for 100 010 accounts
so that ten survive. `transactions` has the same shape for its mosaic aggregation, and `mosaics`
runs four joins — two of them into `blocks` — before the limit applies.

## Solution
The page is selected first and the joins run only for the rows that survive:

  ```sql
  FROM (
      SELECT * FROM accounts a
      {where_condition}
      {order_condition}
      {limit_condition}
  ) a
  LEFT JOIN account_remark ar ON ar.address = a.address
  LEFT JOIN LATERAL ( ... ) am ON true
  {order_condition}
  ```

  The same rewrite applies to `_generate_transaction_sql_query` and `_generate_mosaic_query`. It is
  the shape `_generate_namespace_query` and the account transaction query already use, so this brings
  the remaining three into line rather than introducing a new pattern.

  Every `WHERE` these generators receive refers only to the base table — `accounts`, `transactions` or
  `mosaics` — so nothing needed rewriting to move inside.