### PR TITLE
[explorer/puller] fix: write account remote links after their accounts exist

### DIFF
--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -335,8 +335,11 @@ class NemPuller:
 				last_height
 			)
 
-	def _flush_pending_account_state(self, cursor, pending_addresses, accounts_harvested_fee):
-		"""Flushes accumulated account and harvested fee state, clearing both accumulators."""
+	def _flush_pending_account_state(self, cursor, pending_addresses, accounts_harvested_fee, pending_remote_links):
+		"""Flushes accumulated account state, clearing every accumulator.
+
+		Accounts are upserted first, so the updates that follow always find their row.
+		"""
 
 		if pending_addresses:
 			asyncio.run(self._process_account_batch(cursor, pending_addresses))
@@ -345,6 +348,10 @@ class NemPuller:
 		if accounts_harvested_fee:
 			self._process_harvested_fees(cursor, accounts_harvested_fee)
 			accounts_harvested_fee.clear()
+
+		if pending_remote_links:
+			self._apply_remote_links(cursor, pending_remote_links)
+			pending_remote_links.clear()
 
 	async def refresh_accounts(self, batch_size):
 		"""Refresh vested balance and importance for stored accounts."""
@@ -426,8 +433,12 @@ class NemPuller:
 
 		self.nem_db.upsert_mosaic(cursor, mosaic)
 
-	def _process_account_key_link(self, cursor, transaction):
-		"""Apply a remote link change announced by an account key link transaction."""
+	def _process_account_key_link(self, transaction, pending_remote_links):
+		"""Records a remote link change announced by an account key link transaction.
+
+		Recorded rather than written: the account row is inserted only when the batch is flushed,
+		so an earlier update would match no row. Later blocks overwrite earlier ones.
+		"""
 
 		main_address = self._convert_public_key_to_address(transaction.sender)
 		remote_address = (
@@ -435,7 +446,13 @@ class NemPuller:
 			if ACCOUNT_KEY_LINK_MODE_ACTIVATE == transaction.mode else None
 		)
 
-		self.nem_db.update_account_remote_address(cursor, main_address, remote_address)
+		pending_remote_links[main_address] = remote_address
+
+	def _apply_remote_links(self, cursor, pending_remote_links):
+		"""Writes accumulated remote link changes."""
+
+		for main_address, remote_address in pending_remote_links.items():
+			self.nem_db.update_account_remote_address(cursor, main_address, remote_address)
 
 	def _process_mosaic_supply_change(self, cursor, transaction):
 		"""Process mosaic supply change in a block."""
@@ -540,7 +557,7 @@ class NemPuller:
 			version=transaction.version
 		)
 
-	def _process_transaction(self, cursor, transaction, block_height, is_inner, aggregate_hash=None):
+	def _process_transaction(self, cursor, transaction, block_height, is_inner, pending_remote_links, aggregate_hash=None):
 		# pylint: disable=too-many-arguments,too-many-positional-arguments
 		"""Process a single transaction."""
 
@@ -570,11 +587,11 @@ class NemPuller:
 		elif transaction.transaction_type == TransactionType.MOSAIC_SUPPLY_CHANGE.value:
 			self._process_mosaic_supply_change(cursor, transaction)
 		elif transaction.transaction_type == TransactionType.ACCOUNT_KEY_LINK.value:
-			self._process_account_key_link(cursor, transaction)
+			self._process_account_key_link(transaction, pending_remote_links)
 
 		return transaction_id
 
-	def _process_transactions(self, cursor, block_transactions, height):
+	def _process_transactions(self, cursor, block_transactions, height, pending_remote_links):
 		"""Process transactions in a block."""
 
 		for transaction in block_transactions:
@@ -589,6 +606,7 @@ class NemPuller:
 					transaction=transaction.other_transaction,
 					block_height=height,
 					is_inner=True,
+					pending_remote_links=pending_remote_links,
 					aggregate_hash=transaction.transaction_hash
 				)
 
@@ -596,7 +614,8 @@ class NemPuller:
 				cursor,
 				transaction=transaction,
 				block_height=height,
-				is_inner=False
+				is_inner=False,
+				pending_remote_links=pending_remote_links
 			)
 
 	async def sync_nemesis_block(self):
@@ -613,7 +632,9 @@ class NemPuller:
 		addresses = self._extract_addresses_from_block(cursor, nemesis_block)
 		await self._process_account_batch(cursor, {address: nemesis_block.height for address in addresses})
 
-		self._process_transactions(cursor, nemesis_block.transactions, nemesis_block.height)
+		pending_remote_links = {}
+		self._process_transactions(cursor, nemesis_block.transactions, nemesis_block.height, pending_remote_links)
+		self._apply_remote_links(cursor, pending_remote_links)
 
 		self._commit_blocks('Committed Nemesis block')
 
