### PR TITLE
[explorer/puller] fix: add timestamps to NEM workflow logs

### DIFF
--- a/explorer/puller/puller/workflows/log_utils.py
+++ b/explorer/puller/puller/workflows/log_utils.py
@@ -1,0 +1,12 @@
+import logging
+
+from zenlog import log
+
+LOG_FORMAT = '  %(asctime)s | %(styledname)-8s | %(message)s'
+LOG_DATE_FORMAT = '%Y-%m-%d %H:%M:%S'
+
+
+def configure_logging():
+	"""Replaces the colorized zenlog output format with a timestamped plain text one."""
+
+	log.stream.setFormatter(logging.Formatter(LOG_FORMAT, LOG_DATE_FORMAT))

--- a/explorer/puller/puller/workflows/nem_workflow_utils.py
+++ b/explorer/puller/puller/workflows/nem_workflow_utils.py
@@ -1,0 +1,25 @@
+from zenlog import log
+
+from puller.facade.NemPuller import NemPuller
+from puller.workflows.log_utils import configure_logging
+
+
+def add_common_arguments(parser):
+	"""Adds the common NEM workflow command-line arguments."""
+
+	parser.add_argument('--nem-node', help='NEM node(local) url', default='http://localhost:7890')
+	parser.add_argument('--network', help='mainnet or testnet', choices=['mainnet', 'testnet'], default='mainnet')
+	parser.add_argument('--db-config', help='database config file *.ini', default='config.ini')
+
+
+def bootstrap_nem_workflow(args):
+	"""Configures workflow logging and creates a NEM puller for parsed command arguments."""
+
+	configure_logging()
+
+	facade = NemPuller(args.nem_node, args.db_config, args.network)
+
+	log.info(f'Node URL: {args.nem_node}')
+	log.info(f'Network: {args.network}')
+
+	return facade

--- a/explorer/puller/puller/workflows/refresh_nem_accounts.py
+++ b/explorer/puller/puller/workflows/refresh_nem_accounts.py
@@ -4,6 +4,7 @@ from asyncio import run
 from zenlog import log
 
 from puller.facade.NemPuller import NemPuller
+from puller.workflows.log_utils import configure_logging
 
 
 def parse_args():
@@ -23,6 +24,8 @@ def parse_args():
 
 
 async def main():
+	configure_logging()
+
 	args = parse_args()
 
 	facade = NemPuller(args.nem_node, args.db_config, args.network)

--- a/explorer/puller/puller/workflows/refresh_nem_accounts.py
+++ b/explorer/puller/puller/workflows/refresh_nem_accounts.py
@@ -3,17 +3,14 @@ from asyncio import run
 
 from zenlog import log
 
-from puller.facade.NemPuller import NemPuller
-from puller.workflows.log_utils import configure_logging
+from puller.workflows.nem_workflow_utils import add_common_arguments, bootstrap_nem_workflow
 
 
 def parse_args():
 	"""Parse command line arguments."""
 
 	parser = argparse.ArgumentParser(description='refresh NEM account vested balance and importance')
-	parser.add_argument('--nem-node', help='NEM node(local) url', default='http://localhost:7890')
-	parser.add_argument('--network', help='mainnet or testnet', choices=['mainnet', 'testnet'], default='mainnet')
-	parser.add_argument('--db-config', help='database config file *.ini', default='config.ini')
+	add_common_arguments(parser)
 	parser.add_argument('--batch-size', help='number of accounts to refresh per database batch', type=int, default=500)
 
 	args = parser.parse_args()
@@ -24,14 +21,9 @@ def parse_args():
 
 
 async def main():
-	configure_logging()
-
 	args = parse_args()
+	facade = bootstrap_nem_workflow(args)
 
-	facade = NemPuller(args.nem_node, args.db_config, args.network)
-
-	log.info(f'Node URL: {args.nem_node}')
-	log.info(f'Network: {args.network}')
 	log.info(f'Batch size: {args.batch_size}')
 
 	with facade.nem_db:

--- a/explorer/puller/puller/workflows/symbol.py
+++ b/explorer/puller/puller/workflows/symbol.py
@@ -3,6 +3,7 @@ import asyncio
 
 from puller.facade.SymbolPuller import SymbolPuller
 from puller.workflows import refresh_symbol_accounts, sync_symbol_block
