### PR TITLE
[explorer/rest] fix: cap listing page size

### DIFF
--- a/explorer/rest/rest/routes/nem.py
+++ b/explorer/rest/rest/routes/nem.py
@@ -11,6 +11,18 @@ from rest.facade.NemRestFacade import NemRestFacade
 from rest.model.common import DEFAULT_HARVESTING_ACTIVE_WINDOW_DAYS, DatabaseConfig, Pagination, RestConfig, Sorting
 from rest.model.nem.Transaction import TransactionQuery
 
+MAX_PAGE_LIMIT = 250
+
+
+def _validate_pagination(limit, offset):
+	"""Rejects page requests that are malformed or large enough to strain the database."""
+
+	if limit < 1 or limit > MAX_PAGE_LIMIT:
+		raise ValueError(f'Limit must be between 1 and {MAX_PAGE_LIMIT}')
+
+	if offset < 0:
+		raise ValueError('Offset must be greater than or equal to 0')
+
 
 def setup_nem_facade(app):
 	config = configparser.ConfigParser()
@@ -64,8 +76,7 @@ def setup_nem_routes(app, nem_api_facade):  # pylint: disable=too-many-statement
 			min_height = int(request.args.get('min_height', 1))
 			sort = request.args.get('sort', 'DESC')
 
-			if limit < 0 or offset < 0:
-				raise ValueError('Limit and offset must be greater than or equal to 0')
+			_validate_pagination(limit, offset)
 			if min_height < 1:
 				raise ValueError('Minimum height must be greater than or equal to 1')
 			if sort.upper() not in ['ASC', 'DESC']:
@@ -129,8 +140,7 @@ def setup_nem_routes(app, nem_api_facade):  # pylint: disable=too-many-statement
 			sort_order = request.args.get('sort_order', 'DESC').upper()
 			is_harvesting = request.args.get('is_harvesting', 'false').lower() == 'true'
 
-			if limit < 0 or offset < 0:
-				raise ValueError('Limit and offset must be greater than or equal to 0')
+			_validate_pagination(limit, offset)
 			if sort_order not in ['ASC', 'DESC']:
 				raise ValueError('Sort order must be either ASC or DESC')
 			if sort_field not in ['BALANCE', 'HEIGHT']:
@@ -163,8 +173,7 @@ def setup_nem_routes(app, nem_api_facade):  # pylint: disable=too-many-statement
 			offset = int(request.args.get('offset', 0))
 			sort = request.args.get('sort', 'DESC')
 
-			if limit < 0 or offset < 0:
-				raise ValueError('Limit and offset must be greater than or equal to 0')
+			_validate_pagination(limit, offset)
 			if sort.upper() not in ['ASC', 'DESC']:
 				raise ValueError('Sort must be either ASC or DESC')
 
@@ -194,8 +203,7 @@ def setup_nem_routes(app, nem_api_facade):  # pylint: disable=too-many-statement
 			offset = int(request.args.get('offset', 0))
 			sort = request.args.get('sort', 'DESC')
 
-			if limit < 0 or offset < 0:
-				raise ValueError('Limit and offset must be greater than or equal to 0')
+			_validate_pagination(limit, offset)
 			if sort.upper() not in ['ASC', 'DESC']:
 				raise ValueError('Sort must be either ASC or DESC')
 
@@ -216,8 +224,7 @@ def setup_nem_routes(app, nem_api_facade):  # pylint: disable=too-many-statement
 			offset = int(request.args.get('offset', 0))
 			namespace_name = request.args.get('namespace_name', 'nem.xem')
 
-			if limit < 0 or offset < 0:
-				raise ValueError('Limit and offset must be greater than or equal to 0')
+			_validate_pagination(limit, offset)
 
 		except ValueError as error:
 			abort(400, error)
@@ -284,8 +291,7 @@ def setup_nem_routes(app, nem_api_facade):  # pylint: disable=too-many-statement
 			sender = request.args.get('senderPublicKey', None)
 			mosaic = request.args.get('mosaic', None)
 
-			if limit < 0 or offset < 0:
-				raise ValueError('Limit and offset must be greater than or equal to 0')
+			_validate_pagination(limit, offset)
 
 			if sort.upper() not in ['ASC', 'DESC']:
 				raise ValueError('Sort must be either ASC or DESC')

--- a/explorer/rest/tests/routes/nem/test_routes.py
+++ b/explorer/rest/tests/routes/nem/test_routes.py
@@ -90,6 +90,9 @@ def client(app):  # pylint: disable=redefined-outer-name
 # endregion
 
 
+PAGINATED_MODULES = ['blocks', 'accounts', 'namespaces', 'mosaics', 'mosaic/rich/list', 'transactions']
+
+
 def _assert_status_code_and_headers(response, expected_status_code):
 	assert expected_status_code == response.status_code
 	assert response.headers['Access-Control-Allow-Origin'] == '*'
@@ -108,26 +111,31 @@ def _get_api(client, endpoint, **query_params):  # pylint: disable=redefined-out
 	return client.get(f'/api/nem/{endpoint}?{query_string}')
 
 
