### PR TITLE
[explorer/puller] feat: repair database during rollback

### DIFF
--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -627,7 +627,6 @@ class NemDatabase(DatabaseConnection):
 			for record in results
 		]
 
-
 	def get_accounts_for_refresh(self, limit, last_account_id):
 		"""Gets account addresses that should have vested balance and importance refreshed."""
 

--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -523,6 +523,21 @@ class NemDatabase(DatabaseConnection):
 			(fork_height,)
 		)
 
+	@staticmethod
+	def delete_accounts(cursor, addresses):
+		"""Deletes accounts that were first observed on the orphan chain."""
+
+		if not addresses:
+			return
+
+		cursor.execute(
+			'''
+			DELETE FROM accounts
+			WHERE address = ANY(%s)
+			''',
+			([address.bytes for address in addresses],)
+		)
+
 
 	def get_accounts_for_refresh(self, limit, last_account_id):
 		"""Gets account addresses that should have vested balance and importance refreshed."""

--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -538,6 +538,42 @@ class NemDatabase(DatabaseConnection):
 			([address.bytes for address in addresses],)
 		)
 
+	@staticmethod
+	def refresh_account_from_snapshot(cursor, account_info):
+		"""Refreshes existing account state."""
+
+		cursor.execute(
+			'''
+			UPDATE accounts
+			SET importance = %s,
+				balance = %s,
+				vested_balance = %s,
+				mosaics = %s,
+				harvested_blocks = %s,
+				remote_status = %s,
+				min_cosignatories = %s,
+				cosignatory_of = %s,
+				cosignatories = %s,
+				updated_at = CURRENT_TIMESTAMP
+			WHERE address = %s
+			''',
+			(
+				account_info.importance,
+				account_info.balance,
+				account_info.vested_balance,
+				json.dumps(account_info.mosaics),
+				account_info.harvested_blocks,
+				account_info.remote_status,
+				account_info.min_cosignatories,
+				[address.bytes for address in account_info.cosignatory_of] if account_info.cosignatory_of else None,
+				[address.bytes for address in account_info.cosignatories] if account_info.cosignatories else None,
+				account_info.address.bytes
+			)
+		)
+
+		if 0 == cursor.rowcount:
+			raise RuntimeError(f'Cannot refresh missing NEM account {account_info.address}')
+
 
 	def get_accounts_for_refresh(self, limit, last_account_id):
 		"""Gets account addresses that should have vested balance and importance refreshed."""

--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -3,6 +3,7 @@ from binascii import unhexlify
 from collections import namedtuple
 
 from symbolchain.CryptoTypes import PublicKey
+from symbolchain.nc import TransactionType
 from symbolchain.nem.Network import Address
 
 from .DatabaseConnection import DatabaseConnection
@@ -16,6 +17,10 @@ RollbackTransactionRecord = namedtuple(
 OrphanChainRecords = namedtuple(
 	'OrphanChainRecords',
 	['blocks', 'transactions', 'transfer_levy_recipients']
+)
+RollbackAccountKeyLinkRecord = namedtuple(
+	'RollbackAccountKeyLinkRecord',
+	['sender_address', 'payload']
 )
 
 
@@ -573,6 +578,54 @@ class NemDatabase(DatabaseConnection):
 
 		if 0 == cursor.rowcount:
 			raise RuntimeError(f'Cannot refresh missing NEM account {account_info.address}')
+
+	@staticmethod
+	def clear_account_remote_addresses(cursor, addresses):
+		"""Clears links for accounts whose link history must be replayed."""
+
+		if not addresses:
+			return
+
+		cursor.execute(
+			'''
+			UPDATE accounts
+			SET remote_address = NULL,
+				updated_at = CURRENT_TIMESTAMP
+			WHERE address = ANY(%s)
+			''',
+			([address.bytes for address in addresses],)
+		)
+
+	@staticmethod
+	def get_surviving_account_key_links(cursor, fork_height, addresses):
+		"""Gets the latest surviving account-key-link transition for each affected account."""
+
+		if not addresses:
+			return []
+
+		cursor.execute(
+			'''
+			SELECT DISTINCT ON (sender_address)
+				sender_address,
+				payload
+			FROM transactions
+			WHERE transaction_type = %s
+				AND height <= %s
+				AND sender_address = ANY(%s)
+			ORDER BY sender_address ASC, height DESC, id DESC
+			''',
+			(
+				TransactionType.ACCOUNT_KEY_LINK.value,
+				fork_height,
+				[address.bytes for address in addresses]
+			)
+		)
+		results = cursor.fetchall()
+
+		return [
+			RollbackAccountKeyLinkRecord(Address(bytes(record[0])), record[1])
+			for record in results
+		]
 
 
 	def get_accounts_for_refresh(self, limit, last_account_id):

--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 import json
 from binascii import unhexlify
 from collections import namedtuple
@@ -8,8 +9,10 @@ from symbolchain.nem.Network import Address
 
 from .DatabaseConnection import DatabaseConnection
 
+NEM_NAMESPACE_GRACE_PERIOD = 30 * 1440
+
 AccountRefreshRecord = namedtuple('AccountRefreshRecord', ['id', 'address'])
-RollbackBlockRecord = namedtuple('RollbackBlockRecord', ['beneficiary', 'signer'])
+RollbackBlockRecord = namedtuple('RollbackBlockRecord', ['beneficiary', 'signer', 'total_fee'])
 RollbackTransactionRecord = namedtuple(
 	'RollbackTransactionRecord',
 	['transaction_type', 'sender_address', 'recipient_address', 'payload']
@@ -22,9 +25,17 @@ RollbackAccountKeyLinkRecord = namedtuple(
 	'RollbackAccountKeyLinkRecord',
 	['sender_address', 'payload']
 )
+RollbackNamespaceRegistrationRecord = namedtuple(
+	'RollbackNamespaceRegistrationRecord',
+	['height', 'owner', 'parent', 'namespace']
+)
+RollbackMosaicRecord = namedtuple(
+	'RollbackMosaicRecord',
+	['transaction_type', 'height', 'sender_public_key', 'payload']
+)
 
 
-class NemDatabase(DatabaseConnection):
+class NemDatabase(DatabaseConnection):  # pylint: disable=too-many-public-methods
 	"""Database containing Nem blockchain data."""
 
 	@staticmethod
@@ -435,7 +446,8 @@ class NemDatabase(DatabaseConnection):
 			'''
 			SELECT
 				beneficiary,
-				signer
+				signer,
+				total_fee
 			FROM blocks
 			WHERE height > %s
 			ORDER BY height ASC
@@ -444,7 +456,7 @@ class NemDatabase(DatabaseConnection):
 		)
 		results = cursor.fetchall()
 		blocks = [
-			RollbackBlockRecord(Address(bytes(record[0])), PublicKey(bytes(record[1])))
+			RollbackBlockRecord(Address(bytes(record[0])), PublicKey(bytes(record[1])), record[2])
 			for record in results
 		]
 
@@ -787,15 +799,79 @@ class NemDatabase(DatabaseConnection):
 			DO UPDATE SET
 				owner = EXCLUDED.owner,
 				registered_height = EXCLUDED.registered_height,
-				expiration_height = EXCLUDED.expiration_height
+				expiration_height = EXCLUDED.expiration_height,
+				sub_namespaces = CASE
+					WHEN namespaces.owner = EXCLUDED.owner
+						AND EXCLUDED.registered_height < namespaces.expiration_height + %s
+					THEN namespaces.sub_namespaces
+					ELSE '{}'
+				END
 			''',
 			(
 				namespace.root_namespace,
 				namespace.owner.bytes,
 				namespace.registered_height,
-				namespace.expiration_height
+				namespace.expiration_height,
+				NEM_NAMESPACE_GRACE_PERIOD
 			)
 		)
+
+	@staticmethod
+	def delete_namespaces(cursor, root_namespaces):
+		"""Deletes affected namespace projections before replay."""
+
+		if not root_namespaces:
+			return
+
+		cursor.execute(
+			'''
+			DELETE FROM namespaces
+			WHERE root_namespace = ANY(%s)
+			''',
+			(list(root_namespaces),)
+		)
+
+	@staticmethod
+	def get_surviving_namespace_history(cursor, fork_height, root_namespaces):
+		"""Gets surviving namespace registrations for affected roots in replay order."""
+
+		if not root_namespaces:
+			return []
+
+		cursor.execute(
+			'''
+			SELECT
+				height,
+				sender_public_key,
+				payload->>'parent',
+				payload->>'namespace'
+			FROM transactions
+			WHERE transaction_type = %s
+				AND height <= %s
+				AND (
+					CASE
+						WHEN payload->>'parent' IS NULL THEN payload->>'namespace'
+						ELSE split_part(payload->>'parent', '.', 1)
+					END
+				) = ANY(%s)
+			ORDER BY height ASC, id ASC
+			''',
+			(
+				TransactionType.NAMESPACE_REGISTRATION.value,
+				fork_height,
+				list(root_namespaces)
+			)
+		)
+
+		return [
+			RollbackNamespaceRegistrationRecord(
+				record[0],
+				PublicKey(bytes(record[1])),
+				record[2],
+				record[3]
+			)
+			for record in cursor.fetchall()
+		]
 
 	@staticmethod
 	def update_sub_namespaces(cursor, sub_namespace, root_namespace):
@@ -887,6 +963,58 @@ class NemDatabase(DatabaseConnection):
 		)
 
 	@staticmethod
+	def delete_mosaics(cursor, namespace_names):
+		"""Deletes affected mosaic projections except the seeded network currency."""
+
+		deletable_names = set(namespace_names) - {'nem.xem'}
+		if not deletable_names:
+			return
+
+		cursor.execute(
+			'''
+			DELETE FROM mosaics
+			WHERE namespace_name = ANY(%s)
+			''',
+			(list(deletable_names),)
+		)
+
+	@staticmethod
+	def get_surviving_mosaic_transactions(cursor, fork_height, namespace_names):
+		"""Gets affected mosaic definition and supply transactions in replay order."""
+
+		replay_names = set(namespace_names) - {'nem.xem'}
+		if not replay_names:
+			return []
+
+		cursor.execute(
+			'''
+			SELECT transaction_type, height, sender_public_key, payload
+			FROM transactions
+			WHERE transaction_type = ANY(%s)
+				AND height <= %s
+				AND payload->>'namespace_name' = ANY(%s)
+			ORDER BY height ASC, id ASC
+			''',
+			(
+				[
+					TransactionType.MOSAIC_DEFINITION.value,
+					TransactionType.MOSAIC_SUPPLY_CHANGE.value
+				],
+				fork_height,
+				list(replay_names)
+			)
+		)
+		return [
+			RollbackMosaicRecord(
+				record[0],
+				record[1],
+				PublicKey(bytes(record[2])),
+				record[3]
+			)
+			for record in cursor.fetchall()
+		]
+
+	@staticmethod
 	def insert_transaction(cursor, transaction):
 		"""Inserts transaction information."""
 
