### PR TITLE
[explorer/puller] feat: restore namespace, mosaics and harvested fees from rollback

### DIFF
--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -1083,7 +1083,7 @@ class NemDatabase(DatabaseConnection):  # pylint: disable=too-many-public-method
 	def rollback_account_harvesting(cursor, orphan_harvested_fees_map, fork_height):
 		"""Subtracts orphan block fees and restores the latest surviving harvest height."""
 
-		for beneficiary in sorted(orphan_harvested_fees_map, key=str):
+		for beneficiary, orphan_harvested_fees in orphan_harvested_fees_map.items():
 			cursor.execute(
 				'''
 				UPDATE accounts
@@ -1098,7 +1098,7 @@ class NemDatabase(DatabaseConnection):  # pylint: disable=too-many-public-method
 				WHERE address = %s
 				''',
 				(
-					orphan_harvested_fees_map[beneficiary],
+					orphan_harvested_fees,
 					beneficiary.bytes,
 					fork_height,
 					beneficiary.bytes

--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -8,6 +8,8 @@ from symbolchain.nem.Network import Address
 
 from .DatabaseConnection import DatabaseConnection
 
+NEM_NAMESPACE_GRACE_PERIOD = 30 * 1440
+
 AccountRefreshRecord = namedtuple('AccountRefreshRecord', ['id', 'address'])
 RollbackBlockRecord = namedtuple('RollbackBlockRecord', ['beneficiary', 'signer'])
 RollbackTransactionRecord = namedtuple(
@@ -787,13 +789,20 @@ class NemDatabase(DatabaseConnection):
 			DO UPDATE SET
 				owner = EXCLUDED.owner,
 				registered_height = EXCLUDED.registered_height,
-				expiration_height = EXCLUDED.expiration_height
+				expiration_height = EXCLUDED.expiration_height,
+				sub_namespaces = CASE
+					WHEN namespaces.owner = EXCLUDED.owner
+						AND EXCLUDED.registered_height < namespaces.expiration_height + %s
+					THEN namespaces.sub_namespaces
+					ELSE '{}'
+				END
 			''',
 			(
 				namespace.root_namespace,
 				namespace.owner.bytes,
 				namespace.registered_height,
-				namespace.expiration_height
+				namespace.expiration_height,
+				NEM_NAMESPACE_GRACE_PERIOD
 			)
 		)
 

--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -24,6 +24,10 @@ RollbackAccountKeyLinkRecord = namedtuple(
 	'RollbackAccountKeyLinkRecord',
 	['sender_address', 'payload']
 )
+RollbackNamespaceRegistrationRecord = namedtuple(
+	'RollbackNamespaceRegistrationRecord',
+	['height', 'owner', 'parent', 'namespace']
+)
 
 
 class NemDatabase(DatabaseConnection):
@@ -820,6 +824,48 @@ class NemDatabase(DatabaseConnection):
 			''',
 			(list(root_namespaces),)
 		)
+
+	@staticmethod
+	def get_surviving_namespace_history(cursor, fork_height, root_namespaces):
+		"""Gets surviving namespace registrations for affected roots in replay order."""
+
+		if not root_namespaces:
+			return []
+
+		cursor.execute(
+			'''
+			SELECT
+				height,
+				sender_public_key,
+				payload->>'parent',
+				payload->>'namespace'
+			FROM transactions
+			WHERE transaction_type = %s
+				AND height <= %s
+				AND (
+					CASE
+						WHEN payload->>'parent' IS NULL THEN payload->>'namespace'
+						ELSE split_part(payload->>'parent', '.', 1)
+					END
+				) = ANY(%s)
+			ORDER BY height ASC, id ASC
+			''',
+			(
+				TransactionType.NAMESPACE_REGISTRATION.value,
+				fork_height,
+				list(root_namespaces)
+			)
+		)
+
+		return [
+			RollbackNamespaceRegistrationRecord(
+				record[0],
+				PublicKey(bytes(record[1])),
+				record[2],
+				record[3]
+			)
+			for record in cursor.fetchall()
+		]
 
 	@staticmethod
 	def update_sub_namespaces(cursor, sub_namespace, root_namespace):

--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 import json
 from binascii import unhexlify
 from collections import namedtuple
@@ -34,7 +35,7 @@ RollbackMosaicRecord = namedtuple(
 )
 
 
-class NemDatabase(DatabaseConnection):
+class NemDatabase(DatabaseConnection):  # pylint: disable=too-many-public-methods
 	"""Database containing Nem blockchain data."""
 
 	@staticmethod

--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -12,7 +12,7 @@ from .DatabaseConnection import DatabaseConnection
 NEM_NAMESPACE_GRACE_PERIOD = 30 * 1440
 
 AccountRefreshRecord = namedtuple('AccountRefreshRecord', ['id', 'address'])
-RollbackBlockRecord = namedtuple('RollbackBlockRecord', ['beneficiary', 'signer'])
+RollbackBlockRecord = namedtuple('RollbackBlockRecord', ['beneficiary', 'signer', 'total_fee'])
 RollbackTransactionRecord = namedtuple(
 	'RollbackTransactionRecord',
 	['transaction_type', 'sender_address', 'recipient_address', 'payload']
@@ -446,7 +446,8 @@ class NemDatabase(DatabaseConnection):  # pylint: disable=too-many-public-method
 			'''
 			SELECT
 				beneficiary,
-				signer
+				signer,
+				total_fee
 			FROM blocks
 			WHERE height > %s
 			ORDER BY height ASC
@@ -455,7 +456,7 @@ class NemDatabase(DatabaseConnection):  # pylint: disable=too-many-public-method
 		)
 		results = cursor.fetchall()
 		blocks = [
-			RollbackBlockRecord(Address(bytes(record[0])), PublicKey(bytes(record[1])))
+			RollbackBlockRecord(Address(bytes(record[0])), PublicKey(bytes(record[1])), record[2])
 			for record in results
 		]
 
@@ -1079,25 +1080,27 @@ class NemDatabase(DatabaseConnection):  # pylint: disable=too-many-public-method
 		)
 
 	@staticmethod
-	def recalculate_account_harvesting(cursor, beneficiaries):
-		"""Replaces harvesting fee with aggregates from surviving blocks."""
+	def rollback_account_harvesting(cursor, orphan_harvested_fees, fork_height):
+		"""Subtracts orphan block fees and restores the latest surviving harvest height."""
 
-		for beneficiary in sorted(beneficiaries, key=str):
+		for beneficiary in sorted(orphan_harvested_fees, key=str):
 			cursor.execute(
 				'''
 				UPDATE accounts
-				SET harvested_fees = (
-						SELECT COALESCE(SUM(total_fee), 0)
-						FROM blocks
-						WHERE beneficiary = %s
-					),
+				SET harvested_fees = harvested_fees - %s,
 					last_harvested_height = (
 						SELECT COALESCE(MAX(height), 0)
 						FROM blocks
 						WHERE beneficiary = %s
+							AND height <= %s
 					),
 					updated_at = CURRENT_TIMESTAMP
 				WHERE address = %s
 				''',
-				(beneficiary.bytes, beneficiary.bytes, beneficiary.bytes)
+				(
+					orphan_harvested_fees[beneficiary],
+					beneficiary.bytes,
+					fork_height,
+					beneficiary.bytes
+				)
 			)

--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -1076,3 +1076,27 @@ class NemDatabase(DatabaseConnection):
 				mosaic.quantity
 			)
 		)
+
+	@staticmethod
+	def recalculate_account_harvesting(cursor, beneficiaries):
+		"""Replaces harvesting fee with aggregates from surviving blocks."""
+
+		for beneficiary in sorted(beneficiaries, key=str):
+			cursor.execute(
+				'''
+				UPDATE accounts
+				SET harvested_fees = (
+						SELECT COALESCE(SUM(total_fee), 0)
+						FROM blocks
+						WHERE beneficiary = %s
+					),
+					last_harvested_height = (
+						SELECT COALESCE(MAX(height), 0)
+						FROM blocks
+						WHERE beneficiary = %s
+					),
+					updated_at = CURRENT_TIMESTAMP
+				WHERE address = %s
+				''',
+				(beneficiary.bytes, beneficiary.bytes, beneficiary.bytes)
+			)

--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -1080,10 +1080,10 @@ class NemDatabase(DatabaseConnection):  # pylint: disable=too-many-public-method
 		)
 
 	@staticmethod
-	def rollback_account_harvesting(cursor, orphan_harvested_fees, fork_height):
+	def rollback_account_harvesting(cursor, orphan_harvested_fees_map, fork_height):
 		"""Subtracts orphan block fees and restores the latest surviving harvest height."""
 
-		for beneficiary in sorted(orphan_harvested_fees, key=str):
+		for beneficiary in sorted(orphan_harvested_fees_map, key=str):
 			cursor.execute(
 				'''
 				UPDATE accounts
@@ -1098,7 +1098,7 @@ class NemDatabase(DatabaseConnection):  # pylint: disable=too-many-public-method
 				WHERE address = %s
 				''',
 				(
-					orphan_harvested_fees[beneficiary],
+					orphan_harvested_fees_map[beneficiary],
 					beneficiary.bytes,
 					fork_height,
 					beneficiary.bytes

--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -28,6 +28,10 @@ RollbackNamespaceRegistrationRecord = namedtuple(
 	'RollbackNamespaceRegistrationRecord',
 	['height', 'owner', 'parent', 'namespace']
 )
+RollbackMosaicRecord = namedtuple(
+	'RollbackMosaicRecord',
+	['transaction_type', 'height', 'sender_public_key', 'payload']
+)
 
 
 class NemDatabase(DatabaseConnection):
@@ -955,6 +959,58 @@ class NemDatabase(DatabaseConnection):
 				namespace_name
 			)
 		)
+
+	@staticmethod
+	def delete_mosaics(cursor, namespace_names):
+		"""Deletes affected mosaic projections except the seeded network currency."""
+
+		deletable_names = set(namespace_names) - {'nem.xem'}
+		if not deletable_names:
+			return
+
+		cursor.execute(
+			'''
+			DELETE FROM mosaics
+			WHERE namespace_name = ANY(%s)
+			''',
+			(list(deletable_names),)
+		)
+
+	@staticmethod
+	def get_surviving_mosaic_transactions(cursor, fork_height, namespace_names):
+		"""Gets affected mosaic definition and supply transactions in replay order."""
+
+		replay_names = set(namespace_names) - {'nem.xem'}
+		if not replay_names:
+			return []
+
+		cursor.execute(
+			'''
+			SELECT transaction_type, height, sender_public_key, payload
+			FROM transactions
+			WHERE transaction_type = ANY(%s)
+				AND height <= %s
+				AND payload->>'namespace_name' = ANY(%s)
+			ORDER BY height ASC, id ASC
+			''',
+			(
+				[
+					TransactionType.MOSAIC_DEFINITION.value,
+					TransactionType.MOSAIC_SUPPLY_CHANGE.value
+				],
+				fork_height,
+				list(replay_names)
+			)
+		)
+		return [
+			RollbackMosaicRecord(
+				record[0],
+				record[1],
+				PublicKey(bytes(record[2])),
+				record[3]
+			)
+			for record in cursor.fetchall()
+		]
 
 	@staticmethod
 	def insert_transaction(cursor, transaction):

--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -807,6 +807,21 @@ class NemDatabase(DatabaseConnection):
 		)
 
 	@staticmethod
+	def delete_namespaces(cursor, root_namespaces):
+		"""Deletes affected namespace projections before replay."""
+
+		if not root_namespaces:
+			return
+
+		cursor.execute(
+			'''
+			DELETE FROM namespaces
+			WHERE root_namespace = ANY(%s)
+			''',
+			(list(root_namespaces),)
+		)
+
+	@staticmethod
 	def update_sub_namespaces(cursor, sub_namespace, root_namespace):
 		"""Appends sub-namespace to a root namespace's sub_namespaces array."""
 

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -394,6 +394,57 @@ class NemPuller:
 					)
 				)
 
+	@staticmethod
+	def _create_rollback_mosaic_record(transaction):
+		"""Creates a mosaic projection from a stored surviving definition transaction."""
+
+		payload = transaction.payload
+		properties = payload['mosaic_properties']
+		levy = payload['levy']
+
+		return MosaicRecord(
+			root_namespace=payload['namespace_name'].split('.')[0],
+			namespace_name=payload['namespace_name'],
+			description=payload['description'],
+			creator=transaction.sender_public_key,
+			registered_height=transaction.height,
+			initial_supply=properties['initial_supply'],
+			total_supply=properties['initial_supply'],
+			divisibility=properties['divisibility'],
+			supply_mutable=properties['supply_mutable'],
+			transferable=properties['transferable'],
+			levy_type=levy['type'] if levy else None,
+			levy_namespace_name=levy['namespace_name'] if levy else None,
+			levy_fee=levy['fee'] if levy else None,
+			levy_recipient=Address(levy['recipient']) if levy else None
+		)
+
+	def _restore_rollback_mosaics(self, cursor, rollback_impact):
+		"""Rebuilds affected mosaic projections from surviving transactions."""
+
+		namespace_names = rollback_impact.affected_mosaic_names
+		self.nem_db.delete_mosaics(cursor, namespace_names)
+
+		transactions = self.nem_db.get_surviving_mosaic_transactions(
+			cursor,
+			rollback_impact.fork_height,
+			namespace_names
+		)
+		for transaction in transactions:
+			if TransactionType.MOSAIC_DEFINITION.value == transaction.transaction_type:
+				self.nem_db.upsert_mosaic(
+					cursor,
+					self._create_rollback_mosaic_record(transaction)
+				)
+			else:
+				payload = transaction.payload
+				adjustment = payload['delta'] if 1 == payload['supply_type'] else -payload['delta']
+				self.nem_db.update_mosaic_total_supply(
+					cursor,
+					payload['namespace_name'],
+					adjustment
+				)
+
 	def repair_rollback(self, rollback_impact, account_state):
 		"""Atomically restores NEM database state to a confirmed fork height."""
 
@@ -409,8 +460,7 @@ class NemPuller:
 
 			self._restore_rollback_remote_addresses(cursor, rollback_impact)
 			self._restore_rollback_namespaces(cursor, rollback_impact)
-
-			# Todo: reconstruct_rollback_mosaics, recalculate_account_harvesting
+			self._restore_rollback_mosaics(cursor, rollback_impact)
 
 			self.nem_db.connection.commit()
 		except Exception:

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 import asyncio
 import configparser
 import threading
@@ -17,6 +18,7 @@ from puller.db.NemDatabase import NemDatabase
 
 ACCOUNT_KEY_LINK_MODE_ACTIVATE = 1
 NEM_MAX_ROLLBACK_DEPTH = 360
+NEM_NAMESPACE_DURATION = 365 * 1440
 
 
 class NemRollbackError(RuntimeError):
@@ -363,6 +365,35 @@ class NemPuller:
 				remote_address
 			)
 
+	def _restore_rollback_namespaces(self, cursor, rollback_impact):
+		"""Rebuilds affected namespace projections from surviving registrations."""
+
+		root_namespaces = rollback_impact.affected_namespace_roots
+		self.nem_db.delete_namespaces(cursor, root_namespaces)
+
+		registrations = self.nem_db.get_surviving_namespace_history(
+			cursor,
+			rollback_impact.fork_height,
+			root_namespaces
+		)
+		for record in registrations:
+			if record.parent:
+				self.nem_db.update_sub_namespaces(
+					cursor,
+					f'{record.parent}.{record.namespace}',
+					record.parent.split('.')[0]
+				)
+			else:
+				self.nem_db.upsert_namespace(
+					cursor,
+					NamespaceRecord(
+						record.namespace,
+						record.owner,
+						record.height,
+						record.height + NEM_NAMESPACE_DURATION
+					)
+				)
+
 	def repair_rollback(self, rollback_impact, account_state):
 		"""Atomically restores NEM database state to a confirmed fork height."""
 
@@ -377,8 +408,9 @@ class NemPuller:
 				self.nem_db.refresh_account_from_snapshot(cursor, account_state[address])
 
 			self._restore_rollback_remote_addresses(cursor, rollback_impact)
+			self._restore_rollback_namespaces(cursor, rollback_impact)
 
-			# Todo: reconstruct_rollback_namespaces, reconstruct_rollback_mosaics, recalculate_account_harvesting
+			# Todo: reconstruct_rollback_mosaics, recalculate_account_harvesting
 
 			self.nem_db.connection.commit()
 		except Exception:
@@ -623,7 +655,7 @@ class NemPuller:
 		"""Process root namespace data."""
 
 		# add 1 year to expired height
-		expired_height = block_height + (365 * 1440)
+		expired_height = block_height + NEM_NAMESPACE_DURATION
 
 		namespace = NamespaceRecord(
 			root_namespace=transaction.namespace,

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -109,7 +109,7 @@ NemRollbackImpact = namedtuple('NemRollbackImpact', [
 	'account_creation_heights',
 	'orphan_created_accounts',
 	'surviving_affected_accounts',
-	'orphan_harvested_fees',
+	'orphan_harvested_fees_map',
 	'affected_remote_link_accounts',
 	'affected_namespace_roots',
 	'affected_mosaic_names'
@@ -263,7 +263,7 @@ class NemPuller:
 			raise NemRollbackError(f'Invalid NEM fork height {fork_height}')
 
 		affected_accounts = set()
-		orphan_harvested_fees = {}
+		orphan_harvested_fees_map = {}
 		affected_remote_link_accounts = set()
 		affected_namespace_roots = set()
 		affected_mosaic_names = set()
@@ -273,8 +273,8 @@ class NemPuller:
 		orphan_records = self.nem_db.get_orphan_chain_records(fork_height)
 
 		for block in orphan_records.blocks:
-			orphan_harvested_fees[block.beneficiary] = (
-				orphan_harvested_fees.get(block.beneficiary, 0) + block.total_fee
+			orphan_harvested_fees_map[block.beneficiary] = (
+				orphan_harvested_fees_map.get(block.beneficiary, 0) + block.total_fee
 			)
 			affected_accounts.add(block.beneficiary)
 			affected_accounts.add(self._convert_public_key_to_address(block.signer))
@@ -309,7 +309,7 @@ class NemPuller:
 			account_creation_heights,
 			orphan_created_accounts,
 			surviving_affected_accounts,
-			orphan_harvested_fees,
+			orphan_harvested_fees_map,
 			affected_remote_link_accounts,
 			affected_namespace_roots,
 			affected_mosaic_names
@@ -456,7 +456,7 @@ class NemPuller:
 		try:
 			self.nem_db.rollback_account_harvesting(
 				cursor,
-				rollback_impact.orphan_harvested_fees,
+				rollback_impact.orphan_harvested_fees_map,
 				rollback_impact.fork_height
 			)
 			self.nem_db.delete_orphan_chain_data(cursor, rollback_impact.fork_height)

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -461,6 +461,10 @@ class NemPuller:
 			self._restore_rollback_remote_addresses(cursor, rollback_impact)
 			self._restore_rollback_namespaces(cursor, rollback_impact)
 			self._restore_rollback_mosaics(cursor, rollback_impact)
+			self.nem_db.recalculate_account_harvesting(
+				cursor,
+				rollback_impact.orphan_beneficiaries
+			)
 
 			self.nem_db.connection.commit()
 		except Exception:

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -109,7 +109,7 @@ NemRollbackImpact = namedtuple('NemRollbackImpact', [
 	'account_creation_heights',
 	'orphan_created_accounts',
 	'surviving_affected_accounts',
-	'orphan_beneficiaries',
+	'orphan_harvested_fees',
 	'affected_remote_link_accounts',
 	'affected_namespace_roots',
 	'affected_mosaic_names'
@@ -263,7 +263,7 @@ class NemPuller:
 			raise NemRollbackError(f'Invalid NEM fork height {fork_height}')
 
 		affected_accounts = set()
-		orphan_beneficiaries = set()
+		orphan_harvested_fees = {}
 		affected_remote_link_accounts = set()
 		affected_namespace_roots = set()
 		affected_mosaic_names = set()
@@ -273,7 +273,9 @@ class NemPuller:
 		orphan_records = self.nem_db.get_orphan_chain_records(fork_height)
 
 		for block in orphan_records.blocks:
-			orphan_beneficiaries.add(block.beneficiary)
+			orphan_harvested_fees[block.beneficiary] = (
+				orphan_harvested_fees.get(block.beneficiary, 0) + block.total_fee
+			)
 			affected_accounts.add(block.beneficiary)
 			affected_accounts.add(self._convert_public_key_to_address(block.signer))
 
@@ -307,7 +309,7 @@ class NemPuller:
 			account_creation_heights,
 			orphan_created_accounts,
 			surviving_affected_accounts,
-			orphan_beneficiaries,
+			orphan_harvested_fees,
 			affected_remote_link_accounts,
 			affected_namespace_roots,
 			affected_mosaic_names
@@ -452,6 +454,11 @@ class NemPuller:
 		cursor = self.nem_db.connection.cursor()
 
 		try:
+			self.nem_db.rollback_account_harvesting(
+				cursor,
+				rollback_impact.orphan_harvested_fees,
+				rollback_impact.fork_height
+			)
 			self.nem_db.delete_orphan_chain_data(cursor, rollback_impact.fork_height)
 			self.nem_db.delete_accounts(cursor, rollback_impact.orphan_created_accounts)
 
@@ -461,10 +468,6 @@ class NemPuller:
 			self._restore_rollback_remote_addresses(cursor, rollback_impact)
 			self._restore_rollback_namespaces(cursor, rollback_impact)
 			self._restore_rollback_mosaics(cursor, rollback_impact)
-			self.nem_db.recalculate_account_harvesting(
-				cursor,
-				rollback_impact.orphan_beneficiaries
-			)
 
 			self.nem_db.connection.commit()
 		except Exception:

--- a/explorer/puller/tests/db/test_NemDatabase.py
+++ b/explorer/puller/tests/db/test_NemDatabase.py
@@ -10,7 +10,7 @@ from symbolchain.nc import TransactionType
 from symbolchain.nem.Network import Address
 from symbollightapi.model.Transaction import Mosaic
 
-from puller.db.NemDatabase import NemDatabase, RollbackAccountKeyLinkRecord
+from puller.db.NemDatabase import NemDatabase, RollbackAccountKeyLinkRecord, RollbackNamespaceRegistrationRecord
 from puller.facade.NemPuller import AccountRecord, BlockRecord, MosaicRecord, NamespaceRecord, TransactionRecord
 
 from .test_DatabaseConnection import DatabaseConfig
@@ -975,6 +975,126 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			200,
 			['sub1']
 		))
+
+	def test_namespace_history_filters_affected_roots(self):
+		# Arrange:
+		owner = PublicKey('11' * 32)
+		transactions = [
+			TRANSACTIONS[0]._replace(
+				transaction_hash='11' * 32,
+				transaction_type=TransactionType.NAMESPACE_REGISTRATION.value,
+				height=2,
+				sender_public_key=owner,
+				payload={'parent': None, 'namespace': 'root'}
+			),
+			TRANSACTIONS[0]._replace(
+				transaction_hash='22' * 32,
+				transaction_type=TransactionType.NAMESPACE_REGISTRATION.value,
+				height=2,
+				sender_public_key=owner,
+				payload={'parent': 'root', 'namespace': 'child'}
+			),
+			TRANSACTIONS[0]._replace(
+				transaction_hash='33' * 32,
+				transaction_type=TransactionType.NAMESPACE_REGISTRATION.value,
+				height=2,
+				sender_public_key=owner,
+				payload={'parent': 'root.child', 'namespace': 'grandchild'}
+			),
+			TRANSACTIONS[0]._replace(
+				transaction_hash='44' * 32,
+				transaction_type=TransactionType.NAMESPACE_REGISTRATION.value,
+				height=2,
+				sender_public_key=owner,
+				payload={'parent': None, 'namespace': 'unaffected'}
+			)
+		]
+
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+			cursor = nem_database.connection.cursor()
+			for transaction in transactions:
+				nem_database.insert_transaction(cursor, transaction)
+
+			# Act:
+			results = nem_database.get_surviving_namespace_history(cursor, 2, {'root', 'missing'})
+
+		# Assert:
+		self.assertEqual([
+			RollbackNamespaceRegistrationRecord(2, owner, None, 'root'),
+			RollbackNamespaceRegistrationRecord(2, owner, 'root', 'child'),
+			RollbackNamespaceRegistrationRecord(2, owner, 'root.child', 'grandchild')
+		], results)
+
+	def test_namespace_history_filters_transactions_above_fork_height(self):
+		# Arrange:
+		owner = PublicKey('11' * 32)
+		transactions = [
+			TRANSACTIONS[0]._replace(
+				transaction_hash='11' * 32,
+				transaction_type=TransactionType.NAMESPACE_REGISTRATION.value,
+				height=2,
+				sender_public_key=owner,
+				payload={'parent': None, 'namespace': 'root'}
+			),
+			TRANSACTIONS[0]._replace(
+				transaction_hash='22' * 32,
+				transaction_type=TransactionType.NAMESPACE_REGISTRATION.value,
+				height=3,
+				sender_public_key=owner,
+				payload={'parent': None, 'namespace': 'root'}
+			)
+		]
+
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+			cursor = nem_database.connection.cursor()
+
+			for transaction in transactions:
+				nem_database.insert_transaction(cursor, transaction)
+
+			# Act:
+			results = nem_database.get_surviving_namespace_history(cursor, 2, {'root'})
+
+		# Assert:
+		self.assertEqual([
+			RollbackNamespaceRegistrationRecord(2, owner, None, 'root')
+		], results)
+
+	def test_namespace_history_filters_other_transaction_types(self):
+		# Arrange:
+		owner = PublicKey('11' * 32)
+		transactions = [
+			TRANSACTIONS[0]._replace(
+				transaction_hash='11' * 32,
+				transaction_type=TransactionType.NAMESPACE_REGISTRATION.value,
+				height=2,
+				sender_public_key=owner,
+				payload={'parent': None, 'namespace': 'root'}
+			),
+			TRANSACTIONS[0]._replace(
+				transaction_hash='22' * 32,
+				transaction_type=TransactionType.TRANSFER.value,
+				height=2,
+				sender_public_key=owner,
+				payload={'parent': None, 'namespace': 'root'}
+			)
+		]
+
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+			cursor = nem_database.connection.cursor()
+
+			for transaction in transactions:
+				nem_database.insert_transaction(cursor, transaction)
+
+			# Act:
+			results = nem_database.get_surviving_namespace_history(cursor, 2, {'root'})
+
+		# Assert:
+		self.assertEqual([
+			RollbackNamespaceRegistrationRecord(2, owner, None, 'root')
+		], results)
 
 	def test_can_insert_mosaic(self):
 		# Arrange:

--- a/explorer/puller/tests/db/test_NemDatabase.py
+++ b/explorer/puller/tests/db/test_NemDatabase.py
@@ -10,7 +10,7 @@ from symbolchain.nc import TransactionType
 from symbolchain.nem.Network import Address
 from symbollightapi.model.Transaction import Mosaic
 
-from puller.db.NemDatabase import NemDatabase, RollbackAccountKeyLinkRecord, RollbackNamespaceRegistrationRecord
+from puller.db.NemDatabase import NemDatabase, RollbackAccountKeyLinkRecord, RollbackMosaicRecord, RollbackNamespaceRegistrationRecord
 from puller.facade.NemPuller import AccountRecord, BlockRecord, MosaicRecord, NamespaceRecord, TransactionRecord
 
 from .test_DatabaseConnection import DatabaseConfig
@@ -1639,5 +1639,150 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			RollbackAccountKeyLinkRecord(
 				affected_address,
 				reactivation_payload
+			)
+		], results)
+
+	def _run_delete_mosaics_test(self, prepare_mosaics, mosaics_to_delete, expected_mosaics):
+		# Arrange:
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+			cursor = nem_database.connection.cursor()
+
+			for mosaic in prepare_mosaics:
+				nem_database.upsert_mosaic(cursor, mosaic)
+
+			nem_database.connection.commit()
+
+			# Act:
+			nem_database.delete_mosaics(cursor, mosaics_to_delete)
+
+			cursor.execute('SELECT namespace_name FROM mosaics ORDER BY namespace_name')
+			results = [record[0] for record in cursor.fetchall()]
+
+		# Assert:
+		self.assertEqual(expected_mosaics, results)
+
+	def test_delete_mosaics_preserves_seeded_network_currency(self):
+		# Arrange:
+		other_mosaic = MOSAICS[0]._replace(
+			root_namespace='foo',
+			namespace_name='foo.token'
+		)
+
+		self._run_delete_mosaics_test(
+			prepare_mosaics=[MOSAICS[0], other_mosaic],
+			mosaics_to_delete={'foo.token'},
+			expected_mosaics=['nem.xem']
+		)
+
+	def test_delete_mosaics_deletes_only_affected_mosaics(self):
+		# Arrange:
+		affected_mosaic = MOSAICS[0]._replace(
+			root_namespace='foo',
+			namespace_name='foo.token'
+		)
+		unaffected_mosaic = MOSAICS[0]._replace(
+			root_namespace='bar',
+			namespace_name='bar.token'
+		)
+
+		self._run_delete_mosaics_test(
+			prepare_mosaics=[affected_mosaic, unaffected_mosaic],
+			mosaics_to_delete={'foo.token'},
+			expected_mosaics=['bar.token']
+		)
+
+	def test_can_get_surviving_mosaic_transactions_in_replay_order(self):
+		# Arrange:
+		definition_payload = {
+			'namespace_name': 'foo.token',
+			'description': 'foo mosaic',
+			'mosaic_properties': {
+				'initial_supply': 1000,
+				'divisibility': 2,
+				'supply_mutable': True,
+				'transferable': True
+			},
+			'levy': None
+		}
+		first_supply_change_payload = {
+			'namespace_name': 'foo.token',
+			'supply_type': 1,
+			'delta': 100
+		}
+		second_supply_change_payload = {
+			'namespace_name': 'foo.token',
+			'supply_type': 2,
+			'delta': 50
+		}
+		transactions = [
+			TRANSACTIONS[0]._replace(
+				transaction_hash='11' * 32,
+				transaction_type=TransactionType.MOSAIC_DEFINITION.value,
+				height=1,
+				payload=definition_payload
+			),
+			TRANSACTIONS[0]._replace(
+				transaction_hash='22' * 32,
+				transaction_type=TransactionType.MOSAIC_SUPPLY_CHANGE.value,
+				height=2,
+				payload=first_supply_change_payload
+			),
+			TRANSACTIONS[0]._replace(
+				transaction_hash='33' * 32,
+				transaction_type=TransactionType.MOSAIC_SUPPLY_CHANGE.value,
+				height=2,
+				payload=second_supply_change_payload
+			),
+			TRANSACTIONS[0]._replace(
+				transaction_hash='44' * 32,
+				transaction_type=TransactionType.MOSAIC_SUPPLY_CHANGE.value,
+				height=3,
+				payload={
+					'namespace_name': 'foo.token',
+					'supply_type': 1,
+					'delta': 200
+				}
+			),
+			TRANSACTIONS[0]._replace(
+				transaction_hash='55' * 32,
+				transaction_type=TransactionType.MOSAIC_DEFINITION.value,
+				height=1,
+				payload={**definition_payload, 'namespace_name': 'bar.token'}
+			)
+		]
+
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+			cursor = nem_database.connection.cursor()
+			for transaction in transactions:
+				nem_database.insert_transaction(cursor, transaction)
+
+			# Act:
+			results = nem_database.get_surviving_mosaic_transactions(
+				cursor,
+				2,
+				{'foo.token'}
+			)
+
+		# Assert:
+		self.assertEqual([
+			RollbackMosaicRecord(
+				TransactionType.MOSAIC_DEFINITION.value,
+				1,
+				TRANSACTIONS[0].sender_public_key,
+				definition_payload
+			),
+			RollbackMosaicRecord(
+				TransactionType.MOSAIC_SUPPLY_CHANGE.value,
+				2,
+				TRANSACTIONS[0].sender_public_key,
+				first_supply_change_payload
+			),
+			RollbackMosaicRecord(
+				TransactionType.MOSAIC_SUPPLY_CHANGE.value,
+				2,
+				TRANSACTIONS[0].sender_public_key,
+				second_supply_change_payload
 			)
 		], results)

--- a/explorer/puller/tests/db/test_NemDatabase.py
+++ b/explorer/puller/tests/db/test_NemDatabase.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import unittest
+from collections import namedtuple
 from pathlib import Path
 
 import psycopg2
@@ -14,6 +15,12 @@ from puller.db.NemDatabase import NemDatabase, RollbackAccountKeyLinkRecord, Rol
 from puller.facade.NemPuller import AccountRecord, BlockRecord, MosaicRecord, NamespaceRecord, TransactionRecord
 
 from .test_DatabaseConnection import DatabaseConfig
+
+AccountDbRecord = namedtuple('AccountDbRecord', [
+	*AccountRecord._fields,
+	'harvested_fees',
+	'last_harvested_height'
+])
 
 # region test data
 
@@ -130,19 +137,20 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 				balance,
 				vested_balance,
 				mosaics,
-				harvested_fees,
 				harvested_blocks,
 				remote_status,
-				last_harvested_height,
 				min_cosignatories,
 				cosignatory_of,
-				cosignatories
+				cosignatories,
+				harvested_fees,
+				last_harvested_height
 			FROM accounts
 			WHERE address = %s
 			''',
 			(address.bytes,)
 		)
-		return cursor.fetchone()
+		result = cursor.fetchone()
+		return AccountDbRecord(*result) if result else None
 
 	@staticmethod
 	def _fetch_namespace_from_db(cursor, root_namespace):
@@ -488,13 +496,13 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			1000000,
 			99999,
 			[],
-			0,
 			10,
 			'INACTIVE',
+			None,
+			None,
+			None,
 			0,
-			None,
-			None,
-			None)
+			0)
 		)
 
 	def test_can_update_account_by_address_conflict(self):
