### PR TITLE
[lightapi/python] feat: Added prevBlockHash in block data

### DIFF
--- a/lightapi/python/symbollightapi/connector/NemConnector.py
+++ b/lightapi/python/symbollightapi/connector/NemConnector.py
@@ -365,7 +365,8 @@ class NemConnector(BasicConnector):
 			Address(block_json['beneficiary']),
 			PublicKey(block['signer']),
 			block['signature'],
-			size
+			size,
+			block['prevBlockHash']['data']
 		)
 
 	@staticmethod

--- a/lightapi/python/symbollightapi/model/Block.py
+++ b/lightapi/python/symbollightapi/model/Block.py
@@ -1,7 +1,20 @@
 class Block:  # pylint: disable=too-many-instance-attributes
 	"""Block model."""
 
-	def __init__(self, height, timestamp, transactions, difficulty, block_hash, total_fee, beneficiary, signer, signature, size):
+	def __init__(
+		self,
+		height,
+		timestamp,
+		transactions,
+		difficulty,
+		block_hash,
+		total_fee,
+		beneficiary,
+		signer,
+		signature,
+		size,
+		previous_block_hash
+	):
 		"""Create a Block model."""
 
 		# pylint: disable=too-many-arguments,too-many-positional-arguments
@@ -11,6 +24,7 @@ class Block:  # pylint: disable=too-many-instance-attributes
 		self.transactions = transactions
 		self.difficulty = difficulty
 		self.block_hash = block_hash
+		self.previous_block_hash = previous_block_hash
 		self.total_fee = total_fee
 		self.beneficiary = beneficiary
 		self.signer = signer
@@ -24,6 +38,7 @@ class Block:  # pylint: disable=too-many-instance-attributes
 			self.transactions == other.transactions,
 			self.difficulty == other.difficulty,
 			self.block_hash == other.block_hash,
+			self.previous_block_hash == other.previous_block_hash,
 			self.total_fee == other.total_fee,
 			self.beneficiary == other.beneficiary,
 			self.signer == other.signer,

--- a/lightapi/python/symbollightapi/model/Block.py
+++ b/lightapi/python/symbollightapi/model/Block.py
@@ -24,12 +24,12 @@ class Block:  # pylint: disable=too-many-instance-attributes
 		self.transactions = transactions
 		self.difficulty = difficulty
 		self.block_hash = block_hash
-		self.previous_block_hash = previous_block_hash
 		self.total_fee = total_fee
 		self.beneficiary = beneficiary
 		self.signer = signer
 		self.signature = signature
 		self.size = size
+		self.previous_block_hash = previous_block_hash
 
 	def __eq__(self, other):
 		return isinstance(other, Block) and all([
@@ -38,10 +38,10 @@ class Block:  # pylint: disable=too-many-instance-attributes
 			self.transactions == other.transactions,
 			self.difficulty == other.difficulty,
 			self.block_hash == other.block_hash,
-			self.previous_block_hash == other.previous_block_hash,
 			self.total_fee == other.total_fee,
 			self.beneficiary == other.beneficiary,
 			self.signer == other.signer,
 			self.signature == other.signature,
-			self.size == other.size
+			self.size == other.size,
+			self.previous_block_hash == other.previous_block_hash
 		])

--- a/lightapi/python/tests/connector/test_NemConnector.py
+++ b/lightapi/python/tests/connector/test_NemConnector.py
@@ -1393,7 +1393,8 @@ EXPECTED_BLOCK_2 = Block(
 		'fdf6a9830e9320af79123f467fcb03d6beab735575ff50eab363d812c5581436'
 		'2ad7be0503db2ee70e60ac3408d83cdbcbd941067a6df703e0c21c7bf389f105'
 	),
-	2052
+	2052,
+	'438cf6375dab5a0d32f9b7bf151d4539e00a590f7c022d5572c7d41815a24be4'
 )
 
 
@@ -1423,7 +1424,8 @@ async def test_can_query_blocks_after(server):  # pylint: disable=redefined-oute
 			'919ae66a34119b49812b335827b357f86884ab08b628029fd6e8db3572faeb4f'
 			'323a7bf9488c76ef8faa5b513036bbcce2d949ba3e41086d95a54c0007403c0b'
 		),
-		168
+		168,
+		'1dd9d4d7b6af603d29c082f9aa4e123f07d18154ddbcd7ddc6702491b854c5e4'
 	) == blocks[1]
 
 # endregion

--- a/lightapi/python/tests/model/test_Block.py
+++ b/lightapi/python/tests/model/test_Block.py
@@ -41,7 +41,6 @@ class BlockTest(unittest.TestCase):
 		self.assertEqual([], block.transactions)
 		self.assertEqual(90000000000000, block.difficulty)
 		self.assertEqual('a785cac7259bdd4cf423fd1079cbe0e24e119958a8075f302f9e17a1c407abe0', block.block_hash)