-def test_invalid_pagination_params(client):  # pylint: disable=redefined-outer-name
-
-	for module in ['blocks', 'accounts', 'namespaces', 'mosaics', 'mosaic/rich/list', 'transactions']:
-		for limit in [-1, 0, MAX_PAGE_LIMIT + 1]:
-			# Act:
-			response = client.get(f'/api/nem/{module}', query_string={'limit': limit})
-
-			# Assert:
-			_assert_status_code_400(response, f'Limit must be between 1 and {MAX_PAGE_LIMIT}')
-
+def _assert_pagination_rejected(client, query_string, expected_message):  # pylint: disable=redefined-outer-name
+	for module in PAGINATED_MODULES:
 		# Act:
-		response = client.get(f'/api/nem/{module}', query_string={'offset': -1})
+		response = client.get(f'/api/nem/{module}', query_string=query_string)
 
 		# Assert:
-		_assert_status_code_400(response, 'Offset must be greater than or equal to 0')
+		_assert_status_code_400(response, expected_message)
 
 
-def test_accepts_pagination_params_at_limit_boundary(client):  # pylint: disable=redefined-outer-name, invalid-name
+def test_rejects_limit_below_one(client):  # pylint: disable=redefined-outer-name
+	for limit in [-1, 0]:
+		_assert_pagination_rejected(client, {'limit': limit}, f'Limit must be between 1 and {MAX_PAGE_LIMIT}')
 
-	for module in ['blocks', 'accounts', 'namespaces', 'mosaics', 'mosaic/rich/list', 'transactions']:
+
+def test_rejects_limit_above_maximum(client):  # pylint: disable=redefined-outer-name
+	_assert_pagination_rejected(client, {'limit': MAX_PAGE_LIMIT + 1}, f'Limit must be between 1 and {MAX_PAGE_LIMIT}')
+
+
+def test_rejects_negative_offset(client):  # pylint: disable=redefined-outer-name
+	_assert_pagination_rejected(client, {'offset': -1}, 'Offset must be greater than or equal to 0')
+
+
+def test_accepts_limit_at_maximum(client):  # pylint: disable=redefined-outer-name
+
+	for module in PAGINATED_MODULES:
 		# Act:
 		response = client.get(f'/api/nem/{module}', query_string={'limit': MAX_PAGE_LIMIT})
 

--- a/explorer/rest/tests/routes/nem/test_routes.py
+++ b/explorer/rest/tests/routes/nem/test_routes.py
@@ -8,6 +8,7 @@ import testing.postgresql
 from symbollightapi.model.Exceptions import NodeException
 
 from rest import create_app
+from rest.routes.nem import MAX_PAGE_LIMIT
 
 from ...test.DatabaseTestUtils import (
 	ACCOUNT_STATISTIC_VIEW,
@@ -110,15 +111,28 @@ def _get_api(client, endpoint, **query_params):  # pylint: disable=redefined-out
 def test_invalid_pagination_params(client):  # pylint: disable=redefined-outer-name
 
 	for module in ['blocks', 'accounts', 'namespaces', 'mosaics', 'mosaic/rich/list', 'transactions']:
-		# Act:
-		response = client.get(f'/api/nem/{module}', query_string={'limit': -1})
+		for limit in [-1, 0, MAX_PAGE_LIMIT + 1]:
+			# Act:
+			response = client.get(f'/api/nem/{module}', query_string={'limit': limit})
 
-		_assert_status_code_400(response, 'Limit and offset must be greater than or equal to 0')
+			# Assert:
+			_assert_status_code_400(response, f'Limit must be between 1 and {MAX_PAGE_LIMIT}')
 
 		# Act:
 		response = client.get(f'/api/nem/{module}', query_string={'offset': -1})
 
-		_assert_status_code_400(response, 'Limit and offset must be greater than or equal to 0')
+		# Assert:
+		_assert_status_code_400(response, 'Offset must be greater than or equal to 0')
+
+
+def test_accepts_pagination_params_at_limit_boundary(client):  # pylint: disable=redefined-outer-name, invalid-name
+
+	for module in ['blocks', 'accounts', 'namespaces', 'mosaics', 'mosaic/rich/list', 'transactions']:
+		# Act:
+		response = client.get(f'/api/nem/{module}', query_string={'limit': MAX_PAGE_LIMIT})
+
+		# Assert:
+		_assert_status_code_and_headers(response, 200)
 
 
 def test_invalid_sort_params(client):  # pylint: disable=redefined-outer-name


### PR DESCRIPTION
## Problem

The NEM listing routes validated only that `limit` was not negative, so a single request could
ask the database for any number of rows - `/api/nem/transactions?limit=1000000` was a valid
request that the database had to serve in full. The same check was copy-pasted into six routes.

## Solution
 
Added `MAX_PAGE_LIMIT = 250` and a shared `_validate_pagination(limit, offset)` helper in
`rest/routes/nem.py`. Every paginated NEM route (`blocks`, `accounts`, `namespaces`, `mosaics`,
`mosaic/rich/list`, `transactions`) now rejects a `limit` outside `1..250` and a negative
`offset` with HTTP 400, replacing all six copies of the old inline check.

Related to https://github.com/symbol/product/pull/2510