### PR TITLE
[explorer/puller] fix: drop NEM indexes duplicating unique constraints

### DIFF
--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -20,13 +20,6 @@ class NemDatabase(DatabaseConnection):
 		# Create indexes for accounts table
 		cursor.execute(
 			'''
-			CREATE INDEX IF NOT EXISTS accounts_address_idx
-				ON accounts (address)
-			'''
-		)
-
-		cursor.execute(
-			'''
 			CREATE INDEX IF NOT EXISTS accounts_balance_idx
 				ON accounts(balance DESC);
 			'''
@@ -36,13 +29,6 @@ class NemDatabase(DatabaseConnection):
 			'''
 			CREATE INDEX IF NOT EXISTS accounts_public_key_idx
 				ON accounts (public_key)
-			'''
-		)
-
-		cursor.execute(
-			'''
-			CREATE INDEX IF NOT EXISTS accounts_mosaics_idx
-				ON accounts USING GIN (mosaics)
 			'''
 		)
 
@@ -64,33 +50,12 @@ class NemDatabase(DatabaseConnection):
 		# Create indexes for blocks table
 		cursor.execute(
 			'''
-			CREATE INDEX IF NOT EXISTS blocks_height_idx ON blocks(height DESC);
-			'''
-		)
-
-		cursor.execute(
-			'''
 			CREATE INDEX IF NOT EXISTS blocks_timestamp_idx
 				ON blocks(timestamp)
 			'''
 		)
 
-		# Create indexes for namespaces table
-		cursor.execute(
-			'''
-			CREATE INDEX IF NOT EXISTS namespaces_root_namespace_idx
-				ON namespaces (root_namespace)
-			'''
-		)
-
 		# Create indexes for mosaics table
-		cursor.execute(
-			'''
-			CREATE INDEX IF NOT EXISTS mosaics_namespace_name_idx
-				ON mosaics (namespace_name)
-			'''
-		)
-
 		cursor.execute(
 			'''
 			CREATE INDEX IF NOT EXISTS mosaics_root_namespace_idx
@@ -99,13 +64,6 @@ class NemDatabase(DatabaseConnection):
 		)
 
 		# Create indexes for transactions table
-		cursor.execute(
-			'''
-			CREATE INDEX IF NOT EXISTS transactions_transaction_hash_idx
-				ON transactions (transaction_hash)
-			'''
-		)
-
 		cursor.execute(
 			'''
 			CREATE INDEX IF NOT EXISTS transactions_transaction_type_idx


### PR DESCRIPTION
## Problem

Six indexes on the NEM schema cost writes and disk without answering any query the remaining indexes could not.

  **Five duplicate a `UNIQUE` constraint.** `CREATE TABLE` already emits a unique btree for every `UNIQUE` column, and `_create_table_indexes` then created a second, structurally identical btree on the same column:

  | redundant index | already covered by | size on production |
  | --- | --- | --- |
  | `transactions_transaction_hash_idx` | `transactions_transaction_hash_key` | 652 MB |
  | `blocks_height_idx` | `blocks_height_key` | 223 MB |
  | `accounts_address_idx` | `accounts_address_key` | 66 MB |
  | `mosaics_namespace_name_idx` | `mosaics_namespace_name_key` | 248 kB |
  | `namespaces_root_namespace_idx` | `namespaces_root_namespace_key` | 144 kB |

`blocks_height_idx` is declared `(height DESC)`, but direction is irrelevant for a single-column btree - Postgres walks the index backwards, so `blocks_height_key` serves `ORDER BY height DESC` just as well.

  **One is unusable.** `accounts_mosaics_idx` is a GIN index on `accounts.mosaics`, recorded 0 scans over a 10-day window. This is not idle traffic - no query can use it. The only reads of that column are `jsonb_array_elements` in `rest/db/NemDatabase.py:341` and `:693`, a LATERAL expansion GIN cannot answer,
  and the repository contains no `@>`, `?` or `<@` against it anywhere. It is also the most expensive of the six on the write path, since the puller updates `accounts` continuously.

## Solution

  Remove the six `CREATE INDEX` statements from `NemDatabase._create_table_indexes`.

  The change has to land in code rather than only in the database: `sync_nem_block.py:23` calls `create_tables()` on every pass, and `CREATE INDEX IF NOT EXISTS` would rebuild anything dropped in SQL; a blocking 652 MB rebuild in the middle of a sync.

  ## Deploy

  Deploy and restart the puller **first**, then run against `nem_db`:

  ```sql
  \set ON_ERROR_STOP on
  \timing on

  REINDEX INDEX CONCURRENTLY transactions_transaction_hash_key;

  DROP INDEX CONCURRENTLY IF EXISTS transactions_transaction_hash_idx;
  DROP INDEX CONCURRENTLY IF EXISTS blocks_height_idx;
  DROP INDEX CONCURRENTLY IF EXISTS accounts_address_idx;
  DROP INDEX CONCURRENTLY IF EXISTS accounts_mosaics_idx;
  DROP INDEX CONCURRENTLY IF EXISTS mosaics_namespace_name_idx;
  DROP INDEX CONCURRENTLY IF EXISTS namespaces_root_namespace_idx;