@@ -950,3 +1078,29 @@ class NemDatabase(DatabaseConnection):
 				mosaic.quantity
 			)
 		)
+
+	@staticmethod
+	def rollback_account_harvesting(cursor, orphan_harvested_fees_map, fork_height):
+		"""Subtracts orphan block fees and restores the latest surviving harvest height."""
+
+		for beneficiary, orphan_harvested_fees in orphan_harvested_fees_map.items():
+			cursor.execute(
+				'''
+				UPDATE accounts
+				SET harvested_fees = harvested_fees - %s,
+					last_harvested_height = (
+						SELECT COALESCE(MAX(height), 0)
+						FROM blocks
+						WHERE beneficiary = %s
+							AND height <= %s
+					),
+					updated_at = CURRENT_TIMESTAMP
+				WHERE address = %s
+				''',
+				(
+					orphan_harvested_fees,
+					beneficiary.bytes,
+					fork_height,
+					beneficiary.bytes
+				)
+			)

--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -504,6 +504,26 @@ class NemDatabase(DatabaseConnection):
 
 		return {Address(bytes(record[0])): record[1] for record in results}
 
+	@staticmethod
+	def delete_orphan_chain_data(cursor, fork_height):
+		"""Deletes transaction and block rows above a confirmed fork height."""
+
+		cursor.execute(
+			'''
+			DELETE FROM transactions
+			WHERE height > %s
+			''',
+			(fork_height,)
+		)
+		cursor.execute(
+			'''
+			DELETE FROM blocks
+			WHERE height > %s
+			''',
+			(fork_height,)
+		)
+
+
 	def get_accounts_for_refresh(self, limit, last_account_id):
 		"""Gets account addresses that should have vested balance and importance refreshed."""
 

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -341,6 +341,28 @@ class NemPuller:
 			if rollback_impact.account_creation_heights[address] != account.height:
 				raise NemRollbackError(f'Rollback account snapshot height mismatch for {address}')
 
+	def _restore_rollback_remote_addresses(self, cursor, rollback_impact):
+		"""Restores affected remote links from surviving account-key-link history."""
+
+		addresses = rollback_impact.affected_remote_link_accounts
+		self.nem_db.clear_account_remote_addresses(cursor, addresses)
+
+		transactions = self.nem_db.get_surviving_account_key_links(
+			cursor,
+			rollback_impact.fork_height,
+			addresses
+		)
+		for transaction in transactions:
+			remote_address = (
+				self._convert_public_key_to_address(transaction.payload['remote_account'])
+				if ACCOUNT_KEY_LINK_MODE_ACTIVATE == transaction.payload['mode'] else None
+			)
+			self.nem_db.update_account_remote_address(
+				cursor,
+				transaction.sender_address,
+				remote_address
+			)
+
 	async def _retry_get_account_info(self, address, retries=3, delay=2):
 		"""Retries fetching account info with exponential backoff."""
 

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -311,6 +311,18 @@ class NemPuller:
 			affected_mosaic_names
 		)
 
+	async def prefetch_rollback_account_state(self, rollback_impact):
+		"""Fetches current node state for all affected accounts that survive a rollback."""
+
+		account_state = {}
+		for address in rollback_impact.surviving_affected_accounts:
+			account_state[address] = await self._fetch_account_record(
+				str(address),
+				rollback_impact.account_creation_heights[address]
+			)
+
+		return account_state
+
 	async def _retry_get_account_info(self, address, retries=3, delay=2):
 		"""Retries fetching account info with exponential backoff."""
 

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 import asyncio
 import configparser
 import threading
@@ -17,6 +18,7 @@ from puller.db.NemDatabase import NemDatabase
 
 ACCOUNT_KEY_LINK_MODE_ACTIVATE = 1
 NEM_MAX_ROLLBACK_DEPTH = 360
+NEM_NAMESPACE_DURATION = 365 * 1440
 
 
 class NemRollbackError(RuntimeError):
@@ -107,7 +109,7 @@ NemRollbackImpact = namedtuple('NemRollbackImpact', [
 	'account_creation_heights',
 	'orphan_created_accounts',
 	'surviving_affected_accounts',
-	'orphan_beneficiaries',
+	'orphan_harvested_fees_map',
 	'affected_remote_link_accounts',
 	'affected_namespace_roots',
 	'affected_mosaic_names'
@@ -261,7 +263,7 @@ class NemPuller:
 			raise NemRollbackError(f'Invalid NEM fork height {fork_height}')
 
 		affected_accounts = set()
-		orphan_beneficiaries = set()
+		orphan_harvested_fees_map = {}
 		affected_remote_link_accounts = set()
 		affected_namespace_roots = set()
 		affected_mosaic_names = set()
@@ -271,7 +273,9 @@ class NemPuller:
 		orphan_records = self.nem_db.get_orphan_chain_records(fork_height)
 
 		for block in orphan_records.blocks:
-			orphan_beneficiaries.add(block.beneficiary)
+			orphan_harvested_fees_map[block.beneficiary] = (
+				orphan_harvested_fees_map.get(block.beneficiary, 0) + block.total_fee
+			)
 			affected_accounts.add(block.beneficiary)
 			affected_accounts.add(self._convert_public_key_to_address(block.signer))
 
@@ -305,7 +309,7 @@ class NemPuller:
 			account_creation_heights,
 			orphan_created_accounts,
 			surviving_affected_accounts,
-			orphan_beneficiaries,
+			orphan_harvested_fees_map,
 			affected_remote_link_accounts,
 			affected_namespace_roots,
 			affected_mosaic_names
@@ -363,6 +367,86 @@ class NemPuller:
 				remote_address
 			)
 
+	def _restore_rollback_namespaces(self, cursor, rollback_impact):
+		"""Rebuilds affected namespace projections from surviving registrations."""
+
+		root_namespaces = rollback_impact.affected_namespace_roots
+		self.nem_db.delete_namespaces(cursor, root_namespaces)
+
+		registrations = self.nem_db.get_surviving_namespace_history(
+			cursor,
+			rollback_impact.fork_height,
+			root_namespaces
+		)
+		for record in registrations:
+			if record.parent:
+				self.nem_db.update_sub_namespaces(
+					cursor,
+					f'{record.parent}.{record.namespace}',
+					record.parent.split('.')[0]
+				)
+			else:
+				self.nem_db.upsert_namespace(
+					cursor,
+					NamespaceRecord(
+						record.namespace,
+						record.owner,
+						record.height,
+						record.height + NEM_NAMESPACE_DURATION
+					)
+				)
+
+	@staticmethod
+	def _create_rollback_mosaic_record(transaction):
+		"""Creates a mosaic projection from a stored surviving definition transaction."""
+
+		payload = transaction.payload
+		properties = payload['mosaic_properties']
+		levy = payload['levy']
+
+		return MosaicRecord(
+			root_namespace=payload['namespace_name'].split('.')[0],
+			namespace_name=payload['namespace_name'],
+			description=payload['description'],
+			creator=transaction.sender_public_key,
+			registered_height=transaction.height,
+			initial_supply=properties['initial_supply'],
+			total_supply=properties['initial_supply'],
+			divisibility=properties['divisibility'],
+			supply_mutable=properties['supply_mutable'],
+			transferable=properties['transferable'],
+			levy_type=levy['type'] if levy else None,
+			levy_namespace_name=levy['namespace_name'] if levy else None,
+			levy_fee=levy['fee'] if levy else None,
+			levy_recipient=Address(levy['recipient']) if levy else None
+		)
+
+	def _restore_rollback_mosaics(self, cursor, rollback_impact):
+		"""Rebuilds affected mosaic projections from surviving transactions."""
+
+		namespace_names = rollback_impact.affected_mosaic_names
+		self.nem_db.delete_mosaics(cursor, namespace_names)
+
+		transactions = self.nem_db.get_surviving_mosaic_transactions(
+			cursor,
+			rollback_impact.fork_height,
+			namespace_names
+		)
+		for transaction in transactions:
+			if TransactionType.MOSAIC_DEFINITION.value == transaction.transaction_type:
+				self.nem_db.upsert_mosaic(
+					cursor,
+					self._create_rollback_mosaic_record(transaction)
+				)
+			else:
+				payload = transaction.payload
+				adjustment = payload['delta'] if 1 == payload['supply_type'] else -payload['delta']
+				self.nem_db.update_mosaic_total_supply(
+					cursor,
+					payload['namespace_name'],
+					adjustment
+				)
+
 	def repair_rollback(self, rollback_impact, account_state):
 		"""Atomically restores NEM database state to a confirmed fork height."""
 
@@ -370,6 +454,11 @@ class NemPuller:
 		cursor = self.nem_db.connection.cursor()
 
 		try:
+			self.nem_db.rollback_account_harvesting(
+				cursor,
+				rollback_impact.orphan_harvested_fees_map,
+				rollback_impact.fork_height
+			)
 			self.nem_db.delete_orphan_chain_data(cursor, rollback_impact.fork_height)
 			self.nem_db.delete_accounts(cursor, rollback_impact.orphan_created_accounts)
 
@@ -377,8 +466,8 @@ class NemPuller:
 				self.nem_db.refresh_account_from_snapshot(cursor, account_state[address])
 
 			self._restore_rollback_remote_addresses(cursor, rollback_impact)
-
-			# Todo: reconstruct_rollback_namespaces, reconstruct_rollback_mosaics, recalculate_account_harvesting
+			self._restore_rollback_namespaces(cursor, rollback_impact)
+			self._restore_rollback_mosaics(cursor, rollback_impact)
 
 			self.nem_db.connection.commit()
 		except Exception:
@@ -623,7 +712,7 @@ class NemPuller:
 		"""Process root namespace data."""
 
 		# add 1 year to expired height
-		expired_height = block_height + (365 * 1440)
+		expired_height = block_height + NEM_NAMESPACE_DURATION
 
 		namespace = NamespaceRecord(
 			root_namespace=transaction.namespace,

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -459,6 +459,15 @@ class NemPuller:
 			account_info.cosignatories
 		)
 
+	async def _fetch_account_record(self, address, height):
+		"""Fetches current node state and creates a complete account record."""
+
+		account_info = await self._retry_get_account_info(address)
+		account_mosaics = await self._retry_get_account_mosaics(address)
+		mosaics_json = self._convert_mosaics_to_json(account_mosaics)
+
+		return self._create_account_record(account_info, mosaics_json, height)
+
 	@staticmethod
 	def _create_account_vested_balance_record(account_info):
 		"""Create account vested balance record."""
@@ -479,12 +488,7 @@ class NemPuller:
 
 		# Fetch account info for all addresses (both new and existing)
 		for address, height in address_heights.items():
-			account_info = await self._retry_get_account_info(address)
-			account_mosaics = await self._retry_get_account_mosaics(address)
-
-			mosaics_json = self._convert_mosaics_to_json(account_mosaics)
-			account = self._create_account_record(account_info, mosaics_json, height)
-
+			account = await self._fetch_account_record(address, height)
 			self.nem_db.upsert_account(cursor, account)
 
 	@staticmethod

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -323,6 +323,24 @@ class NemPuller:
 
 		return account_state
 
+	@staticmethod
+	def _validate_rollback_account_state(rollback_impact, account_state):
+		"""Requires one correctly identified node snapshot for every surviving account."""
+
+		expected_addresses = rollback_impact.surviving_affected_accounts
+		actual_addresses = set(account_state)
+		if expected_addresses != actual_addresses:
+			raise NemRollbackError(
+				'Rollback account snapshot does not match surviving affected accounts'
+			)
+
+		for address, account in account_state.items():
+			if address != account.address:
+				raise NemRollbackError(f'Rollback account snapshot address mismatch for {address}')
+
+			if rollback_impact.account_creation_heights[address] != account.height:
+				raise NemRollbackError(f'Rollback account snapshot height mismatch for {address}')
+
 	async def _retry_get_account_info(self, address, retries=3, delay=2):
 		"""Retries fetching account info with exponential backoff."""
 

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -363,6 +363,28 @@ class NemPuller:
 				remote_address
 			)
 