@@ -626,6 +647,7 @@ class NemPuller:
 		processed = 0
 		pending_addresses = {}
 		accounts_harvested_fee = {}
+		pending_remote_links = {}
 
 		log.info('DB writer thread started')
 
@@ -638,7 +660,7 @@ class NemPuller:
 				log.info('Received stop signal, ending DB writer thread')
 
 				# Process any remaining addresses and harvested fees before exiting
-				self._flush_pending_account_state(cursor, pending_addresses, accounts_harvested_fee)
+				self._flush_pending_account_state(cursor, pending_addresses, accounts_harvested_fee, pending_remote_links)
 
 				block_queue.task_done()
 				break
@@ -658,11 +680,11 @@ class NemPuller:
 				block.height
 			)
 
-			self._process_transactions(cursor, block.transactions, block.height)
+			self._process_transactions(cursor, block.transactions, block.height, pending_remote_links)
 
 			# Batch commits
 			if processed % batch_size == 0:
-				self._flush_pending_account_state(cursor, pending_addresses, accounts_harvested_fee)
+				self._flush_pending_account_state(cursor, pending_addresses, accounts_harvested_fee, pending_remote_links)
 
 				self._commit_blocks(f'Committed {processed} blocks')
 

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -1086,7 +1086,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			expected_supply_change=500000
 		)
 
-	def _assert_account_key_link(self, mock_update_account_remote_address, mode, expects_remote_address):
+	def _assert_account_key_link(self, mode, expects_remote_address):
 		# Arrange:
 		transaction = AccountKeyLinkTransaction(
 			'a1cd7bc6d3b13d5eb0e1b6a4c40b1e0c2ea6d6f9f3e0c1a7b2d5e8f0a3c6d9e2',
@@ -1103,26 +1103,49 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			PublicKey('7195f4d7a40ad7e31958ae96c4afed002962229675a4cae8dc8a18e290618981')
 		)
 
-		cursor = Mock()
 		network = self.puller.nem_facade.network
+		pending_remote_links = {}
 
 		# Act:
-		self.puller._process_account_key_link(cursor, transaction)  # pylint: disable=protected-access
+		self.puller._process_account_key_link(transaction, pending_remote_links)  # pylint: disable=protected-access
 
 		# Assert:
-		mock_update_account_remote_address.assert_called_once_with(
-			cursor,
-			network.public_key_to_address(transaction.sender),
-			network.public_key_to_address(transaction.remote_account) if expects_remote_address else None
-		)
+		self.assertEqual(pending_remote_links, {
+			network.public_key_to_address(transaction.sender):
+				network.public_key_to_address(transaction.remote_account) if expects_remote_address else None
+		})
 
-	@patch('puller.facade.NemPuller.NemDatabase.update_account_remote_address')
-	def test_can_process_account_key_link_activate(self, mock_update_account_remote_address):
-		self._assert_account_key_link(mock_update_account_remote_address, mode=1, expects_remote_address=True)
+	def test_can_process_account_key_link_activate(self):
+		self._assert_account_key_link(mode=1, expects_remote_address=True)
 
-	@patch('puller.facade.NemPuller.NemDatabase.update_account_remote_address')
-	def test_can_process_account_key_link_deactivate(self, mock_update_account_remote_address):
-		self._assert_account_key_link(mock_update_account_remote_address, mode=2, expects_remote_address=False)
+	def test_can_process_account_key_link_deactivate(self):
+		self._assert_account_key_link(mode=2, expects_remote_address=False)
+
+	def test_can_apply_remote_links_after_accounts_exist(self):
+		# Arrange: an account whose link arrives in the same batch in which the account first appears
+		network = self.puller.nem_facade.network
+		main_address = network.public_key_to_address(
+			PublicKey('aa455d831430872feb0c6ae14265209182546c985a321c501be7fdc96ed04757'))
+		remote_address = network.public_key_to_address(
+			PublicKey('7195f4d7a40ad7e31958ae96c4afed002962229675a4cae8dc8a18e290618981'))
+		pending_addresses = {str(main_address): 3}
+		pending_remote_links = {main_address: remote_address}
+		call_order = []
+		cursor = Mock()
+
+		with patch.object(self.puller, '_process_account_batch', new=AsyncMock()) as mock_process_account_batch, \
+			patch('puller.facade.NemPuller.NemDatabase.update_account_remote_address') as mock_update_remote:
+			mock_process_account_batch.side_effect = lambda *_: call_order.append('upsert_accounts')
+			mock_update_remote.side_effect = lambda *_: call_order.append('update_remote_address')
+
+			# Act:
+			self.puller._flush_pending_account_state(  # pylint: disable=protected-access
+				cursor, pending_addresses, {}, pending_remote_links)
+
+		# Assert: the link is written only once the account row is guaranteed to exist
+		self.assertEqual(['upsert_accounts', 'update_remote_address'], call_order)
+		mock_update_remote.assert_called_once_with(cursor, main_address, remote_address)
+		self.assertEqual({}, pending_remote_links)
 
 	@patch('puller.facade.NemPuller.NemDatabase.insert_transaction')
 	@patch('puller.facade.NemPuller.NemDatabase.update_account_remote_address')
