### PR TITLE
[explorer] fix: list multisig transfers when filtering by mosaic

### DIFF
--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -175,6 +175,13 @@ class NemDatabase(DatabaseConnection):
 			'''
 		)
 
+		cursor.execute(
+			'''
+			CREATE INDEX IF NOT EXISTS transactions_mosaic_namespace_name_transaction_id_idx
+				ON transactions_mosaic(namespace_name, transaction_id)
+			'''
+		)
+
 	def create_tables(self):
 		"""Creates database tables."""
 

--- a/explorer/rest/rest/db/NemDatabase.py
+++ b/explorer/rest/rest/db/NemDatabase.py
@@ -899,11 +899,10 @@ class NemDatabase(DatabaseConnectionPool):
 
 		if transaction_query.mosaic:
 			condition += (
-				' AND t.transaction_type = %s'
 				' AND EXISTS (SELECT 1 FROM transactions_mosaic tm'
 				' WHERE tm.transaction_id = t.id AND tm.namespace_name = %s)'
 			)
-			params.extend([TransactionType.TRANSFER.value, transaction_query.mosaic])
+			params.append(transaction_query.mosaic)
 
 		return condition, params
 
@@ -963,6 +962,26 @@ class NemDatabase(DatabaseConnectionPool):
 			params + [pagination.limit, pagination.offset]
 		)
 
+	@staticmethod
+	def _create_mosaic_page_condition(mosaic, sort, filters, pagination):
+		"""Restricts the listing to one page of ids, chosen from the mosaic index before any row is hydrated."""
+
+		filter_condition, filter_params = filters
+
+		# a multisig transaction carries its mosaics on the inner transfer, so the mosaic resolves to its owner;
+		# ids are handed out in height order, which lets the page be ordered without joining the transfer first
+		return (
+			' WHERE t.is_inner = false AND t.id IN ('
+			' SELECT COALESCE(o.id, t.id)'
+			' FROM transactions_mosaic tm'
+			' JOIN transactions t ON t.id = tm.transaction_id'
+			' LEFT JOIN transactions o ON o.transaction_hash = t.aggregate_hash'
+			f' WHERE tm.namespace_name = %s{filter_condition}'
+			f' ORDER BY tm.transaction_id {sort}'
+			' LIMIT %s OFFSET %s)',
+			[mosaic] + filter_params + [pagination.limit, pagination.offset]
+		)
+
 	def get_transactions(self, pagination, sort, transaction_query):
 		"""Gets transactions pagination."""
 
@@ -978,6 +997,19 @@ class NemDatabase(DatabaseConnectionPool):
 				branches,
 				sort,
 				self._create_transaction_filters(transaction_query, 'COALESCE(o.transaction_type, t.transaction_type)'),
+				pagination
+			)
+		elif transaction_query.mosaic:
+			limit_condition = ''
+			order_condition += f', t.id {sort}'
+			where_condition, params = self._create_mosaic_page_condition(
+				transaction_query.mosaic,
+				sort,
+				# the mosaic selects the page here, so it must not be repeated as a filter on the rows
+				self._create_transaction_filters(
+					transaction_query._replace(mosaic=None),
+					'COALESCE(o.transaction_type, t.transaction_type)'
+				),
 				pagination
 			)
 		else:

--- a/explorer/rest/tests/db/test_NemDatabase.py
+++ b/explorer/rest/tests/db/test_NemDatabase.py
@@ -830,7 +830,7 @@ class NemDatabaseTest(DatabaseTestBase):  # pylint: disable=too-many-public-meth
 	def test_can_query_transactions_filtered_by_mosaic_nem_xem(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc', self._make_transaction_query(mosaic='nem.xem'),
-			('transfer', 'transfer_v2')
+			('multisig', 'transfer_v2', 'transfer')
 		)
 
 	def test_can_query_transactions_filtered_by_mosaic_other(self):
@@ -842,6 +842,44 @@ class NemDatabaseTest(DatabaseTestBase):  # pylint: disable=too-many-public-meth
 	def test_can_query_transactions_filtered_by_nonexistent_mosaic(self):
 		self._assert_can_query_transactions_with_filter(
 			Pagination(10, 0), 'desc', self._make_transaction_query(mosaic='nonexistent.mosaic'), ()
+		)
+
+	def test_can_query_transactions_filtered_by_mosaic_sorted_by_height_asc(self):
+		self._assert_can_query_transactions_with_filter(
+			Pagination(10, 0), 'asc', self._make_transaction_query(mosaic='nem.xem'),
+			('transfer', 'transfer_v2', 'multisig')
+		)
+
+	def test_can_query_transactions_filtered_by_mosaic_with_limit_offset(self):
+		self._assert_can_query_transactions_with_filter(
+			Pagination(1, 1), 'desc', self._make_transaction_query(mosaic='nem.xem'), ('transfer_v2', )
+		)
+
+	def test_can_query_transactions_filtered_by_mosaic_and_height(self):
+		self._assert_can_query_transactions_with_filter(
+			Pagination(10, 0), 'desc', self._make_transaction_query(mosaic='nem.xem', height=1),
+			('transfer_v2', 'transfer')
+		)
+
+	def test_can_query_transactions_filtered_by_mosaic_and_multisig_transaction_type(self):
+		# MULTISIG (4100)
+		self._assert_can_query_transactions_with_filter(
+			Pagination(10, 0), 'desc', self._make_transaction_query(mosaic='nem.xem', transaction_types=[4100]),
+			('multisig', )
+		)
+
+	def test_can_query_transactions_filtered_by_mosaic_and_transfer_transaction_type(self):
+		# TRANSFER (257)
+		self._assert_can_query_transactions_with_filter(
+			Pagination(10, 0), 'desc', self._make_transaction_query(mosaic='nem.xem', transaction_types=[257]),
+			('transfer_v2', 'transfer')
+		)
+
+	def test_can_query_transactions_filtered_by_mosaic_and_inner_sender_address(self):
+		self._assert_can_query_transactions_with_filter(
+			Pagination(10, 0), 'desc',
+			self._make_transaction_query(mosaic='nem.xem', sender_address=TRANSACTIONS[5].sender_address),
+			('multisig', 'transfer_v2', 'transfer')
 		)
 
 	# endregion

--- a/explorer/rest/tests/routes/nem/test_routes.py
+++ b/explorer/rest/tests/routes/nem/test_routes.py
@@ -877,6 +877,15 @@ def test_api_transactions_applies_mosaic(client):  # pylint: disable=redefined-o
 	_assert_get_api_nem_transactions(client, 200, transaction_dicts('transfer_v2'), mosaic='root.mosaic')
 
 
+def test_api_transactions_applies_mosaic_carried_by_multisig(client):  # pylint: disable=redefined-outer-name, invalid-name
+	_assert_get_api_nem_transactions(
+		client,
+		200,
+		transaction_dicts('multisig', 'transfer_v2', 'transfer'),
+		mosaic='nem.xem'
+	)
+
+
 def test_api_transactions_applies_address_ignore_other(client):  # pylint: disable=redefined-outer-name, invalid-name
 	for query_params in [
 		{'senderAddress': 'NALICEPFLZQRZGPRIJTMJOCPWDNECXTNNG7QLSG3'},


### PR DESCRIPTION
## Problem

Filtering the transaction listing by mosaic dropped every transfer wrapped in a multisig
transaction. The puller attaches `transactions_mosaic` rows to TRANSFER transactions, and
for a multisig that is the inner row - but the filter asked the top level row about the
mosaic and additionally forced `transaction_type = TRANSFER`, so the wrapper failed on both
counts.

# Solution

Select the page from the mosaic side and map each link to the transaction the listing shows,
the resolution the address branches already use:

```sql
WHERE t.is_inner = false AND t.id IN (
    SELECT COALESCE(o.id, t.id)                      -- inner transfer → its wrapper
    FROM transactions_mosaic tm
    JOIN transactions t ON t.id = tm.transaction_id
    LEFT JOIN transactions o ON o.transaction_hash = t.aggregate_hash
    WHERE tm.namespace_name = %s
    ORDER BY tm.transaction_id DESC
    LIMIT %s OFFSET %s)
```

LIMIT now applies to the driving index, so the listing reads ten rows instead of 591 838:
9 ms and roughly fifty buffers with the new transactions_mosaic(namespace_name, transaction_id) index.