+	def repair_rollback(self, rollback_impact, account_state):
+		"""Atomically restores NEM database state to a confirmed fork height."""
+
+		self._validate_rollback_account_state(rollback_impact, account_state)
+		cursor = self.nem_db.connection.cursor()
+
+		try:
+			self.nem_db.delete_orphan_chain_data(cursor, rollback_impact.fork_height)
+			self.nem_db.delete_accounts(cursor, rollback_impact.orphan_created_accounts)
+
+			for address in sorted(account_state, key=str):
+				self.nem_db.refresh_account_from_snapshot(cursor, account_state[address])
+
+			self._restore_rollback_remote_addresses(cursor, rollback_impact)
+
+			# Todo: reconstruct_rollback_namespaces, reconstruct_rollback_mosaics, recalculate_account_harvesting
+
+			self.nem_db.connection.commit()
+		except Exception:
+			self.nem_db.connection.rollback()
+			raise
+
 	async def _retry_get_account_info(self, address, retries=3, delay=2):
 		"""Retries fetching account info with exponential backoff."""
 

--- a/explorer/puller/puller/workflows/sync_nem_block.py
+++ b/explorer/puller/puller/workflows/sync_nem_block.py
@@ -41,6 +41,14 @@ async def main():
 			await facade.sync_nemesis_block()
 			db_height = 1
 
+		fork_height = await facade.detect_rollback(db_height, chain_height)
+		if fork_height is not None:
+			log.warning(f'Rollback detected at height: {fork_height}')
+			rollback_impact = facade.capture_rollback_impact(fork_height)
+			account_state = await facade.prefetch_rollback_account_state(rollback_impact)
+			facade.repair_rollback(rollback_impact, account_state)
+			db_height = fork_height
+
 		# sync network blocks in database
 		await facade.sync_blocks(db_height, chain_height)
 

--- a/explorer/puller/tests/db/test_NemDatabase.py
+++ b/explorer/puller/tests/db/test_NemDatabase.py
@@ -1297,3 +1297,78 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 		self.assertIsNotNone(surviving_result)
 		self.assertIsNone(orphan_result)
 
+	def test_can_refresh_account_from_rollback_snapshot(self):
+		# Arrange:
+		orphan_remote_address = Address('TBKQWJJGPOHL462DBVMTYOAERXGG2BOS5XRFO2P6')
+		orphan_harvested_fees = 500000
+		orphan_last_harvested_height = 10
+		orphan_account = ACCOUNTS[0]._replace(remote_address=orphan_remote_address)
+		snapshot = orphan_account._replace(
+			remote_address=None,
+			importance=0.5,
+			balance=2000000,
+			vested_balance=1500000,
+			mosaics=[{'namespace_name': 'foo.token', 'quantity': 7}],
+			harvested_blocks=25,
+			remote_status='ACTIVE',
+			min_cosignatories=1,
+			cosignatory_of=[orphan_remote_address],
+			cosignatories=[orphan_remote_address]
+		)
+
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+			cursor = nem_database.connection.cursor()
+
+			nem_database.upsert_account(cursor, orphan_account)
+			nem_database.update_account_harvested_fees(
+				cursor,
+				orphan_account.address,
+				orphan_harvested_fees,
+				orphan_last_harvested_height
+			)
+			nem_database.connection.commit()
+
+			# Act:
+			nem_database.refresh_account_from_snapshot(cursor, snapshot)
+			nem_database.connection.commit()
+			result = self._fetch_account_from_db(cursor, snapshot.address)
+
+		# Assert:
+		self.assertEqual(snapshot.address.bytes.hex(), result[0])
+		self.assertEqual(snapshot.height, result[1])
+		self.assertEqual(snapshot.public_key.bytes.hex(), result[2])
+		self.assertEqual(orphan_remote_address.bytes.hex(), result[3])  # remote_address should remain unchanged
+		self.assertEqual(f'{snapshot.importance:.10f}', result[4])
+		self.assertEqual(snapshot.balance, result[5])
+		self.assertEqual(snapshot.vested_balance, result[6])
+		self.assertEqual(snapshot.mosaics, result[7])
+		self.assertEqual(orphan_harvested_fees, result[8])  # harvested_fees should remain unchanged
+		self.assertEqual(snapshot.harvested_blocks, result[9])
+		self.assertEqual(snapshot.remote_status, result[10])
+		self.assertEqual(orphan_last_harvested_height, result[11])  # last_harvested_height should remain unchanged
+		self.assertEqual(snapshot.min_cosignatories, result[12])
+		self.assertEqual(
+			[address.bytes for address in snapshot.cosignatory_of],
+			[bytes(address) for address in result[13]]
+		)
+		self.assertEqual(
+			[address.bytes for address in snapshot.cosignatories],
+			[bytes(address) for address in result[14]]
+		)
+
+	def test_rejects_refreshing_missing_account_from_rollback_snapshot(self):
+		# Arrange:
+		missing_account = ACCOUNTS[0]
+
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+			cursor = nem_database.connection.cursor()
+
+			# Act + Assert:
+			with self.assertRaisesRegex(
+				RuntimeError,
+				f'Cannot refresh missing NEM account {missing_account.address}'
+			):
+				nem_database.refresh_account_from_snapshot(cursor, missing_account)
+

--- a/explorer/puller/tests/db/test_NemDatabase.py
+++ b/explorer/puller/tests/db/test_NemDatabase.py
@@ -6,10 +6,11 @@ from pathlib import Path
 import psycopg2
 import testing.postgresql
 from symbolchain.CryptoTypes import PublicKey
+from symbolchain.nc import TransactionType
 from symbolchain.nem.Network import Address
 from symbollightapi.model.Transaction import Mosaic
 
-from puller.db.NemDatabase import NemDatabase
+from puller.db.NemDatabase import NemDatabase, RollbackAccountKeyLinkRecord
 from puller.facade.NemPuller import AccountRecord, BlockRecord, MosaicRecord, NamespaceRecord, TransactionRecord
 
 from .test_DatabaseConnection import DatabaseConfig
@@ -1371,4 +1372,87 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 				f'Cannot refresh missing NEM account {missing_account.address}'
 			):
 				nem_database.refresh_account_from_snapshot(cursor, missing_account)
+
+	def test_can_clear_selected_account_remote_addresses(self):
+		# Arrange:
+		remote_address = Address('TBKQWJJGPOHL462DBVMTYOAERXGG2BOS5XRFO2P6')
+		cleared_account = ACCOUNTS[0]._replace(remote_address=remote_address)
+
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+			cursor = nem_database.connection.cursor()
+
+			nem_database.upsert_account(cursor, cleared_account)
+
+			# Act:
+			nem_database.clear_account_remote_addresses(cursor, {cleared_account.address})
+
+			cleared_result = self._fetch_account_from_db(cursor, cleared_account.address)
+
+		# Assert:
+		self.assertIsNone(cleared_result[3])
+
+	def test_can_get_latest_surviving_account_key_link(self):
+		# Arrange:
+		fork_height = 2
+		affected_address = ACCOUNTS[0].address
+		first_remote_key = PublicKey('7195f4d7a40ad7e31958ae96c4afed002962229675a4cae8dc8a18e290618981')
+		second_remote_key = PublicKey('f94e8702eb1943b23570b1b83be1b81536df35538978820e98bfce8f999e2d37')
+		activation_payload = {'mode': 1, 'remote_account': str(first_remote_key)}
+		deactivation_payload = {'mode': 2, 'remote_account': str(first_remote_key)}
+		reactivation_payload = {'mode': 1, 'remote_account': str(second_remote_key)}
+		transactions = [
+			TRANSACTIONS[0]._replace(
+				transaction_hash='11' * 32,
+				transaction_type=TransactionType.ACCOUNT_KEY_LINK.value,
+				height=1,
+				sender_address=affected_address,
+				payload=activation_payload
+			),
+			TRANSACTIONS[0]._replace(
+				transaction_hash='22' * 32,
+				transaction_type=TransactionType.ACCOUNT_KEY_LINK.value,
+				height=2,
+				is_inner=True,
+				sender_address=affected_address,
+				payload=deactivation_payload
+			),
+			TRANSACTIONS[0]._replace(
+				transaction_hash='33' * 32,
+				transaction_type=TransactionType.ACCOUNT_KEY_LINK.value,
+				height=2,
+				is_inner=True,
+				sender_address=affected_address,
+				payload=reactivation_payload
+			),
+			TRANSACTIONS[0]._replace(
+				transaction_hash='44' * 32,
+				transaction_type=TransactionType.ACCOUNT_KEY_LINK.value,
+				height=3,
+				sender_address=affected_address,
+				payload=activation_payload
+			)
+		]
+
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+			cursor = nem_database.connection.cursor()
+
+			for transaction in transactions:
+				nem_database.insert_transaction(cursor, transaction)
+
+			# Act:
+			results = nem_database.get_surviving_account_key_links(
+				cursor,
+				fork_height,
+				{affected_address}
+			)
+
+		# Assert:
+		self.assertEqual([
+			RollbackAccountKeyLinkRecord(
+				affected_address,
+				reactivation_payload
+			)
+		], results)
 