+from puller.workflows.log_utils import configure_logging
 
 COMMANDS = (
 	('sync-block', 'Synchronize Symbol block headers.', sync_symbol_block),
@@ -43,6 +44,8 @@ def parse_args(argv=None):
 
 async def main(argv=None, symbol_puller_factory=SymbolPuller, environment=None):
 	"""Dispatches one Symbol workflow command."""
+
+	configure_logging()
 
 	args = parse_args(argv)
 	await args.run_main(args, symbol_puller_factory, environment)

--- a/explorer/puller/puller/workflows/sync_nem_block.py
+++ b/explorer/puller/puller/workflows/sync_nem_block.py
@@ -3,30 +3,21 @@ from asyncio import run
 
 from zenlog import log
 
-from puller.facade.NemPuller import NemPuller
-from puller.workflows.log_utils import configure_logging
+from puller.workflows.nem_workflow_utils import add_common_arguments, bootstrap_nem_workflow
 
 
 def parse_args():
 	"""Parse command line arguments."""
 
 	parser = argparse.ArgumentParser(description='sync blocks from network')
-	parser.add_argument('--nem-node', help='NEM node(local) url', default='http://localhost:7890')
-	parser.add_argument('--network', help='mainnet or testnet', choices=['mainnet', 'testnet'], default='mainnet')
-	parser.add_argument('--db-config', help='database config file *.ini', default='config.ini')
+	add_common_arguments(parser)
 	parser.add_argument('--account-remark', help='optional account remark seed JSON file')
 	return parser.parse_args()
 
 
 async def main():
-	configure_logging()
-
 	args = parse_args()
-
-	facade = NemPuller(args.nem_node, args.db_config, args.network)
-
-	log.info(f'Node URL: {args.nem_node}')
-	log.info(f'Network: {args.network}')
+	facade = bootstrap_nem_workflow(args)
 
 	with facade.nem_db as databases:
 		databases.create_tables()

--- a/explorer/puller/puller/workflows/sync_nem_block.py
+++ b/explorer/puller/puller/workflows/sync_nem_block.py
@@ -4,6 +4,7 @@ from asyncio import run
 from zenlog import log
 
 from puller.facade.NemPuller import NemPuller
+from puller.workflows.log_utils import configure_logging
 
 
 def parse_args():
@@ -18,6 +19,8 @@ def parse_args():
 
 
 async def main():
+	configure_logging()
+
 	args = parse_args()
 
 	facade = NemPuller(args.nem_node, args.db_config, args.network)

--- a/explorer/puller/tests/workflows/test_nem_workflow_utils.py
+++ b/explorer/puller/tests/workflows/test_nem_workflow_utils.py
@@ -1,0 +1,61 @@
+import argparse
+import unittest
+from unittest.mock import patch
+
+from workflow_test_utils import assert_common_args, create_facade_with_mock_db, create_main_args
+
+from puller.workflows.nem_workflow_utils import add_common_arguments, bootstrap_nem_workflow
+
+
+class NemWorkflowUtilsTest(unittest.TestCase):
+	def test_add_common_arguments_parses_shared_workflow_arguments(self):
+		# Arrange:
+		parser = argparse.ArgumentParser()
+		add_common_arguments(parser)
+
+		# Act:
+		args = parser.parse_args([
+			'--nem-node', 'http://localhost:7890',
+			'--network', 'testnet',
+			'--db-config', 'test_config.ini'
+		])
+
+		# Assert:
+		assert_common_args(self, args, 'testnet', 'test_config.ini')
+
+	def test_add_common_arguments_applies_defaults(self):
+		# Arrange:
+		parser = argparse.ArgumentParser()
+		add_common_arguments(parser)
+
+		# Act:
+		args = parser.parse_args([])
+
+		# Assert:
+		assert_common_args(self, args)
+
+	@patch('puller.workflows.nem_workflow_utils.NemPuller')
+	def test_bootstrap_logs_target_node_and_network(self, mock_nem_puller):
+		# Arrange:
+		create_facade_with_mock_db(mock_nem_puller)
+
+		# Act:
+		with self.assertLogs(level='INFO') as captured:
+			bootstrap_nem_workflow(create_main_args())
+
+		# Assert:
+		self.assertEqual(
+			['Node URL: http://localhost:7890', 'Network: testnet'],
+			[record.getMessage() for record in captured.records])
+
+	@patch('puller.workflows.nem_workflow_utils.configure_logging')
+	@patch('puller.workflows.nem_workflow_utils.NemPuller')
+	def test_bootstrap_configures_logging(self, mock_nem_puller, mock_configure_logging):
+		# Arrange:
+		create_facade_with_mock_db(mock_nem_puller)
+
+		# Act:
+		bootstrap_nem_workflow(create_main_args())
+
+		# Assert:
+		self.assertEqual(1, mock_configure_logging.call_count)

--- a/explorer/puller/tests/workflows/test_refresh_nem_accounts.py
+++ b/explorer/puller/tests/workflows/test_refresh_nem_accounts.py
@@ -37,7 +37,7 @@ class RefreshNemAccountsTest(unittest.TestCase):
 			with self.assertRaises(SystemExit):
 				parse_args()
 
-	@patch('puller.workflows.refresh_nem_accounts.NemPuller')
+	@patch('puller.workflows.nem_workflow_utils.NemPuller')
 	@patch('puller.workflows.refresh_nem_accounts.parse_args')
 	def test_can_refresh_accounts(self, mock_parse_args, mock_nem_puller):
 		# Arrange:

--- a/explorer/puller/tests/workflows/test_sync_nem_block.py
+++ b/explorer/puller/tests/workflows/test_sync_nem_block.py
@@ -28,7 +28,7 @@ class SyncNemBlockTest(unittest.TestCase):
 		# Assert:
 		assert_common_args(self, args, 'testnet', 'test_config.ini')
 
-	@patch('puller.workflows.sync_nem_block.NemPuller')
+	@patch('puller.workflows.nem_workflow_utils.NemPuller')
 	@patch('puller.workflows.sync_nem_block.parse_args')
 	def _run_main_test(self, mock_parse_args, mock_nem_puller, db_height, account_remark=None):  # pylint: disable=no-self-use
 		# Arrange:


### PR DESCRIPTION
Problem:
zenlog configures its handler with colorlog.ColoredFormatter and a format that carries no timestamp. ColoredFormatter emits ANSI escapes unconditionally, so it never checks whether the stream is a terminal. Both NEM workflows run from cron with output redirected to a file, which leaves puller.log full of literal
"ESC[32m    i    ESC[0m | ESC[32m" prefixes and no way to tell when any line was
written - the log shows repeated sync cycles that cannot be correlated with a
block height or an incident.

Solution:
configure_logging replaces the formatter on the zenlog handler with a plain logging.Formatter that prefixes every record with an ISO-like timestamp and drops the color escapes. sync_nem_block and refresh_nem_accounts call it first thing in main.