@@ -530,13 +538,13 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			2000000,
 			99999,
 			[],
-			0,
 			10,
 			'INACTIVE',
+			None,
+			None,
+			None,
 			0,
-			None,
-			None,
-			None)
+			0)
 		)
 
 	def test_account_height_remains_unchanged_on_update(self):
@@ -562,7 +570,7 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			result = self._fetch_account_from_db(cursor, ACCOUNTS[0].address)
 
 		# Assert:
-		self.assertEqual(result[1], 1)
+		self.assertEqual(result.height, 1)
 
 	def test_upsert_account_does_not_overwrite_remote_address(self):
 		# Arrange:
@@ -589,8 +597,8 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			result = self._fetch_account_from_db(cursor, ACCOUNTS[0].address)
 
 		# Assert:
-		self.assertEqual(result[3], remote_address.bytes.hex())
-		self.assertEqual(result[5], 2000000)
+		self.assertEqual(result.remote_address, remote_address.bytes.hex())
+		self.assertEqual(result.balance, 2000000)
 
 	def test_can_set_account_remote_address(self):
 		# Arrange:
@@ -609,7 +617,7 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			result = self._fetch_account_from_db(cursor, ACCOUNTS[0].address)
 
 		# Assert:
-		self.assertEqual(result[3], remote_address.bytes.hex())
+		self.assertEqual(result.remote_address, remote_address.bytes.hex())
 
 	def test_can_clear_account_remote_address(self):
 		# Arrange:
