### PR TITLE
[explorer/puller] fix: refresh accounts stuck in a transient remote status

### DIFF
--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -448,7 +448,12 @@ class NemDatabase(DatabaseConnection):
 			SELECT id, address
 			FROM accounts
 			WHERE id > %s
-				AND (balance > 0 OR vested_balance > 0 OR importance > 0)
+				AND (
+					balance > 0
+					OR vested_balance > 0
+					OR importance > 0
+					OR remote_status IN ('ACTIVATING', 'DEACTIVATING')
+				)
 			ORDER BY id ASC
 			LIMIT %s
 			''',
@@ -547,20 +552,22 @@ class NemDatabase(DatabaseConnection):
 		)
 
 	@staticmethod
-	def update_vested_balance_and_importance(cursor, account_info):
-		"""Updates vested balance and importance for an account."""
+	def update_refreshed_account(cursor, account_info):
+		"""Updates vested balance, importance and remote status for an account."""
 
 		cursor.execute(
 			'''
 			UPDATE accounts
 			SET vested_balance = %s,
 				importance = %s,
+				remote_status = %s,
 				updated_at = CURRENT_TIMESTAMP
 			WHERE address = %s
 			''',
 			(
 				account_info.vested_balance,
 				account_info.importance,
+				account_info.remote_status,
 				account_info.address.bytes
 			)
 		)

--- a/explorer/puller/puller/facade/NemPuller.py
+++ b/explorer/puller/puller/facade/NemPuller.py
@@ -44,10 +44,11 @@ AccountRecord = namedtuple('AccountRecord', [
 	'cosignatory_of',
 	'cosignatories'
 ])
-AccountVestedBalanceRecord = namedtuple('AccountVestedBalanceRecord', [
+RefreshedAccountRecord = namedtuple('RefreshedAccountRecord', [
 	'address',
 	'importance',
-	'vested_balance'
+	'vested_balance',
+	'remote_status'
 ])
 NamespaceRecord = namedtuple('NamespaceRecord', [
 	'root_namespace',
@@ -289,13 +290,14 @@ class NemPuller:
 		)
 
 	@staticmethod
-	def _create_account_vested_balance_record(account_info):
-		"""Create account vested balance record."""
+	def _create_refreshed_account_record(account_info):
+		"""Create refreshed account record."""
 
-		return AccountVestedBalanceRecord(
+		return RefreshedAccountRecord(
 			account_info.address,
 			account_info.importance,
-			_format_xem_absolute(account_info.vested_balance)
+			_format_xem_absolute(account_info.vested_balance),
+			account_info.remote_status
 		)
 
 	async def _process_account_batch(self, cursor, address_heights):
@@ -354,7 +356,7 @@ class NemPuller:
 			pending_remote_links.clear()
 
 	async def refresh_accounts(self, batch_size):
-		"""Refresh vested balance and importance for stored accounts."""
+		"""Refresh vested balance, importance and remote status for stored accounts."""
 
 		cursor = self.nem_db.connection.cursor()
 		last_account_id = 0
@@ -367,8 +369,8 @@ class NemPuller:
 
 			for account in accounts:
 				account_info = await self._retry_get_account_info(str(account.address))
-				account_vested_balance = self._create_account_vested_balance_record(account_info)
-				self.nem_db.update_vested_balance_and_importance(cursor, account_vested_balance)
+				refreshed_account = self._create_refreshed_account_record(account_info)
+				self.nem_db.update_refreshed_account(cursor, refreshed_account)
 				last_account_id = account.id
 				total_refreshed += 1
 

--- a/explorer/puller/tests/db/test_NemDatabase.py
+++ b/explorer/puller/tests/db/test_NemDatabase.py
@@ -635,6 +635,20 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 				balance=0,
 				vested_balance=0,
 				importance=0
+			),
+			ACCOUNTS[0]._replace(
+				address=Address('TCARLOS5VILUENPKLFYIUKFHYXNVJ357NIXVFXEH'),
+				balance=0,
+				vested_balance=0,
+				importance=0,
+				remote_status='ACTIVATING'
+			),
+			ACCOUNTS[0]._replace(
+				address=Address('TDEBBIE7CROVQAOEDGXXTDPQVYCP4KEXPHNPHNMB'),
+				balance=0,
+				vested_balance=0,
+				importance=0,
+				remote_status='DEACTIVATING'
 			)
 		]
 
@@ -650,6 +664,7 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			# Act:
 			first_batch = nem_database.get_accounts_for_refresh(2, 0)
 			second_batch = nem_database.get_accounts_for_refresh(2, first_batch[-1].id)
+			third_batch = nem_database.get_accounts_for_refresh(2, second_batch[-1].id)
 
 		# Assert:
 		self.assertEqual([str(account.address) for account in first_batch], [
@@ -657,7 +672,11 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			'TCJLCZSOQ6RGWHTPSV2DW467WZSHK4NBSITND4OF'
 		])
 		self.assertEqual([str(account.address) for account in second_batch], [
-			'TALICE6XEEEOBFJVY3ZCENZ7WBG6LB4KB7P7KMQX'
+			'TALICE6XEEEOBFJVY3ZCENZ7WBG6LB4KB7P7KMQX',
+			'TCARLOS5VILUENPKLFYIUKFHYXNVJ357NIXVFXEH'
+		])
+		self.assertEqual([str(account.address) for account in third_batch], [
+			'TDEBBIE7CROVQAOEDGXXTDPQVYCP4KEXPHNPHNMB'
 		])
 
 	def test_can_get_mosaic_levy_recipients(self):
@@ -695,7 +714,7 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 		self.assertEqual(empty_results, [])
 		self.assertEqual([str(result) for result in results], [str(levy_recipient)])
 
-	def test_can_update_vested_balance_and_importance(self):
+	def test_can_update_refreshed_account(self):
 		# Arrange:
 		with NemDatabase(self.db_config) as nem_database:
 			nem_database.create_tables()
@@ -704,11 +723,11 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 
 			nem_database.upsert_account(
 				cursor,
-				ACCOUNTS[0]
+				ACCOUNTS[0]._replace(remote_status='ACTIVATING')
 			)
 
 			# Act:
-			nem_database.update_vested_balance_and_importance(
+			nem_database.update_refreshed_account(
 				cursor,
 				ACCOUNTS[0]._replace(
 					importance=0.654321,
@@ -735,7 +754,7 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 			[],
 			0,
 			10,
-			'INACTIVE',
+			'ACTIVE',
 			0,
 			None,
 			None,

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -30,7 +30,7 @@ from symbollightapi.model.Transaction import (
 from puller.db.NemDatabase import AccountRefreshRecord
 from puller.facade.NemPuller import (
 	AccountRecord,
-	AccountVestedBalanceRecord,
+	RefreshedAccountRecord,
 	DatabaseConfig,
 	MosaicRecord,
 	NamespaceRecord,
@@ -871,10 +871,10 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 
 	@patch('puller.facade.NemPuller.NemPuller._retry_get_account_info')
 	@patch('puller.facade.NemPuller.NemDatabase.get_accounts_for_refresh')
-	@patch('puller.facade.NemPuller.NemDatabase.update_vested_balance_and_importance')
+	@patch('puller.facade.NemPuller.NemDatabase.update_refreshed_account')
 	def test_can_refresh_accounts_in_batches(
 		self,
-		mock_update_vested_balance_and_importance,  # pylint: disable=invalid-name
+		mock_update_refreshed_account,
 		mock_get_accounts_for_refresh,
 		mock_retry_get_account_info
 	):
@@ -897,16 +897,19 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		account_info_1.address = account_1.address
 		account_info_1.importance = 0.1
 		account_info_1.vested_balance = 6449.201816
+		account_info_1.remote_status = 'ACTIVE'
 
 		account_info_2 = Mock()
 		account_info_2.address = account_2.address
 		account_info_2.importance = 0.2
 		account_info_2.vested_balance = 1234.000001
+		account_info_2.remote_status = 'INACTIVE'
 
 		account_info_3 = Mock()
 		account_info_3.address = account_3.address
 		account_info_3.importance = 0.3
 		account_info_3.vested_balance = 0
+		account_info_3.remote_status = 'DEACTIVATING'
 
 		mock_retry_get_account_info.side_effect = [
 			account_info_1,
@@ -932,19 +935,19 @@ class NemPullerTest(unittest.TestCase):  # pylint: disable=too-many-public-metho
 		self.assertEqual(retry_get_account_info_calls[1][0], (str(account_2.address),))
 		self.assertEqual(retry_get_account_info_calls[2][0], (str(account_3.address),))
 
-		update_account_calls = mock_update_vested_balance_and_importance.call_args_list
+		update_account_calls = mock_update_refreshed_account.call_args_list
 		self.assertEqual(len(update_account_calls), 3)
 		self.assertEqual(update_account_calls[0][0], (
 			cursor,
-			AccountVestedBalanceRecord(account_1.address, 0.1, 6449201816)
+			RefreshedAccountRecord(account_1.address, 0.1, 6449201816, 'ACTIVE')
 		))
 		self.assertEqual(update_account_calls[1][0], (
 			cursor,
-			AccountVestedBalanceRecord(account_2.address, 0.2, 1234000001)
+			RefreshedAccountRecord(account_2.address, 0.2, 1234000001, 'INACTIVE')
 		))
 		self.assertEqual(update_account_calls[2][0], (
 			cursor,
-			AccountVestedBalanceRecord(account_3.address, 0.3, 0)
+			RefreshedAccountRecord(account_3.address, 0.3, 0, 'DEACTIVATING')
 		))
 		self.assertEqual(self.puller.nem_db.connection.commit.call_count, 2)
 

--- a/explorer/puller/tests/facade/test_NemPuller.py
+++ b/explorer/puller/tests/facade/test_NemPuller.py
@@ -30,11 +30,11 @@ from symbollightapi.model.Transaction import (
 from puller.db.NemDatabase import AccountRefreshRecord
 from puller.facade.NemPuller import (
 	AccountRecord,
-	RefreshedAccountRecord,
 	DatabaseConfig,
 	MosaicRecord,
 	NamespaceRecord,
 	NemPuller,
+	RefreshedAccountRecord,
 	TransactionRecord
 )
 


### PR DESCRIPTION
## Problem

`accounts.remote_status` mirrors the NIS `meta.remoteStatus` field. Two of its
values are transient - `ACTIVATING` and `DEACTIVATING` - and settle into
`ACTIVE` / `INACTIVE` roughly six hours after a delegated harvesting key link.

The puller writes `remote_status` in exactly one place, `_process_account_batch`,
which runs only when a block touches the account. An account whose status is
captured mid-transition keeps that stale value indefinitely, until some later
transaction happens to touch it again.

## Solution

- `get_accounts_for_refresh` additionally selects accounts whose `remote_status`
  is `ACTIVATING` or `DEACTIVATING`.
- The refresh `UPDATE` now carries `remote_status` from the node response.