### PR TITLE
[bridge/reporting] feat: added report tables

### DIFF
--- a/bridge/reporting/__tests__/components/ReportPanel.test.jsx
+++ b/bridge/reporting/__tests__/components/ReportPanel.test.jsx
@@ -2,10 +2,10 @@ import ReportPanel from '@/components/ReportPanel';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 
+const BASE_URL = 'https://bridge.example/wrapped';
 const tab = {
 	id: 'xym-wxym-requests',
 	label: 'XYM → WXYM',
-	baseUrl: 'https://bridge.example/wrapped',
 	operation: 'wrap',
 	resource: 'requests',
 	sourceAsset: { ticker: 'XYM', divisibility: 6 },
@@ -14,10 +14,12 @@ const tab = {
 	destinationNetwork: 'wrappedNetwork'
 };
 
+const renderPanel = currentTab => render(<ReportPanel baseUrl={BASE_URL} isActive tab={currentTab} />);
+
 describe('ReportPanel', () => {
 	it('renders validation error given invalid input', () => {
 		// Arrange:
-		render(<ReportPanel isActive tab={tab} />);
+		renderPanel(tab);
 		const input = screen.getByRole('textbox', { name: /filter by address/i });
 		fireEvent.change(input, { target: { value: 'invalid' } });
 
@@ -31,7 +33,7 @@ describe('ReportPanel', () => {
 
 	it('accepts a valid search and removes an existing validation error', () => {
 		// Arrange:
-		render(<ReportPanel isActive tab={tab} />);
+		renderPanel(tab);
 		const input = screen.getByRole('textbox', { name: /filter by address/i });
 		fireEvent.change(input, { target: { value: 'invalid' } });
 		fireEvent.submit(input.closest('form'));
@@ -47,7 +49,7 @@ describe('ReportPanel', () => {
 
 	it('clears the search input and its validation error', () => {
 		// Arrange:
-		render(<ReportPanel isActive tab={tab} />);
+		renderPanel(tab);
 		const input = screen.getByRole('textbox', { name: /filter by address/i });
 		fireEvent.change(input, { target: { value: 'invalid' } });
 		fireEvent.submit(input.closest('form'));
@@ -63,7 +65,7 @@ describe('ReportPanel', () => {
 
 	it('selects one payout status at a time', () => {
 		// Arrange:
-		render(<ReportPanel isActive tab={tab} />);
+		renderPanel(tab);
 		const allButton = screen.getByRole('button', { name: 'All' });
 		const sentButton = screen.getByRole('button', { name: 'Sent' });
 		const failedButton = screen.getByRole('button', { name: 'Failed' });
@@ -82,7 +84,7 @@ describe('ReportPanel', () => {
 		const errorTab = { ...tab, id: 'xym-wxym-errors', resource: 'errors' };
 
 		// Act:
-		render(<ReportPanel isActive tab={errorTab} />);
+		renderPanel(errorTab);
 
 		// Assert:
 		expect(screen.queryByRole('group', { name: 'Payout status' })).not.toBeInTheDocument();

--- a/bridge/reporting/__tests__/components/ReportTable.test.jsx
+++ b/bridge/reporting/__tests__/components/ReportTable.test.jsx
@@ -119,6 +119,48 @@ describe('ReportTable', () => {
 		expect(failedStatus).toHaveAttribute('data-tooltip', 'Payout rejected');
 	});
 
+	it('renders an unknown payout status', () => {
+		// Arrange:
+		const { table } = renderTable({
+			rows: [{
+				...REQUEST_ROW,
+				payoutStatus: 99
+			}]
+		});
+
+		// Act:
+		const tableView = within(table);
+
+		// Assert:
+		expect(tableView.getByText('Unknown')).toBeInTheDocument();
+	});
+
+	it('renders incomplete payout details without explorer links', () => {
+		// Arrange:
+		const { table } = renderTable({
+			configuration: null,
+			rows: [{
+				...REQUEST_ROW,
+				payoutConversionRate: null,
+				payoutNetAmount: null,
+				payoutStatus: 0,
+				payoutTimestamp: null,
+				payoutTotalFee: null,
+				payoutTransactionHash: null
+			}]
+		});
+
+		// Act:
+		const tableView = within(table);
+
+		// Assert:
+		expect(tableView.getByText('Unprocessed')).toBeInTheDocument();
+		expect(tableView.queryAllByRole('link')).toHaveLength(0);
+		expect(tableView.getAllByText('—')).toHaveLength(5);
+		expect(tableView.getByText('XYM')).toBeInTheDocument();
+		expect(tableView.queryByText('WXYM')).not.toBeInTheDocument();
+	});
+
 	it('renders links addresses and transactions to their configured explorers', () => {
 		// Arrange:
 		const { table } = renderTable();
@@ -161,6 +203,20 @@ describe('ReportTable', () => {
 		expect(sortButton.closest('th')).toHaveAttribute('aria-sort', 'descending');
 	});
 
+	it('renders the alternate request sort direction', () => {
+		// Arrange:
+		const { table } = renderTable({ sort: 1 });
+
+		// Act:
+		const sortButton = within(table).getByRole('button', {
+			name: 'Sort by request block height descending'
+		});
+
+		// Assert:
+		expect(sortButton.closest('th')).toHaveAttribute('aria-sort', 'ascending');
+		expect(sortButton).toHaveTextContent('↑');
+	});
+
 	it('renders and formats errors report fields', () => {
 		// Arrange:
 		const { table } = renderTable({
@@ -175,6 +231,26 @@ describe('ReportTable', () => {
 		expect(tableView.getByText('TARDV42KT…IXVJQY')).toHaveAttribute('title', 'TARDV42KTAIZEF64EQT4NXT7K55DHWBEFIXVJQY');
 		expect(tableView.getByText('CCCCCCCC…CCCCCC')).toHaveAttribute('title', 'C'.repeat(64));
 		expect(tableView.getByText('Required message is missing')).toBeInTheDocument();
+	});
+
+	it('renders missing error messages and the alternate sort direction', () => {
+		// Arrange:
+		const { table } = renderTable({
+			rows: [{ ...ERROR_ROW, errorMessage: null }],
+			sort: 1,
+			tab: ERROR_TAB
+		});
+
+		// Act:
+		const tableView = within(table);
+		const sortButton = tableView.getByRole('button', {
+			name: 'Sort by request block height descending'
+		});
+
+		// Assert:
+		expect(tableView.getByText('—')).toBeInTheDocument();
+		expect(sortButton.closest('th')).toHaveAttribute('aria-sort', 'ascending');
+		expect(sortButton).toHaveTextContent('↑');
 	});
 
 	it('renders and formats request mobile card fields', () => {

--- a/bridge/reporting/__tests__/components/ReportTable.test.jsx
+++ b/bridge/reporting/__tests__/components/ReportTable.test.jsx
@@ -1,0 +1,225 @@
+import ReportTable from '@/components/ReportTable';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+
+const REQUEST_TAB = {
+	resource: 'requests',
+	sourceAsset: { ticker: 'XYM', divisibility: 6 },
+	destinationAsset: { ticker: 'WXYM', divisibility: 6 },
+	sourceNetwork: 'nativeNetwork',
+	destinationNetwork: 'wrappedNetwork'
+};
+
+const ERROR_TAB = {
+	...REQUEST_TAB,
+	resource: 'errors'
+};
+
+const CONFIGURATION = {
+	nativeNetwork: {
+		blockchain: 'symbol',
+		explorerUrl: 'https://symbol.example'
+	},
+	wrappedNetwork: {
+		blockchain: 'ethereum',
+		explorerUrl: 'https://ethereum.example'
+	}
+};
+
+const REQUEST_ROW = {
+	destinationAddress: '0x1f533cd9711049fA7604D0F49C45B6e5Af30ef8e',
+	errorMessage: null,
+	payoutConversionRate: '1000000',
+	payoutNetAmount: '299642570825',
+	payoutSentTimestamp: 4,
+	payoutStatus: 2,
+	payoutTimestamp: 3,
+	payoutTotalFee: '357429175',
+	payoutTransactionHash: 'A'.repeat(64),
+	payoutTransactionHeight: '11',
+	requestAmount: '300000000000',
+	requestTimestamp: 2,
+	requestTransactionHash: 'B'.repeat(64),
+	requestTransactionHeight: '10',
+	requestTransactionSubindex: -1,
+	senderAddress: 'TCONKG47FW2ZEZBPV6G7F422LXBDSMVT3JMYM4I'
+};
+
+const ERROR_ROW = {
+	errorMessage: 'Required message is missing',
+	requestTimestamp: 5,
+	requestTransactionHash: 'C'.repeat(64),
+	requestTransactionHeight: '13',
+	requestTransactionSubindex: -1,
+	senderAddress: 'TARDV42KTAIZEF64EQT4NXT7K55DHWBEFIXVJQY'
+};
+
+const renderTable = ({
+	configuration = CONFIGURATION,
+	onSortChange = jest.fn(),
+	rows = [REQUEST_ROW],
+	sort = 0,
+	tab = REQUEST_TAB
+} = {}) => {
+	const reportTable = (
+		<ReportTable
+			configuration={configuration}
+			onSortChange={onSortChange}
+			rows={rows}
+			sort={sort}
+			tab={tab}
+		/>
+	);
+	const result = render(reportTable);
+
+	return {
+		...result,
+		onSortChange,
+		table: screen.getByRole('table')
+	};
+};
+
+describe('ReportTable', () => {
+	it('renders and formats request report fields', () => {
+		// Arrange:
+		const { table } = renderTable();
+
+		// Act:
+		const tableView = within(table);
+
+		// Assert:
+		expect(tableView.getByText('Completed')).toBeInTheDocument();
+		expect(tableView.getByText('TCONKG47F…JMYM4I')).toHaveAttribute('title', 'TCONKG47FW2ZEZBPV6G7F422LXBDSMVT3JMYM4I');
+		expect(tableView.getByText('AAAAAAAA…AAAAAA')).toHaveAttribute('title', 'A'.repeat(64));
+		expect(tableView.getByText('300000')).toBeInTheDocument();
+		expect(tableView.getByText('0x1f533cd…30ef8e')).toHaveAttribute('title', '0x1f533cd9711049fA7604D0F49C45B6e5Af30ef8e');
+		expect(tableView.getByText('BBBBBBBB…BBBBBB')).toHaveAttribute('title', 'B'.repeat(64));
+		expect(tableView.getByText('1')).toHaveAttribute('title', '1000000 PPM');
+		expect(tableView.getByText('357.429175')).toBeInTheDocument();
+		expect(tableView.getByText('299642.570825')).toBeInTheDocument();
+		expect(tableView.getByText('1970-01-01 00:00:02 UTC')).toBeInTheDocument();
+		expect(tableView.getByText('1970-01-01 00:00:03 UTC')).toBeInTheDocument();
+	});
+
+	it('renders failed status details through an accessible tooltip', () => {
+		// Arrange:
+		const { table } = renderTable({
+			rows: [{
+				...REQUEST_ROW,
+				errorMessage: 'Payout rejected',
+				payoutStatus: 3
+			}]
+		});
+
+		// Act:
+		const failedStatus = within(table).getByLabelText('Failed: Payout rejected');
+
+		// Assert:
+		expect(failedStatus).toHaveTextContent('Failed');
+		expect(failedStatus).toHaveAttribute('data-tooltip', 'Payout rejected');
+	});
+
+	it('renders links addresses and transactions to their configured explorers', () => {
+		// Arrange:
+		const { table } = renderTable();
+		const tableView = within(table);
+		const symbolTransactionUrl = `https://symbol.example/transactions/${REQUEST_ROW.requestTransactionHash}`;
+		const ethereumTransactionUrl = `https://ethereum.example/tx/0x${REQUEST_ROW.payoutTransactionHash}`;
+
+		// Act:
+		const senderLink = tableView.getByTitle(REQUEST_ROW.senderAddress);
+		const requestLink = tableView.getByTitle(REQUEST_ROW.requestTransactionHash);
+		const destinationLink = tableView.getByTitle(REQUEST_ROW.destinationAddress);
+		const payoutLink = tableView.getByTitle(REQUEST_ROW.payoutTransactionHash);
+
+		// Assert:
+		expect(senderLink).toHaveAttribute(
+			'href',
+			`https://symbol.example/accounts/${REQUEST_ROW.senderAddress}`
+		);
+		expect(requestLink).toHaveAttribute('href', symbolTransactionUrl);
+		expect(destinationLink).toHaveAttribute(
+			'href',
+			`https://ethereum.example/address/${REQUEST_ROW.destinationAddress}`
+		);
+		expect(payoutLink).toHaveAttribute('href', ethereumTransactionUrl);
+	});
+
+	it('renders the active sort direction and handles sort changes', () => {
+		// Arrange:
+		const onSortChange = jest.fn();
+		const { table } = renderTable({ onSortChange });
+		const sortButton = within(table).getByRole('button', {
+			name: 'Sort by request block height ascending'
+		});
+
+		// Act:
+		fireEvent.click(sortButton);
+
+		// Assert:
+		expect(onSortChange).toHaveBeenCalledTimes(1);
+		expect(sortButton.closest('th')).toHaveAttribute('aria-sort', 'descending');
+	});
+
+	it('renders and formats errors report fields', () => {
+		// Arrange:
+		const { table } = renderTable({
+			rows: [ERROR_ROW],
+			tab: ERROR_TAB
+		});
+
+		// Act:
+		const tableView = within(table);
+
+		// Assert:
+		expect(tableView.getByText('TARDV42KT…IXVJQY')).toHaveAttribute('title', 'TARDV42KTAIZEF64EQT4NXT7K55DHWBEFIXVJQY');
+		expect(tableView.getByText('CCCCCCCC…CCCCCC')).toHaveAttribute('title', 'C'.repeat(64));
+		expect(tableView.getByText('Required message is missing')).toBeInTheDocument();
+	});
+
+	it('renders and formats request mobile card fields', () => {
+		// Arrange:
+		renderTable();
+
+		// Act:
+		const mobileCard = screen.getByRole('article');
+		const cardView = within(mobileCard);
+
+		// Assert:
+		expect(cardView.getByText('#10')).toBeInTheDocument();
+		expect(cardView.getByText('Completed')).toBeInTheDocument();
+		expect(cardView.getByText('Sender')).toBeInTheDocument();
+		expect(cardView.getByText('TCONKG47F…JMYM4I')).toHaveAttribute('title', REQUEST_ROW.senderAddress);
+		expect(cardView.getByText('Request')).toBeInTheDocument();
+		expect(cardView.getByText('BBBBBBBB…BBBBBB')).toHaveAttribute('title', REQUEST_ROW.requestTransactionHash);
+		expect(cardView.getByText('300000')).toBeInTheDocument();
+		expect(cardView.getByText('Payout Address')).toBeInTheDocument();
+		expect(cardView.getByText('0x1f533cd…30ef8e')).toHaveAttribute('title', REQUEST_ROW.destinationAddress);
+		expect(cardView.getByText('AAAAAAAA…AAAAAA')).toHaveAttribute('title', REQUEST_ROW.payoutTransactionHash);
+		expect(cardView.getByText('1')).toHaveAttribute('title', '1000000 PPM');
+		expect(cardView.getByText('357.429175')).toBeInTheDocument();
+		expect(cardView.getByText('299642.570825')).toBeInTheDocument();
+	});
+
+	it('renders and formats errors mobile card fields', () => {
+		// Arrange:
+		renderTable({
+			rows: [ERROR_ROW],
+			tab: ERROR_TAB
+		});
+
+		// Act:
+		const mobileCard = screen.getByRole('article');
+		const cardView = within(mobileCard);
+
+		// Assert:
+		expect(cardView.getByText('#13')).toBeInTheDocument();
+		expect(cardView.getByText('Error')).toBeInTheDocument();
+		expect(cardView.getByText('Sender')).toBeInTheDocument();
+		expect(cardView.getByText('TARDV42KT…IXVJQY')).toHaveAttribute('title', ERROR_ROW.senderAddress);
+		expect(cardView.getByText('Request')).toBeInTheDocument();
+		expect(cardView.getByText('CCCCCCCC…CCCCCC')).toHaveAttribute('title', ERROR_ROW.requestTransactionHash);
+		expect(cardView.getByText('1970-01-01 00:00:05 UTC')).toBeInTheDocument();
+		expect(cardView.getByText('Required message is missing')).toBeInTheDocument();
+	});
+});

--- a/bridge/reporting/__tests__/components/ReportTable.test.jsx
+++ b/bridge/reporting/__tests__/components/ReportTable.test.jsx
@@ -201,6 +201,7 @@ describe('ReportTable', () => {
 		// Assert:
 		expect(onSortChange).toHaveBeenCalledTimes(1);
 		expect(sortButton.closest('th')).toHaveAttribute('aria-sort', 'descending');
+		expect(sortButton).toHaveTextContent('↓');
 	});
 
 	it('renders the alternate request sort direction', () => {

--- a/bridge/reporting/__tests__/pages/index.test.jsx
+++ b/bridge/reporting/__tests__/pages/index.test.jsx
@@ -1,7 +1,21 @@
-import { Home } from '@/pages/index';
+import { fetchBridgeConfiguration } from '@/api/bridge';
+import config from '@/config';
+import { Home, getServerSideProps } from '@/pages/index';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 
+jest.mock('@/api/bridge');
+jest.mock('@/components/ReportPanel', () => {
+	const ReportPanel = ({ baseUrl, tab }) => (
+		<div data-base-url={baseUrl} data-testid={`report-panel-${tab.id}`} />
+	);
+	return ReportPanel;
+});
+
 describe('Home', () => {
+	const bridgeBaseUrls = {
+		native: 'https://bridge.example/native',
+		wrapped: 'https://bridge.example/wrapped'
+	};
 	const bridgeConfigurations = {
 		wrapped: {
 			enabled: true,
@@ -13,7 +27,48 @@ describe('Home', () => {
 		}
 	};
 
-	const renderHome = () => render(<Home bridgeConfigurations={bridgeConfigurations} />);
+	const renderHome = () => render(<Home bridgeBaseUrls={bridgeBaseUrls} bridgeConfigurations={bridgeConfigurations} />);
+
+	it('returns bridge base URLs with bridge type keys', async () => {
+		// Arrange:
+		fetchBridgeConfiguration.mockResolvedValue(bridgeConfigurations);
+
+		// Act:
+		const result = await getServerSideProps();
+
+		// Assert:
+		expect(result).toEqual({
+			props: {
+				bridgeBaseUrls: {
+					native: config.PUBLIC_BRIDGE_NATIVE_URL,
+					wrapped: config.PUBLIC_BRIDGE_WRAPPED_URL
+				},
+				bridgeConfigurations
+			}
+		});
+	});
+
+	it('passes the wrapped base URL to wrapped bridge panels', () => {
+		// Arrange:
+		renderHome();
+
+		// Act:
+		const reportPanel = screen.getByTestId('report-panel-xym-wxym-requests');
+
+		// Assert:
+		expect(reportPanel.getAttribute('data-base-url')).toBe(bridgeBaseUrls.wrapped);
+	});
+
+	it('passes the native base URL to native bridge panels', () => {
+		// Arrange:
+		renderHome();
+
+		// Act:
+		const reportPanel = screen.getByTestId('report-panel-xym-eth-requests');
+
+		// Assert:
+		expect(reportPanel.getAttribute('data-base-url')).toBe(bridgeBaseUrls.native);
+	});
 
 	it('renders bridge network status', () => {
 		// Arrange:

--- a/bridge/reporting/__tests__/utils/format.test.js
+++ b/bridge/reporting/__tests__/utils/format.test.js
@@ -1,0 +1,86 @@
+import { createExplorerUrl, formatAtomicAmount, formatPpm, formatTimestamp } from '@/utils/format';
+
+describe('report formatting', () => {
+	it('formats atomic values without losing integer precision', () => {
+		// Arrange:
+		const inputs = [
+			['100000000', 6],
+			['151458904500184', 18],
+			['999999999999999999999999', 18]
+		];
+
+		// Act:
+		const formattedAmounts = inputs.map(([value, divisibility]) => formatAtomicAmount(value, divisibility));
+
+		// Assert:
+		expect(formattedAmounts).toEqual(['100', '0.000151458904500184', '999999.999999999999999999']);
+	});
+
+	it('formats conversion rate PPM values', () => {
+		// Arrange:
+		const rates = ['1000000', '999999', '2000000'];
+
+		// Act:
+		const formattedRates = rates.map(formatPpm);
+
+		// Assert:
+		expect(formattedRates).toEqual(['1', '0.999999', '2']);
+	});
+
+	it('formats Unix seconds as UTC', () => {
+		// Arrange:
+		const timestamps = [1759781792.879, null, 'hello'];
+
+		// Act:
+		const formattedTimestamps = timestamps.map(formatTimestamp);
+
+		// Assert:
+		expect(formattedTimestamps).toEqual(['2025-10-06 20:16:32 UTC', '—', '—']);
+	});
+
+	it('creates Symbol explorer URLs', () => {
+		// Arrange:
+		const network = { blockchain: 'symbol', explorerUrl: 'https://symbol.example/' };
+
+		// Act:
+		const transactionUrl = createExplorerUrl(network, 'transaction', 'ABC123');
+		const accountUrl = createExplorerUrl(network, 'address', 'TADDRESS');
+
+		// Assert:
+		expect(transactionUrl).toBe('https://symbol.example/transactions/ABC123');
+		expect(accountUrl).toBe('https://symbol.example/accounts/TADDRESS');
+	});
+
+	it('creates Ethereum explorer URLs and normalizes transaction hash prefixes', () => {
+		// Arrange:
+		const network = { blockchain: 'ethereum', explorerUrl: 'https://ethereum.example/' };
+
+		// Act:
+		const transactionUrls = [
+			createExplorerUrl(network, 'transaction', 'ABC123'),
+			createExplorerUrl(network, 'transaction', '0xABC123')
+		];
+		const addressUrl = createExplorerUrl(network, 'address', '0x123ABC');
+
+		// Assert:
+		expect(transactionUrls).toEqual([
+			'https://ethereum.example/tx/0xABC123',
+			'https://ethereum.example/tx/0xABC123'
+		]);
+		expect(addressUrl).toBe('https://ethereum.example/address/0x123ABC');
+	});
+
+	it('returns null when explorer URL or value is missing', () => {
+		// Arrange:
+		const network = { blockchain: 'symbol', explorerUrl: 'https://symbol.example' };
+
+		// Act:
+		const urls = [
+			createExplorerUrl({}, 'transaction', 'ABC123'),
+			createExplorerUrl(network, 'transaction', null)
+		];
+
+		// Assert:
+		expect(urls).toEqual([null, null]);
+	});
+});

--- a/bridge/reporting/__tests__/utils/format.test.js
+++ b/bridge/reporting/__tests__/utils/format.test.js
@@ -23,19 +23,42 @@ describe('report formatting', () => {
 		});
 	});
 
-	it('formats atomic values without losing integer precision', () => {
-		// Arrange:
-		const inputs = [
-			['100000000', 6],
-			['151458904500184', 18],
-			['999999999999999999999999', 18]
-		];
+	describe('formatAtomicAmount', () => {
+		const runFormatAtomicAmountTest = (value, divisibility, expectedOutput) => {
+			// Act:
+			const formattedAmount = formatAtomicAmount(value, divisibility);
 
-		// Act:
-		const formattedAmounts = inputs.map(([value, divisibility]) => formatAtomicAmount(value, divisibility));
+			// Assert:
+			expect(formattedAmount).toBe(expectedOutput);
+		};
 
-		// Assert:
-		expect(formattedAmounts).toEqual(['100', '0.000151458904500184', '999999.999999999999999999']);
+		it('formats atomic values without losing integer precision', () => {
+			runFormatAtomicAmountTest('100000000', 6, '100');
+			runFormatAtomicAmountTest('151458904500184', 18, '0.000151458904500184');
+			runFormatAtomicAmountTest('999999999999999999999999', 18, '999999.999999999999999999');
+		});
+
+		it('returns a placeholder when atomic value is missing', () => {
+			runFormatAtomicAmountTest(null, 6, '—');
+			runFormatAtomicAmountTest(undefined, 6, '—');
+			runFormatAtomicAmountTest('', 6, '—');
+		});
+
+		it('returns a nonnumeric atomic value unchanged', () => {
+			runFormatAtomicAmountTest('hello', 6, 'hello');
+		});
+
+		it('returns an atomic value unchanged when divisibility is zero', () => {
+			runFormatAtomicAmountTest('123', 0, '123');
+		});
+
+		it('returns an atomic value unchanged when divisibility is missing', () => {
+			// Act:
+			const formattedAmount = formatAtomicAmount('123');
+
+			// Assert:
+			expect(formattedAmount).toBe('123');
+		});
 	});
 
 	it('formats conversion rate PPM values', () => {

--- a/bridge/reporting/__tests__/utils/format.test.js
+++ b/bridge/reporting/__tests__/utils/format.test.js
@@ -1,6 +1,34 @@
-import { createExplorerUrl, formatAtomicAmount, formatPpm, formatTimestamp, truncateMiddle } from '@/utils/format';
+import {
+	createExplorerUrl,
+	formatAtomicAmount,
+	formatPpm,
+	formatTimestamp,
+	isValueMissing,
+	truncateMiddle
+} from '@/utils/format';
 
 describe('report formatting', () => {
+	describe('isValueMissing', () => {
+		const runIsValueMissingTest = (value, expectedResult) => {
+			// Act:
+			const result = isValueMissing(value);
+
+			// Assert:
+			expect(result).toBe(expectedResult);
+		};
+
+		it('returns true when value is missing', () => {
+			runIsValueMissingTest(null, true);
+			runIsValueMissingTest(undefined, true);
+		});
+
+		it('returns false when value is defined', () => {
+			runIsValueMissingTest('', false);
+			runIsValueMissingTest(0, false);
+			runIsValueMissingTest(false, false);
+		});
+	});
+
 	describe('formatTimestamp', () => {
 		const runTimestampTest = (input, expectedOutput) => {
 			// Act:

--- a/bridge/reporting/__tests__/utils/format.test.js
+++ b/bridge/reporting/__tests__/utils/format.test.js
@@ -1,4 +1,4 @@
-import { createExplorerUrl, formatAtomicAmount, formatPpm, formatTimestamp } from '@/utils/format';
+import { createExplorerUrl, formatAtomicAmount, formatPpm, formatTimestamp, truncateMiddle } from '@/utils/format';
 
 describe('report formatting', () => {
 	describe('formatTimestamp', () => {
@@ -58,6 +58,34 @@ describe('report formatting', () => {
 
 			// Assert:
 			expect(formattedAmount).toBe('123');
+		});
+	});
+
+	describe('truncateMiddle', () => {
+		const runTruncateMiddleTest = (value, expectedOutput, start, end) => {
+			// Act:
+			const truncatedValue = truncateMiddle(value, start, end);
+
+			// Assert:
+			expect(truncatedValue).toBe(expectedOutput);
+		};
+
+		it('returns a placeholder when value is missing', () => {
+			runTruncateMiddleTest(null, '—');
+			runTruncateMiddleTest(undefined, '—');
+			runTruncateMiddleTest('', '—');
+		});
+
+		it('returns a value at the maximum visible length unchanged', () => {
+			runTruncateMiddleTest('12345678901234', '12345678901234');
+		});
+
+		it('truncates a long value using default lengths', () => {
+			runTruncateMiddleTest('123456789012345', '12345678…012345');
+		});
+
+		it('truncates a long value using custom lengths', () => {
+			runTruncateMiddleTest('1234567890', '1234…890', 4, 3);
 		});
 	});
 

--- a/bridge/reporting/__tests__/utils/format.test.js
+++ b/bridge/reporting/__tests__/utils/format.test.js
@@ -100,49 +100,68 @@ describe('report formatting', () => {
 		expect(formattedRates).toEqual(['1', '0.999999', '2']);
 	});
 
-	it('creates Symbol explorer URLs', () => {
-		// Arrange:
-		const network = { blockchain: 'symbol', explorerUrl: 'https://symbol.example/' };
+	describe('createExplorerUrl', () => {
+		const runSymbolAndNemExplorerUrlTest = blockchain => {
+			// Arrange:
+			const explorerUrl = `https://${blockchain}.example`;
+			const network = { blockchain, explorerUrl: `${explorerUrl}/` };
 
-		// Act:
-		const transactionUrl = createExplorerUrl(network, 'transaction', 'ABC123');
-		const accountUrl = createExplorerUrl(network, 'address', 'TADDRESS');
+			// Act:
+			const transactionUrl = createExplorerUrl(network, 'transaction', 'ABC123');
+			const accountUrl = createExplorerUrl(network, 'address', 'TADDRESS');
 
-		// Assert:
-		expect(transactionUrl).toBe('https://symbol.example/transactions/ABC123');
-		expect(accountUrl).toBe('https://symbol.example/accounts/TADDRESS');
-	});
+			// Assert:
+			expect(transactionUrl).toBe(`${explorerUrl}/transactions/ABC123`);
+			expect(accountUrl).toBe(`${explorerUrl}/accounts/TADDRESS`);
+		};
 
-	it('creates Ethereum explorer URLs and normalizes transaction hash prefixes', () => {
-		// Arrange:
-		const network = { blockchain: 'ethereum', explorerUrl: 'https://ethereum.example/' };
+		it('creates Symbol or NEM explorer URLs', () => {
+			runSymbolAndNemExplorerUrlTest('symbol');
+			runSymbolAndNemExplorerUrlTest('nem');
+		});
 
-		// Act:
-		const transactionUrls = [
-			createExplorerUrl(network, 'transaction', 'ABC123'),
-			createExplorerUrl(network, 'transaction', '0xABC123')
-		];
-		const addressUrl = createExplorerUrl(network, 'address', '0x123ABC');
+		it('creates Ethereum explorer URLs and normalizes transaction hash prefixes', () => {
+			// Arrange:
+			const network = { blockchain: 'ethereum', explorerUrl: 'https://ethereum.example/' };
 
-		// Assert:
-		expect(transactionUrls).toEqual([
-			'https://ethereum.example/tx/0xABC123',
-			'https://ethereum.example/tx/0xABC123'
-		]);
-		expect(addressUrl).toBe('https://ethereum.example/address/0x123ABC');
-	});
+			// Act:
+			const transactionUrls = [
+				createExplorerUrl(network, 'transaction', 'ABC123'),
+				createExplorerUrl(network, 'transaction', '0xABC123')
+			];
+			const addressUrl = createExplorerUrl(network, 'address', '0x123ABC');
 
-	it('returns null when explorer URL or value is missing', () => {
-		// Arrange:
-		const network = { blockchain: 'symbol', explorerUrl: 'https://symbol.example' };
+			// Assert:
+			expect(transactionUrls).toEqual([
+				'https://ethereum.example/tx/0xABC123',
+				'https://ethereum.example/tx/0xABC123'
+			]);
+			expect(addressUrl).toBe('https://ethereum.example/address/0x123ABC');
+		});
 
-		// Act:
-		const urls = [
-			createExplorerUrl({}, 'transaction', 'ABC123'),
-			createExplorerUrl(network, 'transaction', null)
-		];
+		it('returns null when explorer URL or value is missing', () => {
+			// Arrange:
+			const network = { blockchain: 'symbol', explorerUrl: 'https://symbol.example' };
 
-		// Assert:
-		expect(urls).toEqual([null, null]);
+			// Act:
+			const urls = [
+				createExplorerUrl({}, 'transaction', 'ABC123'),
+				createExplorerUrl(network, 'transaction', null)
+			];
+
+			// Assert:
+			expect(urls).toEqual([null, null]);
+		});
+
+		it('returns null when blockchain is unsupported', () => {
+			// Arrange:
+			const network = { blockchain: 'bitcoin', explorerUrl: 'https://bitcoin.example' };
+
+			// Act:
+			const url = createExplorerUrl(network, 'transaction', 'ABC123');
+
+			// Assert:
+			expect(url).toBeNull();
+		});
 	});
 });

--- a/bridge/reporting/__tests__/utils/format.test.js
+++ b/bridge/reporting/__tests__/utils/format.test.js
@@ -129,7 +129,7 @@ describe('report formatting', () => {
 	});
 
 	describe('createExplorerUrl', () => {
-		const runSymbolAndNemExplorerUrlTest = blockchain => {
+		const runExplorerUrlTest = blockchain => {
 			// Arrange:
 			const explorerUrl = `https://${blockchain}.example`;
 			const network = { blockchain, explorerUrl: `${explorerUrl}/` };
@@ -143,9 +143,12 @@ describe('report formatting', () => {
 			expect(accountUrl).toBe(`${explorerUrl}/accounts/TADDRESS`);
 		};
 
-		it('creates Symbol or NEM explorer URLs', () => {
-			runSymbolAndNemExplorerUrlTest('symbol');
-			runSymbolAndNemExplorerUrlTest('nem');
+		it('creates Symbol explorer URLs', () => {
+			runExplorerUrlTest('symbol');
+		});
+
+		it('creates NEM explorer URLs', () => {
+			runExplorerUrlTest('nem');
 		});
 
 		it('creates Ethereum explorer URLs and normalizes transaction hash prefixes', () => {

--- a/bridge/reporting/__tests__/utils/format.test.js
+++ b/bridge/reporting/__tests__/utils/format.test.js
@@ -1,6 +1,28 @@
 import { createExplorerUrl, formatAtomicAmount, formatPpm, formatTimestamp } from '@/utils/format';
 
 describe('report formatting', () => {
+	describe('formatTimestamp', () => {
+		const runTimestampTest = (input, expectedOutput) => {
+			// Act:
+			const formattedTimestamp = formatTimestamp(input);
+
+			// Assert:
+			expect(formattedTimestamp).toBe(expectedOutput);
+		};
+
+		it('formats Unix seconds as UTC', () => {
+			runTimestampTest(1759781792.879, '2025-10-06 20:16:32 UTC');
+		});
+
+		it('returns a placeholder when timestamp is missing', () => {
+			runTimestampTest(null, '—');
+		});
+
+		it('returns a placeholder when timestamp is invalid', () => {
+			runTimestampTest('hello', '—');
+		});
+	});
+
 	it('formats atomic values without losing integer precision', () => {
 		// Arrange:
 		const inputs = [
@@ -25,17 +47,6 @@ describe('report formatting', () => {
 
 		// Assert:
 		expect(formattedRates).toEqual(['1', '0.999999', '2']);
-	});
-
-	it('formats Unix seconds as UTC', () => {
-		// Arrange:
-		const timestamps = [1759781792.879, null, 'hello'];
-
-		// Act:
-		const formattedTimestamps = timestamps.map(formatTimestamp);
-
-		// Assert:
-		expect(formattedTimestamps).toEqual(['2025-10-06 20:16:32 UTC', '—', '—']);
 	});
 
 	it('creates Symbol explorer URLs', () => {

--- a/bridge/reporting/__tests__/utils/format.test.js
+++ b/bridge/reporting/__tests__/utils/format.test.js
@@ -29,28 +29,6 @@ describe('report formatting', () => {
 		});
 	});
 
-	describe('formatTimestamp', () => {
-		const runTimestampTest = (input, expectedOutput) => {
-			// Act:
-			const formattedTimestamp = formatTimestamp(input);
-
-			// Assert:
-			expect(formattedTimestamp).toBe(expectedOutput);
-		};
-
-		it('formats Unix seconds as UTC', () => {
-			runTimestampTest(1759781792.879, '2025-10-06 20:16:32 UTC');
-		});
-
-		it('returns a placeholder when timestamp is missing', () => {
-			runTimestampTest(null, '—');
-		});
-
-		it('returns a placeholder when timestamp is invalid', () => {
-			runTimestampTest('hello', '—');
-		});
-	});
-
 	describe('formatAtomicAmount', () => {
 		const runFormatAtomicAmountTest = (value, divisibility, expectedOutput) => {
 			// Act:
@@ -89,6 +67,41 @@ describe('report formatting', () => {
 		});
 	});
 
+	describe('formatPpm', () => {
+		it('formats conversion rate PPM values', () => {
+			// Arrange:
+			const rates = ['1000000', '999999', '2000000'];
+
+			// Act:
+			const formattedRates = rates.map(formatPpm);
+
+			// Assert:
+			expect(formattedRates).toEqual(['1', '0.999999', '2']);
+		});
+	});
+
+	describe('formatTimestamp', () => {
+		const runTimestampTest = (input, expectedOutput) => {
+			// Act:
+			const formattedTimestamp = formatTimestamp(input);
+
+			// Assert:
+			expect(formattedTimestamp).toBe(expectedOutput);
+		};
+
+		it('formats Unix seconds as UTC', () => {
+			runTimestampTest(1759781792.879, '2025-10-06 20:16:32 UTC');
+		});
+
+		it('returns a placeholder when timestamp is missing', () => {
+			runTimestampTest(null, '—');
+		});
+
+		it('returns a placeholder when timestamp is invalid', () => {
+			runTimestampTest('hello', '—');
+		});
+	});
+
 	describe('truncateMiddle', () => {
 		const runTruncateMiddleTest = (value, expectedOutput, start, end) => {
 			// Act:
@@ -115,17 +128,6 @@ describe('report formatting', () => {
 		it('truncates a long value using custom lengths', () => {
 			runTruncateMiddleTest('1234567890', '1234…890', 4, 3);
 		});
-	});
-
-	it('formats conversion rate PPM values', () => {
-		// Arrange:
-		const rates = ['1000000', '999999', '2000000'];
-
-		// Act:
-		const formattedRates = rates.map(formatPpm);
-
-		// Assert:
-		expect(formattedRates).toEqual(['1', '0.999999', '2']);
 	});
 
 	describe('createExplorerUrl', () => {

--- a/bridge/reporting/components/ReportPanel.jsx
+++ b/bridge/reporting/components/ReportPanel.jsx
@@ -3,8 +3,8 @@ import styles from '@/styles/ReportPanel.module.css';
 import { parseSearchInput } from '@/utils/validation';
 import { useRef, useState } from 'react';
 
-const createDefaultCriteria = tab => ({
-	baseUrl: tab.baseUrl,
+const createDefaultCriteria = (tab, baseUrl) => ({
+	baseUrl,
 	operation: tab.operation,
 	resource: tab.resource,
 	limit: PAGE_SIZE,
@@ -13,10 +13,10 @@ const createDefaultCriteria = tab => ({
 	sort: 0
 });
 
-const ReportPanel = ({ tab, isActive }) => {
+const ReportPanel = ({ tab, isActive, baseUrl }) => {
 	const [searchInput, setSearchInput] = useState('');
 	const [validationError, setValidationError] = useState('');
-	const [criteria, setCriteria] = useState(() => createDefaultCriteria(tab));
+	const [criteria, setCriteria] = useState(() => createDefaultCriteria(tab, baseUrl));
 	const criteriaRef = useRef(criteria);
 
 	const updateCriteria = nextCriteria => {

--- a/bridge/reporting/components/ReportTable.jsx
+++ b/bridge/reporting/components/ReportTable.jsx
@@ -1,0 +1,254 @@
+import { PAYOUT_STATUS_DETAILS } from '@/constants';
+import styles from '@/styles/ReportTable.module.css';
+import { createExplorerUrl, formatAtomicAmount, formatPpm, formatTimestamp, truncateMiddle } from '@/utils/format';
+
+const StatusBadge = ({ status, errorMessage }) => {
+	const details = PAYOUT_STATUS_DETAILS[status] || { label: 'Unknown', tone: 'neutral' };
+	const className = `${styles.statusBadge} ${styles[`status_${details.tone}`]}`;
+
+	if (!errorMessage)
+		return <span className={className}>{details.label}</span>;
+
+	return (
+		<span
+			aria-label={`${details.label}: ${errorMessage}`}
+			className={`${className} ${styles.statusWithTooltip}`}
+			data-tooltip={errorMessage}
+			tabIndex="0"
+		>
+			{details.label}
+		</span>
+	);
+};
+
+const ExternalValue = ({ network, type, value, truncateType = 'default' }) => {
+	const url = createExplorerUrl(network, type, value);
+	const label = 'hash' === truncateType ? truncateMiddle(value, 8, 6) : truncateMiddle(value, 9, 6);
+
+	if (!url)
+		return <span title={value || ''}>{label}</span>;
+
+	return (
+		<a className={styles.externalValue} href={url} rel="noreferrer" target="_blank" title={value}>
+			{label}
+			<span aria-hidden="true" className={styles.externalMark}>↗</span>
+		</a>
+	);
+};
+
+const TransactionValue = ({ hash, timestamp, network }) => (
+	<div className={styles.transactionValue}>
+		<span className={styles.timestamp}>{formatTimestamp(timestamp)}</span>
+		<ExternalValue network={network} type="transaction" value={hash} truncateType="hash" />
+	</div>
+);
+
+const AmountValue = ({ value, asset }) => (
+	<div className={styles.amountValue} title={value ?? ''}>
+		<span>{formatAtomicAmount(value, asset.divisibility)}</span>
+		{null !== value && value !== undefined && <small>{asset.ticker}</small>}
+	</div>
+);
+
+const RateValue = ({ value }) => (
+	<span className={styles.rateValue} title={null === value || value === undefined ? '' : `${value} PPM`}>
+		{formatPpm(value)}
+	</span>
+);
+
+const SortHeader = ({ sort, onSortChange }) => (
+	<button
+		aria-label={`Sort by request block height ${0 === sort ? 'ascending' : 'descending'}`}
+		className={styles.sortButton}
+		onClick={onSortChange}
+		title="Sorted by request block height"
+		type="button"
+	>
+		Request hash
+		<span aria-hidden="true">{0 === sort ? '↓' : '↑'}</span>
+	</button>
+);
+
+const RequestRow = ({ row, tab, configuration }) => {
+	const sourceNetwork = configuration?.[tab.sourceNetwork];
+	const destinationNetwork = configuration?.[tab.destinationNetwork];
+
+	return (
+		<tr>
+			<td><StatusBadge status={row.payoutStatus} errorMessage={row.errorMessage} /></td>
+			<td><ExternalValue network={sourceNetwork} type="address" value={row.senderAddress} /></td>
+			<td><TransactionValue hash={row.requestTransactionHash} timestamp={row.requestTimestamp} network={sourceNetwork} /></td>
+			<td><AmountValue value={row.requestAmount} asset={tab.sourceAsset} /></td>
+			<td><ExternalValue network={destinationNetwork} type="address" value={row.destinationAddress} /></td>
+			<td><TransactionValue hash={row.payoutTransactionHash} timestamp={row.payoutTimestamp} network={destinationNetwork} /></td>
+			<td><RateValue value={row.payoutConversionRate} /></td>
+			<td><AmountValue value={row.payoutTotalFee} asset={tab.destinationAsset} /></td>
+			<td><AmountValue value={row.payoutNetAmount} asset={tab.destinationAsset} /></td>
+		</tr>
+	);
+};
+
+const ErrorRow = ({ row, tab, configuration }) => {
+	const sourceNetwork = configuration?.[tab.sourceNetwork];
+	return (
+		<tr>
+			<td><ExternalValue network={sourceNetwork} type="address" value={row.senderAddress} /></td>
+			<td><TransactionValue hash={row.requestTransactionHash} timestamp={row.requestTimestamp} network={sourceNetwork} /></td>
+			<td className={styles.errorMessage}>{row.errorMessage || '—'}</td>
+		</tr>
+	);
+};
+
+const MobileField = ({ label, children, wide }) => (
+	<div className={`${styles.mobileField} ${wide ? styles.mobileFieldWide : ''}`}>
+		<dt>{label}</dt>
+		<dd>{children}</dd>
+	</div>
+);
+
+const RequestCard = ({ row, tab, configuration }) => {
+	const sourceNetwork = configuration?.[tab.sourceNetwork];
+	const destinationNetwork = configuration?.[tab.destinationNetwork];
+	return (
+		<article className={styles.mobileCard}>
+			<div className={styles.mobileCardTop}>
+				<span className={styles.mobileRowId}>#{row.requestTransactionHeight}</span>
+				<StatusBadge status={row.payoutStatus} errorMessage={row.errorMessage} />
+			</div>
+			<dl className={styles.mobileGrid}>
+				<MobileField label="Sender">
+					<ExternalValue network={sourceNetwork} type="address" value={row.senderAddress} />
+				</MobileField>
+				<MobileField label="Request" wide>
+					<TransactionValue
+						hash={row.requestTransactionHash}
+						network={sourceNetwork}
+						timestamp={row.requestTimestamp}
+					/>
+				</MobileField>
+				<MobileField label="Request amount">
+					<AmountValue asset={tab.sourceAsset} value={row.requestAmount} />
+				</MobileField>
+				<MobileField label="Payout Address">
+					<ExternalValue network={destinationNetwork} type="address" value={row.destinationAddress} />
+				</MobileField>
+				<MobileField label="Payout" wide>
+					<TransactionValue
+						hash={row.payoutTransactionHash}
+						network={destinationNetwork}
+						timestamp={row.payoutTimestamp}
+					/>
+				</MobileField>
+				<MobileField label="Rate">
+					<RateValue value={row.payoutConversionRate} />
+				</MobileField>
+				<MobileField label="Fee">
+					<AmountValue asset={tab.destinationAsset} value={row.payoutTotalFee} />
+				</MobileField>
+				<MobileField label="Payout amount">
+					<AmountValue asset={tab.destinationAsset} value={row.payoutNetAmount} />
+				</MobileField>
+			</dl>
+		</article>
+	);
+};
+
+const ErrorCard = ({ row, tab, configuration }) => {
+	const sourceNetwork = configuration?.[tab.sourceNetwork];
+	return (
+		<article className={styles.mobileCard}>
+			<div className={styles.mobileCardTop}>
+				<span className={styles.mobileRowId}>#{row.requestTransactionHeight}</span>
+				<span className={`${styles.statusBadge} ${styles.status_danger}`}>Error</span>
+			</div>
+			<dl className={styles.mobileGrid}>
+				<MobileField label="Sender">
+					<ExternalValue network={sourceNetwork} type="address" value={row.senderAddress} />
+				</MobileField>
+				<MobileField label="Request" wide>
+					<TransactionValue
+						hash={row.requestTransactionHash}
+						network={sourceNetwork}
+						timestamp={row.requestTimestamp}
+					/>
+				</MobileField>
+				<MobileField label="Error message" wide>{row.errorMessage || '—'}</MobileField>
+			</dl>
+		</article>
+	);
+};
+
+const ReportTable = ({ rows, tab, configuration, sort, onSortChange }) => {
+	const isRequests = 'requests' === tab.resource;
+	return (
+		<>
+			<table className={`${styles.table} ${isRequests ? styles.requestTable : styles.errorTable}`}>
+				<thead>
+					{isRequests ? (
+						<tr>
+							<th>Payout status</th>
+							<th>Sender address</th>
+							<th aria-sort={0 === sort ? 'descending' : 'ascending'}>
+								<SortHeader onSortChange={onSortChange} sort={sort} />
+							</th>
+							<th>Request amount</th>
+							<th>Payout address</th>
+							<th>Payout hash</th>
+							<th>Conversion rate</th>
+							<th>Payout fee</th>
+							<th>Payout amount</th>
+						</tr>
+					) : (
+						<tr>
+							<th>Sender address</th>
+							<th aria-sort={0 === sort ? 'descending' : 'ascending'}>
+								<SortHeader onSortChange={onSortChange} sort={sort} />
+							</th>
+							<th>Error message</th>
+						</tr>
+					)}
+				</thead>
+				<tbody>
+					{rows.map(row => isRequests
+						? (
+							<RequestRow
+								configuration={configuration}
+								key={`${row.requestTransactionHash}-${row.requestTransactionSubindex}`}
+								row={row}
+								tab={tab}
+							/>
+						)
+						: (
+							<ErrorRow
+								configuration={configuration}
+								key={`${row.requestTransactionHash}-${row.requestTransactionSubindex}`}
+								row={row}
+								tab={tab}
+							/>
+						))}
+				</tbody>
+			</table>
+			<div className={styles.mobileList}>
+				{rows.map(row => isRequests
+					? (
+						<RequestCard
+							configuration={configuration}
+							key={`${row.requestTransactionHash}-${row.requestTransactionSubindex}`}
+							row={row}
+							tab={tab}
+						/>
+					)
+					: (
+						<ErrorCard
+							configuration={configuration}
+							key={`${row.requestTransactionHash}-${row.requestTransactionSubindex}`}
+							row={row}
+							tab={tab}
+						/>
+					))}
+			</div>
+		</>
+	);
+};
+
+export default ReportTable;

--- a/bridge/reporting/components/ReportTable.jsx
+++ b/bridge/reporting/components/ReportTable.jsx
@@ -53,7 +53,7 @@ const TransactionValue = ({ hash, timestamp, network }) => (
 const AmountValue = ({ value, asset }) => (
 	<div className={styles.amountValue} title={value ?? ''}>
 		<span>{formatAtomicAmount(value, asset.divisibility)}</span>
-		{null !== value && value !== undefined && <small>{asset.ticker}</small>}
+		{!isValueMissing(value) && <small>{asset.ticker}</small>}
 	</div>
 );
 

--- a/bridge/reporting/components/ReportTable.jsx
+++ b/bridge/reporting/components/ReportTable.jsx
@@ -1,6 +1,13 @@
 import { PAYOUT_STATUS_DETAILS } from '@/constants';
 import styles from '@/styles/ReportTable.module.css';
-import { createExplorerUrl, formatAtomicAmount, formatPpm, formatTimestamp, truncateMiddle } from '@/utils/format';
+import {
+	createExplorerUrl,
+	formatAtomicAmount,
+	formatPpm,
+	formatTimestamp,
+	isValueMissing,
+	truncateMiddle
+} from '@/utils/format';
 
 const StatusBadge = ({ status, errorMessage }) => {
 	const details = PAYOUT_STATUS_DETAILS[status] || { label: 'Unknown', tone: 'neutral' };
@@ -51,7 +58,7 @@ const AmountValue = ({ value, asset }) => (
 );
 
 const RateValue = ({ value }) => (
-	<span className={styles.rateValue} title={null === value || value === undefined ? '' : `${value} PPM`}>
+	<span className={styles.rateValue} title={isValueMissing(value) ? '' : `${value} PPM`}>
 		{formatPpm(value)}
 	</span>
 );

--- a/bridge/reporting/constants/index.js
+++ b/bridge/reporting/constants/index.js
@@ -69,3 +69,10 @@ export const PAYOUT_STATUS_OPTIONS = [
 	{ label: 'Completed', value: PAYOUT_STATUS.COMPLETED },
 	{ label: 'Failed', value: PAYOUT_STATUS.FAILED }
 ];
+
+export const PAYOUT_STATUS_DETAILS = {
+	[PAYOUT_STATUS.UNPROCESSED]: { label: 'Unprocessed', tone: 'neutral' },
+	[PAYOUT_STATUS.SENT]: { label: 'Sent', tone: 'info' },
+	[PAYOUT_STATUS.COMPLETED]: { label: 'Completed', tone: 'success' },
+	[PAYOUT_STATUS.FAILED]: { label: 'Failed', tone: 'danger' }
+};

--- a/bridge/reporting/pages/index.jsx
+++ b/bridge/reporting/pages/index.jsx
@@ -1,6 +1,7 @@
 import { fetchBridgeConfiguration } from '@/api/bridge';
 import ReportPanel from '@/components/ReportPanel';
 import ReportTabs from '@/components/ReportTabs';
+import config from '@/config';
 import { BRIDGE_TABS } from '@/constants';
 import styles from '@/styles/Home.module.css';
 import Head from 'next/head';
@@ -12,12 +13,16 @@ export const getServerSideProps = async () => {
 
 	return {
 		props: {
+			bridgeBaseUrls: {
+				native: config.PUBLIC_BRIDGE_NATIVE_URL,
+				wrapped: config.PUBLIC_BRIDGE_WRAPPED_URL
+			},
 			bridgeConfigurations
 		}
 	};
 };
 
-export const Home = ({ bridgeConfigurations }) => {
+export const Home = ({ bridgeBaseUrls, bridgeConfigurations }) => {
 	const [activeTabId, setActiveTabId] = useState(BRIDGE_TABS[0].id);
 	const activeTab = BRIDGE_TABS.find(tab => tab.id === activeTabId);
 	const bridgeTypes = [...new Set(BRIDGE_TABS.map(tab => tab.bridgeType))];
@@ -54,6 +59,7 @@ export const Home = ({ bridgeConfigurations }) => {
 				<div className={styles.panelStack}>
 					{BRIDGE_TABS.map(tab => (
 						<ReportPanel
+							baseUrl={bridgeBaseUrls[tab.bridgeType]}
 							isActive={tab.id === activeTabId}
 							key={tab.id}
 							tab={tab}

--- a/bridge/reporting/styles/ReportTable.module.css
+++ b/bridge/reporting/styles/ReportTable.module.css
@@ -1,0 +1,248 @@
+.table {
+	width: 100%;
+	color: var(--color-text);
+	font: 700 11px/1.45 var(--font-data);
+	border-collapse: separate;
+	border-spacing: 0;
+	table-layout: fixed;
+}
+
+.requestTable {
+	min-width: 1480px;
+}
+
+.errorTable {
+	min-width: 880px;
+}
+
+.table thead {
+	position: sticky;
+	top: 0;
+	z-index: 5;
+}
+
+.table th {
+	height: 40px;
+	padding: 0 12px;
+	color: var(--color-muted);
+	font: 700 9px/1 var(--font-data);
+	letter-spacing: 0.09em;
+	text-align: left;
+	text-transform: uppercase;
+	background: #1b1527;
+	border-bottom: 1px solid var(--color-line);
+}
+
+.requestTable th:nth-child(1) { width: 118px; }
+.requestTable th:nth-child(2) { width: 170px; }
+.requestTable th:nth-child(3) { width: 205px; }
+.requestTable th:nth-child(4) { width: 130px; }
+.requestTable th:nth-child(5) { width: 170px; }
+.requestTable th:nth-child(6) { width: 205px; }
+.requestTable th:nth-child(7) { width: 115px; }
+.requestTable th:nth-child(8) { width: 130px; }
+.requestTable th:nth-child(9) { width: 140px; }
+.errorTable th:nth-child(1) { width: 220px; }
+.errorTable th:nth-child(2) { width: 250px; }
+
+.table td {
+	height: 52px;
+	padding: 8px 12px;
+	vertical-align: middle;
+	background: rgba(34, 28, 49, 0.62);
+	border-bottom: 1px solid #342d42;
+}
+
+.table tbody tr:nth-child(even) td {
+	background: rgba(25, 19, 36, 0.88);
+}
+
+.table tbody tr:hover td {
+	background: #30283e;
+}
+
+.sortButton {
+	display: flex;
+	gap: 8px;
+	align-items: center;
+	padding: 0;
+	color: inherit;
+	font: inherit;
+	letter-spacing: inherit;
+	text-transform: inherit;
+	background: transparent;
+	border: 0;
+	cursor: pointer;
+}
+
+.sortButton span {
+	color: var(--color-cyan);
+	font-size: 13px;
+}
+
+.statusBadge {
+	position: relative;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 82px;
+	height: 24px;
+	padding: 0 10px;
+	font: 700 9px/1 var(--font-data);
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	border: 1px solid currentColor;
+	border-radius: 999px;
+}
+
+.status_neutral { color: #a6a0ac; background: rgba(166, 160, 172, 0.1); }
+.status_info { color: var(--color-cyan); background: rgba(38, 195, 242, 0.1); }
+.status_success { color: var(--color-success); background: rgba(139, 224, 160, 0.1); }
+.status_danger { color: var(--color-danger); background: rgba(255, 146, 157, 0.1); }
+
+.statusWithTooltip {
+	cursor: help;
+}
+
+.statusWithTooltip::after {
+	position: absolute;
+	bottom: calc(100% + 9px);
+	left: 0;
+	z-index: 20;
+	display: none;
+	width: max-content;
+	max-width: 280px;
+	padding: 9px 11px;
+	color: var(--color-text);
+	font: 400 11px/1.4 var(--font-body);
+	letter-spacing: 0;
+	text-align: left;
+	text-transform: none;
+	background: #06000d;
+	border: 1px solid var(--color-danger);
+	box-shadow: 0 10px 30px rgba(0, 0, 0, 0.45);
+	content: attr(data-tooltip);
+}
+
+.statusWithTooltip:hover::after,
+.statusWithTooltip:focus::after {
+	display: block;
+}
+
+.externalValue {
+	display: inline-flex;
+	gap: 5px;
+	align-items: center;
+	max-width: 100%;
+	overflow: hidden;
+	color: #bcecff;
+	text-decoration: none;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.externalValue:hover {
+	color: var(--color-cyan);
+	text-decoration: underline;
+}
+
+.externalMark {
+	color: var(--color-purple);
+	font-size: 9px;
+}
+
+.transactionValue,
+.amountValue {
+	display: flex;
+	flex-direction: column;
+	gap: 3px;
+}
+
+.timestamp,
+.amountValue small {
+	color: var(--color-muted);
+	font: 400 9px/1.2 var(--font-body);
+}
+
+.amountValue span,
+.rateValue {
+	font-variant-numeric: tabular-nums;
+}
+
+.amountValue small {
+	color: var(--color-purple);
+	font-family: var(--font-data);
+}
+
+.errorMessage {
+	color: #ffd8dc;
+	font-family: var(--font-body);
+	font-weight: 400;
+}
+
+.mobileList {
+	display: none;
+}
+
+@media (max-width: 700px) {
+	.table {
+		display: none;
+	}
+
+	.mobileList {
+		display: flex;
+		flex-direction: column;
+		gap: 10px;
+		padding: 10px;
+	}
+
+	.mobileCard {
+		padding: 12px;
+		background: var(--color-surface);
+		border: 1px solid var(--color-line);
+		border-left: 2px solid var(--color-purple);
+	}
+
+	.mobileCardTop {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		margin-bottom: 12px;
+		padding-bottom: 9px;
+		border-bottom: 1px solid var(--color-line);
+	}
+
+	.mobileRowId {
+		color: var(--color-muted);
+		font: 700 9px/1 var(--font-data);
+	}
+
+	.mobileGrid {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 14px 12px;
+		margin: 0;
+	}
+
+	.mobileField {
+		min-width: 0;
+	}
+
+	.mobileFieldWide {
+		grid-column: 1 / -1;
+	}
+
+	.mobileField dt {
+		margin-bottom: 4px;
+		color: var(--color-muted);
+		font: 700 8px/1 var(--font-data);
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+	}
+
+	.mobileField dd {
+		min-width: 0;
+		margin: 0;
+		font: 700 11px/1.4 var(--font-data);
+	}
+}

--- a/bridge/reporting/utils/format.js
+++ b/bridge/reporting/utils/format.js
@@ -1,5 +1,7 @@
+export const isValueMissing = value => null === value || value === undefined;
+
 export const formatAtomicAmount = (value, divisibility) => {
-	if (null === value || value === undefined || '' === value)
+	if (isValueMissing(value) || '' === value)
 		return '—';
 
 	const digits = String(value);
@@ -20,7 +22,7 @@ export const formatAtomicAmount = (value, divisibility) => {
 export const formatPpm = value => formatAtomicAmount(value, 6);
 
 export const formatTimestamp = value => {
-	if (null === value || value === undefined)
+	if (isValueMissing(value))
 		return '—';
 
 	const date = new Date(Number(value) * 1000);

--- a/bridge/reporting/utils/format.js
+++ b/bridge/reporting/utils/format.js
@@ -49,5 +49,8 @@ export const createExplorerUrl = (network, type, value) => {
 		return `${baseUrl}/${path}/${normalizedValue}`;
 	}
 
-	return `${baseUrl}/${'transaction' === type ? 'transactions' : 'accounts'}/${value}`;
+	if ('symbol' === network.blockchain || 'nem' === network.blockchain)
+		return `${baseUrl}/${'transaction' === type ? 'transactions' : 'accounts'}/${value}`;
+
+	return null;
 };

--- a/bridge/reporting/utils/format.js
+++ b/bridge/reporting/utils/format.js
@@ -1,0 +1,53 @@
+export const formatAtomicAmount = (value, divisibility) => {
+	if (null === value || value === undefined || '' === value)
+		return '—';
+
+	const digits = String(value);
+
+	if (!/^\d+$/.test(digits))
+		return digits;
+
+	if (!divisibility)
+		return digits;
+
+	const padded = digits.padStart(divisibility + 1, '0');
+	const whole = padded.slice(0, -divisibility);
+	const fraction = padded.slice(-divisibility).replace(/0+$/, '');
+
+	return `${whole}${fraction ? `.${fraction}` : ''}`;
+};
+
+export const formatPpm = value => formatAtomicAmount(value, 6);
+
+export const formatTimestamp = value => {
+	if (null === value || value === undefined)
+		return '—';
+
+	const date = new Date(Number(value) * 1000);
+	if (Number.isNaN(date.getTime()))
+		return '—';
+
+	return `${date.toISOString().slice(0, 19).replace('T', ' ')} UTC`;
+};
+
+export const truncateMiddle = (value, start = 8, end = 6) => {
+	if (!value)
+		return '—';
+
+	const text = String(value);
+	return text.length <= start + end ? text : `${text.slice(0, start)}…${text.slice(-end)}`;
+};
+
+export const createExplorerUrl = (network, type, value) => {
+	if (!network?.explorerUrl || !value)
+		return null;
+
+	const baseUrl = network.explorerUrl.replace(/\/$/, '');
+	if ('ethereum' === network.blockchain) {
+		const path = 'transaction' === type ? 'tx' : 'address';
+		const normalizedValue = 'transaction' === type ? `0x${value.replace(/^0x/i, '')}` : value;
+		return `${baseUrl}/${path}/${normalizedValue}`;
+	}
+
+	return `${baseUrl}/${'transaction' === type ? 'transactions' : 'accounts'}/${value}`;
+};


### PR DESCRIPTION
Problem: The bridge reporting UI lacked a table component for displaying request and error data.

Solution: 
- Added responsive report tables with the required columns and formatting utilities for amounts, conversion rates, timestamps, addresses, and transaction hashes. 
- Added tests covering rendering, sorting, explorer links, payout statuses, and mobile layouts.