@@ -628,7 +636,7 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			result = self._fetch_account_from_db(cursor, ACCOUNTS[0].address)
 
 		# Assert:
-		self.assertIsNone(result[3])
+		self.assertIsNone(result.remote_address)
 
 	def test_can_get_accounts_for_refresh(self):
 		# Arrange:
@@ -754,13 +762,13 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			1000000,
 			88888,
 			[],
-			0,
 			10,
 			'INACTIVE',
+			None,
+			None,
+			None,
 			0,
-			None,
-			None,
-			None)
+			0)
 		)
 
 	def test_can_update_account_harvested_fees(self):
@@ -796,8 +804,8 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			result = self._fetch_account_from_db(cursor, ACCOUNTS[0].address)
 
 		# Assert:
-		self.assertEqual(result[8], 750000)  # harvested_fees
-		self.assertEqual(result[11], 20)      # last_harvested_height
+		self.assertEqual(result.harvested_fees, 750000)
+		self.assertEqual(result.last_harvested_height, 20)
 
 	def test_can_insert_namespace(self):
 		# Arrange:
@@ -1523,26 +1531,26 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			result = self._fetch_account_from_db(cursor, snapshot.address)
 
 		# Assert:
-		self.assertEqual(snapshot.address.bytes.hex(), result[0])
-		self.assertEqual(snapshot.height, result[1])
-		self.assertEqual(snapshot.public_key.bytes.hex(), result[2])
-		self.assertEqual(orphan_remote_address.bytes.hex(), result[3])  # remote_address should remain unchanged
-		self.assertEqual(f'{snapshot.importance:.10f}', result[4])
-		self.assertEqual(snapshot.balance, result[5])
-		self.assertEqual(snapshot.vested_balance, result[6])
-		self.assertEqual(snapshot.mosaics, result[7])
-		self.assertEqual(orphan_harvested_fees, result[8])  # harvested_fees should remain unchanged
-		self.assertEqual(snapshot.harvested_blocks, result[9])
-		self.assertEqual(snapshot.remote_status, result[10])
-		self.assertEqual(orphan_last_harvested_height, result[11])  # last_harvested_height should remain unchanged
-		self.assertEqual(snapshot.min_cosignatories, result[12])
+		self.assertEqual(snapshot.address.bytes.hex(), result.address)
+		self.assertEqual(snapshot.height, result.height)
+		self.assertEqual(snapshot.public_key.bytes.hex(), result.public_key)
+		self.assertEqual(orphan_remote_address.bytes.hex(), result.remote_address)
+		self.assertEqual(f'{snapshot.importance:.10f}', result.importance)
+		self.assertEqual(snapshot.balance, result.balance)
+		self.assertEqual(snapshot.vested_balance, result.vested_balance)
+		self.assertEqual(snapshot.mosaics, result.mosaics)
+		self.assertEqual(orphan_harvested_fees, result.harvested_fees)
+		self.assertEqual(snapshot.harvested_blocks, result.harvested_blocks)
+		self.assertEqual(snapshot.remote_status, result.remote_status)
+		self.assertEqual(orphan_last_harvested_height, result.last_harvested_height)
+		self.assertEqual(snapshot.min_cosignatories, result.min_cosignatories)
 		self.assertEqual(
 			[address.bytes for address in snapshot.cosignatory_of],
-			[bytes(address) for address in result[13]]
+			[bytes(address) for address in result.cosignatory_of]
 		)
 		self.assertEqual(
 			[address.bytes for address in snapshot.cosignatories],
-			[bytes(address) for address in result[14]]
+			[bytes(address) for address in result.cosignatories]
 		)
 
 	def test_rejects_refreshing_missing_account_from_rollback_snapshot(self):
