### PR TITLE
[explorer/frontend] fix: keep 50 blocks in the home visualisation after refresh

### DIFF
--- a/explorer/frontend/__tests__/components/BlockPreview.test.js
+++ b/explorer/frontend/__tests__/components/BlockPreview.test.js
@@ -1,0 +1,175 @@
+import '@testing-library/jest-dom';
+import BlockPreview from '@/app/components/BlockPreview';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import TimeAgo from 'javascript-time-ago';
+import en from 'javascript-time-ago/locale/en.json';
+
+TimeAgo.addDefaultLocale(en);
+
+jest.mock('next/router', () => ({
+	useRouter: () => ({ locale: 'en' })
+}));
+
+beforeAll(() => {
+	jest.useFakeTimers();
+});
+
+// next/image rewrites the src to an optimized URL with the original path URL-encoded; decode before asserting.
+const getIconPath = image => decodeURIComponent(image.getAttribute('src'));
+
+describe('components/BlockPreview', () => {
+	// The component reveals the transaction squares 250ms after mount and clears the expanded style 300ms after collapsing.
+	const TRANSACTION_SQUARES_DELAY = 250;
+	const COLLAPSE_DELAY = 300;
+
+	const block = {
+		height: 4695085,
+		timestamp: '2024-03-30 01:06:25',
+		totalFee: 1.5,
+		transactionCount: 3
+	};
+	const chainStatus = { height: 4696085 };
+	const transactions = [{ hash: 'transaction-hash', fee: 0.5 }];
+
+	const renderPreview = async (props = {}) => {
+		let result;
+
+		// Awaiting the render resolves the dynamic imports of the lazily loaded children.
+		await act(async () => {
+			result = render(<BlockPreview data={block} transactions={transactions} chainStatus={chainStatus} {...props} />);
+		});
+
+		return result;
+	};
+
+	describe('collapsed', () => {
+		it('renders the block summary in a cube', async () => {
+			// Act:
+			await renderPreview();
+
+			// Assert:
+			expect(screen.getByText('4695085')).toBeInTheDocument();
+			expect(screen.getByText('3 TXs.')).toBeInTheDocument();
+			expect(screen.getByText('field_totalFee')).toBeInTheDocument();
+			expect(screen.queryByText('field_height')).not.toBeInTheDocument();
+		});
+
+		const runChainIconTest = async (isNext, expectedIcon) => {
+			// Act:
+			await renderPreview({ isNext });
+
+			// Assert:
+			expect(getIconPath(screen.getByAltText('Chain icon'))).toContain(expectedIcon);
+		};
+
+		it('renders the confirmed chain icon for a harvested block', () => runChainIconTest(false, '/images/icon-chain.svg'));
+		it('renders the pending chain icon for the next block', () => runChainIconTest(true, '/images/icon-chain-pending.svg'));
+
+		it('selects the block on click', async () => {
+			// Arrange:
+			const onSelect = jest.fn();
+			await renderPreview({ onSelect });
+
+			// Act:
+			fireEvent.click(screen.getByText('4695085'));
+
+			// Assert:
+			expect(onSelect).toHaveBeenCalledWith(block.height);
+		});
+	});
+
+	describe('expanded', () => {
+		it('renders the block details', async () => {
+			// Act:
+			await renderPreview({ isSelected: true });
+
+			// Assert:
+			expect(screen.getByText('field_height')).toBeInTheDocument();
+			expect(screen.getByText('4695085')).toBeInTheDocument();
+			expect(screen.getByText('field_status')).toBeInTheDocument();
+			expect(screen.getByText('label_safe')).toBeInTheDocument();
+			expect(screen.getByText('field_totalFee')).toBeInTheDocument();
+			expect(screen.getByText('field_transactionFees')).toBeInTheDocument();
+			expect(screen.queryByText('3 TXs.')).not.toBeInTheDocument();
+		});
+
+		it('links to the block page', async () => {
+			// Act:
+			await renderPreview({ isSelected: true });
+
+			// Assert:
+			expect(screen.getByAltText('More').closest('a')).toHaveAttribute('href', '/blocks/4695085');
+		});
+
+		it('does not re-select the block on click', async () => {
+			// Arrange:
+			const onSelect = jest.fn();
+			await renderPreview({ isSelected: true, onSelect });
+
+			// Act:
+			fireEvent.click(screen.getByText('4695085'));
+
+			// Assert:
+			expect(onSelect).not.toHaveBeenCalled();
+		});
+
+		it('closes the details on close button click', async () => {
+			// Arrange:
+			const onClose = jest.fn();
+			await renderPreview({ isSelected: true, onClose });
+
+			// Act:
+			fireEvent.click(screen.getByAltText('Close'));
+
+			// Assert:
+			expect(onClose).toHaveBeenCalled();
+		});
+	});
+
+	describe('transaction squares', () => {
+		it('delays the rendering of the transaction squares', async () => {
+			// Act:
+			await renderPreview({ isSelected: true });
+
+			// Assert:
+			expect(screen.queryByText('Mocked React ApexCharts')).not.toBeInTheDocument();
+		});
+
+		it('renders the transaction squares once the delay has passed', async () => {
+			// Arrange:
+			await renderPreview({ isSelected: true });
+
+			// Act:
+			await act(async () => {
+				jest.advanceTimersByTime(TRANSACTION_SQUARES_DELAY);
+			});
+
+			// Assert:
+			expect(screen.getByText('Mocked React ApexCharts')).toBeInTheDocument();
+		});
+	});
+
+	describe('expanded style', () => {
+		const expandedStyle = 'blockPreview_expanded';
+
+		it('is applied while the block is selected', async () => {
+			// Act:
+			const { container } = await renderPreview({ isSelected: true });
+
+			// Assert:
+			expect(container.firstChild).toHaveClass(expandedStyle);
+		});
+
+		it('is removed once the collapse animation has finished', async () => {
+			// Arrange:
+			const { container, rerender } = await renderPreview({ isSelected: true });
+
+			// Act:
+			rerender(<BlockPreview data={block} transactions={transactions} chainStatus={chainStatus} isSelected={false} />);
+			act(() => jest.advanceTimersByTime(COLLAPSE_DELAY));
+
+			// Assert:
+			expect(container.firstChild).not.toHaveClass(expandedStyle);
+		});
+	});
+});