--- a/explorer/puller/tests/db/test_NemDatabase.py
+++ b/explorer/puller/tests/db/test_NemDatabase.py
@@ -1229,3 +1229,45 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 
 		# Assert:
 		self.assertEqual({}, account_heights)
+
+	def test_can_delete_orphan_chain_data(self):
+		# Arrange:
+		surviving_transaction = TRANSACTIONS[0]._replace(
+			transaction_hash='11' * 32,
+			height=1
+		)
+		orphan_transaction = TRANSACTIONS[0]._replace(
+			transaction_hash='22' * 32,
+			height=2
+		)
+
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+			cursor = nem_database.connection.cursor()
+
+			for block in BLOCKS:
+				nem_database.insert_block(cursor, block)
+
+			surviving_transaction_id = nem_database.insert_transaction(cursor, surviving_transaction)
+			orphan_transaction_id = nem_database.insert_transaction(cursor, orphan_transaction)
+			nem_database.insert_transaction_mosaic(cursor, surviving_transaction_id, Mosaic('nem.xem', 1))
+			nem_database.insert_transaction_mosaic(cursor, orphan_transaction_id, Mosaic('nem.xem', 2))
+			nem_database.connection.commit()
+
+			# Act:
+			nem_database.delete_orphan_chain_data(cursor, 1)
+
+			cursor.execute('SELECT height FROM blocks')
+			block_heights = [record[0] for record in cursor.fetchall()]
+
+			cursor.execute('SELECT height FROM transactions')
+			transaction_heights = [record[0] for record in cursor.fetchall()]
+
+			cursor.execute('SELECT transaction_id FROM transactions_mosaic')
+			transaction_id = [record[0] for record in cursor.fetchall()]
+
+		# Assert:
+		self.assertEqual([1], block_heights)
+		self.assertEqual([1], transaction_heights)
+		self.assertEqual([1], transaction_id)
+

--- a/explorer/puller/tests/db/test_NemDatabase.py
+++ b/explorer/puller/tests/db/test_NemDatabase.py
@@ -1271,3 +1271,29 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 		self.assertEqual([1], transaction_heights)
 		self.assertEqual([1], transaction_id)
 
+	def test_can_delete_accounts(self):
+		# Arrange:
+		surviving_account = ACCOUNTS[0]
+		orphan_account = ACCOUNTS[0]._replace(
+			address=Address('TALICE6XEEEOBFJVY3ZCENZ7WBG6LB4KB7P7KMQX'),
+			height=2
+		)
+
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+			cursor = nem_database.connection.cursor()
+
+			nem_database.upsert_account(cursor, surviving_account)
+			nem_database.upsert_account(cursor, orphan_account)
+			nem_database.connection.commit()
+
+			# Act:
+			nem_database.delete_accounts(cursor, {orphan_account.address})
+
+			surviving_result = self._fetch_account_from_db(cursor, surviving_account.address)
+			orphan_result = self._fetch_account_from_db(cursor, orphan_account.address)
+
+		# Assert:
+		self.assertIsNotNone(surviving_result)
+		self.assertIsNone(orphan_result)
+

--- a/explorer/puller/tests/db/test_NemDatabase.py
+++ b/explorer/puller/tests/db/test_NemDatabase.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import unittest
+from collections import namedtuple
 from pathlib import Path
 
 import psycopg2
@@ -10,10 +11,16 @@ from symbolchain.nc import TransactionType
 from symbolchain.nem.Network import Address
 from symbollightapi.model.Transaction import Mosaic
 
-from puller.db.NemDatabase import NemDatabase, RollbackAccountKeyLinkRecord
+from puller.db.NemDatabase import NemDatabase, RollbackAccountKeyLinkRecord, RollbackMosaicRecord, RollbackNamespaceRegistrationRecord
 from puller.facade.NemPuller import AccountRecord, BlockRecord, MosaicRecord, NamespaceRecord, TransactionRecord
 
 from .test_DatabaseConnection import DatabaseConfig
+
+AccountDbRecord = namedtuple('AccountDbRecord', [
+	*AccountRecord._fields,
+	'harvested_fees',
+	'last_harvested_height'
+])
 
 # region test data
 
@@ -130,19 +137,20 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 				balance,
 				vested_balance,
 				mosaics,
-				harvested_fees,
 				harvested_blocks,
 				remote_status,
-				last_harvested_height,
 				min_cosignatories,
 				cosignatory_of,