-		self.assertEqual('438cf6375dab5a0d32f9b7bf151d4539e00a590f7c022d5572c7d41815a24be4', block.previous_block_hash)
 		self.assertEqual(0, block.total_fee)
 		self.assertEqual(Address('TCJLCZSOQ6RGWHTPSV2DW467WZSHK4NBSITND4OF'), block.beneficiary)
 		self.assertEqual(PublicKey('7e6d6a11c4a79f6eb1f0e3489fd683a9381c8e1bef6bcaedbbc9f03c70b65a57'), block.signer)
@@ -51,6 +50,7 @@ class BlockTest(unittest.TestCase):
 				'e0037c08e1994bc07adc4f790bcb09c1d727066b0308463e406e175572c4150a'
 			), block.signature)
 		self.assertEqual(888, block.size)
+		self.assertEqual('438cf6375dab5a0d32f9b7bf151d4539e00a590f7c022d5572c7d41815a24be4', block.previous_block_hash)
 
 	def test_eq_is_supported(self):
 		# Arrange:
@@ -65,9 +65,9 @@ class BlockTest(unittest.TestCase):
 		self.assertNotEqual(block, self._create_default_block(('transactions', [1, 2, 3])))
 		self.assertNotEqual(block, self._create_default_block(('difficulty', 10000)))
 		self.assertNotEqual(block, self._create_default_block(('block_hash', 'invalid hash')))
-		self.assertNotEqual(block, self._create_default_block(('previous_block_hash', 'invalid hash')))
 		self.assertNotEqual(block, self._create_default_block(('total_fee', 5000)))
 		self.assertNotEqual(block, self._create_default_block(('beneficiary', 'invalid beneficiary')))
 		self.assertNotEqual(block, self._create_default_block(('signer', 'invalid signer')))
 		self.assertNotEqual(block, self._create_default_block(('signature', 'invalid signature')))
 		self.assertNotEqual(block, self._create_default_block(('size', 123)))
+		self.assertNotEqual(block, self._create_default_block(('previous_block_hash', 'invalid hash')))

--- a/lightapi/python/tests/model/test_Block.py
+++ b/lightapi/python/tests/model/test_Block.py
@@ -22,7 +22,8 @@ class BlockTest(unittest.TestCase):
 				'a4bbf324a3480f58c2d15bdb15d0232da94db9519d5b727a3ea12c11cc11d368'
 				'e0037c08e1994bc07adc4f790bcb09c1d727066b0308463e406e175572c4150a'
 			),
-			888
+			888,
+			'438cf6375dab5a0d32f9b7bf151d4539e00a590f7c022d5572c7d41815a24be4'
 		)
 
 		if override:
@@ -40,6 +41,7 @@ class BlockTest(unittest.TestCase):
 		self.assertEqual([], block.transactions)
 		self.assertEqual(90000000000000, block.difficulty)
 		self.assertEqual('a785cac7259bdd4cf423fd1079cbe0e24e119958a8075f302f9e17a1c407abe0', block.block_hash)
+		self.assertEqual('438cf6375dab5a0d32f9b7bf151d4539e00a590f7c022d5572c7d41815a24be4', block.previous_block_hash)
 		self.assertEqual(0, block.total_fee)
 		self.assertEqual(Address('TCJLCZSOQ6RGWHTPSV2DW467WZSHK4NBSITND4OF'), block.beneficiary)
 		self.assertEqual(PublicKey('7e6d6a11c4a79f6eb1f0e3489fd683a9381c8e1bef6bcaedbbc9f03c70b65a57'), block.signer)
@@ -63,6 +65,7 @@ class BlockTest(unittest.TestCase):
 		self.assertNotEqual(block, self._create_default_block(('transactions', [1, 2, 3])))
 		self.assertNotEqual(block, self._create_default_block(('difficulty', 10000)))
 		self.assertNotEqual(block, self._create_default_block(('block_hash', 'invalid hash')))
+		self.assertNotEqual(block, self._create_default_block(('previous_block_hash', 'invalid hash')))
 		self.assertNotEqual(block, self._create_default_block(('total_fee', 5000)))
 		self.assertNotEqual(block, self._create_default_block(('beneficiary', 'invalid beneficiary')))
 		self.assertNotEqual(block, self._create_default_block(('signer', 'invalid signer')))


### PR DESCRIPTION
Problem: missing previous block hash in block information. It need in the NEM Explorer rollback.
Solution: Added the `previous_block_hash` field.