### PR TITLE
[explorer/frontend] fix: search only the entity type a filter needs

### DIFF
--- a/explorer/frontend/__tests__/api/search.test.js
+++ b/explorer/frontend/__tests__/api/search.test.js
@@ -14,8 +14,7 @@ jest.mock('@/app/utils/server', () => {
 	};
 });
 
-const runSearchTest = async (searchQuery, responseMap, expectedResult) => {
-	// Arrange:
+const mockMakeRequest = responseMap => {
 	const spy = jest.spyOn(utils, 'makeRequest');
 
 	spy.mockImplementation(url => {
@@ -27,11 +26,30 @@ const runSearchTest = async (searchQuery, responseMap, expectedResult) => {
 			return Promise.reject(error404Response);
 	});
 
+	return spy;
+};
+
+const runSearchTest = async (searchQuery, responseMap, expectedResult) => {
+	// Arrange:
+	mockMakeRequest(responseMap);
+
 	// Act:
 	const result = await search(searchQuery);
 
 	// Assert:
 	expect(result).toStrictEqual(expectedResult);
+};
+
+const runScopedSearchTest = async (searchQuery, type, responseMap, expectedResult, expectedRequestedURLs) => {
+	// Arrange:
+	const spy = mockMakeRequest(responseMap);
+
+	// Act:
+	const result = await search(searchQuery, type);
+
+	// Assert:
+	expect(result).toStrictEqual(expectedResult);
+	expect(spy.mock.calls.map(call => call[0])).toStrictEqual(expectedRequestedURLs);
 };
 
 describe('api/search', () => {
@@ -160,5 +178,63 @@ describe('api/search', () => {
 
 		// Act + Assert:
 		await runSearchTest(searchQuery, responseMap, expectedResult);
+	});
+
+	it('requests only the account when scoped to account', async () => {
+		// Arrange:
+		const searchQuery = 'NADMEHCFJD45GPTDL4HZP2LJLZVAZRLYWYPNEMLY';
+		const responseMap = {
+			'https://explorer.backend/account?address=NADMEHCFJD45GPTDL4HZP2LJLZVAZRLYWYPNEMLY': accountInfoResponse
+		};
+		const expectedResult = {
+			account: accountInfoResult
+		};
+
+		// Act + Assert:
+		await runScopedSearchTest(searchQuery, 'account', responseMap, expectedResult, [
+			'https://explorer.backend/account?address=NADMEHCFJD45GPTDL4HZP2LJLZVAZRLYWYPNEMLY'
+		]);
+	});
+
+	it('requests only the mosaic when scoped to mosaic', async () => {
+		// Arrange:
+		const searchQuery = 'namespace-name.sub-name';
+		const responseMap = {
+			'https://explorer.backend/mosaic/namespace-name.sub-name': mosaicInfoResponse,
+			'https://explorer.backend/namespace/namespace-name.sub-name': namespaceInfoResponse
+		};
+		const expectedResult = {
+			mosaic: mosaicInfoResult
+		};
+
+		// Act + Assert:
+		await runScopedSearchTest(searchQuery, 'mosaic', responseMap, expectedResult, [
+			'https://explorer.backend/mosaic/namespace-name.sub-name'
+		]);
+	});
+
+	it('requests only the block when scoped to block', async () => {
+		// Arrange:
+		const searchQuery = '1';
+		const responseMap = {
+			'https://explorer.backend/block/1': blockInfoResponse,
+			'https://explorer.backend/namespace/1': namespaceInfoResponse
+		};
+		const expectedResult = {
+			block: blockInfoResult
+		};
+
+		// Act + Assert:
+		await runScopedSearchTest(searchQuery, 'block', responseMap, expectedResult, ['https://explorer.backend/block/1']);
+	});
+
+	it('requests nothing when scoped to account and the text cannot be an account', async () => {
+		// Arrange:
+		const searchQuery = 'NADMEHCFJD45';
+		const responseMap = {};
+		const expectedResult = {};
+
+		// Act + Assert:
+		await runScopedSearchTest(searchQuery, 'account', responseMap, expectedResult, []);
 	});
 });

--- a/explorer/frontend/__tests__/api/search.test.js
+++ b/explorer/frontend/__tests__/api/search.test.js
@@ -40,7 +40,7 @@ const runSearchTest = async (searchQuery, responseMap, expectedResult) => {
 	expect(result).toStrictEqual(expectedResult);
 };
 
-const runScopedSearchTest = async (searchQuery, type, responseMap, expectedResult, expectedRequestedURLs) => {
+const runScopedSearchTest = async (searchQuery, type, responseMap, expectedResult) => {
 	// Arrange:
 	const spy = mockMakeRequest(responseMap);
 
@@ -49,7 +49,7 @@ const runScopedSearchTest = async (searchQuery, type, responseMap, expectedResul
 
 	// Assert:
 	expect(result).toStrictEqual(expectedResult);
-	expect(spy.mock.calls.map(call => call[0])).toStrictEqual(expectedRequestedURLs);
+	expect(spy.mock.calls.map(call => call[0])).toStrictEqual(Object.keys(responseMap));
 };
 
 describe('api/search', () => {
@@ -191,41 +191,74 @@ describe('api/search', () => {
 		};
 
 		// Act + Assert:
-		await runScopedSearchTest(searchQuery, 'account', responseMap, expectedResult, [
-			'https://explorer.backend/account?address=NADMEHCFJD45GPTDL4HZP2LJLZVAZRLYWYPNEMLY'
-		]);
+		await runScopedSearchTest(searchQuery, 'account', responseMap, expectedResult);
 	});
 
 	it('requests only the mosaic when scoped to mosaic', async () => {
 		// Arrange:
 		const searchQuery = 'namespace-name.sub-name';
 		const responseMap = {
-			'https://explorer.backend/mosaic/namespace-name.sub-name': mosaicInfoResponse,
-			'https://explorer.backend/namespace/namespace-name.sub-name': namespaceInfoResponse
+			'https://explorer.backend/mosaic/namespace-name.sub-name': mosaicInfoResponse
 		};
 		const expectedResult = {
 			mosaic: mosaicInfoResult
 		};
 
 		// Act + Assert:
-		await runScopedSearchTest(searchQuery, 'mosaic', responseMap, expectedResult, [
-			'https://explorer.backend/mosaic/namespace-name.sub-name'
-		]);
+		await runScopedSearchTest(searchQuery, 'mosaic', responseMap, expectedResult);
 	});
 
 	it('requests only the block when scoped to block', async () => {
 		// Arrange:
 		const searchQuery = '1';
 		const responseMap = {
-			'https://explorer.backend/block/1': blockInfoResponse,
-			'https://explorer.backend/namespace/1': namespaceInfoResponse
+			'https://explorer.backend/block/1': blockInfoResponse
 		};
 		const expectedResult = {
 			block: blockInfoResult
 		};
 
 		// Act + Assert:
-		await runScopedSearchTest(searchQuery, 'block', responseMap, expectedResult, ['https://explorer.backend/block/1']);
+		await runScopedSearchTest(searchQuery, 'block', responseMap, expectedResult);
+	});
+
+	it('requests only the namespace when scoped to namespace', async () => {
+		// Arrange:
+		const searchQuery = 'namespace-name.sub-name';
+		const responseMap = {
+			'https://explorer.backend/namespace/namespace-name.sub-name': namespaceInfoResponse
+		};
+		const expectedResult = {
+			namespace: namespaceInfoResult
+		};
+
+		// Act + Assert:
+		await runScopedSearchTest(searchQuery, 'namespace', responseMap, expectedResult);
+	});
+
+	it('requests only the transaction when scoped to transaction', async () => {
+		// Arrange:
+		const searchQuery = '89DFA7AAD61024CCB564C41239CA865221A8984EE970FBDA0F492B09E4C70691';
+		const responseMap = {
+			'https://explorer.backend/transaction/89DFA7AAD61024CCB564C41239CA865221A8984EE970FBDA0F492B09E4C70691':
+				transactionInfoResponse
+		};
+		const expectedResult = {
+			transaction: transactionInfoResult
+		};
+
+		// Act + Assert:
+		await runScopedSearchTest(searchQuery, 'transaction', responseMap, expectedResult);
+	});
+
+	it('requests nothing when scoped to transaction and the text cannot be a transaction hash', async () => {
+		// Arrange:
+		const searchQuery = '89DFA7AAD610';
+		const responseMap = {};
+		const expectedResult = {};
+
+		// Act + Assert:
+		await runScopedSearchTest(searchQuery, 'transaction', responseMap, expectedResult);
 	});
 
 	it('requests nothing when scoped to account and the text cannot be an account', async () => {
@@ -235,6 +268,6 @@ describe('api/search', () => {
 		const expectedResult = {};
 
 		// Act + Assert:
-		await runScopedSearchTest(searchQuery, 'account', responseMap, expectedResult, []);
+		await runScopedSearchTest(searchQuery, 'account', responseMap, expectedResult);
 	});
 });

--- a/explorer/frontend/__tests__/components/Flter.test.js
+++ b/explorer/frontend/__tests__/components/Flter.test.js
@@ -267,7 +267,7 @@ describe('Filter', () => {
 
 			// Assert:
 			if (shouldUseSearch)
-				expect(search).toHaveBeenCalledWith(searchText);
+				expect(search).toHaveBeenCalledWith(searchText, filterConfig.find(filter => filter.title === filterToPress).type);
 
 			const assertionPromises = expectedTextList.map(text => {
 				return waitFor(() => expect(screen.getByText(text)).toBeInTheDocument());

--- a/explorer/frontend/components/Filter.jsx
+++ b/explorer/frontend/components/Filter.jsx
@@ -61,7 +61,7 @@ const FilterModal = ({ isVisible, title, type, isSearchEnabled, options, onSearc
 	const [text, setText] = useState('');
 	const [searchResult, setSearchResult] = useState(null);
 	const [search, isLoading] = useDataManager(async text => {
-		const searchResult = await onSearchRequest(text);
+		const searchResult = await onSearchRequest(text, type);
 		if (searchResult?.[type])
 			setSearchResult(searchResult[type]);
 		else

--- a/explorer/frontend/variants/nem/api/search.js
+++ b/explorer/frontend/variants/nem/api/search.js
@@ -4,37 +4,55 @@ import { fetchMosaicInfo } from './mosaics';
 import { fetchNamespaceInfo } from './namespaces';
 import { fetchTransactionInfo } from './transactions';
 
-export const search = async text => {
+const ADDRESS_LENGTH = 40;
+const HEX_KEY_LENGTH = 64;
+
+const searchAccount = query => {
+	if (ADDRESS_LENGTH === query.length)
+		return fetchAccountInfo(query);
+
+	if (HEX_KEY_LENGTH === query.length)
+		return fetchAccountInfoByPublicKey(query);
+
+	return null;
+};
+
+const searchNamespace = async query => {
+	const namespace = await fetchNamespaceInfo(query.toLowerCase());
+
+	if (namespace || 2 > query.split('.').length)
+		return namespace;
+
+	const rootNamespaceName = query.split('.')[0] || '';
+
+	return fetchNamespaceInfo(rootNamespaceName.toLowerCase());
+};
+
+const searchHandlers = {
+	block: query => fetchBlockInfo(query),
+	transaction: query => (HEX_KEY_LENGTH === query.length ? fetchTransactionInfo(query) : null),
+	account: searchAccount,
+	mosaic: query => fetchMosaicInfo(query.toLowerCase()),
+	namespace: searchNamespace
+};
+
+/**
+ * Searches for the entity matching the text.
+ * @param {string} text - search text
+ * @param {string} [type] - entity type to search for; every type is searched when omitted
+ * @returns {Promise<object>} map of the entities found, keyed by type
+ */
+export const search = async (text, type) => {
 	const query = `${text}`.trim().toUpperCase();
+	const requestedTypes = type ? [type] : Object.keys(searchHandlers);
+	const types = requestedTypes.filter(requestedType => searchHandlers[requestedType]);
+	const entities = await Promise.all(types.map(searchType => searchHandlers[searchType](query)));
 	const results = {};
-	let account;
-	let transaction;
-	let namespace;
 
-	const block = await fetchBlockInfo(query);
-	if (query.length === 64) 
-		transaction = await fetchTransactionInfo(query);
-	if (query.length === 40) 
-		account = await fetchAccountInfo(query);
-	if (!account && query.length === 64) 
-		account = await fetchAccountInfoByPublicKey(query);
-	const mosaic = await fetchMosaicInfo(query.toLowerCase());
-	namespace = await fetchNamespaceInfo(query.toLowerCase());
-	if (!namespace && query.split('.').length > 1) {
-		const mosaicRootNamespaceName = query.split('.')[0] || '';
-		namespace = await fetchNamespaceInfo(mosaicRootNamespaceName.toLowerCase());
-	}
-
-	if (block) 
-		results.block = block;
-	if (transaction) 
-		results.transaction = transaction;
-	if (account) 
-		results.account = account;
-	if (mosaic) 
-		results.mosaic = mosaic;
-	if (namespace) 
-		results.namespace = namespace;
+	types.forEach((searchType, index) => {
+		if (entities[index])
+			results[searchType] = entities[index];
+	});
 
 	return results;
 };


### PR DESCRIPTION
## Problem

The searchable filters each queried endpoints they have no use for. Typing into one sent a
request for every other entity type as well, and only the matching one was rendered:

| Filter | Endpoint it uses | Endpoints it queried needlessly |
| --- | --- | --- |
| From / To - 40-char address | `account?address=` | `block`, `mosaic`, `namespace` |
| From / To - 64-char public key | `account?publicKey=` | `block`, `transaction`, `mosaic`, `namespace` |
| From / To - partial text | none | `block`, `mosaic`, `namespace` (+ parent namespace) |
| Transferred mosaic | `mosaic` | `block`, `namespace` (+ parent namespace) |
| Block | `block` | `mosaic`, `namespace` |

Two causes:

- The filter modal calls the shared global search, which looks up every entity type by
  design, and then discards all but one (`Filter.jsx`, `searchResult?.[type]`).
- The lookups inside `search` were chained with `await`, so the discarded requests were not
  just extra - they ran one after another ahead of the useful one.

Each miss came back as 400/404 and was swallowed by `createTryFetchInfoFunction`, so the
only visible symptom was the wait after every debounce tick.

## Solution

- `FilterModal` passes its type: `onSearchRequest(text, type)`.
- `search(text, type)` resolves a single handler for that type, so a filter queries exactly
  the endpoint it renders. An unknown type yields an empty result rather than an error.
- Called without a type - the global search bar in `Header.jsx`, which does need every type
  - the full set still runs, now through `Promise.all` rather than a chain of awaits.
- For the account filter partial text now produces no request at all: the account lookup
  was already guarded by text length, and the block, mosaic and namespace lookups that used
  to fire alongside it are gone.