@@ -1577,7 +1585,7 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			cleared_result = self._fetch_account_from_db(cursor, cleared_account.address)
 
 		# Assert:
-		self.assertIsNone(cleared_result[3])
+		self.assertIsNone(cleared_result.remote_address)
 
 	def test_can_get_latest_surviving_account_key_link(self):
 		# Arrange:
@@ -1827,7 +1835,7 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			second_result = self._fetch_account_from_db(cursor, second_account.address)
 
 		# Assert:
-		self.assertEqual(first_harvested_fees - first_orphan_block.total_fee, first_result[8])
-		self.assertEqual(BLOCKS[0].height, first_result[11])
-		self.assertEqual(0, second_result[8])
-		self.assertEqual(0, second_result[11])
+		self.assertEqual(first_harvested_fees - first_orphan_block.total_fee, first_result.harvested_fees)
+		self.assertEqual(BLOCKS[0].height, first_result.last_harvested_height)
+		self.assertEqual(0, second_result.harvested_fees)
+		self.assertEqual(0, second_result.last_harvested_height)

--- a/explorer/puller/tests/db/test_NemDatabase.py
+++ b/explorer/puller/tests/db/test_NemDatabase.py
@@ -920,6 +920,24 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			[]
 		), result)
 
+	def test_can_delete_affected_namespace_roots(self):
+		# Arrange:
+		owner = PublicKey('11' * 32)
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+			cursor = nem_database.connection.cursor()
+
+			nem_database.upsert_namespace(cursor, NamespaceRecord('affected', owner, 100, 200))
+			nem_database.upsert_namespace(cursor, NamespaceRecord('unaffected', owner, 100, 200))
+
+			# Act:
+			nem_database.delete_namespaces(cursor, {'affected'})
+			cursor.execute('SELECT root_namespace FROM namespaces ORDER BY root_namespace')
+			results = [record[0] for record in cursor.fetchall()]
+
+		# Assert:
+		self.assertEqual(['unaffected'], results)
+
 	def test_can_update_sub_namespaces(self):
 		# Arrange:
 		with NemDatabase(self.db_config) as nem_database:

