### PR TITLE
[Explorer/puller] fix: symbol effective fee overflow

### DIFF
--- a/explorer/puller/puller/db/SymbolDatabase.py
+++ b/explorer/puller/puller/db/SymbolDatabase.py
@@ -1870,7 +1870,7 @@ class SymbolDatabase(DatabaseConnection):  # pylint: disable=too-many-public-met
 				%(deadline)s,
 				%(network_deadline)s,
 				%(max_fee)s,
-				LEAST(%(max_fee)s, %(size)s * (SELECT fee_multiplier FROM symbol_blocks WHERE height = %(height)s)),
+				LEAST(%(max_fee)s, CAST(%(size)s AS bigint) * (SELECT fee_multiplier FROM symbol_blocks WHERE height = %(height)s)),
 				%(size)s,
 				%(message_type)s,
 				%(message_payload)s,

--- a/explorer/puller/tests/db/test_SymbolDatabase.py
+++ b/explorer/puller/tests/db/test_SymbolDatabase.py
@@ -3987,6 +3987,59 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 			(None, None)
 		], results)
 
+	def test_upsert_transactions_for_height_stores_effective_fee_when_product_exceeds_integer_range(self):
+		# Arrange:
+		database = self._create_database()
+		database.upsert_blocks([_create_block(2, fee_multiplier=45221)])
+
+		# These values reproduce the Symbol testnet transaction that exceeded PostgreSQL's 32-bit integer range.
+		transaction = create_transaction_entry(2, 'overflow', max_fee=5000000000, size=110568)
+
+		# Act:
+		database.upsert_transactions_for_height(2, [transaction])
+
+		# Assert:
+		cursor = database.connection.cursor()
+		cursor.execute(
+			'''
+			SELECT hash, is_embedded, height, type, max_fee, size, effective_fee, body
+			FROM symbol_transactions
+			WHERE height = 2
+			''')
+		result = cursor.fetchone()
+		result = (bytes(result[0]), *result[1:])
+		self.assertEqual([(
+			b'hash-overflow',
+			False,
+			2,
+			TransactionType.TRANSFER.value,
+			5000000000,
+			110568,
+			4999995528,
+			{'height': 2, 'key': 'overflow'}
+		)], [result])
+
+	def test_upsert_transactions_for_height_uses_max_fee_when_product_is_higher(self):
+		# Arrange:
+		database = self._create_database()
+		database.upsert_blocks([_create_block(2, fee_multiplier=45221)])
+
+		# The product exceeds PostgreSQL's 32-bit integer range, while max_fee is the expected cap.
+		transaction = create_transaction_entry(2, 'capped', max_fee=4000000000, size=110568)
+
+		# Act:
+		database.upsert_transactions_for_height(2, [transaction])
+
+		# Assert:
+		cursor = database.connection.cursor()
+		cursor.execute(
+			'''
+			SELECT max_fee, size, effective_fee
+			FROM symbol_transactions
+			WHERE height = 2
+			''')
+		self.assertEqual([(4000000000, 110568, 4000000000)], cursor.fetchall())
+
 	def test_upsert_transactions_for_height_replaces_parent_and_child_rows(self):
 		# Arrange:
 		database = self._create_database()


### PR DESCRIPTION
## What is the current behavior?

Symbol Puller calculates a transaction's effective fee with:

```text
min(max_fee, transaction_size * block_fee_multiplier)
```

Although `symbol_transactions.effective_fee` is a PostgreSQL `bigint`, both operands of the multiplication are `integer` values. PostgreSQL therefore evaluates the multiplication as a 32-bit integer before storing the result.

## What's the issue?

Live testnet synchronization failed at height 47,470 with:

```text
psycopg2.errors.NumericValueOutOfRange: integer out of range
```

The affected aggregate transaction had the following values:

```text
transaction size:     110568
block fee multiplier: 45221
calculated fee:       4999995528
max fee:              5000000000
```

The calculated fee exceeds PostgreSQL's 32-bit integer limit even though it fits in the existing `bigint` destination column. This prevents transaction persistence and stops block synchronization.

## How have you changed the behavior?

- Cast the transaction size to `bigint` before multiplying it by the block fee multiplier.
- Preserve the existing effective fee behavior:

  ```text
  effective_fee = min(max_fee, transaction_size * block_fee_multiplier)
  ```

- Add PostgreSQL integration tests covering:
  - a calculated fee above the 32-bit integer range;
  - a calculated fee above the 32-bit range that is capped by `max_fee`.
- Preserve the existing `NULL` effective fee behavior for embedded transactions.

This change does not require a schema migration because `effective_fee` is already stored as `bigint`.

This is not a breaking change.