@@ -1158,16 +1181,17 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		mock_insert_transaction.return_value = 1
 		cursor = Mock()
 		network = self.puller.nem_facade.network
+		pending_remote_links = {}
 
 		# Act:
-		self.puller._process_transactions(cursor, [multisig_transaction], 3)  # pylint: disable=protected-access
+		self.puller._process_transactions(  # pylint: disable=protected-access
+			cursor, [multisig_transaction], 3, pending_remote_links)
 
-		# Assert:
-		mock_update_account_remote_address.assert_called_once_with(
-			cursor,
-			network.public_key_to_address(multisig_account),
-			network.public_key_to_address(remote_account)
-		)
+		# Assert: the link belongs to the multisig account, not to the cosignatory that announced it
+		self.assertEqual(pending_remote_links, {
+			network.public_key_to_address(multisig_account): network.public_key_to_address(remote_account)
+		})
+		mock_update_account_remote_address.assert_not_called()
 
 	def _assert_transaction_record(self, transaction, payload, recipient_address=None):
 		# Act:
@@ -1389,7 +1413,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		cursor = Mock()
 
 		# Act:
-		self.puller._process_transaction(cursor, transaction, 3, is_inner=False)  # pylint: disable=protected-access
+		self.puller._process_transaction(cursor, transaction, 3, is_inner=False, pending_remote_links={})  # pylint: disable=protected-access
 
 		# Assert:
 		mock_build_transaction_record.assert_called_once()
@@ -1421,7 +1445,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		cursor = Mock()
 
 		# Act:
-		self.puller._process_transaction(cursor, transaction, 3, is_inner=False)  # pylint: disable=protected-access
+		self.puller._process_transaction(cursor, transaction, 3, is_inner=False, pending_remote_links={})  # pylint: disable=protected-access
 
 		# Assert:
 		mock_build_transaction_record.assert_called_once()
@@ -1447,7 +1471,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		cursor = Mock()
 
 		# Act:
-		self.puller._process_transaction(cursor, transaction, 3, is_inner=False)  # pylint: disable=protected-access
+		self.puller._process_transaction(cursor, transaction, 3, is_inner=False, pending_remote_links={})  # pylint: disable=protected-access
 
 		# Assert:
 		mock_build_transaction_record.assert_called_once()
@@ -1469,7 +1493,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		cursor = Mock()
 
 		# Act:
-		self.puller._process_transaction(cursor, transaction, 3, is_inner=False)  # pylint: disable=protected-access
+		self.puller._process_transaction(cursor, transaction, 3, is_inner=False, pending_remote_links={})  # pylint: disable=protected-access
 
 		# Assert:
 		mock_build_transaction_record.assert_called_once()
@@ -1491,7 +1515,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		cursor = Mock()
 
 		# Act:
-		self.puller._process_transaction(cursor, transaction, 3, is_inner=False)  # pylint: disable=protected-access
+		self.puller._process_transaction(cursor, transaction, 3, is_inner=False, pending_remote_links={})  # pylint: disable=protected-access
 
 		# Assert:
 		mock_build_transaction_record.assert_called_once()
@@ -1519,9 +1543,11 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		)
 
 		cursor = Mock()
+		pending_remote_links = {}
 
 		# Act:
-		self.puller._process_transactions(cursor, block.transactions, block.height)  # pylint: disable=protected-access
+		self.puller._process_transactions(  # pylint: disable=protected-access
+			cursor, block.transactions, block.height, pending_remote_links)
 
 		# Assert:
 		process_transaction_calls = mock_process_transaction.call_args_list
@@ -1537,6 +1563,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			'transaction': block.transactions[0].other_transaction,
 			'block_height': 3,
 			'is_inner': True,
+			'pending_remote_links': pending_remote_links,
 			'aggregate_hash': block.transactions[0].transaction_hash
 		})
 
@@ -1545,5 +1572,6 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		self.assertEqual(process_transaction_calls[1][1], {
 			'transaction': block.transactions[0],
 			'block_height': 3,
-			'is_inner': False
+			'is_inner': False,
+			'pending_remote_links': pending_remote_links
 		})

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -1131,29 +1131,31 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		pending_addresses = {str(main_address): 3}
 		pending_remote_links = {main_address: remote_address}
 		call_order = []