--- a/explorer/frontend/__tests__/pages/Home.test.js
+++ b/explorer/frontend/__tests__/pages/Home.test.js
@@ -1,0 +1,101 @@
+import '@testing-library/jest-dom';
+import { blockPageResult } from '../test-utils/blocks';
+import { blockStatisticsResult, dailyTransactionChartResult, marketDataResult, transactionStatisticsResult } from '../test-utils/stats';
+import { transactionPageResult } from '../test-utils/transactions';
+import * as BlockService from '@/app/api/blocks';
+import * as StatsService from '@/app/api/stats';
+import * as TransactionService from '@/app/api/transactions';
+import Home, { getServerSideProps } from '@/app/pages/index';
+import { act, render } from '@testing-library/react';
+import TimeAgo from 'javascript-time-ago';
+import en from 'javascript-time-ago/locale/en.json';
+
+TimeAgo.addDefaultLocale(en);
+
+jest.mock('next/router', () => ({
+	useRouter: () => ({ locale: 'en' })
+}));
+
+jest.mock('@/app/api/blocks', () => {
+	return {
+		__esModule: true,
+		...jest.requireActual('@/app/api/blocks')
+	};
+});
+
+jest.mock('@/app/api/stats', () => {
+	return {
+		__esModule: true,
+		...jest.requireActual('@/app/api/stats')
+	};
+});
+
+jest.mock('@/app/api/transactions', () => {
+	return {
+		__esModule: true,
+		...jest.requireActual('@/app/api/transactions')
+	};
+});
+
+const chainStatusResult = { height: blockPageResult.data[0].height, finalizedHeight: null };
+const nodeStatsResult = { total: 3, supernodes: 2 };
+
+beforeAll(() => {
+	jest.useFakeTimers();
+});
+
+beforeEach(() => {
+	jest.spyOn(BlockService, 'fetchBlockPage').mockResolvedValue(blockPageResult);
+	jest.spyOn(BlockService, 'fetchChainStatus').mockResolvedValue(chainStatusResult);
+	jest.spyOn(TransactionService, 'fetchTransactionPage').mockResolvedValue(transactionPageResult);
+	jest.spyOn(StatsService, 'fetchBlockStats').mockResolvedValue(blockStatisticsResult);
+	jest.spyOn(StatsService, 'fetchMarketData').mockResolvedValue(marketDataResult);
+	jest.spyOn(StatsService, 'fetchNodeStats').mockResolvedValue(nodeStatsResult);
+	jest.spyOn(StatsService, 'fetchTransactionStats').mockResolvedValue(transactionStatisticsResult);
+	jest.spyOn(StatsService, 'fetchTransactionChart').mockResolvedValue(dailyTransactionChartResult);
+});
+
+describe('Home', () => {
+	const RECENT_BLOCK_COUNT = 50;
+	const DATA_REFRESH_INTERVAL = 60000;
+
+	describe('getServerSideProps', () => {
+		it('preloads the recent block page', async () => {
+			// Arrange:
+			const locale = 'en';
+			const fetchBlockPage = jest.spyOn(BlockService, 'fetchBlockPage');
+
+			// Act:
+			await getServerSideProps({ locale });
+
+			// Assert:
+			expect(fetchBlockPage).toHaveBeenCalledWith({ pageSize: RECENT_BLOCK_COUNT });
+		});
+	});
+
+	describe('page', () => {
+		it('requests the recent block page of the preloaded size on refresh', async () => {
+			// Arrange:
+			const fetchBlockPage = jest.spyOn(BlockService, 'fetchBlockPage');
+			const props = {
+				preloadedBlocks: blockPageResult,
+				preloadedLatestTransactions: transactionPageResult,
+				preloadedPendingTransactions: transactionPageResult,
+				transactionChart: dailyTransactionChartResult,
+				transactionStats: transactionStatisticsResult,
+				marketData: marketDataResult,
+				nodeStats: nodeStatsResult,
+				blockTime: blockStatisticsResult.blockTime
+			};
+			render(<Home {...props} />);
+
+			// Act:
+			await act(async () => {
+				jest.advanceTimersByTime(DATA_REFRESH_INTERVAL);
+			});
+
+			// Assert:
+			expect(fetchBlockPage).toHaveBeenCalledWith({ pageSize: RECENT_BLOCK_COUNT });
+		});
+	});
+});