--- a/explorer/puller/tests/db/test_NemDatabase.py
+++ b/explorer/puller/tests/db/test_NemDatabase.py
@@ -872,6 +872,54 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			[]
 		))
 
+	def test_same_owner_namespace_renewal_before_grace_period_end_preserves_sub_namespaces(self):
+		# Arrange:
+		owner = PublicKey('11' * 32)
+		renewal_height = 200 + (30 * 1440) - 1
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+			cursor = nem_database.connection.cursor()
+
+			nem_database.upsert_namespace(cursor, NamespaceRecord('root', owner, 100, 200))
+			nem_database.update_sub_namespaces(cursor, 'root.child', 'root')
+
+			# Act:
+			nem_database.upsert_namespace(cursor, NamespaceRecord('root', owner, renewal_height, 500000))
+			result = self._fetch_namespace_from_db(cursor, 'root')
+
+		# Assert:
+		self.assertEqual((
+			'root',
+			str(owner),
+			renewal_height,
+			500000,
+			['root.child']
+		), result)
+
+	def test_same_owner_namespace_registration_at_grace_period_end_clears_sub_namespaces(self):
+		# Arrange:
+		owner = PublicKey('11' * 32)
+		registration_height = 200 + (30 * 1440)  # grace period end
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+			cursor = nem_database.connection.cursor()
+
+			nem_database.upsert_namespace(cursor, NamespaceRecord('root', owner, 100, 200))
+			nem_database.update_sub_namespaces(cursor, 'root.child', 'root')
+
+			# Act:
+			nem_database.upsert_namespace(cursor, NamespaceRecord('root', owner, registration_height, 500000))
+			result = self._fetch_namespace_from_db(cursor, 'root')
+
+		# Assert:
+		self.assertEqual((
+			'root',
+			str(owner),
+			registration_height,
+			500000,
+			[]
+		), result)
+
 	def test_can_update_sub_namespaces(self):
 		# Arrange:
 		with NemDatabase(self.db_config) as nem_database:

--- a/explorer/puller/tests/db/test_NemDatabase.py
+++ b/explorer/puller/tests/db/test_NemDatabase.py
@@ -1390,6 +1390,7 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 		self.assertEqual(1, len(orphan_blocks))
 		self.assertEqual(BLOCKS[1].beneficiary, orphan_blocks[0].beneficiary)
 		self.assertEqual(BLOCKS[1].signer, orphan_blocks[0].signer)
+		self.assertEqual(BLOCKS[1].total_fee, orphan_blocks[0].total_fee)
 
 		self.assertEqual(2, len(orphan_transactions))
 		self.assertEqual(['outer', 'inner'], [
@@ -1787,41 +1788,46 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			)
 		], results)
 
-	def _run_recalculate_account_harvesting_test(self, account, blocks):
+	def test_can_subtract_orphan_harvesting_from_accounts(self):
 		# Arrange:
+		fork_height = 1
+		first_account = ACCOUNTS[0]
+		second_account = ACCOUNTS[0]._replace(address=BLOCKS[1].beneficiary)
+		first_orphan_block = BLOCKS[0]._replace(
+			height=2,
+			total_fee=50,
+			block_hash='11' * 32
+		)
+		second_orphan_block = BLOCKS[1]._replace(height=3)
+		first_harvested_fees = 1000
+
 		with NemDatabase(self.db_config) as nem_database:
 			nem_database.create_tables()
 			cursor = nem_database.connection.cursor()
 
-			for block in blocks:
+			for block in [BLOCKS[0], first_orphan_block, second_orphan_block]:
 				nem_database.insert_block(cursor, block)
 
-			nem_database.upsert_account(cursor, account)
-			nem_database.update_account_harvested_fees(cursor, account.address, 1, 99)
+			for account, harvested_fees in [
+				(first_account, first_harvested_fees),
+				(second_account, second_orphan_block.total_fee)
+			]:
+				nem_database.upsert_account(cursor, account)
+				nem_database.update_account_harvested_fees(cursor, account.address, harvested_fees, 3)
+
 			nem_database.connection.commit()
 
 			# Act:
-			nem_database.recalculate_account_harvesting(cursor, {account.address})
+			nem_database.rollback_account_harvesting(cursor, {
+				first_account.address: first_orphan_block.total_fee,
+				second_account.address: second_orphan_block.total_fee
+			}, fork_height)
 
-			return self._fetch_account_from_db(cursor, account.address)
-
-	def test_can_recalculate_harvesting_from_surviving_blocks(self):
-		# Act:
-		result = self._run_recalculate_account_harvesting_test(ACCOUNTS[0], [BLOCKS[0]])
-
-		# Assert:
-		self.assertEqual(BLOCKS[0].total_fee, result[8])
-		self.assertEqual(BLOCKS[0].height, result[11])
-
-	def test_can_reset_harvesting_when_no_surviving_blocks(self):
-		# Arrange:
-		account = ACCOUNTS[0]._replace(
-			address=Address('TALICE6XEEEOBFJVY3ZCENZ7WBG6LB4KB7P7KMQX')
-		)
-
-		# Act:
-		result = self._run_recalculate_account_harvesting_test(account, [])
+			first_result = self._fetch_account_from_db(cursor, first_account.address)
+			second_result = self._fetch_account_from_db(cursor, second_account.address)
 
 		# Assert:
-		self.assertEqual(0, result[8])
-		self.assertEqual(0, result[11])
+		self.assertEqual(first_harvested_fees - first_orphan_block.total_fee, first_result[8])
+		self.assertEqual(BLOCKS[0].height, first_result[11])
+		self.assertEqual(0, second_result[8])
+		self.assertEqual(0, second_result[11])

--- a/explorer/puller/tests/db/test_NemDatabase.py
+++ b/explorer/puller/tests/db/test_NemDatabase.py
@@ -1786,3 +1786,42 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 				second_supply_change_payload
 			)
 		], results)
+
+	def _run_recalculate_account_harvesting_test(self, account, blocks):
+		# Arrange:
+		with NemDatabase(self.db_config) as nem_database:
+			nem_database.create_tables()
+			cursor = nem_database.connection.cursor()
+
+			for block in blocks:
+				nem_database.insert_block(cursor, block)
+
+			nem_database.upsert_account(cursor, account)
+			nem_database.update_account_harvested_fees(cursor, account.address, 1, 99)
+			nem_database.connection.commit()
+
+			# Act:
+			nem_database.recalculate_account_harvesting(cursor, {account.address})
+
+			return self._fetch_account_from_db(cursor, account.address)
+
+	def test_can_recalculate_harvesting_from_surviving_blocks(self):
+		# Act:
+		result = self._run_recalculate_account_harvesting_test(ACCOUNTS[0], [BLOCKS[0]])
+
+		# Assert:
+		self.assertEqual(BLOCKS[0].total_fee, result[8])
+		self.assertEqual(BLOCKS[0].height, result[11])
+
+	def test_can_reset_harvesting_when_no_surviving_blocks(self):
+		# Arrange:
+		account = ACCOUNTS[0]._replace(
+			address=Address('TALICE6XEEEOBFJVY3ZCENZ7WBG6LB4KB7P7KMQX')
+		)
+
+		# Act:
+		result = self._run_recalculate_account_harvesting_test(account, [])
+
+		# Assert:
+		self.assertEqual(0, result[8])
+		self.assertEqual(0, result[11])

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -2271,7 +2271,8 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		}
 		rollback_impact = Mock(
 			fork_height=123,
-			orphan_created_accounts={orphan_address}
+			orphan_created_accounts={orphan_address},
+			orphan_beneficiaries={first_address}
 		)
 		database = Mock()
 		cursor = database.connection.cursor.return_value
@@ -2283,7 +2284,10 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		) as mock_restore_remote_addresses, patch.object(
 			self.puller,
 			'_restore_rollback_namespaces'
-		) as mock_restore_namespaces:
+		) as mock_restore_namespaces, patch.object(
+			self.puller,
+			'_restore_rollback_mosaics'
+		) as mock_restore_mosaics:
 			# Act:
 			self.puller.repair_rollback(rollback_impact, account_state)
 
