### PR TITLE
[explorer/frontend] fix: stop requesting a whole block in a single call

### DIFF
--- a/explorer/frontend/__tests__/components/ValueTransactionSquares.test.js
+++ b/explorer/frontend/__tests__/components/ValueTransactionSquares.test.js
@@ -1,9 +1,16 @@
 import '@testing-library/jest-dom';
 import ValueTransactionSquares, { MAX_TRANSACTION_SQUARES } from '@/app/components/ValueTransactionSquares';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
+
+const mockChart = jest.fn();
+jest.mock('react-apexcharts', () => props => {
+	mockChart(props);
+	return null;
+});
 
 describe('ValueTransactionSquares', () => {
-	const createTransactions = count => Array.from({ length: count }, (_, index) => ({ fee: index, hash: `hash-${index}` }));
+	const createTransactions = count =>
+		Array.from({ length: count }, (_, index) => ({ fee: index, hash: `hash-${index}`, type: 16724, amount: index }));
 
 	it('renders the fees of a block within the cap', () => {
 		// Arrange:
@@ -54,5 +61,66 @@ describe('ValueTransactionSquares', () => {
 		// Assert:
 		expect(screen.getByRole('status')).toBeInTheDocument();
 		expect(screen.queryByText('message_tooManyTransactionsToVisualize')).not.toBeInTheDocument();
+	});
+
+	describe('data point interactions', () => {
+		const selectDataPoint = (options, dataPointIndex) => {
+			act(() => {
+				options.chart.events.dataPointSelection(null, null, { dataPointIndex });
+			});
+		};
+
+		it('shows the selected transaction when a data point is clicked', () => {
+			// Arrange:
+			const data = createTransactions(3);
+			render(<ValueTransactionSquares isTransactionPreviewEnabled data={data} transactionCount={data.length} />);
+			const { options } = mockChart.mock.calls[0][0];
+
+			// Act:
+			selectDataPoint(options, 1);
+
+			// Assert:
+			expect(screen.getByText(data[1].hash)).toBeInTheDocument();
+		});
+
+		it('hides the selected transaction when its data point is clicked again', () => {
+			// Arrange:
+			const data = createTransactions(3);
+			render(<ValueTransactionSquares isTransactionPreviewEnabled data={data} transactionCount={data.length} />);
+			const { options } = mockChart.mock.calls[0][0];
+			selectDataPoint(options, 1);
+
+			// Act:
+			selectDataPoint(options, 1);
+
+			// Assert:
+			expect(screen.queryByText(data[1].hash)).not.toBeInTheDocument();
+		});
+
+		it('does not show the selected transaction when the preview is disabled', () => {
+			// Arrange:
+			const data = createTransactions(3);
+			render(<ValueTransactionSquares data={data} transactionCount={data.length} />);
+			const { options } = mockChart.mock.calls[0][0];
+
+			// Act:
+			selectDataPoint(options, 1);
+
+			// Assert:
+			expect(screen.queryByText(data[1].hash)).not.toBeInTheDocument();
+		});
+
+		it('builds a tooltip showing the fee of the hovered data point', () => {
+			// Arrange:
+			const data = createTransactions(3);
+			render(<ValueTransactionSquares data={data} transactionCount={data.length} />);
+			const { options } = mockChart.mock.calls[0][0];
+
+			// Act:
+			const tooltipHtml = options.tooltip.custom({ series: [[100, 200, 300]], seriesIndex: 0, dataPointIndex: 2 });
+
+			// Assert:
+			expect(tooltipHtml).toContain('300');
+		});
 	});
 });

--- a/explorer/frontend/__tests__/components/ValueTransactionSquares.test.js
+++ b/explorer/frontend/__tests__/components/ValueTransactionSquares.test.js
@@ -1,0 +1,58 @@
+import '@testing-library/jest-dom';
+import ValueTransactionSquares, { MAX_TRANSACTION_SQUARES } from '@/app/components/ValueTransactionSquares';
+import { render, screen } from '@testing-library/react';
+
+describe('ValueTransactionSquares', () => {
+	const createTransactions = count => Array.from({ length: count }, (_, index) => ({ fee: index, hash: `hash-${index}` }));
+
+	it('renders the fees of a block within the cap', () => {
+		// Arrange:
+		const data = createTransactions(3);
+
+		// Act:
+		render(<ValueTransactionSquares data={data} transactionCount={data.length} />);
+
+		// Assert:
+		expect(screen.queryByText('message_emptyTable')).not.toBeInTheDocument();
+		expect(screen.queryByText('message_tooManyTransactionsToVisualize')).not.toBeInTheDocument();
+	});
+
+	it('renders the empty message when there is nothing to show', () => {
+		// Act:
+		render(<ValueTransactionSquares data={[]} transactionCount={0} />);
+
+		// Assert:
+		expect(screen.getByText('message_emptyTable')).toBeInTheDocument();
+		expect(screen.queryByText('message_tooManyTransactionsToVisualize')).not.toBeInTheDocument();
+	});
+
+	it('renders the fees of a block sitting exactly on the cap', () => {
+		// Arrange:
+		const data = createTransactions(MAX_TRANSACTION_SQUARES);
+
+		// Act:
+		render(<ValueTransactionSquares data={data} transactionCount={MAX_TRANSACTION_SQUARES} />);
+
+		// Assert:
+		expect(screen.queryByText('message_tooManyTransactionsToVisualize')).not.toBeInTheDocument();
+		expect(screen.queryByText('message_emptyTable')).not.toBeInTheDocument();
+	});
+
+	it('renders the cap message when the block is too large for the chart', () => {
+		// Act:
+		render(<ValueTransactionSquares data={[]} transactionCount={MAX_TRANSACTION_SQUARES + 1} />);
+
+		// Assert:
+		expect(screen.getByText('message_tooManyTransactionsToVisualize')).toBeInTheDocument();
+		expect(screen.queryByText('message_emptyTable')).not.toBeInTheDocument();
+	});
+
+	it('renders the loading state instead of any message', () => {
+		// Act:
+		render(<ValueTransactionSquares data={[]} transactionCount={MAX_TRANSACTION_SQUARES + 1} isLoading />);
+
+		// Assert:
+		expect(screen.getByRole('status')).toBeInTheDocument();
+		expect(screen.queryByText('message_tooManyTransactionsToVisualize')).not.toBeInTheDocument();
+	});
+});

--- a/explorer/frontend/__tests__/pages/BlockInfo.test.js
+++ b/explorer/frontend/__tests__/pages/BlockInfo.test.js
@@ -1,9 +1,14 @@
 import '@testing-library/jest-dom';
 import { blockInfoResult } from '../test-utils/blocks';
+import { transactionPageResult } from '../test-utils/transactions';
 import * as BlockService from '@/app/api/blocks';
+import * as TransactionService from '@/app/api/transactions';
+import { MAX_TRANSACTION_SQUARES } from '@/app/components/ValueTransactionSquares';
 import BlockInfo, { getServerSideProps } from '@/app/pages/blocks/[height]';
 import * as utils from '@/app/utils';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
+/* eslint-disable import/no-unresolved */
+import { mockAllIsIntersecting } from 'react-intersection-observer/test-utils';
 
 jest.mock('@/app/utils', () => {
 	return {
@@ -16,6 +21,13 @@ jest.mock('@/app/api/blocks', () => {
 	return {
 		__esModule: true,
 		...jest.requireActual('@/app/api/blocks')
+	};
+});
+
+jest.mock('@/app/api/transactions', () => {
+	return {
+		__esModule: true,
+		...jest.requireActual('@/app/api/transactions')
 	};
 });
 
@@ -113,6 +125,97 @@ describe('BlockInfo', () => {
 
 			// Act + Assert:
 			runStatusLabelTest(chainHeightOffset, expectedShownLabelText, expectedHiddenLabelText);
+		});
+	});
+
+	describe('transactions', () => {
+		const TRANSACTION_PAGE_SIZE = 50;
+
+		const renderPage = async (blockInfo, nextPageResult = { data: [], pageNumber: 2 }) => {
+			mockAllIsIntersecting(false);
+			const fetchTransactionPage = jest.spyOn(TransactionService, 'fetchTransactionPage');
+			fetchTransactionPage.mockResolvedValue(nextPageResult);
+			fetchTransactionPage.mockResolvedValueOnce({ ...transactionPageResult, pageNumber: 1 });
+			jest.spyOn(BlockService, 'fetchChainStatus').mockResolvedValue({ height: blockInfo.height, finalizedHeight: null });
+
+			await act(async () => {
+				render(<BlockInfo blockInfo={blockInfo} />);
+			});
+
+			return fetchTransactionPage;
+		};
+
+		it('requests the first transaction page of the block', async () => {
+			// Arrange + Act:
+			const fetchTransactionPage = await renderPage(blockInfoResult);
+
+			// Assert:
+			expect(fetchTransactionPage).toHaveBeenCalledWith({
+				pageNumber: 1,
+				height: blockInfoResult.height,
+				pageSize: TRANSACTION_PAGE_SIZE
+			});
+		});
+
+		it('requests the next transaction page from the server', async () => {
+			// Arrange:
+			const fetchTransactionPage = await renderPage(blockInfoResult);
+
+			// Act:
+			await act(async () => {
+				mockAllIsIntersecting(true);
+			});
+
+			// Assert:
+			expect(fetchTransactionPage).toHaveBeenCalledWith({
+				pageNumber: 2,
+				height: blockInfoResult.height,
+				pageSize: TRANSACTION_PAGE_SIZE
+			});
+		});
+
+		it('requests all the transactions of the block for the fee visualisation', async () => {
+			// Arrange + Act:
+			const fetchTransactionPage = await renderPage(blockInfoResult);
+
+			// Assert:
+			expect(fetchTransactionPage).toHaveBeenCalledWith({
+				height: blockInfoResult.height,
+				pageSize: MAX_TRANSACTION_SQUARES
+			});
+			expect(screen.queryByText('message_tooManyTransactionsToVisualize')).not.toBeInTheDocument();
+		});
+
+		it('requests the fee visualisation for a block sitting exactly on the cap', async () => {
+			// Arrange:
+			const blockInfo = { ...blockInfoResult, transactionCount: MAX_TRANSACTION_SQUARES };
+
+			// Act:
+			const fetchTransactionPage = await renderPage(blockInfo);
+
+			// Assert:
+			expect(fetchTransactionPage).toHaveBeenCalledWith({
+				height: blockInfo.height,
+				pageSize: MAX_TRANSACTION_SQUARES
+			});
+			expect(screen.queryByText('message_tooManyTransactionsToVisualize')).not.toBeInTheDocument();
+		});
+
+		it('skips the fee visualisation when the block is too large for the chart', async () => {
+			// Arrange:
+			const blockInfo = { ...blockInfoResult, transactionCount: MAX_TRANSACTION_SQUARES + 1 };
+
+			// Act:
+			const fetchTransactionPage = await renderPage(blockInfo);
+
+			// Assert:
+			expect(fetchTransactionPage).toHaveBeenCalledTimes(1);
+			expect(fetchTransactionPage).toHaveBeenCalledWith({
+				pageNumber: 1,
+				height: blockInfo.height,
+				pageSize: TRANSACTION_PAGE_SIZE
+			});
+			expect(screen.getByText('message_tooManyTransactionsToVisualize')).toBeInTheDocument();
 		});
 	});
 });

--- a/explorer/frontend/__tests__/pages/BlockInfo.test.js
+++ b/explorer/frontend/__tests__/pages/BlockInfo.test.js
@@ -32,6 +32,24 @@ jest.mock('@/app/api/transactions', () => {
 });
 
 describe('BlockInfo', () => {
+	const renderPage = async (blockInfo, nextPageResult = { data: [], pageNumber: 2 }) => {
+		mockAllIsIntersecting(false);
+		const fetchTransactionPage = jest.spyOn(TransactionService, 'fetchTransactionPage');
+		fetchTransactionPage.mockImplementation(async ({ pageNumber }) => {
+			if (undefined === pageNumber)
+				return transactionPageResult;
+
+			return 1 === pageNumber ? { ...transactionPageResult, pageNumber: 1 } : nextPageResult;
+		});
+		jest.spyOn(BlockService, 'fetchChainStatus').mockResolvedValue({ height: blockInfo.height, finalizedHeight: null });
+
+		await act(async () => {
+			render(<BlockInfo blockInfo={blockInfo} />);
+		});
+
+		return fetchTransactionPage;
+	};
+
 	describe('getServerSideProps', () => {
 		const runTest = async (blockInfoResult, expectedResult) => {
 			// Arrange:
@@ -75,7 +93,7 @@ describe('BlockInfo', () => {
 	});
 
 	describe('page', () => {
-		it('renders page with the information about the block', () => {
+		it('renders page with the information about the block', async () => {
 			// Arrange:
 			const pageSectionText = 'section_block';
 			const heightText = blockInfoResult.height;
@@ -84,7 +102,7 @@ describe('BlockInfo', () => {
 			const harvesterText = blockInfoResult.harvester;
 
 			// Act:
-			render(<BlockInfo blockInfo={blockInfoResult} />);
+			await renderPage(blockInfoResult);
 
 			// Assert:
 			expect(screen.getByText(pageSectionText)).toBeInTheDocument();
@@ -94,67 +112,64 @@ describe('BlockInfo', () => {
 			expect(screen.getByText(harvesterText)).toBeInTheDocument();
 		});
 
-		const runStatusLabelTest = (chainHeightOffset, expectedShownLabelText, expectedHiddenLabelText) => {
+		const runStatusLabelTest = async (chainHeightOffset, expectedShownLabelText, expectedHiddenLabelText) => {
 			// Arrange:
 			const spy = jest.spyOn(utils, 'useAsyncCall');
 			spy.mockImplementation(() => ({ height: blockInfoResult.height + chainHeightOffset, finalizedHeight: null }));
 
 			// Act:
-			render(<BlockInfo blockInfo={blockInfoResult} />);
+			await renderPage(blockInfoResult);
 
 			// Assert:
 			expect(screen.getByText(expectedShownLabelText)).toBeInTheDocument();
 			expect(screen.queryByText(expectedHiddenLabelText)).not.toBeInTheDocument();
 		};
 
-		it('renders safe label', () => {
+		it('renders safe label', async () => {
 			// Arrange:
 			const chainHeightOffset = 361;
 			const expectedShownLabelText = 'label_safe';
 			const expectedHiddenLabelText = 'label_unsafe';
 
 			// Act + Assert:
-			runStatusLabelTest(chainHeightOffset, expectedShownLabelText, expectedHiddenLabelText);
+			await runStatusLabelTest(chainHeightOffset, expectedShownLabelText, expectedHiddenLabelText);
 		});
 
-		it('renders created label', () => {
+		it('renders created label', async () => {
 			// Arrange:
 			const chainHeightOffset = 100;
 			const expectedShownLabelText = 'label_created';
 			const expectedHiddenLabelText = 'label_safe';
 
 			// Act + Assert:
-			runStatusLabelTest(chainHeightOffset, expectedShownLabelText, expectedHiddenLabelText);
+			await runStatusLabelTest(chainHeightOffset, expectedShownLabelText, expectedHiddenLabelText);
 		});
 	});
 
 	describe('transactions', () => {
 		const TRANSACTION_PAGE_SIZE = 50;
 
-		const renderPage = async (blockInfo, nextPageResult = { data: [], pageNumber: 2 }) => {
-			mockAllIsIntersecting(false);
-			const fetchTransactionPage = jest.spyOn(TransactionService, 'fetchTransactionPage');
-			fetchTransactionPage.mockResolvedValue(nextPageResult);
-			fetchTransactionPage.mockResolvedValueOnce({ ...transactionPageResult, pageNumber: 1 });
-			jest.spyOn(BlockService, 'fetchChainStatus').mockResolvedValue({ height: blockInfo.height, finalizedHeight: null });
+		it('requests the first transaction page and the fee visualisation data', async () => {
+			// Arrange:
+			const transactionHashes = transactionPageResult.data.map(transaction => utils.truncateString(transaction.hash, 'hash'));
 
-			await act(async () => {
-				render(<BlockInfo blockInfo={blockInfo} />);
-			});
-
-			return fetchTransactionPage;
-		};
-
-		it('requests the first transaction page of the block', async () => {
-			// Arrange + Act:
+			// Act:
 			const fetchTransactionPage = await renderPage(blockInfoResult);
 
 			// Assert:
+			expect(fetchTransactionPage).toHaveBeenCalledTimes(2);
 			expect(fetchTransactionPage).toHaveBeenCalledWith({
 				pageNumber: 1,
 				height: blockInfoResult.height,
 				pageSize: TRANSACTION_PAGE_SIZE
 			});
+			expect(fetchTransactionPage).toHaveBeenCalledWith({
+				height: blockInfoResult.height,
+				pageSize: MAX_TRANSACTION_SQUARES
+			});
+			transactionHashes.forEach(hash => expect(screen.getByText(hash)).toBeInTheDocument());
+			expect(screen.queryByText('message_emptyTable')).not.toBeInTheDocument();
+			expect(screen.queryByText('message_tooManyTransactionsToVisualize')).not.toBeInTheDocument();
 		});
 
 		it('requests the next transaction page from the server', async () => {
@@ -174,19 +189,7 @@ describe('BlockInfo', () => {
 			});
 		});
 
-		it('requests all the transactions of the block for the fee visualisation', async () => {
-			// Arrange + Act:
-			const fetchTransactionPage = await renderPage(blockInfoResult);
-
-			// Assert:
-			expect(fetchTransactionPage).toHaveBeenCalledWith({
-				height: blockInfoResult.height,
-				pageSize: MAX_TRANSACTION_SQUARES
-			});
-			expect(screen.queryByText('message_tooManyTransactionsToVisualize')).not.toBeInTheDocument();
-		});
-
-		it('requests the fee visualisation for a block sitting exactly on the cap', async () => {
+		it('keeps the fee visualisation when the block sits exactly on the cap', async () => {
 			// Arrange:
 			const blockInfo = { ...blockInfoResult, transactionCount: MAX_TRANSACTION_SQUARES };
 
@@ -194,6 +197,7 @@ describe('BlockInfo', () => {
 			const fetchTransactionPage = await renderPage(blockInfo);
 
 			// Assert:
+			expect(fetchTransactionPage).toHaveBeenCalledTimes(2);
 			expect(fetchTransactionPage).toHaveBeenCalledWith({
 				height: blockInfo.height,
 				pageSize: MAX_TRANSACTION_SQUARES

--- a/explorer/frontend/__tests__/utils/hooks.test.js
+++ b/explorer/frontend/__tests__/utils/hooks.test.js
@@ -1,7 +1,6 @@
 import {
 	useAsyncCall,
 	useClientSideFilter,
-	useClientSidePagination,
 	useDataManager,
 	useDebounce,
 	useFilter,
@@ -270,49 +269,6 @@ describe('utils/hooks', () => {
 			expect(result.current.isError).toBe(true);
 			expect(result.current.isLastPage).toBe(false);
 			expect(result.current.pageNumber).toBe(1);
-		});
-	});
-
-	describe('useClientSidePagination', () => {
-		it('paginates a data list', () => {
-			// Arrange:
-			const fullData = [1, 2, 3, 4, 5, 6, 7, 8, 9];
-			const pageSize = 3;
-
-			// Act:
-			const { result } = renderHook(() => useClientSidePagination(fullData, pageSize));
-
-			// Assert initial state:
-			const { data, pageNumber, isLastPage } = result.current;
-			expect(data).toStrictEqual([1, 2, 3]);
-			expect(pageNumber).toBe(1);
-			expect(isLastPage).toBe(false);
-
-			// Request next page:
-			act(() => {
-				result.current.requestNextPage();
-			});
-
-			// Assert state after request:
-			const { data: dataAfterRequest, pageNumber: pageNumberAfterRequest, isLastPage: isLastPageAfterRequest } = result.current;
-			expect(dataAfterRequest).toStrictEqual([1, 2, 3, 4, 5, 6]);
-			expect(pageNumberAfterRequest).toBe(2);
-			expect(isLastPageAfterRequest).toBe(false);
-
-			// Request last page:
-			act(() => {
-				result.current.requestNextPage();
-			});
-
-			// Assert state after last request:
-			const {
-				data: dataAfterLastRequest,
-				pageNumber: pageNumberAfterLastRequest,
-				isLastPage: isLastPageAfterLastRequest
-			} = result.current;
-			expect(dataAfterLastRequest).toStrictEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
-			expect(pageNumberAfterLastRequest).toBe(3);
-			expect(isLastPageAfterLastRequest).toBe(true);
 		});
 	});
 

--- a/explorer/frontend/components/BlockPreview.jsx
+++ b/explorer/frontend/components/BlockPreview.jsx
@@ -14,7 +14,7 @@ import { useTranslation } from 'next-i18next';
 import { useEffect, useState } from 'react';
 
 const BlockExpanded = ({ data, transactions, chainStatus, isTransactionSquaresRendered, onClose }) => {
-	const { height, timestamp, totalFee } = data;
+	const { height, timestamp, totalFee, transactionCount } = data;
 	const { t } = useTranslation();
 	const href = createPageHref('blocks', height);
 
@@ -39,7 +39,7 @@ const BlockExpanded = ({ data, transactions, chainStatus, isTransactionSquaresRe
 				</Field>
 			</div>
 			<Field title={t('field_transactionFees')}>
-				{isTransactionSquaresRendered && <ValueTransactionSquares data={transactions} />}
+				{isTransactionSquaresRendered && <ValueTransactionSquares data={transactions} transactionCount={transactionCount} />}
 			</Field>
 		</div>
 	);

--- a/explorer/frontend/components/ValueTransactionSquares.jsx
+++ b/explorer/frontend/components/ValueTransactionSquares.jsx
@@ -10,13 +10,15 @@ import { renderToString } from 'react-dom/server';
 
 const ReactApexChart = dynamic(() => import('react-apexcharts'), { ssr: false });
 
-const MAX_DATA_LENGTH = 400;
+// The largest block the fee treemap is drawn for. It caps the single request that has to return every
+// transaction of the block.
+export const MAX_TRANSACTION_SQUARES = 250;
 
 const Tooltip = ({ fee }) => <ValueMosaic isNative amount={fee} />;
 
-const ValueTransactionSquares = ({ data = [], isTransactionPreviewEnabled, isLoading, className }) => {
+const ValueTransactionSquares = ({ data = [], transactionCount, isTransactionPreviewEnabled, isLoading, className }) => {
 	const { t } = useTranslation('common');
-	const isChartPresentable = data.length < MAX_DATA_LENGTH;
+	const isChartPresentable = transactionCount <= MAX_TRANSACTION_SQUARES;
 	const [selectedTransaction, setSelectedTransaction] = useState(null);
 	const series = [
 		{
@@ -88,7 +90,10 @@ const ValueTransactionSquares = ({ data = [], isTransactionPreviewEnabled, isLoa
 			{!!data.length && !isLoading && isChartPresentable && (
 				<ReactApexChart className={styles.chart} options={options} series={series} type="treemap" height="100%" />
 			)}
-			{!data.length && !isLoading && <div className={styles.emptyDataMessage}>{t('message_emptyTable')}</div>}
+			{!data.length && !isLoading && isChartPresentable && <div className={styles.emptyDataMessage}>{t('message_emptyTable')}</div>}
+			{!isLoading && !isChartPresentable && (
+				<div className={styles.emptyDataMessage}>{t('message_tooManyTransactionsToVisualize')}</div>
+			)}
 			{!!isTransactionPreviewEnabled && !!selectedTransaction && (
 				<div className={styles.selectedTransaction}>
 					<ValueTransaction

--- a/explorer/frontend/pages/blocks/[height].jsx
+++ b/explorer/frontend/pages/blocks/[height].jsx
@@ -11,10 +11,10 @@ import ValueCopy from '@/app/components/ValueCopy';
 import ValueList from '@/app/components/ValueList';
 import ValueMosaic from '@/app/components/ValueMosaic';
 import ValueTransactionHash from '@/app/components/ValueTransactionHash';
-import ValueTransactionSquares from '@/app/components/ValueTransactionSquares';
+import ValueTransactionSquares, { MAX_TRANSACTION_SQUARES } from '@/app/components/ValueTransactionSquares';
 import ValueTransactionType from '@/app/components/ValueTransactionType';
 import styles from '@/app/styles/pages/BlockInfo.module.scss';
-import { useAsyncCall, useClientSidePagination, usePagination } from '@/app/utils';
+import { useAsyncCall, useDataManager, usePagination } from '@/app/utils';
 import Head from 'next/head';
 import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
@@ -37,13 +37,22 @@ export const getServerSideProps = async ({ locale, params }) => {
 	};
 };
 
+const TRANSACTION_PAGE_SIZE = 50;
+
 const BlockInfo = ({ blockInfo }) => {
 	const { t } = useTranslation();
-	const transactionInitialPagination = usePagination(
-		async () => await fetchTransactionPage({ pageSize: blockInfo.transactionCount, height: blockInfo.height }),
-		[]
+	const transactionPagination = usePagination(fetchTransactionPage, [], {
+		height: blockInfo.height,
+		pageSize: TRANSACTION_PAGE_SIZE
+	});
+	// The fee treemap needs every transaction of the block in a single request, so larger blocks skip it.
+	const isTransactionSquaresAvailable = blockInfo.transactionCount <= MAX_TRANSACTION_SQUARES;
+	const [fetchTransactionSquares, isTransactionSquaresLoading, transactionSquares] = useDataManager(
+		async () => (await fetchTransactionPage({ pageSize: MAX_TRANSACTION_SQUARES, height: blockInfo.height })).data,
+		[],
+		null,
+		isTransactionSquaresAvailable
 	);
-	const transactionPagination = useClientSidePagination(transactionInitialPagination.data);
 	const chainStatus = useAsyncCall(fetchChainStatus, null);
 
 	const tableColumns = [
@@ -87,7 +96,10 @@ const BlockInfo = ({ blockInfo }) => {
 	];
 
 	useEffect(() => {
-		transactionInitialPagination.initialRequest();
+		transactionPagination.initialRequest();
+
+		if (isTransactionSquaresAvailable)
+			fetchTransactionSquares();
 	}, [blockInfo.height]);
 
 	return (
@@ -113,8 +125,9 @@ const BlockInfo = ({ blockInfo }) => {
 						<Field title={t('field_transactionFees')}>
 							<ValueTransactionSquares
 								isTransactionPreviewEnabled
-								data={transactionInitialPagination.data}
-								isLoading={transactionInitialPagination.isLoading}
+								data={transactionSquares}
+								transactionCount={blockInfo.transactionCount}
+								isLoading={isTransactionSquaresLoading}
 								className={styles.valueTransactionSquares}
 							/>
 						</Field>
@@ -142,9 +155,9 @@ const BlockInfo = ({ blockInfo }) => {
 					columns={tableColumns}
 					renderItemMobile={data => <ItemTransactionMobile data={data} />}
 					data={transactionPagination.data}
-					isLoading={transactionInitialPagination.isLoading}
+					isLoading={transactionPagination.isLoading}
 					isLastPage={transactionPagination.isLastPage}
-					isError={transactionInitialPagination.isError}
+					isError={transactionPagination.isError}
 					onEndReached={transactionPagination.requestNextPage}
 				/>
 			</Section>

--- a/explorer/frontend/pages/index.jsx
+++ b/explorer/frontend/pages/index.jsx
@@ -10,6 +10,7 @@ import RecentTransactions from '@/app/components/RecentTransactions';
 import Section from '@/app/components/Section';
 import Separator from '@/app/components/Separator';
 import ValuePrice from '@/app/components/ValuePrice';
+import { MAX_TRANSACTION_SQUARES } from '@/app/components/ValueTransactionSquares';
 import config from '@/app/config';
 import { TRANSACTION_CHART_TYPE, TRANSACTION_GROUP } from '@/app/constants';
 import styles from '@/app/styles/pages/Home.module.scss';
@@ -79,7 +80,10 @@ const Home = ({
 	const blocks = useAsyncCall(() => fetchBlockPage({ pageSize: RECENT_BLOCK_COUNT }), preloadedBlocks, DATA_REFRESH_INTERVAL);
 	const chainStatus = useAsyncCall(fetchChainStatus, null, DATA_REFRESH_INTERVAL);
 
-	const fetchBlockTransactions = useCallback(height => fetchTransactionPage({ pageSize: 160, height }), [fetchTransactionPage]);
+	const fetchBlockTransactions = useCallback(
+		height => fetchTransactionPage({ pageSize: MAX_TRANSACTION_SQUARES, height }),
+		[fetchTransactionPage]
+	);
 
 	return (
 		<div className={styles.wrapper}>

--- a/explorer/frontend/public/locales/en/common.json
+++ b/explorer/frontend/public/locales/en/common.json
@@ -178,6 +178,7 @@
 	"message_addressBook_addressAlreadyAdded": "Address already added",
 	"message_addressBook_nameAlreadyAdded": "Address with such Name already added",
 	"message_emptyTable": "Nothing to show.",
+	"message_tooManyTransactionsToVisualize": "Too many transactions to visualize.",
 	"message_noLinkedKeys": "No linked keys",
 	"message_nothingFound": "Nothing found.",
 	"message_404": "We can't seem to find the resource you're looking for.",

--- a/explorer/frontend/public/locales/isv/common.json
+++ b/explorer/frontend/public/locales/isv/common.json
@@ -178,6 +178,7 @@
 	"message_addressBook_addressAlreadyAdded": "Adresa juže dodana",
 	"message_addressBook_nameAlreadyAdded": "Adresa s takim imenem juže dodana",
 	"message_emptyTable": "Ničto pokazati.",
+	"message_tooManyTransactionsToVisualize": "Previše transakcij za vizualizaciju.",
 	"message_noLinkedKeys": "Ne ma svězanyh klučev",
 	"message_nothingFound": "Ničto najdeno.",
 	"message_404": "Ne možem najti resurs kotory iskate.",

--- a/explorer/frontend/public/locales/ja/common.json
+++ b/explorer/frontend/public/locales/ja/common.json
@@ -182,6 +182,7 @@
 	"message_addressBook_addressAlreadyAdded": "このアドレスはすでに追加されています",
 	"message_addressBook_nameAlreadyAdded": "この名前はすでに使用されています",
 	"message_emptyTable": "表示するものがありません。",
+	"message_tooManyTransactionsToVisualize": "トランザクションが多すぎるため表示できません。",
 	"message_noLinkedKeys": "リンクされたキーはありません。",
 	"message_nothingFound": "何も見つかりませんでした。",
 	"message_404": "お探しのリソースが見つかりません。",

--- a/explorer/frontend/utils/hooks.js
+++ b/explorer/frontend/utils/hooks.js
@@ -1,5 +1,4 @@
 import { STORAGE_KEY } from '@/app/constants';
-import _ from 'lodash';
 import { useEffect, useState } from 'react';
 
 // Makes an async call. Handles the loading and error states.
@@ -80,38 +79,6 @@ export const usePagination = (callback, defaultData, defaultFilter = {}) => {
 	};
 
 	return { requestNextPage, initialRequest, data, isLoading, pageNumber, isLastPage, filter, isError, changeFilter, clearFilter };
-};
-
-// Paginate a data list.
-export const useClientSidePagination = (fullData, pageSize = 10) => {
-	const [isLastPage, setIsLastPage] = useState(false);
-	const [pageNumber, setPageNumber] = useState(1);
-	const [dataChunks, setDataChunks] = useState([]);
-	const [data, setData] = useState([]);
-
-	const requestNextPage = () => {
-		const nextPageNumber = pageNumber + 1;
-		const page = dataChunks[pageNumber];
-
-		if (!dataChunks[nextPageNumber])
-			setIsLastPage(true);
-
-		if (page) {
-			setData([...data, ...page]);
-			setPageNumber(nextPageNumber);
-		}
-	};
-
-	useEffect(() => {
-		const dataChunks = _.chunk(fullData, pageSize);
-		const page = dataChunks[0];
-		setDataChunks(dataChunks);
-		setData(page || []);
-		setIsLastPage(false);
-		setPageNumber(1);
-	}, [fullData, pageSize]);
-
-	return { requestNextPage, data, pageNumber, isLastPage };
 };
 
 // Makes an async call and handle a filter.


### PR DESCRIPTION
## Problem
The block page asked for every transaction of the block at once - `fetchTransactionPage` was called with `pageSize: blockInfo.transactionCount` - and paged the result on the client. Nothing was lost, because `/api/nem/transactions` does not bound `limit`. The fee treemap made it worse by needing the same full set. Above its own guard of 400 data points it rendered nothing at all - not a chart, not a message, just an empty field - so the cost was paid for a block whose chart was never shown.

## Solution
The table now uses ordinary server-side pagination, 50 transactions per page, through `usePagination`. The treemap keeps its own single request, capped at `MAX_TRANSACTION_SQUARES`, and is skipped entirely for blocks above that size - no request is sent and the chart is replaced with `message_tooManyTransactionsToVisualize` rather than a partial picture. The chart no longer decides from the length of the data it received, but from the block's `transactionCount`, which both call sites pass, and the preview fetch was aligned with the same cap so its data is complete whenever the chart is drawn. `useClientSidePagination` had no remaining users and was removed.

Related to https://github.com/symbol/product/pull/2509