### PR TITLE
[explorer/puller] fix: prevent fee overflow and mixed block branches

### DIFF
--- a/explorer/puller/puller/db/SymbolDatabase.py
+++ b/explorer/puller/puller/db/SymbolDatabase.py
@@ -1870,7 +1870,7 @@ class SymbolDatabase(DatabaseConnection):  # pylint: disable=too-many-public-met
 				%(deadline)s,
 				%(network_deadline)s,
 				%(max_fee)s,
-				LEAST(%(max_fee)s, %(size)s * (SELECT fee_multiplier FROM symbol_blocks WHERE height = %(height)s)),
+				LEAST(%(max_fee)s, CAST(%(size)s AS bigint) * (SELECT fee_multiplier FROM symbol_blocks WHERE height = %(height)s)),
 				%(size)s,
 				%(message_type)s,
 				%(message_payload)s,

--- a/explorer/puller/puller/facade/SymbolPuller.py
+++ b/explorer/puller/puller/facade/SymbolPuller.py
@@ -361,6 +361,7 @@ class SymbolPuller:
 		last_synced_height = None
 		last_synced_block_hash = None
 		all_offsets = range(start_height - 1, chain_height, MAX_PAGE_SIZE)
+		previous_block_hash = self.symbol_db.get_block_hash(start_height - 1) if start_height > 1 else None
 
 		for batch_start in range(0, len(all_offsets), BLOCK_PAGE_FETCH_CONCURRENCY):
 			batch_offsets = all_offsets[batch_start:batch_start + BLOCK_PAGE_FETCH_CONCURRENCY]
@@ -380,6 +381,7 @@ class SymbolPuller:
 					raise ValueError(f'Symbol block page at offset {offset} does not contain blocks at or below chain height {chain_height}')
 
 				self._validate_block_page(rows, offset + 1)
+				previous_block_hash = self._validate_block_chain(rows, previous_block_hash)
 				last_row = rows[-1]
 				if len(blocks) < MAX_PAGE_SIZE and last_row['height'] < chain_height:
 					raise ValueError(f'Short Symbol block page ended at height {last_row["height"]} before chain height {chain_height}')
@@ -1339,3 +1341,20 @@ class SymbolPuller:
 			expected_height = expected_start_height + index
 			if row['height'] != expected_height:
 				raise ValueError(f'Unexpected Symbol block height {row["height"]}; expected {expected_height}')
+
+	@staticmethod
+	def _validate_block_chain(rows, previous_block_hash):
+		for row in rows:
+			if 1 < row['height']:
+				expected_hash = bytes(previous_block_hash) if previous_block_hash is not None else None
+				actual_previous_hash = bytes(row['previous_hash'])
+				if actual_previous_hash != expected_hash:
+					expected_hash_text = expected_hash.hex().upper() if expected_hash is not None else 'None'
+					raise ValueError(
+						f'Symbol block chain mismatch at height {row["height"]}: '
+						f'expected previous hash {expected_hash_text}, got {actual_previous_hash.hex().upper()}'
+					)
+
+			previous_block_hash = row['hash']
+
+		return previous_block_hash

--- a/explorer/puller/tests/db/test_SymbolDatabase.py
+++ b/explorer/puller/tests/db/test_SymbolDatabase.py
@@ -3987,6 +3987,59 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 			(None, None)
 		], results)
 