@@ -2299,6 +2303,8 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 
 			mock_restore_remote_addresses.assert_called_once_with(cursor, rollback_impact)
 			mock_restore_namespaces.assert_called_once_with(cursor, rollback_impact)
+			mock_restore_mosaics.assert_called_once_with(cursor, rollback_impact)
+			database.recalculate_account_harvesting.assert_called_once_with(cursor, {first_address})
 			database.connection.commit.assert_called_once_with()
 			database.connection.rollback.assert_not_called()
 

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -1652,7 +1652,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			account_creation_heights={address: height},
 			orphan_created_accounts=set(),
 			surviving_affected_accounts={address},
-			orphan_beneficiaries=set(),
+			orphan_harvested_fees={},
 			affected_remote_link_accounts=set(),
 			affected_namespace_roots=set(),
 			affected_mosaic_names=set()
@@ -1813,13 +1813,25 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			database.insert_block(cursor, BlockRecord(
 				orphan_height,
 				'2015-03-29 00:00:00+00:00',
-				0,
+				20,
 				len(transactions),
 				1,
 				'AA' * 32,
 				beneficiary,
 				signer,
 				'BB' * 64,
+				100
+			))
+			database.insert_block(cursor, BlockRecord(
+				orphan_height + 1,
+				'2015-03-29 00:01:00+00:00',
+				30,
+				0,
+				1,
+				'CC' * 32,
+				beneficiary,
+				signer,
+				'DD' * 64,
 				100
 			))
 			database.upsert_mosaic(cursor, MosaicRecord(
@@ -1861,7 +1873,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		self.assertEqual(expected_accounts, capture.affected_accounts)
 		self.assertEqual({recipient}, capture.orphan_created_accounts)
 		self.assertEqual(expected_accounts - {recipient}, capture.surviving_affected_accounts)
-		self.assertEqual({beneficiary}, capture.orphan_beneficiaries)
+		self.assertEqual({beneficiary: 50}, capture.orphan_harvested_fees)
 		self.assertEqual({sender}, capture.affected_remote_link_accounts)
 		self.assertEqual({'root'}, capture.affected_namespace_roots)
 		self.assertEqual({'root.token', 'root.supply'}, capture.affected_mosaic_names)
@@ -1921,7 +1933,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		}, impact.account_creation_heights)
 		self.assertEqual(set(), impact.orphan_created_accounts)
 		self.assertEqual(expected_accounts, impact.surviving_affected_accounts)
-		self.assertEqual(set(), impact.orphan_beneficiaries)
+		self.assertEqual({}, impact.orphan_harvested_fees)
 		self.assertEqual(set(), impact.affected_remote_link_accounts)
 		self.assertEqual(set(), impact.affected_namespace_roots)
 		self.assertEqual(set(), impact.affected_mosaic_names)
@@ -1974,7 +1986,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			account_creation_heights={first_survivor: 2, second_survivor: 5},
 			orphan_created_accounts={},
 			surviving_affected_accounts={first_survivor, second_survivor},
-			orphan_beneficiaries=set(),
+			orphan_harvested_fees={},
 			affected_remote_link_accounts=set(),
 			affected_namespace_roots=set(),
 			affected_mosaic_names=set()
@@ -2272,7 +2284,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		rollback_impact = Mock(
 			fork_height=123,
 			orphan_created_accounts={orphan_address},
-			orphan_beneficiaries={first_address}
+			orphan_harvested_fees={first_address: 50}
 		)
 		database = Mock()
 		cursor = database.connection.cursor.return_value
@@ -2293,7 +2305,12 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 
 			# Assert:
 			mock_validate.assert_called_once_with(rollback_impact, account_state)
+			database.rollback_account_harvesting.assert_called_once_with(cursor, {first_address: 50}, 123)
 			database.delete_orphan_chain_data.assert_called_once_with(cursor, 123)
+			self.assertLess(
+				database.mock_calls.index(call.rollback_account_harvesting(cursor, {first_address: 50}, 123)),
+				database.mock_calls.index(call.delete_orphan_chain_data(cursor, 123))
+			)
 			database.delete_accounts.assert_called_once_with(cursor, {orphan_address})
 
 			refresh_calls = database.refresh_account_from_snapshot.call_args_list
@@ -2304,7 +2321,6 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			mock_restore_remote_addresses.assert_called_once_with(cursor, rollback_impact)
 			mock_restore_namespaces.assert_called_once_with(cursor, rollback_impact)
 			mock_restore_mosaics.assert_called_once_with(cursor, rollback_impact)
-			database.recalculate_account_harvesting.assert_called_once_with(cursor, {first_address})
 			database.connection.commit.assert_called_once_with()
 			database.connection.rollback.assert_not_called()
 

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -1652,7 +1652,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			account_creation_heights={address: height},
 			orphan_created_accounts=set(),
 			surviving_affected_accounts={address},
-			orphan_harvested_fees={},
+			orphan_harvested_fees_map={},
 			affected_remote_link_accounts=set(),
 			affected_namespace_roots=set(),
 			affected_mosaic_names=set()
@@ -1873,7 +1873,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		self.assertEqual(expected_accounts, capture.affected_accounts)
 		self.assertEqual({recipient}, capture.orphan_created_accounts)
 		self.assertEqual(expected_accounts - {recipient}, capture.surviving_affected_accounts)
-		self.assertEqual({beneficiary: 50}, capture.orphan_harvested_fees)
+		self.assertEqual({beneficiary: 50}, capture.orphan_harvested_fees_map)
 		self.assertEqual({sender}, capture.affected_remote_link_accounts)
 		self.assertEqual({'root'}, capture.affected_namespace_roots)
 		self.assertEqual({'root.token', 'root.supply'}, capture.affected_mosaic_names)
@@ -1933,7 +1933,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		}, impact.account_creation_heights)
 		self.assertEqual(set(), impact.orphan_created_accounts)
 		self.assertEqual(expected_accounts, impact.surviving_affected_accounts)
-		self.assertEqual({}, impact.orphan_harvested_fees)
+		self.assertEqual({}, impact.orphan_harvested_fees_map)
 		self.assertEqual(set(), impact.affected_remote_link_accounts)
 		self.assertEqual(set(), impact.affected_namespace_roots)
 		self.assertEqual(set(), impact.affected_mosaic_names)
@@ -1986,7 +1986,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			account_creation_heights={first_survivor: 2, second_survivor: 5},
 			orphan_created_accounts={},
 			surviving_affected_accounts={first_survivor, second_survivor},
-			orphan_harvested_fees={},
+			orphan_harvested_fees_map={},
 			affected_remote_link_accounts=set(),
 			affected_namespace_roots=set(),
 			affected_mosaic_names=set()
@@ -2284,7 +2284,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		rollback_impact = Mock(
 			fork_height=123,
 			orphan_created_accounts={orphan_address},
-			orphan_harvested_fees={first_address: 50}
+			orphan_harvested_fees_map={first_address: 50}
 		)
 		database = Mock()
 		cursor = database.connection.cursor.return_value

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -28,7 +28,7 @@ from symbollightapi.model.Transaction import (
 	TransferTransaction
 )
 