-				cosignatories
+				cosignatories,
+				harvested_fees,
+				last_harvested_height
 			FROM accounts
 			WHERE address = %s
 			''',
 			(address.bytes,)
 		)
-		return cursor.fetchone()
+		result = cursor.fetchone()
+		return AccountDbRecord(*result) if result else None
 
 	@staticmethod
 	def _fetch_namespace_from_db(cursor, root_namespace):
@@ -488,13 +496,13 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			1000000,
 			99999,
 			[],
-			0,
 			10,
 			'INACTIVE',
+			None,
+			None,
+			None,
 			0,
-			None,
-			None,
-			None)
+			0)
 		)
 
 	def test_can_update_account_by_address_conflict(self):
@@ -530,13 +538,13 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			2000000,
 			99999,
 			[],
-			0,
 			10,
 			'INACTIVE',
+			None,
+			None,
+			None,
 			0,
-			None,
-			None,
-			None)
+			0)
 		)
 
 	def test_account_height_remains_unchanged_on_update(self):
@@ -562,7 +570,7 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			result = self._fetch_account_from_db(cursor, ACCOUNTS[0].address)
 
 		# Assert:
-		self.assertEqual(result[1], 1)
+		self.assertEqual(result.height, 1)
 
 	def test_upsert_account_does_not_overwrite_remote_address(self):
 		# Arrange:
@@ -589,8 +597,8 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			result = self._fetch_account_from_db(cursor, ACCOUNTS[0].address)
 
 		# Assert:
-		self.assertEqual(result[3], remote_address.bytes.hex())
-		self.assertEqual(result[5], 2000000)
+		self.assertEqual(result.remote_address, remote_address.bytes.hex())
+		self.assertEqual(result.balance, 2000000)
 
 	def test_can_set_account_remote_address(self):
 		# Arrange:
@@ -609,7 +617,7 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			result = self._fetch_account_from_db(cursor, ACCOUNTS[0].address)
 
 		# Assert:
-		self.assertEqual(result[3], remote_address.bytes.hex())
+		self.assertEqual(result.remote_address, remote_address.bytes.hex())
 
 	def test_can_clear_account_remote_address(self):
 		# Arrange:
@@ -628,7 +636,7 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			result = self._fetch_account_from_db(cursor, ACCOUNTS[0].address)
 
 		# Assert:
-		self.assertIsNone(result[3])
+		self.assertIsNone(result.remote_address)
 
 	def test_can_get_accounts_for_refresh(self):
 		# Arrange:
@@ -754,13 +762,13 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			1000000,
 			88888,
 			[],
-			0,
 			10,
 			'INACTIVE',
+			None,
+			None,
+			None,
 			0,
-			None,
-			None,
-			None)
+			0)
 		)
 
 	def test_can_update_account_harvested_fees(self):
@@ -796,8 +804,8 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			result = self._fetch_account_from_db(cursor, ACCOUNTS[0].address)
 
 		# Assert:
-		self.assertEqual(result[8], 750000)  # harvested_fees
-		self.assertEqual(result[11], 20)      # last_harvested_height
+		self.assertEqual(result.harvested_fees, 750000)
+		self.assertEqual(result.last_harvested_height, 20)
 
 	def test_can_insert_namespace(self):
 		# Arrange:
@@ -872,6 +880,72 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			[]
 		))
 
+	def test_same_owner_namespace_renewal_before_grace_period_end_preserves_sub_namespaces(self):
+		# Arrange:
+		owner = PublicKey('11' * 32)
+		renewal_height = 200 + (30 * 1440) - 1
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+			cursor = nem_database.connection.cursor()
+
+			nem_database.upsert_namespace(cursor, NamespaceRecord('root', owner, 100, 200))
+			nem_database.update_sub_namespaces(cursor, 'root.child', 'root')
+
+			# Act:
+			nem_database.upsert_namespace(cursor, NamespaceRecord('root', owner, renewal_height, 500000))
+			result = self._fetch_namespace_from_db(cursor, 'root')
+
+		# Assert:
+		self.assertEqual((
+			'root',
+			str(owner),
+			renewal_height,
+			500000,
+			['root.child']
+		), result)
+
+	def test_same_owner_namespace_registration_at_grace_period_end_clears_sub_namespaces(self):
+		# Arrange:
+		owner = PublicKey('11' * 32)
+		registration_height = 200 + (30 * 1440)  # grace period end
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+			cursor = nem_database.connection.cursor()
+
+			nem_database.upsert_namespace(cursor, NamespaceRecord('root', owner, 100, 200))
+			nem_database.update_sub_namespaces(cursor, 'root.child', 'root')
+
+			# Act:
+			nem_database.upsert_namespace(cursor, NamespaceRecord('root', owner, registration_height, 500000))
+			result = self._fetch_namespace_from_db(cursor, 'root')
+
+		# Assert:
+		self.assertEqual((
+			'root',
+			str(owner),
+			registration_height,
+			500000,
+			[]
+		), result)
+
+	def test_can_delete_affected_namespace_roots(self):
+		# Arrange:
+		owner = PublicKey('11' * 32)
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+			cursor = nem_database.connection.cursor()
+
+			nem_database.upsert_namespace(cursor, NamespaceRecord('affected', owner, 100, 200))
+			nem_database.upsert_namespace(cursor, NamespaceRecord('unaffected', owner, 100, 200))
+
+			# Act:
+			nem_database.delete_namespaces(cursor, {'affected'})
+			cursor.execute('SELECT root_namespace FROM namespaces ORDER BY root_namespace')
+			results = [record[0] for record in cursor.fetchall()]
+
+		# Assert:
+		self.assertEqual(['unaffected'], results)
+
 	def test_can_update_sub_namespaces(self):
 		# Arrange:
 		with NemDatabase(self.db_config) as nem_database:
@@ -909,6 +983,126 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			200,
 			['sub1']
 		))
+
+	def test_namespace_history_filters_affected_roots(self):
+		# Arrange:
+		owner = PublicKey('11' * 32)
+		transactions = [
+			TRANSACTIONS[0]._replace(
+				transaction_hash='11' * 32,
+				transaction_type=TransactionType.NAMESPACE_REGISTRATION.value,
+				height=2,
+				sender_public_key=owner,
+				payload={'parent': None, 'namespace': 'root'}
+			),
+			TRANSACTIONS[0]._replace(
+				transaction_hash='22' * 32,
+				transaction_type=TransactionType.NAMESPACE_REGISTRATION.value,
+				height=2,
+				sender_public_key=owner,
+				payload={'parent': 'root', 'namespace': 'child'}
+			),
+			TRANSACTIONS[0]._replace(
+				transaction_hash='33' * 32,
+				transaction_type=TransactionType.NAMESPACE_REGISTRATION.value,
+				height=2,
+				sender_public_key=owner,
+				payload={'parent': 'root.child', 'namespace': 'grandchild'}
+			),
+			TRANSACTIONS[0]._replace(
+				transaction_hash='44' * 32,
+				transaction_type=TransactionType.NAMESPACE_REGISTRATION.value,
+				height=2,
+				sender_public_key=owner,
+				payload={'parent': None, 'namespace': 'unaffected'}
+			)
+		]
+
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+			cursor = nem_database.connection.cursor()
+			for transaction in transactions:
+				nem_database.insert_transaction(cursor, transaction)
+
+			# Act:
+			results = nem_database.get_surviving_namespace_history(cursor, 2, {'root', 'missing'})
+
+		# Assert:
+		self.assertEqual([
+			RollbackNamespaceRegistrationRecord(2, owner, None, 'root'),
+			RollbackNamespaceRegistrationRecord(2, owner, 'root', 'child'),
+			RollbackNamespaceRegistrationRecord(2, owner, 'root.child', 'grandchild')
+		], results)
+
+	def test_namespace_history_filters_transactions_above_fork_height(self):
+		# Arrange:
+		owner = PublicKey('11' * 32)
+		transactions = [
+			TRANSACTIONS[0]._replace(
+				transaction_hash='11' * 32,
+				transaction_type=TransactionType.NAMESPACE_REGISTRATION.value,
+				height=2,
+				sender_public_key=owner,
+				payload={'parent': None, 'namespace': 'root'}
+			),
+			TRANSACTIONS[0]._replace(
+				transaction_hash='22' * 32,
+				transaction_type=TransactionType.NAMESPACE_REGISTRATION.value,
+				height=3,
+				sender_public_key=owner,
+				payload={'parent': None, 'namespace': 'root'}
+			)
+		]
+
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+			cursor = nem_database.connection.cursor()
+
+			for transaction in transactions:
+				nem_database.insert_transaction(cursor, transaction)
+
+			# Act:
+			results = nem_database.get_surviving_namespace_history(cursor, 2, {'root'})
+
+		# Assert:
+		self.assertEqual([
+			RollbackNamespaceRegistrationRecord(2, owner, None, 'root')
+		], results)
+
+	def test_namespace_history_filters_other_transaction_types(self):
+		# Arrange:
+		owner = PublicKey('11' * 32)
+		transactions = [
+			TRANSACTIONS[0]._replace(
+				transaction_hash='11' * 32,
+				transaction_type=TransactionType.NAMESPACE_REGISTRATION.value,
+				height=2,
+				sender_public_key=owner,
+				payload={'parent': None, 'namespace': 'root'}
+			),
+			TRANSACTIONS[0]._replace(
+				transaction_hash='22' * 32,
+				transaction_type=TransactionType.TRANSFER.value,
+				height=2,
+				sender_public_key=owner,
+				payload={'parent': None, 'namespace': 'root'}
+			)
+		]
+
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+			cursor = nem_database.connection.cursor()
+
+			for transaction in transactions:
+				nem_database.insert_transaction(cursor, transaction)
+
+			# Act:
+			results = nem_database.get_surviving_namespace_history(cursor, 2, {'root'})
+
+		# Assert:
+		self.assertEqual([
+			RollbackNamespaceRegistrationRecord(2, owner, None, 'root')
+		], results)
 
 	def test_can_insert_mosaic(self):
 		# Arrange:
@@ -1204,6 +1398,7 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 		self.assertEqual(1, len(orphan_blocks))
 		self.assertEqual(BLOCKS[1].beneficiary, orphan_blocks[0].beneficiary)
 		self.assertEqual(BLOCKS[1].signer, orphan_blocks[0].signer)
+		self.assertEqual(BLOCKS[1].total_fee, orphan_blocks[0].total_fee)
 
 		self.assertEqual(2, len(orphan_transactions))
 		self.assertEqual(['outer', 'inner'], [
@@ -1336,26 +1531,26 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			result = self._fetch_account_from_db(cursor, snapshot.address)
 
 		# Assert:
-		self.assertEqual(snapshot.address.bytes.hex(), result[0])
-		self.assertEqual(snapshot.height, result[1])
-		self.assertEqual(snapshot.public_key.bytes.hex(), result[2])
-		self.assertEqual(orphan_remote_address.bytes.hex(), result[3])  # remote_address should remain unchanged
-		self.assertEqual(f'{snapshot.importance:.10f}', result[4])
-		self.assertEqual(snapshot.balance, result[5])
-		self.assertEqual(snapshot.vested_balance, result[6])
-		self.assertEqual(snapshot.mosaics, result[7])
-		self.assertEqual(orphan_harvested_fees, result[8])  # harvested_fees should remain unchanged
-		self.assertEqual(snapshot.harvested_blocks, result[9])
-		self.assertEqual(snapshot.remote_status, result[10])
-		self.assertEqual(orphan_last_harvested_height, result[11])  # last_harvested_height should remain unchanged
-		self.assertEqual(snapshot.min_cosignatories, result[12])
+		self.assertEqual(snapshot.address.bytes.hex(), result.address)
+		self.assertEqual(snapshot.height, result.height)
+		self.assertEqual(snapshot.public_key.bytes.hex(), result.public_key)
+		self.assertEqual(orphan_remote_address.bytes.hex(), result.remote_address)
+		self.assertEqual(f'{snapshot.importance:.10f}', result.importance)
+		self.assertEqual(snapshot.balance, result.balance)
+		self.assertEqual(snapshot.vested_balance, result.vested_balance)
+		self.assertEqual(snapshot.mosaics, result.mosaics)
+		self.assertEqual(orphan_harvested_fees, result.harvested_fees)
+		self.assertEqual(snapshot.harvested_blocks, result.harvested_blocks)
+		self.assertEqual(snapshot.remote_status, result.remote_status)
+		self.assertEqual(orphan_last_harvested_height, result.last_harvested_height)
+		self.assertEqual(snapshot.min_cosignatories, result.min_cosignatories)
 		self.assertEqual(
 			[address.bytes for address in snapshot.cosignatory_of],
-			[bytes(address) for address in result[13]]
+			[bytes(address) for address in result.cosignatory_of]
 		)
 		self.assertEqual(
 			[address.bytes for address in snapshot.cosignatories],
-			[bytes(address) for address in result[14]]
+			[bytes(address) for address in result.cosignatories]
 		)
 
 	def test_rejects_refreshing_missing_account_from_rollback_snapshot(self):
@@ -1390,7 +1585,7 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			cleared_result = self._fetch_account_from_db(cursor, cleared_account.address)
 
 		# Assert:
-		self.assertIsNone(cleared_result[3])
+		self.assertIsNone(cleared_result.remote_address)
 
 	def test_can_get_latest_surviving_account_key_link(self):
 		# Arrange:
@@ -1455,3 +1650,192 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 				reactivation_payload
 			)
 		], results)
+
+	def _run_delete_mosaics_test(self, prepare_mosaics, mosaics_to_delete, expected_mosaics):
+		# Arrange:
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+			cursor = nem_database.connection.cursor()
+
+			for mosaic in prepare_mosaics:
+				nem_database.upsert_mosaic(cursor, mosaic)
+
+			nem_database.connection.commit()
+
+			# Act:
+			nem_database.delete_mosaics(cursor, mosaics_to_delete)
+
+			cursor.execute('SELECT namespace_name FROM mosaics ORDER BY namespace_name')
+			results = [record[0] for record in cursor.fetchall()]
+
+		# Assert:
+		self.assertEqual(expected_mosaics, results)
+
+	def test_delete_mosaics_preserves_seeded_network_currency(self):
+		# Arrange:
+		other_mosaic = MOSAICS[0]._replace(
+			root_namespace='foo',
+			namespace_name='foo.token'
+		)
+
+		self._run_delete_mosaics_test(
+			prepare_mosaics=[MOSAICS[0], other_mosaic],
+			mosaics_to_delete={'foo.token'},
+			expected_mosaics=['nem.xem']
+		)
+
+	def test_delete_mosaics_deletes_only_affected_mosaics(self):
+		# Arrange:
+		affected_mosaic = MOSAICS[0]._replace(
+			root_namespace='foo',
+			namespace_name='foo.token'
+		)
+		unaffected_mosaic = MOSAICS[0]._replace(
+			root_namespace='bar',
+			namespace_name='bar.token'
+		)
+
+		self._run_delete_mosaics_test(
+			prepare_mosaics=[affected_mosaic, unaffected_mosaic],
+			mosaics_to_delete={'foo.token'},
+			expected_mosaics=['bar.token']
+		)
+
+	def test_can_get_surviving_mosaic_transactions_in_replay_order(self):
+		# Arrange:
+		definition_payload = {
+			'namespace_name': 'foo.token',
+			'description': 'foo mosaic',
+			'mosaic_properties': {
+				'initial_supply': 1000,
+				'divisibility': 2,
+				'supply_mutable': True,
+				'transferable': True
+			},
+			'levy': None
+		}
+		first_supply_change_payload = {
+			'namespace_name': 'foo.token',
+			'supply_type': 1,
+			'delta': 100
+		}
+		second_supply_change_payload = {
+			'namespace_name': 'foo.token',
+			'supply_type': 2,
+			'delta': 50
+		}
+		transactions = [
+			TRANSACTIONS[0]._replace(
+				transaction_hash='11' * 32,
+				transaction_type=TransactionType.MOSAIC_DEFINITION.value,
+				height=1,
+				payload=definition_payload
+			),
+			TRANSACTIONS[0]._replace(
+				transaction_hash='22' * 32,
+				transaction_type=TransactionType.MOSAIC_SUPPLY_CHANGE.value,
+				height=2,
+				payload=first_supply_change_payload
+			),
+			TRANSACTIONS[0]._replace(
+				transaction_hash='33' * 32,
+				transaction_type=TransactionType.MOSAIC_SUPPLY_CHANGE.value,
+				height=2,
+				payload=second_supply_change_payload
+			),
+			TRANSACTIONS[0]._replace(
+				transaction_hash='44' * 32,
+				transaction_type=TransactionType.MOSAIC_SUPPLY_CHANGE.value,
+				height=3,
+				payload={
+					'namespace_name': 'foo.token',
+					'supply_type': 1,
+					'delta': 200
+				}
+			),
+			TRANSACTIONS[0]._replace(
+				transaction_hash='55' * 32,
+				transaction_type=TransactionType.MOSAIC_DEFINITION.value,
+				height=1,
+				payload={**definition_payload, 'namespace_name': 'bar.token'}
+			)
+		]
+
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+			cursor = nem_database.connection.cursor()
+			for transaction in transactions:
+				nem_database.insert_transaction(cursor, transaction)
+
+			# Act:
+			results = nem_database.get_surviving_mosaic_transactions(
+				cursor,
+				2,
+				{'foo.token'}
+			)
+
+		# Assert:
+		self.assertEqual([
+			RollbackMosaicRecord(
+				TransactionType.MOSAIC_DEFINITION.value,
+				1,
+				TRANSACTIONS[0].sender_public_key,
+				definition_payload
+			),
+			RollbackMosaicRecord(
+				TransactionType.MOSAIC_SUPPLY_CHANGE.value,
+				2,
+				TRANSACTIONS[0].sender_public_key,
+				first_supply_change_payload
+			),
+			RollbackMosaicRecord(
+				TransactionType.MOSAIC_SUPPLY_CHANGE.value,
+				2,
+				TRANSACTIONS[0].sender_public_key,
+				second_supply_change_payload
+			)
+		], results)
+
+	def test_can_subtract_orphan_harvesting_from_accounts(self):
+		# Arrange:
+		fork_height = 1
+		first_account = ACCOUNTS[0]
+		second_account = ACCOUNTS[0]._replace(address=BLOCKS[1].beneficiary)
+		first_orphan_block = BLOCKS[0]._replace(
+			height=2,
+			total_fee=50,
+			block_hash='11' * 32
+		)
+		second_orphan_block = BLOCKS[1]._replace(height=3)
+		first_harvested_fees = 1000
+
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+			cursor = nem_database.connection.cursor()
+
+			for block in [BLOCKS[0], first_orphan_block, second_orphan_block]:
+				nem_database.insert_block(cursor, block)
+
+			for account, harvested_fees in [
+				(first_account, first_harvested_fees),
+				(second_account, second_orphan_block.total_fee)
+			]:
+				nem_database.upsert_account(cursor, account)
+				nem_database.update_account_harvested_fees(cursor, account.address, harvested_fees, 3)
+
+			nem_database.connection.commit()
+
+			# Act:
+			nem_database.rollback_account_harvesting(cursor, {
+				first_account.address: first_orphan_block.total_fee,
+				second_account.address: second_orphan_block.total_fee
+			}, fork_height)
+
+			first_result = self._fetch_account_from_db(cursor, first_account.address)
+			second_result = self._fetch_account_from_db(cursor, second_account.address)
+
+		# Assert:
+		self.assertEqual(first_harvested_fees - first_orphan_block.total_fee, first_result.harvested_fees)
+		self.assertEqual(BLOCKS[0].height, first_result.last_harvested_height)
+		self.assertEqual(0, second_result.harvested_fees)
+		self.assertEqual(0, second_result.last_harvested_height)

--- a/explorer/puller/tests/db/test_NemDatabase.py
+++ b/explorer/puller/tests/db/test_NemDatabase.py
@@ -1455,4 +1455,3 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 				reactivation_payload
 			)
 		], results)
-

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -2046,3 +2046,53 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 				account_state
 			)
 
+	def test_can_restore_rollback_remote_address_from_surviving_key_link(self):
+		# Arrange:
+		account = Address('TALICE6XEEEOBFJVY3ZCENZ7WBG6LB4KB7P7KMQX')
+		surviving_remote_key = PublicKey('7195f4d7a40ad7e31958ae96c4afed002962229675a4cae8dc8a18e290618981')
+		orphan_remote_key = PublicKey('1fbdbdde28daf828245e4533765726f0b7790e0b7146e2ce205df3e86366980b')
+		surviving_remote_address = self.puller._convert_public_key_to_address(  # pylint: disable=protected-access
+			surviving_remote_key
+		)
+		orphan_remote_address = self.puller._convert_public_key_to_address(  # pylint: disable=protected-access
+			orphan_remote_key
+		)
+		rollback_impact = self._create_surviving_account_rollback_impact(account)._replace(
+			fork_height=1,
+			affected_remote_link_accounts={account}
+		)
+
+		with self.puller.nem_db as database:
+			database.create_tables()
+			cursor = database.connection.cursor()
+
+			database.upsert_account(
+				cursor,
+				self._create_rollback_account(account, 1)._replace(remote_address=orphan_remote_address)
+			)
+			database.insert_transaction(
+				cursor,
+				self._create_rollback_transaction(
+					1,
+					TransactionType.ACCOUNT_KEY_LINK.value,
+					1,
+					account,
+					payload={'mode': 1, 'remote_account': str(surviving_remote_key)}
+				)
+			)
+
+			# Act:
+			self.puller._restore_rollback_remote_addresses(  # pylint: disable=protected-access
+				cursor,
+				rollback_impact
+			)
+
+			cursor.execute(
+				'SELECT encode(remote_address, \'hex\') FROM accounts WHERE address = %s',
+				(account.bytes,)
+			)
+			remote_address = cursor.fetchone()[0]
+
+		# Assert:
+		self.assertEqual(surviving_remote_address.bytes.hex(), remote_address)
+

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -1577,11 +1577,8 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		return asyncio.run(self.puller.detect_rollback(db_height, chain_height))
 
 	def test_returns_none_when_comparison_hash_matches(self):
-		# Arrange + Act:
-		fork_height = self._run_detect_rollback_test({3: 'ABCDEF'}, {3: 'abcdef'}, 3, 3)
-
-		# Assert:
-		self.assertIsNone(fork_height)
+		# Act + Assert: no exception
+		self._run_detect_rollback_test({3: 'ABCDEF'}, {3: 'abcdef'}, 3, 3)
 
 	def test_returns_chain_height_when_database_is_ahead(self):
 		# Arrange + Act:
@@ -2001,14 +1998,11 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		rollback_impact = self._create_surviving_account_rollback_impact(address)
 		account_state = {address: self._create_rollback_account(address, 1)}
 
-		# Act:
-		result = self.puller._validate_rollback_account_state(  # pylint: disable=protected-access
+		# Act + Assert: no exception
+		self.puller._validate_rollback_account_state(  # pylint: disable=protected-access
 			rollback_impact,
 			account_state
 		)
-
-		# Assert:
-		self.assertIsNone(result)
 
 	def test_rejects_rollback_account_state_with_missing_snapshot(self):
 		# Arrange:

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -3,7 +3,7 @@ import asyncio
 import datetime
 import tempfile
 import unittest
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock, call, patch
 
 import testing.postgresql
 from symbolchain.CryptoTypes import PublicKey
@@ -28,9 +28,10 @@ from symbollightapi.model.Transaction import (
 	TransferTransaction
 )
 
-from puller.db.NemDatabase import AccountRefreshRecord
+from puller.db.NemDatabase import AccountRefreshRecord, RollbackMosaicRecord, RollbackNamespaceRegistrationRecord
 from puller.facade.NemPuller import (
 	NEM_MAX_ROLLBACK_DEPTH,
+	NEM_NAMESPACE_DURATION,
 	AccountRecord,
 	AccountVestedBalanceRecord,
 	BlockRecord,
@@ -985,7 +986,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 				root_namespace='namespace',
 				owner=PublicKey('a700809530e5428066807ec0d34859c52e260fc60634aaac13e3972dcfc08736'),
 				registered_height=3,
-				expiration_height=3 + (365 * 1440)
+				expiration_height=3 + NEM_NAMESPACE_DURATION
 			)
 		))
 
@@ -1651,7 +1652,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			account_creation_heights={address: height},
 			orphan_created_accounts=set(),
 			surviving_affected_accounts={address},
-			orphan_beneficiaries=set(),
+			orphan_harvested_fees_map={},
 			affected_remote_link_accounts=set(),
 			affected_namespace_roots=set(),
 			affected_mosaic_names=set()
@@ -1812,13 +1813,25 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			database.insert_block(cursor, BlockRecord(
 				orphan_height,
 				'2015-03-29 00:00:00+00:00',
-				0,
+				20,
 				len(transactions),
 				1,
 				'AA' * 32,
 				beneficiary,
 				signer,
 				'BB' * 64,
+				100
+			))
+			database.insert_block(cursor, BlockRecord(
+				orphan_height + 1,
+				'2015-03-29 00:01:00+00:00',
+				30,
+				0,
+				1,
+				'CC' * 32,
+				beneficiary,
+				signer,
+				'DD' * 64,
 				100
 			))
 			database.upsert_mosaic(cursor, MosaicRecord(
@@ -1860,7 +1873,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		self.assertEqual(expected_accounts, capture.affected_accounts)
 		self.assertEqual({recipient}, capture.orphan_created_accounts)
 		self.assertEqual(expected_accounts - {recipient}, capture.surviving_affected_accounts)
-		self.assertEqual({beneficiary}, capture.orphan_beneficiaries)
+		self.assertEqual({beneficiary: 50}, capture.orphan_harvested_fees_map)
 		self.assertEqual({sender}, capture.affected_remote_link_accounts)
 		self.assertEqual({'root'}, capture.affected_namespace_roots)
 		self.assertEqual({'root.token', 'root.supply'}, capture.affected_mosaic_names)
@@ -1920,7 +1933,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		}, impact.account_creation_heights)
 		self.assertEqual(set(), impact.orphan_created_accounts)
 		self.assertEqual(expected_accounts, impact.surviving_affected_accounts)
-		self.assertEqual(set(), impact.orphan_beneficiaries)
+		self.assertEqual({}, impact.orphan_harvested_fees_map)
 		self.assertEqual(set(), impact.affected_remote_link_accounts)
 		self.assertEqual(set(), impact.affected_namespace_roots)
 		self.assertEqual(set(), impact.affected_mosaic_names)
@@ -1973,7 +1986,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			account_creation_heights={first_survivor: 2, second_survivor: 5},
 			orphan_created_accounts={},
 			surviving_affected_accounts={first_survivor, second_survivor},
-			orphan_beneficiaries=set(),
+			orphan_harvested_fees_map={},
 			affected_remote_link_accounts=set(),
 			affected_namespace_roots=set(),
 			affected_mosaic_names=set()
@@ -2090,6 +2103,173 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		# Assert:
 		self.assertEqual(surviving_remote_address.bytes.hex(), remote_address)
 
+	def test_can_restore_rollback_namespaces_by_replaying_surviving_registrations(self):
+		# Arrange:
+		owner = PublicKey('11' * 32)
+		namespace_registration_records = [
+			RollbackNamespaceRegistrationRecord(5, owner, None, 'root'),
+			RollbackNamespaceRegistrationRecord(6, owner, 'root', 'child'),
+			RollbackNamespaceRegistrationRecord(7, owner, 'root.child', 'grandchild')
+		]
+		rollback_impact = Mock(
+			fork_height=10,
+			affected_namespace_roots={'root'}
+		)
+		database = Mock()
+		database.get_surviving_namespace_history.return_value = namespace_registration_records
+		cursor = Mock()
+		self.puller.nem_db = database
+
+		# Act:
+		self.puller._restore_rollback_namespaces(cursor, rollback_impact)  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual([
+			call.delete_namespaces(cursor, {'root'}),
+			call.get_surviving_namespace_history(cursor, 10, {'root'})
+		], database.mock_calls[:2])
+		database.get_surviving_namespace_history.assert_called_once_with(
+			cursor,
+			10,
+			{'root'}
+		)
+		database.upsert_namespace.assert_called_once_with(
+			cursor,
+			NamespaceRecord('root', owner, 5, 5 + NEM_NAMESPACE_DURATION)
+		)
+		self.assertEqual([
+			call(cursor, 'root.child', 'root'),
+			call(cursor, 'root.child.grandchild', 'root')
+		], database.update_sub_namespaces.call_args_list)
+
+	def test_removes_orphan_root_when_it_has_no_surviving_registration(self):
+		# Arrange:
+		rollback_impact = Mock(
+			fork_height=10,
+			affected_namespace_roots={'orphan'}
+		)
+		database = Mock()
+		database.get_surviving_namespace_history.return_value = []
+		cursor = Mock()
+		self.puller.nem_db = database
+
+		# Act:
+		self.puller._restore_rollback_namespaces(cursor, rollback_impact)  # pylint: disable=protected-access
+
+		# Assert:
+		database.delete_namespaces.assert_called_once_with(cursor, {'orphan'})
+		database.upsert_namespace.assert_not_called()
+		database.update_sub_namespaces.assert_not_called()
+
+	def _run_rollback_mosaics_test(self, transactions, namespace_name='root.token'):
+		rollback_impact = Mock(
+			fork_height=10,
+			affected_mosaic_names={namespace_name}
+		)
+		database = Mock()
+		database.get_surviving_mosaic_transactions.return_value = transactions
+		cursor = Mock()
+		self.puller.nem_db = database
+
+		# Act:
+		self.puller._restore_rollback_mosaics(cursor, rollback_impact)  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual([
+			call.delete_mosaics(cursor, {namespace_name}),
+			call.get_surviving_mosaic_transactions(cursor, 10, {namespace_name})
+		], database.mock_calls[:2])
+
+		return database, cursor
+
+	def test_can_restore_rollback_mosaic_definition(self):
+		# Arrange:
+		creator = PublicKey('11' * 32)
+		levy_recipient = Address('TALICE6XEEEOBFJVY3ZCENZ7WBG6LB4KB7P7KMQX')
+		definition_payload = {
+			'namespace_name': 'root.token',
+			'description': 'rollback mosaic',
+			'mosaic_properties': {
+				'initial_supply': 1000,
+				'divisibility': 2,
+				'supply_mutable': True,
+				'transferable': False
+			},
+			'levy': {
+				'type': 1,
+				'namespace_name': 'levy.token',
+				'fee': 25,
+				'recipient': str(levy_recipient)
+			}
+		}
+		transaction = RollbackMosaicRecord(
+			TransactionType.MOSAIC_DEFINITION.value,
+			5,
+			creator,
+			definition_payload
+		)
+
+		# Act:
+		database, cursor = self._run_rollback_mosaics_test([transaction])
+
+		# Assert:
+		database.upsert_mosaic.assert_called_once_with(
+			cursor,
+			MosaicRecord(
+				root_namespace='root',
+				namespace_name='root.token',
+				description='rollback mosaic',
+				creator=creator,
+				registered_height=5,
+				initial_supply=1000,
+				total_supply=1000,
+				divisibility=2,
+				supply_mutable=True,
+				transferable=False,
+				levy_type=1,
+				levy_namespace_name='levy.token',
+				levy_fee=25,
+				levy_recipient=levy_recipient
+			)
+		)
+		database.update_mosaic_total_supply.assert_not_called()
+
+	def test_can_restore_rollback_mosaic_supply_changes(self):
+		# Arrange:
+		creator = PublicKey('11' * 32)
+		transactions = [
+			RollbackMosaicRecord(
+				TransactionType.MOSAIC_SUPPLY_CHANGE.value,
+				6,
+				creator,
+				{'namespace_name': 'root.token', 'supply_type': 1, 'delta': 300}
+			),
+			RollbackMosaicRecord(
+				TransactionType.MOSAIC_SUPPLY_CHANGE.value,
+				7,
+				creator,
+				{'namespace_name': 'root.token', 'supply_type': 2, 'delta': 100}
+			)
+		]
+
+		# Act:
+		database, cursor = self._run_rollback_mosaics_test(transactions)
+
+		# Assert:
+		database.upsert_mosaic.assert_not_called()
+		self.assertEqual([
+			call(cursor, 'root.token', 300),
+			call(cursor, 'root.token', -100)
+		], database.update_mosaic_total_supply.call_args_list)
+
+	def test_removes_orphan_mosaic_when_it_has_no_surviving_transaction(self):
+		# Act:
+		database, _ = self._run_rollback_mosaics_test([], 'orphan.token')
+
+		# Assert:
+		database.upsert_mosaic.assert_not_called()
+		database.update_mosaic_total_supply.assert_not_called()
+
 	def test_can_repair_rollback_with_expected_operations(self):
 		# Arrange:
 		first_address = Address('TALICE6XEEEOBFJVY3ZCENZ7WBG6LB4KB7P7KMQX')
@@ -2103,7 +2283,8 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		}
 		rollback_impact = Mock(
 			fork_height=123,
-			orphan_created_accounts={orphan_address}
+			orphan_created_accounts={orphan_address},
+			orphan_harvested_fees_map={first_address: 50}
 		)
 		database = Mock()
 		cursor = database.connection.cursor.return_value
@@ -2112,13 +2293,24 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		with patch.object(self.puller, '_validate_rollback_account_state') as mock_validate, patch.object(
 			self.puller,
 			'_restore_rollback_remote_addresses'
-		) as mock_restore_remote_addresses:
+		) as mock_restore_remote_addresses, patch.object(
+			self.puller,
+			'_restore_rollback_namespaces'
+		) as mock_restore_namespaces, patch.object(
+			self.puller,
+			'_restore_rollback_mosaics'
+		) as mock_restore_mosaics:
 			# Act:
 			self.puller.repair_rollback(rollback_impact, account_state)
 
 			# Assert:
 			mock_validate.assert_called_once_with(rollback_impact, account_state)
+			database.rollback_account_harvesting.assert_called_once_with(cursor, {first_address: 50}, 123)
 			database.delete_orphan_chain_data.assert_called_once_with(cursor, 123)
+			self.assertLess(
+				database.mock_calls.index(call.rollback_account_harvesting(cursor, {first_address: 50}, 123)),
+				database.mock_calls.index(call.delete_orphan_chain_data(cursor, 123))
+			)
 			database.delete_accounts.assert_called_once_with(cursor, {orphan_address})
 
 			refresh_calls = database.refresh_account_from_snapshot.call_args_list
@@ -2127,6 +2319,8 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			self.assertEqual((cursor, second_account), refresh_calls[1][0])
 
 			mock_restore_remote_addresses.assert_called_once_with(cursor, rollback_impact)
+			mock_restore_namespaces.assert_called_once_with(cursor, rollback_impact)
+			mock_restore_mosaics.assert_called_once_with(cursor, rollback_impact)
 			database.connection.commit.assert_called_once_with()
 			database.connection.rollback.assert_not_called()
 

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -2096,3 +2096,62 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		# Assert:
 		self.assertEqual(surviving_remote_address.bytes.hex(), remote_address)
 
+	def test_can_repair_rollback_with_expected_operations(self):
+		# Arrange:
+		first_address = Address('TALICE6XEEEOBFJVY3ZCENZ7WBG6LB4KB7P7KMQX')
+		second_address = Address('TCJLCZSOQ6RGWHTPSV2DW467WZSHK4NBSITND4OF')
+		orphan_address = Address('TBKQWJJGPOHL462DBVMTYOAERXGG2BOS5XRFO2P6')
+		first_account = Mock()
+		second_account = Mock()
+		account_state = {
+			second_address: second_account,
+			first_address: first_account
+		}
+		rollback_impact = Mock(
+			fork_height=123,
+			orphan_created_accounts={orphan_address}
+		)
+		database = Mock()
+		cursor = database.connection.cursor.return_value
+		self.puller.nem_db = database
+
+		with patch.object(self.puller, '_validate_rollback_account_state') as mock_validate, patch.object(
+			self.puller,
+			'_restore_rollback_remote_addresses'
+		) as mock_restore_remote_addresses:
+			# Act:
+			self.puller.repair_rollback(rollback_impact, account_state)
+
+			# Assert:
+			mock_validate.assert_called_once_with(rollback_impact, account_state)
+			database.delete_orphan_chain_data.assert_called_once_with(cursor, 123)
+			database.delete_accounts.assert_called_once_with(cursor, {orphan_address})
+
+			refresh_calls = database.refresh_account_from_snapshot.call_args_list
+			self.assertEqual(2, len(refresh_calls))
+			self.assertEqual((cursor, first_account), refresh_calls[0][0])
+			self.assertEqual((cursor, second_account), refresh_calls[1][0])
+
+			mock_restore_remote_addresses.assert_called_once_with(cursor, rollback_impact)
+			database.connection.commit.assert_called_once_with()
+			database.connection.rollback.assert_not_called()
+
+	def test_repair_rollback_rolls_back_transaction_on_failure(self):
+		# Arrange:
+		address = Address('TALICE6XEEEOBFJVY3ZCENZ7WBG6LB4KB7P7KMQX')
+		account_state = {address: Mock()}
+		rollback_impact = Mock(fork_height=123, orphan_created_accounts=set())
+		database = Mock()
+		self.puller.nem_db = database
+
+		with patch.object(self.puller, '_validate_rollback_account_state'), patch.object(
+			self.puller,
+			'_restore_rollback_remote_addresses',
+			side_effect=RuntimeError('forced repair failure')
+		):
+			# Act + Assert:
+			with self.assertRaisesRegex(RuntimeError, 'forced repair failure'):
+				self.puller.repair_rollback(rollback_impact, account_state)
+
+		database.connection.rollback.assert_called_once_with()
+		database.connection.commit.assert_not_called()

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -39,8 +39,8 @@ from puller.facade.NemPuller import (
 	NamespaceRecord,
 	NemPuller,
 	NemRollbackError,
-	RollbackPayloadAccounts,
 	NemRollbackImpact,
+	RollbackPayloadAccounts,
 	TransactionRecord
 )
 
@@ -1646,6 +1646,20 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			1
 		)
 
+	@staticmethod
+	def _create_surviving_account_rollback_impact(address, height=1):
+		return NemRollbackImpact(
+			fork_height=10,
+			affected_accounts={address},
+			account_creation_heights={address: height},
+			orphan_created_accounts=set(),
+			surviving_affected_accounts={address},
+			orphan_beneficiaries=set(),
+			affected_remote_link_accounts=set(),
+			affected_namespace_roots=set(),
+			affected_mosaic_names=set()
+		)
+
 	def test_extracts_multisig_account_and_all_signature_senders(self):
 		# Arrange:
 		multisig_account = Address('TAWUGAUSWSVB35T5QE44ICIK2WE3AUOTSGZBO5O4')
@@ -1980,3 +1994,55 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			[(str(first_survivor), 2), (str(second_survivor), 5)],
 			[call.args for call in self.puller._fetch_account_record.await_args_list]  # pylint: disable=protected-access
 		)
+
+	def test_accepts_complete_rollback_account_state(self):
+		# Arrange:
+		address = Address('TALICE6XEEEOBFJVY3ZCENZ7WBG6LB4KB7P7KMQX')
+		rollback_impact = self._create_surviving_account_rollback_impact(address)
+		account_state = {address: self._create_rollback_account(address, 1)}
+
+		# Act:
+		result = self.puller._validate_rollback_account_state(  # pylint: disable=protected-access
+			rollback_impact,
+			account_state
+		)
+
+		# Assert:
+		self.assertIsNone(result)
+
+	def test_rejects_rollback_account_state_with_missing_snapshot(self):
+		# Arrange:
+		address = Address('TALICE6XEEEOBFJVY3ZCENZ7WBG6LB4KB7P7KMQX')
+		rollback_impact = self._create_surviving_account_rollback_impact(address)
+
+		# Act + Assert:
+		with self.assertRaisesRegex(NemRollbackError, 'Rollback account snapshot does not match surviving affected accounts'):
+			self.puller._validate_rollback_account_state(rollback_impact, {})  # pylint: disable=protected-access
+
+	def test_rejects_rollback_account_state_with_mismatched_address(self):
+		# Arrange:
+		address = Address('TALICE6XEEEOBFJVY3ZCENZ7WBG6LB4KB7P7KMQX')
+		other_address = Address('TCJLCZSOQ6RGWHTPSV2DW467WZSHK4NBSITND4OF')
+		rollback_impact = self._create_surviving_account_rollback_impact(address)
+		account_state = {address: self._create_rollback_account(other_address, 1)}
+
+		# Act + Assert:
+		with self.assertRaisesRegex(NemRollbackError, f'Rollback account snapshot address mismatch for {address}'):
+			self.puller._validate_rollback_account_state(  # pylint: disable=protected-access
+				rollback_impact,
+				account_state
+			)
+
+	def test_rejects_rollback_account_state_with_mismatched_height(self):
+		# Arrange:
+		address = Address('TALICE6XEEEOBFJVY3ZCENZ7WBG6LB4KB7P7KMQX')
+		rollback_impact = self._create_surviving_account_rollback_impact(address)
+		account_state = {address: self._create_rollback_account(address, 2)}
+
+		# Act + Assert:
+		with self.assertRaisesRegex(NemRollbackError, f'Rollback account snapshot height mismatch for {address}'):
+			self.puller._validate_rollback_account_state(  # pylint: disable=protected-access
+				rollback_impact,
+				account_state
+			)
+

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -40,6 +40,7 @@ from puller.facade.NemPuller import (
 	NemPuller,
 	NemRollbackError,
 	RollbackPayloadAccounts,
+	NemRollbackImpact,
 	TransactionRecord
 )
 
@@ -1940,3 +1941,42 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			expected_message = 'Missing creation heights for 2 affected NEM account'
 			with self.assertRaisesRegex(NemRollbackError, expected_message):
 				self.puller.capture_rollback_impact(fork_height)
+
+	def test_prefetches_current_state_for_surviving_affected_accounts(self):
+		# Arrange:
+		first_survivor = Address('TALICE6XEEEOBFJVY3ZCENZ7WBG6LB4KB7P7KMQX')
+		second_survivor = Address('TCJLCZSOQ6RGWHTPSV2DW467WZSHK4NBSITND4OF')
+		first_account_record = Mock()
+		second_account_record = Mock()
+		accounts_by_address = {
+			str(first_survivor): first_account_record,
+			str(second_survivor): second_account_record
+		}
+		self.puller._fetch_account_record = AsyncMock(  # pylint: disable=protected-access
+			side_effect=lambda address, _height: accounts_by_address[address]
+		)
+
+		rollback_impact = NemRollbackImpact(
+			fork_height=10,
+			affected_accounts={first_survivor, second_survivor},
+			account_creation_heights={first_survivor: 2, second_survivor: 5},
+			orphan_created_accounts={},
+			surviving_affected_accounts={first_survivor, second_survivor},
+			orphan_beneficiaries=set(),
+			affected_remote_link_accounts=set(),
+			affected_namespace_roots=set(),
+			affected_mosaic_names=set()
+		)
+
+		# Act:
+		account_state = asyncio.run(self.puller.prefetch_rollback_account_state(rollback_impact))
+
+		# Assert:
+		self.assertEqual({
+			first_survivor: first_account_record,
+			second_survivor: second_account_record
+		}, account_state)
+		self.assertCountEqual(
+			[(str(first_survivor), 2), (str(second_survivor), 5)],
+			[call.args for call in self.puller._fetch_account_record.await_args_list]  # pylint: disable=protected-access
+		)

--- a/explorer/puller/tests/workflows/test_sync_nem_block.py
+++ b/explorer/puller/tests/workflows/test_sync_nem_block.py
@@ -30,7 +30,14 @@ class SyncNemBlockTest(unittest.TestCase):
 
 	@patch('puller.workflows.sync_nem_block.NemPuller')
 	@patch('puller.workflows.sync_nem_block.parse_args')
-	def _run_main_test(self, mock_parse_args, mock_nem_puller, db_height, account_remark=None):  # pylint: disable=no-self-use
+	def _run_main_test(
+		self,
+		mock_parse_args,
+		mock_nem_puller,
+		db_height,
+		account_remark=None,
+		fork_height=None
+	):  # pylint: disable=no-self-use,too-many-arguments,too-many-positional-arguments
 		# Arrange:
 		mock_parse_args.return_value = create_main_args(account_remark=account_remark)
 		mock_facade, mock_db = create_facade_with_mock_db(mock_nem_puller)
@@ -41,6 +48,11 @@ class SyncNemBlockTest(unittest.TestCase):
 
 		mock_db.get_current_height.return_value = db_height
 		mock_facade.sync_nemesis_block = AsyncMock()
+		mock_facade.detect_rollback = AsyncMock(return_value=fork_height)
+		rollback_impact = Mock()
+		account_state = Mock()
+		mock_facade.capture_rollback_impact.return_value = rollback_impact
+		mock_facade.prefetch_rollback_account_state = AsyncMock(return_value=account_state)
 		mock_facade.sync_blocks = AsyncMock()
 
 		# Act:
@@ -55,7 +67,17 @@ class SyncNemBlockTest(unittest.TestCase):
 			mock_db.seed_account_remark.assert_not_called()
 		mock_db.get_current_height.assert_called_once()
 		mock_connector.chain_height.assert_called_once()
-		mock_facade.sync_blocks.assert_called_once_with(1, 10)
+		mock_facade.detect_rollback.assert_called_once_with(1, 10)
+		if fork_height is None:
+			mock_facade.capture_rollback_impact.assert_not_called()
+			mock_facade.prefetch_rollback_account_state.assert_not_awaited()
+			mock_facade.repair_rollback.assert_not_called()
+			mock_facade.sync_blocks.assert_called_once_with(1, 10)
+		else:
+			mock_facade.capture_rollback_impact.assert_called_once_with(fork_height)
+			mock_facade.prefetch_rollback_account_state.assert_awaited_once_with(rollback_impact)
+			mock_facade.repair_rollback.assert_called_once_with(rollback_impact, account_state)
+			mock_facade.sync_blocks.assert_awaited_once_with(fork_height, 10)
 
 		return mock_facade
 
@@ -76,3 +98,7 @@ class SyncNemBlockTest(unittest.TestCase):
 	def test_can_seed_account_remark_when_configured(self):
 		# Act:
 		self._run_main_test(db_height=1, account_remark='test_remark.json')  # pylint: disable=no-value-for-parameter
+
+	def test_repairs_rollback_before_syncing_canonical_blocks(self):
+		# Act:
+		self._run_main_test(db_height=1, fork_height=5)  # pylint: disable=no-value-for-parameter


### PR DESCRIPTION
Problem: Database rollback repair was not implemented or integrated into the sync workflow.

Solution:

- Implemented fork detection in the sync workflow.
- Before each sync, the workflow validates the chain height and checks for a fork.
- When a fork is detected, it captures the rollback impact and prefetches the current state of surviving accounts.
- Once all required data is available, it repairs the database to the confirmed fork height.
- Account state is prefetched from the node to ensure the repair uses clean, authoritative data rather than potentially stale database records.

**Note**: To keep this PR small, namespace and mosaic reconstruction, along with harvested-fee recalculation in `repair_rollback`, will be implemented in a next PR.