+	def test_upsert_transactions_for_height_stores_effective_fee_when_product_exceeds_integer_range(self):
+		# Arrange:
+		database = self._create_database()
+		database.upsert_blocks([_create_block(2, fee_multiplier=45221)])
+
+		# These values reproduce the Symbol testnet transaction that exceeded PostgreSQL's 32-bit integer range.
+		transaction = create_transaction_entry(2, 'overflow', max_fee=5000000000, size=110568)
+
+		# Act:
+		database.upsert_transactions_for_height(2, [transaction])
+
+		# Assert:
+		cursor = database.connection.cursor()
+		cursor.execute(
+			'''
+			SELECT hash, is_embedded, height, type, max_fee, size, effective_fee, body
+			FROM symbol_transactions
+			WHERE height = 2
+			''')
+		result = cursor.fetchone()
+		result = (bytes(result[0]), *result[1:])
+		self.assertEqual([(
+			b'hash-overflow',
+			False,
+			2,
+			TransactionType.TRANSFER.value,
+			5000000000,
+			110568,
+			4999995528,
+			{'height': 2, 'key': 'overflow'}
+		)], [result])
+
+	def test_upsert_transactions_for_height_uses_max_fee_when_product_is_higher(self):
+		# Arrange:
+		database = self._create_database()
+		database.upsert_blocks([_create_block(2, fee_multiplier=45221)])
+
+		# The product exceeds PostgreSQL's 32-bit integer range, while max_fee is the expected cap.
+		transaction = create_transaction_entry(2, 'capped', max_fee=4000000000, size=110568)
+
+		# Act:
+		database.upsert_transactions_for_height(2, [transaction])
+
+		# Assert:
+		cursor = database.connection.cursor()
+		cursor.execute(
+			'''
+			SELECT max_fee, size, effective_fee
+			FROM symbol_transactions
+			WHERE height = 2
+			''')
+		self.assertEqual([(4000000000, 110568, 4000000000)], cursor.fetchall())
+
 	def test_upsert_transactions_for_height_replaces_parent_and_child_rows(self):
 		# Arrange:
 		database = self._create_database()

--- a/explorer/puller/tests/facade/symbol/test_PullerSync.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerSync.py
@@ -765,6 +765,182 @@ class SymbolPullerSyncTest(SymbolPullerTestBase):  # pylint: disable=too-many-pu
 			bytes(sync_state['last_synced_block_hash'])
 		)
 