-from puller.db.NemDatabase import AccountRefreshRecord, RollbackNamespaceRegistrationRecord
+from puller.db.NemDatabase import AccountRefreshRecord, RollbackMosaicRecord, RollbackNamespaceRegistrationRecord
 from puller.facade.NemPuller import (
 	NEM_MAX_ROLLBACK_DEPTH,
 	NEM_NAMESPACE_DURATION,
@@ -2148,6 +2148,115 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		database.delete_namespaces.assert_called_once_with(cursor, {'orphan'})
 		database.upsert_namespace.assert_not_called()
 		database.update_sub_namespaces.assert_not_called()
+
+	def _run_rollback_mosaics_test(self, transactions, namespace_name='root.token'):
+		rollback_impact = Mock(
+			fork_height=10,
+			affected_mosaic_names={namespace_name}
+		)
+		database = Mock()
+		database.get_surviving_mosaic_transactions.return_value = transactions
+		cursor = Mock()
+		self.puller.nem_db = database
+
+		# Act:
+		self.puller._restore_rollback_mosaics(cursor, rollback_impact)  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual([
+			call.delete_mosaics(cursor, {namespace_name}),
+			call.get_surviving_mosaic_transactions(cursor, 10, {namespace_name})
+		], database.mock_calls[:2])
+
+		return database, cursor
+
+	def test_can_restore_rollback_mosaic_definition(self):
+		# Arrange:
+		creator = PublicKey('11' * 32)
+		levy_recipient = Address('TALICE6XEEEOBFJVY3ZCENZ7WBG6LB4KB7P7KMQX')
+		definition_payload = {
+			'namespace_name': 'root.token',
+			'description': 'rollback mosaic',
+			'mosaic_properties': {
+				'initial_supply': 1000,
+				'divisibility': 2,
+				'supply_mutable': True,
+				'transferable': False
+			},
+			'levy': {
+				'type': 1,
+				'namespace_name': 'levy.token',
+				'fee': 25,
+				'recipient': str(levy_recipient)
+			}
+		}
+		transaction = RollbackMosaicRecord(
+			TransactionType.MOSAIC_DEFINITION.value,
+			5,
+			creator,
+			definition_payload
+		)
+
+		# Act:
+		database, cursor = self._run_rollback_mosaics_test([transaction])
+
+		# Assert:
+		database.upsert_mosaic.assert_called_once_with(
+			cursor,
+			MosaicRecord(
+				root_namespace='root',
+				namespace_name='root.token',
+				description='rollback mosaic',
+				creator=creator,
+				registered_height=5,
+				initial_supply=1000,
+				total_supply=1000,
+				divisibility=2,
+				supply_mutable=True,
+				transferable=False,
+				levy_type=1,
+				levy_namespace_name='levy.token',
+				levy_fee=25,
+				levy_recipient=levy_recipient
+			)
+		)
+		database.update_mosaic_total_supply.assert_not_called()
+
+	def test_can_restore_rollback_mosaic_supply_changes(self):
+		# Arrange:
+		creator = PublicKey('11' * 32)
+		transactions = [
+			RollbackMosaicRecord(
+				TransactionType.MOSAIC_SUPPLY_CHANGE.value,
+				6,
+				creator,
+				{'namespace_name': 'root.token', 'supply_type': 1, 'delta': 300}
+			),
+			RollbackMosaicRecord(
+				TransactionType.MOSAIC_SUPPLY_CHANGE.value,
+				7,
+				creator,
+				{'namespace_name': 'root.token', 'supply_type': 2, 'delta': 100}
+			)
+		]
+
+		# Act:
+		database, cursor = self._run_rollback_mosaics_test(transactions)
+
+		# Assert:
+		database.upsert_mosaic.assert_not_called()
+		self.assertEqual([
+			call(cursor, 'root.token', 300),
+			call(cursor, 'root.token', -100)
+		], database.update_mosaic_total_supply.call_args_list)
+
+	def test_removes_orphan_mosaic_when_it_has_no_surviving_transaction(self):
+		# Act:
+		database, _ = self._run_rollback_mosaics_test([], 'orphan.token')
+
+		# Assert:
+		database.upsert_mosaic.assert_not_called()
+		database.update_mosaic_total_supply.assert_not_called()
 
 	def test_can_repair_rollback_with_expected_operations(self):
 		# Arrange:

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -3,7 +3,7 @@ import asyncio
 import datetime
 import tempfile
 import unittest
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock, call, patch
 
 import testing.postgresql
 from symbolchain.CryptoTypes import PublicKey
@@ -28,9 +28,10 @@ from symbollightapi.model.Transaction import (
 	TransferTransaction
 )
 
-from puller.db.NemDatabase import AccountRefreshRecord
+from puller.db.NemDatabase import AccountRefreshRecord, RollbackNamespaceRegistrationRecord
 from puller.facade.NemPuller import (
 	NEM_MAX_ROLLBACK_DEPTH,
+	NEM_NAMESPACE_DURATION,
 	AccountRecord,
 	AccountVestedBalanceRecord,
 	BlockRecord,
@@ -985,7 +986,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 				root_namespace='namespace',
 				owner=PublicKey('a700809530e5428066807ec0d34859c52e260fc60634aaac13e3972dcfc08736'),
 				registered_height=3,
-				expiration_height=3 + (365 * 1440)
+				expiration_height=3 + NEM_NAMESPACE_DURATION
 			)
 		))
 
@@ -2090,6 +2091,64 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		# Assert:
 		self.assertEqual(surviving_remote_address.bytes.hex(), remote_address)
 
+	def test_can_restore_rollback_namespaces_by_replaying_surviving_registrations(self):
+		# Arrange:
+		owner = PublicKey('11' * 32)
+		namespace_registration_records = [
+			RollbackNamespaceRegistrationRecord(5, owner, None, 'root'),
+			RollbackNamespaceRegistrationRecord(6, owner, 'root', 'child'),
+			RollbackNamespaceRegistrationRecord(7, owner, 'root.child', 'grandchild')
+		]
+		rollback_impact = Mock(
+			fork_height=10,
+			affected_namespace_roots={'root'}
+		)
+		database = Mock()
+		database.get_surviving_namespace_history.return_value = namespace_registration_records
+		cursor = Mock()
+		self.puller.nem_db = database
+
+		# Act:
+		self.puller._restore_rollback_namespaces(cursor, rollback_impact)  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual([
+			call.delete_namespaces(cursor, {'root'}),
+			call.get_surviving_namespace_history(cursor, 10, {'root'})
+		], database.mock_calls[:2])
+		database.get_surviving_namespace_history.assert_called_once_with(
+			cursor,
+			10,
+			{'root'}
+		)
+		database.upsert_namespace.assert_called_once_with(
+			cursor,
+			NamespaceRecord('root', owner, 5, 5 + NEM_NAMESPACE_DURATION)
+		)
+		self.assertEqual([
+			call(cursor, 'root.child', 'root'),
+			call(cursor, 'root.child.grandchild', 'root')
+		], database.update_sub_namespaces.call_args_list)
+
+	def test_removes_orphan_root_when_it_has_no_surviving_registration(self):
+		# Arrange:
+		rollback_impact = Mock(
+			fork_height=10,
+			affected_namespace_roots={'orphan'}
+		)
+		database = Mock()
+		database.get_surviving_namespace_history.return_value = []
+		cursor = Mock()
+		self.puller.nem_db = database
+
+		# Act:
+		self.puller._restore_rollback_namespaces(cursor, rollback_impact)  # pylint: disable=protected-access
+
+		# Assert:
+		database.delete_namespaces.assert_called_once_with(cursor, {'orphan'})
+		database.upsert_namespace.assert_not_called()
+		database.update_sub_namespaces.assert_not_called()
+
 	def test_can_repair_rollback_with_expected_operations(self):
 		# Arrange:
 		first_address = Address('TALICE6XEEEOBFJVY3ZCENZ7WBG6LB4KB7P7KMQX')
@@ -2112,7 +2171,10 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		with patch.object(self.puller, '_validate_rollback_account_state') as mock_validate, patch.object(
 			self.puller,
 			'_restore_rollback_remote_addresses'
-		) as mock_restore_remote_addresses:
+		) as mock_restore_remote_addresses, patch.object(
+			self.puller,
+			'_restore_rollback_namespaces'
+		) as mock_restore_namespaces:
 			# Act:
 			self.puller.repair_rollback(rollback_impact, account_state)
 
@@ -2127,6 +2189,7 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 			self.assertEqual((cursor, second_account), refresh_calls[1][0])
 
 			mock_restore_remote_addresses.assert_called_once_with(cursor, rollback_impact)
+			mock_restore_namespaces.assert_called_once_with(cursor, rollback_impact)
 			database.connection.commit.assert_called_once_with()
 			database.connection.rollback.assert_not_called()
 


### PR DESCRIPTION
Here is part 2.

Problem: 

- Rollback repair did not fully restore the derived blockchain state. A rollback could leave namespace and mosaic inconsistent, while harvested fees and the latest harvested height could still include orphaned blocks.
- Namespace re-registration after the grace period could also retain stale sub-namespaces.

Solution:

- Rebuild affected namespaces by replaying surviving namespace registration transactions up to the fork height.
- Rebuild affected mosaics by replaying surviving mosaic definition and supply change transactions.
- Preserve the seeded `nem.xem` mosaic during restoration.
- Recalculate harvested fees and the latest harvested height from surviving blocks.
- Preserve sub-namespaces for valid same-owner renewals within the grace period.
- Clear stale sub-namespaces when a root namespace is registered after the grace period.