+		# the accumulator is cleared after the flush, so snapshot it at call time
+		captured_addresses = []
 		cursor = Mock()
+
+		def record_upsert_accounts(_cursor, address_heights):
+			captured_addresses.append(dict(address_heights))
+			call_order.append('upsert_accounts')
 
 		with patch.object(self.puller, '_process_account_batch', new=AsyncMock()) as mock_process_account_batch, \
 			patch('puller.facade.NemPuller.NemDatabase.update_account_remote_address') as mock_update_remote:
-			mock_process_account_batch.side_effect = lambda *_: call_order.append('upsert_accounts')
+			mock_process_account_batch.side_effect = record_upsert_accounts
 			mock_update_remote.side_effect = lambda *_: call_order.append('update_remote_address')
 
 			# Act:
 			self.puller._flush_pending_account_state(  # pylint: disable=protected-access
 				cursor, pending_addresses, {}, pending_remote_links)
 
-		# Assert: the link is written only once the account row is guaranteed to exist
+		# Assert: the link is written only once the account it belongs to has been upserted
 		self.assertEqual(['upsert_accounts', 'update_remote_address'], call_order)
-		mock_update_remote.assert_called_once_with(cursor, main_address, remote_address)
+		self.assertEqual([{str(main_address): 3}], captured_addresses)
+		mock_update_remote.assert_called_with(cursor, main_address, remote_address)
 		self.assertEqual({}, pending_remote_links)
 
 	@patch('puller.facade.NemPuller.NemDatabase.insert_transaction')
-	@patch('puller.facade.NemPuller.NemDatabase.update_account_remote_address')
-	def test_can_process_multisig_account_key_link_links_multisig_account(
-		self,
-		mock_update_account_remote_address,
-		mock_insert_transaction
-	):
+	def test_can_process_multisig_account_key_link_links_multisig_account(self, mock_insert_transaction):
 		# Arrange:
 		multisig_account = PublicKey('fbae41931de6a0cc25153781321f3de0806c7ba9a191474bb9a838118c8de4d3')
 		cosignatory = PublicKey('aa455d831430872feb0c6ae14265209182546c985a321c501be7fdc96ed04757')
@@ -1191,7 +1193,6 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		self.assertEqual(pending_remote_links, {
 			network.public_key_to_address(multisig_account): network.public_key_to_address(remote_account)
 		})
-		mock_update_account_remote_address.assert_not_called()
 
 	def _assert_transaction_record(self, transaction, payload, recipient_address=None):
 		# Act:


### PR DESCRIPTION
## Problem

Delegated harvesting links (`accounts.remote_address`) were silently dropped during sync.

`_process_account_key_link` issued an immediate `UPDATE accounts SET remote_address = … WHERE address = …`
from `_process_transactions`, which runs per block. Account rows, however, are inserted by
`_flush_pending_account_state` only at the batch boundary, every 50 blocks. When a main account first
appears in the same batch as its own key link transaction, the `UPDATE` matches zero rows.

Nothing recovers afterwards: the flush inserts the account with `remote_address = NULL`
(hardcoded in `_create_account_record`), and the `DO UPDATE` clause of `upsert_account` does not
list that column.

## Solution

The link change is recorded into an accumulator and written in `_flush_pending_account_state`,
after `_process_account_batch` has upserted the accounts — so the row is guaranteed to exist.
This mirrors the existing handling of `accounts_harvested_fee`, which is already applied after
the account upsert for the same reason.

Keying the accumulator by main address gives last-write-wins within a batch, which matches block
order when an account links and unlinks inside one window.

## Backfill

```sql

BEGIN;

  WITH latest_link AS (
        -- the newest key link of each main account is the one in force
        SELECT DISTINCT ON (t.sender_address)
                t.sender_address,
                t.payload->>'mode'           AS mode,
                t.payload->>'remote_account' AS remote_account
        FROM transactions t
        WHERE t.transaction_type = 2049 -- ACCOUNT_KEY_LINK
        ORDER BY t.sender_address, t.height DESC, t.id DESC
  ),
  resolved AS (
        SELECT
                l.sender_address,
                CASE WHEN '1' = l.mode THEN r.address END AS remote_address -- mode 1 activates, 2 deactivates
        FROM latest_link l
        LEFT JOIN accounts r
                ON r.public_key = decode(lower(l.remote_account), 'hex')
        -- an activation whose remote account is unknown would clear the link instead of setting it
        WHERE '1' <> l.mode OR r.address IS NOT NULL
  )
  UPDATE accounts a
  SET remote_address = resolved.remote_address
  FROM resolved
  WHERE a.address = resolved.sender_address AND a.remote_address IS DISTINCT FROM resolved.remote_address;

  COMMIT;

```