+	def test_sync_block_headers_accepts_valid_parent_hash_chain(self):
+		# Arrange:
+		connector = FakeConnector(
+			3,
+			{0: [create_node_block(1), create_node_block(2), create_node_block(3)]}
+		)
+
+		# Act:
+		block_heights, sync_state = self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual([1, 2, 3], block_heights)
+		self.assertEqual(3, sync_state['last_synced_height'])
+
+	def test_sync_block_headers_accepts_height_one_without_stored_parent_hash(self):
+		# Arrange:
+		connector = FakeConnector(1, {0: [create_node_block(1, previous_hash='A' * 64)]})
+
+		# Act:
+		block_heights, sync_state = self._sync_with_connector(connector)
+
+		# Assert:
+		self.assertEqual([1], block_heights)
+		self.assertEqual(1, sync_state['last_synced_height'])
+
+	def test_sync_block_headers_rejects_parent_hash_mismatch_at_stored_block_boundary(self):
+		# Arrange:
+		stored_height = 1
+		connector = FakeConnector(
+			2,
+			{1: [create_node_block(2, previous_hash='A' * 64)]}
+		)
+		self._seed_blocks(self.puller.symbol_db, [stored_height])
+		existing_sync_state = create_sync_state(
+			chain_height=stored_height,
+			last_synced_height=stored_height,
+			last_synced_block_hash=bytes.fromhex(f'{stored_height:064X}'))
+		self.puller.symbol_db.upsert_sync_state(existing_sync_state)
+		expected_state = self._fetch_complete_batch_state()
+		set_symbol_connector(self.puller, connector)
+
+		# Act / Assert:
+		with self.assertRaisesRegex(
+			ValueError,
+			f'Symbol block chain mismatch at height 2: expected previous hash {1:064X}, got {"A" * 64}'
+		):
+			asyncio.run(self.puller.sync_block_headers())
+
+		# Assert:
+		self.assertEqual(expected_state, self._fetch_complete_batch_state())
+		self.assertEqual([
+			'chain/info',
+			'network/properties',
+			f'mosaics/{NATIVE_MOSAIC_ID}',
+			'blocks?pageSize=100&offset=1&orderBy=height'
+		], connector.paths)
+
+	def test_sync_block_headers_rejects_parent_hash_mismatch_within_page_before_related_fetches(self):
+		# Arrange:
+		connector = FakeConnector(
+			2,
+			{0: [create_node_block(1), create_node_block(2, previous_hash='A' * 64)]},
+			transactions_by_path={
+				transaction_path(1, 2): {'data': [create_node_transaction(2)]}
+			},
+			statement_pages={
+				statement_path(1, 2): {'data': [create_amount_statement_item(2, 2000)]}
+			}
+		)
+		expected_state = self._fetch_complete_batch_state()
+		set_symbol_connector(self.puller, connector)
+
+		# Act / Assert:
+		with self.assertRaisesRegex(
+			ValueError,
+			f'Symbol block chain mismatch at height 2: expected previous hash {1:064X}, got {"A" * 64}'
+		):
+			asyncio.run(self.puller.sync_block_headers())
+
+		# Assert:
+		self.assertEqual(expected_state, self._fetch_complete_batch_state())
+		self.assertEqual([
+			'chain/info',
+			'network/properties',
+			f'mosaics/{NATIVE_MOSAIC_ID}',
+			'blocks?pageSize=100&offset=0&orderBy=height'
+		], connector.paths)
+
+	def test_sync_block_headers_rejects_parent_hash_mismatch_at_page_boundary(self):
+		# Arrange:
+		first_page = [create_node_block(height) for height in range(1, 101)]
+		second_page = [create_node_block(101, previous_hash='A' * 64)]
+		connector = FakeConnector(101, {0: first_page, 100: second_page})
+		expected_state = self._fetch_complete_batch_state()
+		set_symbol_connector(self.puller, connector)
+
+		# Act / Assert:
+		with self.assertRaisesRegex(
+			ValueError,
+			f'Symbol block chain mismatch at height 101: expected previous hash {100:064X}, got {"A" * 64}'
+		):
+			asyncio.run(self.puller.sync_block_headers())
+
+		# Assert:
+		self.assertEqual(expected_state, self._fetch_complete_batch_state())
+		self.assertEqual([
+			'chain/info',
+			'network/properties',
+			f'mosaics/{NATIVE_MOSAIC_ID}',
+			'blocks?pageSize=100&offset=0&orderBy=height',
+			'blocks?pageSize=100&offset=100&orderBy=height'
+		], connector.paths)
+
+	def test_sync_block_headers_rejects_parent_hash_mismatch_at_parallel_page_batch_boundary(self):
+		# Arrange:
+		chain_height = BLOCK_PAGE_FETCH_CONCURRENCY * MAX_PAGE_SIZE + 1
+		pages = {
+			offset: [
+				create_node_block(height)
+				for height in range(offset + 1, min(offset + MAX_PAGE_SIZE + 1, chain_height + 1))
+			]
+			for offset in range(0, chain_height, MAX_PAGE_SIZE)
+		}
+		pages[BLOCK_PAGE_FETCH_CONCURRENCY * MAX_PAGE_SIZE] = [
+			create_node_block(chain_height, previous_hash='A' * 64)
+		]
+		connector = FakeConnector(chain_height, pages)
+		set_symbol_connector(self.puller, connector)
+
+		# Act / Assert:
+		with self.assertRaisesRegex(
+			ValueError,
+			f'Symbol block chain mismatch at height {chain_height}: '
+			f'expected previous hash {chain_height - 1:064X}, got {"A" * 64}'
+		):
+			asyncio.run(self.puller.sync_block_headers())
+
+		# Assert:
+		self.assertEqual(list(range(1, chain_height)), self._fetch_block_heights(self.puller.symbol_db))
+		self.assertIsNone(self.puller.symbol_db.get_sync_state())
+		block_paths = [path for path in connector.paths if path.startswith('blocks?pageSize=100&offset=')]
+		transaction_paths = [path for path in connector.paths if path.startswith('transactions/confirmed?')]
+		statement_paths = [path for path in connector.paths if path.startswith('statements/transaction?')]
+		self.assertEqual(BLOCK_PAGE_FETCH_CONCURRENCY + 1, len(block_paths))
+		self.assertEqual([transaction_path(1, chain_height - 1)], transaction_paths)
+		self.assertEqual([statement_path(1, chain_height - 1)], statement_paths)
+
+	def test_sync_block_headers_keeps_previous_watermark_when_next_run_parent_hash_mismatches(self):
+		# Arrange:
+		first_connector = FakeConnector(1, {0: [create_node_block(1)]})
+
+		# Act:
+		self._sync_with_connector(first_connector)
+
+		# Assert:
+		first_state = self._fetch_complete_batch_state()
+		self.assertEqual(1, self.puller.symbol_db.get_sync_state()['last_synced_height'])
+
+		# Arrange:
+		second_connector = FakeConnector(2, {1: [create_node_block(2, previous_hash='A' * 64)]})
+		set_symbol_connector(self.puller, second_connector)
+
+		# Act / Assert:
+		with self.assertRaisesRegex(
+			ValueError,
+			f'Symbol block chain mismatch at height 2: expected previous hash {1:064X}, got {"A" * 64}'
+		):
+			asyncio.run(self.puller.sync_block_headers())
+
+		# Assert:
+		self.assertEqual(first_state, self._fetch_complete_batch_state())
+		self.assertEqual([
+			'chain/info',
+			'blocks?pageSize=100&offset=1&orderBy=height'
+		], second_connector.paths)
+
 	def test_sync_block_headers_persists_importance_block_fields(self):
 		# Arrange:
 		connector = FakeConnector(1, {0: [create_node_block(


### PR DESCRIPTION
## What is the current behavior?

Symbol Puller calculates transaction effective fees using PostgreSQL integer multiplication before applying the `LEAST(max_fee, ...)` cap. Large transaction sizes and fee multipliers can overflow before the cap is evaluated.

New block synchronization validates height continuity, but does not verify that each block's `previous_hash` matches the preceding block's `hash`.

## What's the issue?

The fee calculation can reject otherwise valid Symbol transactions with a PostgreSQL integer overflow.

Height-only validation can also persist adjacent blocks from different branches. That can leave block, transaction, receipt, and current-state data internally inconsistent while advancing the sync watermark as healthy.

This PR supersedes #2507 by including its effective-fee overflow fix together with the block-chain continuity validation requested for the same Puller fix.

## How have you changed the behavior?

- Cast transaction size to `bigint` before multiplying by the block fee multiplier.
- Initialize block-chain validation from the stored `start_height - 1` hash when synchronization resumes above height 1.
- Validate `block[h].previous_hash == block[h - 1].hash` in memory across rows, pages, parallel page groups, 1,000-block batches, and consecutive sync runs.
- Exempt height 1 from requiring a stored parent block.
- Raise a deterministic error containing the mismatched height, expected hash, and actual previous hash.
- Complete continuity validation before transaction, receipt, current-state fetches, or writes for the affected batch.
- Preserve the prior sync watermark and persisted state when validation fails.
- Add no Symbol node requests for parent-hash validation.

This is not a breaking API or schema change. NEM, REST, and frontend code are unchanged.

## How was this change tested?

- `bash scripts/ci/lint.sh` passed against a tracked-files-only copy of `explorer/puller` and `explorer/common` (pylint 10.00/10). The original worktree contains a pre-existing untracked zsh helper that the script's broad `find` attempts to pass to ShellCheck; that file is not part of this PR.
- Parent-hash targeted tests: 7 passed.
- Parent-hash plus pagination/batch regression selection: 10 passed.
- `tests/facade/symbol/test_PullerSync.py`: 44 passed.
- Effective-fee targeted tests: 2 passed.
- Symbol/shared Puller suite: 842 passed, 15 existing deprecation warnings, 143 subtests passed.
- Three shared `DatabaseConnectionTest` cases could not start their private `testing.postgresql` instance because macOS reported `could not create shared memory segment: No space left on device`. The dedicated Docker PostgreSQL remained healthy with 1 GiB shared memory, no other pytest process was running, and one serial retry failed at the same setup step.
- Coverage reports no missing changed executable lines or branches in the new continuity logic; the effective-fee SQL path is also executed by its targeted tests.

----

## Requirements

* [x] My pull request title is prefixed with the directory and subdirectory it affects.
* [x] My pull request contains a single Puller correctness fix set.
* [x] My commits are clearly labeled with an allowed fix type.
* [x] My code has been linted.
* [x] My code has comments where non-obvious context is required, and tests use Arrange / Act / Assert structure.
* [x] My code follows the style guidelines.
* [x] I have written and supplied test cases.
* [ ] Documentation changes are not required because this changes internal validation and persistence correctness without changing a public contract.