### PR TITLE
[explorer/puller] fix: carry public key through NEM account upsert

### DIFF
--- a/explorer/puller/puller/db/NemDatabase.py
+++ b/explorer/puller/puller/db/NemDatabase.py
@@ -465,6 +465,7 @@ class NemDatabase(DatabaseConnection):
 			VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 			ON CONFLICT (address)
 			DO UPDATE SET
+				public_key = EXCLUDED.public_key,
 				importance = EXCLUDED.importance,
 				balance = EXCLUDED.balance,
 				vested_balance = EXCLUDED.vested_balance,

--- a/explorer/puller/tests/db/test_NemDatabase.py
+++ b/explorer/puller/tests/db/test_NemDatabase.py
@@ -483,10 +483,10 @@ class NemDatabaseTest(unittest.TestCase):  # pylint: disable=too-many-public-met
 
 			cursor = nem_database.connection.cursor()
 
-			# insert initial account
+			# insert initial account, seen as a recipient before it revealed a public key
 			nem_database.upsert_account(
 				cursor,
-				ACCOUNTS[0]
+				ACCOUNTS[0]._replace(public_key=None)
 			)
 
 			# Act:


### PR DESCRIPTION
Problem:
A NEM account reveals its public key when it first signs a transaction, but ON CONFLICT DO UPDATE never carried public_key over. An account inserted while the node still reported a null key kept that null forever, because the later upsert that did bring the key landed on the update branch that dropped it.

Solution:
Add the missing assignment.

Backfill:

```sql

WITH missing AS MATERIALIZED (
        SELECT a.address, a.height, a.balance
        FROM accounts a
        WHERE a.public_key IS NULL
                AND EXISTS (SELECT 1 FROM transactions t WHERE t.sender_address = a.address)
  )
  SELECT
        encode(m.address, 'hex') AS address,
        encode(k.public_key, 'hex') AS public_key_to_write,
        k.distinct_public_keys,
        k.sent_transactions,
        k.sent_as_inner,
        k.first_sent_height,
        k.last_sent_height,
        m.height AS first_seen_height,
        m.balance
  FROM missing m
  JOIN LATERAL (
        SELECT
                count(*) AS sent_transactions,
                count(*) FILTER (WHERE t.is_inner) AS sent_as_inner,
                count(DISTINCT t.sender_public_key) AS distinct_public_keys,
                min(t.height) AS first_sent_height,
                max(t.height) AS last_sent_height,
                (array_agg(t.sender_public_key ORDER BY t.height, t.id))[1] AS public_key
        FROM transactions t
        WHERE t.sender_address = m.address
  ) k ON true
  ORDER BY k.distinct_public_keys DESC, k.last_sent_height DESC;

=====

WITH missing AS MATERIALIZED (
        SELECT a.address
        FROM accounts a
        WHERE a.public_key IS NULL
                AND EXISTS (SELECT 1 FROM transactions t WHERE t.sender_address = a.address)
  ),
  resolved AS (
        SELECT m.address, k.public_key
        FROM missing m
        JOIN LATERAL (
                SELECT
                        count(DISTINCT t.sender_public_key) AS distinct_public_keys,
                        (array_agg(t.sender_public_key ORDER BY t.height, t.id))[1] AS public_key
                FROM transactions t
                WHERE t.sender_address = m.address
        ) k ON true
        WHERE 1 = k.distinct_public_keys
  )
  UPDATE accounts a
  SET public_key = r.public_key,
        updated_at = CURRENT_TIMESTAMP
  FROM resolved r
  WHERE a.address = r.address
        AND a.public_key IS NULL;

```