--- a/explorer/frontend/pages/index.jsx
+++ b/explorer/frontend/pages/index.jsx
@@ -22,10 +22,11 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import { useCallback } from 'react';
 
 const DATA_REFRESH_INTERVAL = 60000;
+const RECENT_BLOCK_COUNT = 50;
 
 export const getServerSideProps = async ({ locale }) => {
 	const [blocksPage, latestTransactionsPage, pendingTransactionsPage] = await Promise.all([
-		fetchBlockPage({ pageSize: 50 }),
+		fetchBlockPage({ pageSize: RECENT_BLOCK_COUNT }),
 		fetchTransactionPage({ pageSize: 5 }),
 		fetchTransactionPage({ pageSize: 5, group: TRANSACTION_GROUP.UNCONFIRMED })
 	]);
@@ -75,7 +76,7 @@ const Home = ({
 		preloadedPendingTransactions,
 		DATA_REFRESH_INTERVAL
 	);
-	const blocks = useAsyncCall(fetchBlockPage, preloadedBlocks, DATA_REFRESH_INTERVAL);
+	const blocks = useAsyncCall(() => fetchBlockPage({ pageSize: RECENT_BLOCK_COUNT }), preloadedBlocks, DATA_REFRESH_INTERVAL);
 	const chainStatus = useAsyncCall(fetchChainStatus, null, DATA_REFRESH_INTERVAL);
 
 	const fetchBlockTransactions = useCallback(height => fetchTransactionPage({ pageSize: 160, height }), [fetchTransactionPage]);


### PR DESCRIPTION
## Problem

The recent blocks visualisation on the home page shows 50 blocks when the page
loads and shrinks to 10 roughly a minute later, then stays that way.

`getServerSideProps` preloads the strip with `fetchBlockPage({ pageSize: 50 })`,
but the 60 s refresh went through `useAsyncCall(fetchBlockPage, preloadedBlocks,
DATA_REFRESH_INTERVAL)`. `useAsyncCall` invokes its callback with no arguments,
so `createSearchCriteria` fell back to its default of 10 rows per page
(`utils/server.js`). The first poll therefore replaced the preloaded 50 blocks
with 10.

## Solution

- `RECENT_BLOCK_COUNT` is now a single constant used by both `getServerSideProps`
  and the polling call.
- The polling call is wrapped in an arrow function, so it keeps passing
  `{ pageSize: RECENT_BLOCK_COUNT }` on every refresh - matching how the latest
  and pending transaction sections on the same page are already written.