### PR TITLE
[explorer/puller] feat: Add Symbol sync performance observability

### DIFF
--- a/explorer/puller/puller/db/SymbolDatabase.py
+++ b/explorer/puller/puller/db/SymbolDatabase.py
@@ -1,4 +1,5 @@
 # pylint: disable=too-many-lines
+import time
 from collections import namedtuple
 from contextlib import contextmanager
 
@@ -499,6 +500,41 @@ def _create_table(cursor, name, definitions):
 class SymbolDatabase(DatabaseConnection):  # pylint: disable=too-many-public-methods
 	"""Database containing Symbol blockchain data."""
 
+	def __init__(self, db_config, commit_observer=None, time_source=time.monotonic):
+		"""Creates a Symbol database wrapper with an optional commit observation hook."""
+
+		super().__init__(db_config)
+		self._commit_observer = commit_observer
+		self._time_source = time_source
+
+	def _commit(self):
+		started_at = self._read_commit_time()
+		try:
+			self.connection.commit()
+		except Exception:
+			self._notify_commit_observer(started_at, False)
+			raise
+
+		self._notify_commit_observer(started_at, True)
+
+	def _read_commit_time(self):
+		try:
+			return self._time_source()
+		except Exception:  # pylint: disable=broad-exception-caught
+			return None
+
+	def _notify_commit_observer(self, started_at, succeeded):
+		if self._commit_observer is None:
+			return
+
+		try:
+			ended_at = self._read_commit_time()
+			elapsed_seconds = 0 if started_at is None or ended_at is None else max(0, ended_at - started_at)
+			self._commit_observer(elapsed_seconds, succeeded)
+		except Exception:  # pylint: disable=broad-exception-caught
+			# Performance observation must never alter database commit semantics.
+			return
+
 	def create_tables(self):  # pylint: disable=too-many-statements
 		"""Creates Symbol block synchronization tables."""
 
@@ -605,7 +641,7 @@ class SymbolDatabase(DatabaseConnection):  # pylint: disable=too-many-public-met
 		cursor.execute('CREATE INDEX IF NOT EXISTS idx_symbol_transaction_addresses_height ON symbol_transaction_addresses(height)')
 		for index_sql in SYMBOL_RECEIPT_INDEXES:
 			cursor.execute(index_sql)
-		self.connection.commit()
+		self._commit()
 
 	def check_connection(self):
 		"""Checks whether the configured Symbol database is reachable and initialized."""
@@ -626,7 +662,7 @@ class SymbolDatabase(DatabaseConnection):  # pylint: disable=too-many-public-met
 
 		cursor = self.connection.cursor()
 		self._execute_upsert_sync_state(cursor, sync_state)
-		self.connection.commit()
+		self._commit()
 
 	def mark_sync_write_intent(self, height):
 		"""Persists the earliest height whose batch may start a local write."""
@@ -713,7 +749,7 @@ class SymbolDatabase(DatabaseConnection):  # pylint: disable=too-many-public-met
 		try:
 			cursor = self.connection.cursor()
 			yield cursor
-			self.connection.commit()
+			self._commit()
 		except Exception:
 			self.connection.rollback()
 			raise
@@ -1503,7 +1539,7 @@ class SymbolDatabase(DatabaseConnection):  # pylint: disable=too-many-public-met
 		cursor = self.connection.cursor()
 		if multisig_row_or_none is None:
 			cursor.execute('DELETE FROM symbol_multisig WHERE address = %s', (address,))
-			self.connection.commit()
+			self._commit()
 			return
 
 		cursor.execute(
@@ -1532,7 +1568,7 @@ class SymbolDatabase(DatabaseConnection):  # pylint: disable=too-many-public-met
 				updated_at_height = EXCLUDED.updated_at_height
 			''',
 			multisig_row_or_none)
-		self.connection.commit()
+		self._commit()
 
 	@staticmethod
 	def _execute_insert_account_refresh_snapshot_rows(  # pylint: disable=too-many-arguments,too-many-positional-arguments

--- a/explorer/puller/puller/facade/RequestRateLimiter.py
+++ b/explorer/puller/puller/facade/RequestRateLimiter.py
@@ -17,14 +17,16 @@ class RequestRateLimiter:
 	async def wait_for_turn(self):
 		"""Blocks until this caller's turn to dispatch a request, per the configured rate."""
 
+		started_at = self._time_source()
 		async with self._lock:
 			now = self._time_source()
 			if self._next_allowed_time is None:
 				self._next_allowed_time = now
 
-			wait_seconds = self._next_allowed_time - now
-			if wait_seconds > 0:
-				await self._sleep(wait_seconds)
+			required_wait_seconds = self._next_allowed_time - now
+			if required_wait_seconds > 0:
+				await self._sleep(required_wait_seconds)
 				now = self._time_source()
 
 			self._next_allowed_time = now + self._min_interval_seconds
+			return max(0, now - started_at)

--- a/explorer/puller/puller/facade/SymbolPuller.py
+++ b/explorer/puller/puller/facade/SymbolPuller.py
@@ -2,6 +2,8 @@
 
 import asyncio
 import configparser
+import json
+import time
 import uuid
 from collections import defaultdict, namedtuple
 from datetime import datetime, timedelta, timezone
@@ -18,6 +20,7 @@ from zenlog import log
 from puller.db.SymbolDatabase import RollbackRefreshEntries, SymbolDatabase
 from puller.facade.async_utils import gather_in_chunks
 from puller.facade.RequestRateLimiter import RequestRateLimiter
+from puller.facade.SymbolSyncPerformance import SyncPerformance, request_category
 from puller.model.symbol.Account import HARVESTING_ACTIVE_WINDOW_DAYS, create_account_row, create_multisig_row
 from puller.model.symbol.Block import create_block_row
 from puller.model.symbol.format import is_exact_integer
@@ -99,7 +102,7 @@ def _is_not_found_response(response):
 	return isinstance(response, dict) and 'ResourceNotFound' == response.get('code')
 
 
-class SymbolPuller:
+class SymbolPuller:  # pylint: disable=too-many-instance-attributes
 	"""Facade for pulling data from Symbol network."""
 
 	def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
@@ -110,7 +113,9 @@ class SymbolPuller:
 		node_config=None,
 		connector=None,
 		max_requests_per_second=DEFAULT_MAX_REQUESTS_PER_SECOND,
-		rate_limiter=None
+		rate_limiter=None,
+		time_source=time.monotonic,
+		performance_logger=log
 	):
 		"""Creates a Symbol puller facade object."""
 
@@ -121,16 +126,43 @@ class SymbolPuller:
 
 		network = _get_symbol_network(network_type)
 
-		self.symbol_db = SymbolDatabase(DatabaseConfiguration(**db_config))
+		self._time_source = time_source
+		self._performance_logger = performance_logger
+		self._active_performance = None
+		self.symbol_db = SymbolDatabase(
+			DatabaseConfiguration(**db_config),
+			commit_observer=self._record_commit,
+			time_source=time_source)
 		self.node_config = node_config or SymbolNodeConfiguration.from_url(node_url)
 		symbol_node_endpoint = self.node_config.assert_request_allowed(self.node_config.base_url)
 		self._symbol_connector = connector or SymbolConnector(symbol_node_endpoint)
 		self._symbol_connector.timeout_seconds = self.node_config.timeout_seconds
 		self.symbol_facade = SymbolFacade(network)
 		self._retry_delay = 2
-		self._rate_limiter = rate_limiter or RequestRateLimiter(max_requests_per_second)
+		self._rate_limiter = rate_limiter or RequestRateLimiter(max_requests_per_second, time_source=time_source)
 		self._native_mosaic_info = None
 		self._network_properties = None
+
+	def _record_performance(self, method_name, *args):
+		if self._active_performance is None:
+			return
+
+		try:
+			getattr(self._active_performance, method_name)(*args)
+		except Exception:  # pylint: disable=broad-exception-caught
+			# Metrics must not alter synchronization or exception propagation.
+			return
+
+	def _record_commit(self, elapsed_seconds, succeeded):
+		self._record_performance('record_commit', elapsed_seconds, succeeded)
+
+	def _log_performance_event(self, performance, event_name, status, exception=None):
+		try:
+			event = performance.event(event_name, status, exception)
+			self._performance_logger.info(json.dumps(event, sort_keys=True, separators=(',', ':')))
+		except Exception:  # pylint: disable=broad-exception-caught
+			# Event construction or logging failure must never replace the synchronization result.
+			pass
 
 	def __enter__(self):
 		self.symbol_db.__enter__()
@@ -151,14 +183,26 @@ class SymbolPuller:
 
 		return normalized_path
 
-	async def _retry_operation(self, operation, description, retries=3, not_found_as_error=True):
+	async def _retry_operation(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+		self,
+		operation,
+		description,
+		retries=3,
+		not_found_as_error=True,
+		method='GET',
+		category='other'
+	):
 		"""Retries a Symbol node operation with exponential backoff."""
 
 		for attempt_index in range(retries):
 			try:
-				await self._rate_limiter.wait_for_turn()
+				wait_seconds = await self._rate_limiter.wait_for_turn()
+				self._record_performance('record_rate_limit_wait', wait_seconds or 0)
+				self._record_performance('record_request_attempt', method, category)
 				response = await operation()
 				_raise_if_node_error(response, allow_not_found=not not_found_as_error)
+				if not isinstance(response, dict) or 'code' not in response or 'message' not in response:
+					self._record_performance('record_request_success')
 				return response
 			except NodeException as error:
 				attempt = attempt_index + 1
@@ -167,6 +211,7 @@ class SymbolPuller:
 					raise
 
 				wait_time = self._retry_delay * (2 ** attempt_index)
+				self._record_performance('record_retry')
 				log.warning(f'Error {description} (attempt {attempt}/{retries}): {error}. Retrying in {wait_time}s...')
 				await asyncio.sleep(wait_time)
 
@@ -177,7 +222,9 @@ class SymbolPuller:
 		return await self._retry_operation(
 			lambda: self._symbol_connector.get(normalized_path, property_name, not_found_as_error),
 			f'fetching Symbol node path {normalized_path}',
-			not_found_as_error=not_found_as_error
+			not_found_as_error=not_found_as_error,
+			method='GET',
+			category=request_category('GET', normalized_path)
 		)
 
 	async def post_symbol_node(self, url_path, request_payload, property_name=None, not_found_as_error=True):
@@ -187,15 +234,20 @@ class SymbolPuller:
 		return await self._retry_operation(
 			lambda: self._symbol_connector.post(normalized_path, request_payload, property_name, not_found_as_error),
 			f'posting Symbol node path {normalized_path}',
-			not_found_as_error=not_found_as_error
+			not_found_as_error=not_found_as_error,
+			method='POST',
+			category=request_category('POST', normalized_path)
 		)
 
 	async def sync_block_headers(self, max_height=None):  # pylint: disable=too-many-locals
 		"""Synchronizes Symbol block headers; an external scheduler must prevent overlap."""
 
+		performance = SyncPerformance(self._time_source)
+		self._active_performance = performance
 		try:
 			await self._sync_block_headers(max_height)
-		except Exception:
+			self._log_performance_event(performance, 'symbol_sync_completed', 'completed')
+		except Exception as exception:
 			try:
 				sync_state = self.symbol_db.get_sync_state()
 				if sync_state and sync_state['dirty_state_from_height'] is not None:
@@ -203,12 +255,18 @@ class SymbolPuller:
 			except Exception as state_error:  # pylint: disable=broad-exception-caught
 				# Preserve the primary failure if the best-effort failure-state update also fails.
 				log.error(f'Failed to record Symbol sync failure: {state_error}')
+			performance.set_failed_phase()
+			self._log_performance_event(performance, 'symbol_sync_failed', 'failed', exception)
 			raise
+		finally:
+			self._active_performance = None
 
 	async def _sync_block_headers(self, max_height=None):  # pylint: disable=too-many-locals
 		"""Runs one non-overlapping Symbol block synchronization attempt."""
 
+		self._record_performance('set_phase', 'chain_info_fetch')
 		chain_info = await self.get_symbol_node('/chain/info')
+		self._record_performance('set_phase', 'network_properties_fetch')
 		network_properties = await self._get_network_properties()
 		node_chain_height = int(chain_info['height'])
 		chain_height = self._get_sync_chain_height(int(chain_info['height']), max_height)
@@ -216,7 +274,9 @@ class SymbolPuller:
 			self._get_finalized_watermark(chain_info, chain_height)
 		)
 		epoch_adjustment_seconds = self._parse_epoch_adjustment(network_properties)
+		self._record_performance('set_phase', 'native_mosaic_fetch')
 		native_mosaic_info = await self._get_native_mosaic_info()
+		self._record_performance('set_phase', 'sync_state_read')
 		raw_sync_state = self.symbol_db.get_sync_state()
 		if is_finalization_capped and raw_sync_state:
 			raw_last_synced_height = raw_sync_state['last_synced_height']
@@ -232,6 +292,7 @@ class SymbolPuller:
 		# A dirty marker gives only the tail's lower bound, so capped repair could change rows outside the operator scope.
 		# When blocked by the cap, exclude the marker from this repair decision and skip unfinalized verification; finalized
 		# safety checks still run. The persisted marker is then retained, status is set unhealthy, and forward sync is skipped.
+		self._record_performance('set_phase', 'rollback_repair')
 		start_height = await self._repair_unfinalized_rollback(
 			raw_sync_state,
 			finalized_height,
@@ -255,7 +316,9 @@ class SymbolPuller:
 				'last_synced_height': start_height - 1 if start_height > 1 else None,
 				'last_synced_block_hash': self.symbol_db.get_block_hash(start_height - 1) if start_height > 1 else None
 			}
+		self._active_performance.set_bounds(start_height, chain_height)
 
+		self._record_performance('set_phase', 'block_sync')
 		last_synced_height, last_synced_block_hash = await self._sync_block_pages(
 			start_height,
 			chain_height,
@@ -264,13 +327,16 @@ class SymbolPuller:
 		if last_synced_height is None and bounded_sync_state:
 			last_synced_height = bounded_sync_state['last_synced_height']
 			last_synced_block_hash = bounded_sync_state['last_synced_block_hash']
+		self._record_performance('set_last_completed_height', last_synced_height)
 		if is_finalization_capped:
 			finalized_hash = last_synced_block_hash if finalized_height == last_synced_height else self.symbol_db.get_block_hash(finalized_height)
 			if not finalized_hash:
 				raise ValueError(f'Unable to determine finalized hash for height {finalized_height}')
 
+		self._record_performance('set_phase', 'finalization_lock_cleanup')
 		await self._sync_finalization_lock_cleanup(finalized_height)
 
+		self._record_performance('set_phase', 'sync_state_write')
 		self.symbol_db.upsert_sync_state({
 			'status': 'healthy',
 			'chain_height': chain_height,
@@ -442,88 +508,140 @@ class SymbolPuller:
 
 		for batch_start in range(0, len(all_offsets), BLOCK_PAGE_FETCH_CONCURRENCY):
 			batch_offsets = all_offsets[batch_start:batch_start + BLOCK_PAGE_FETCH_CONCURRENCY]
-			pages = await asyncio.gather(*[self._get_block_page(offset) for offset in batch_offsets])
+			batch = self._active_performance.start_batch(
+				batch_offsets[0] + 1,
+				min(chain_height, batch_offsets[-1] + MAX_PAGE_SIZE))
+			try:
+				is_final_batch = False
+				with batch.measure('block_fetch_ms', 'block_fetch'):
+					pages = await asyncio.gather(*[self._get_block_page(offset) for offset in batch_offsets])
 
-			batch_rows = []
-			for offset, blocks in zip(batch_offsets, pages):
-				if not blocks:
-					raise ValueError(f'Expected Symbol blocks at offset {offset} before chain height {chain_height}')
+					batch_rows = []
+					for offset, blocks in zip(batch_offsets, pages):
+						if not blocks:
+							raise ValueError(f'Expected Symbol blocks at offset {offset} before chain height {chain_height}')
 
-				rows = [
-					create_block_row(block, epoch_adjustment_seconds, self.symbol_facade.network)
-					for block in blocks
-					if int(block['block']['height']) <= chain_height
-				]
-				if not rows:
-					raise ValueError(f'Symbol block page at offset {offset} does not contain blocks at or below chain height {chain_height}')
+						rows = [
+							create_block_row(block, epoch_adjustment_seconds, self.symbol_facade.network)
+							for block in blocks
+							if int(block['block']['height']) <= chain_height
+						]
+						if not rows:
+							raise ValueError(
+								f'Symbol block page at offset {offset} does not contain blocks at or below chain height {chain_height}')
 
-				self._validate_block_page(rows, offset + 1)
-				previous_block_hash = self._validate_block_chain(rows, previous_block_hash)
-				last_row = rows[-1]
-				if len(blocks) < MAX_PAGE_SIZE and last_row['height'] < chain_height:
-					raise ValueError(f'Short Symbol block page ended at height {last_row["height"]} before chain height {chain_height}')
+						self._validate_block_page(rows, offset + 1)
+						previous_block_hash = self._validate_block_chain(rows, previous_block_hash)
+						last_row = rows[-1]
+						if len(blocks) < MAX_PAGE_SIZE and last_row['height'] < chain_height:
+							raise ValueError(
+								f'Short Symbol block page ended at height {last_row["height"]} before chain height {chain_height}')
 
-				batch_rows.extend(rows)
-				last_synced_height = last_row['height']
-				last_synced_block_hash = last_row['hash']
+						batch_rows.extend(rows)
+						batch.set_count('block_count', len(batch_rows))
+						last_synced_height = last_row['height']
+						last_synced_block_hash = last_row['hash']
 
-				if len(blocks) < MAX_PAGE_SIZE:
+						if len(blocks) < MAX_PAGE_SIZE:
+							batch.set_range(batch_rows[0]['height'], batch_rows[-1]['height'])
+							is_final_batch = True
+							break
+
+				if is_final_batch:
 					await self._sync_block_batch_with_dirty_state(
-						batch_rows, epoch_adjustment_seconds, native_mosaic_info)
+						batch_rows, epoch_adjustment_seconds, native_mosaic_info, batch)
+					self._active_performance.complete_batch(batch)
+					self._log_performance_event(
+						batch, 'symbol_sync_batch_completed', 'completed')
 					return last_synced_height, last_synced_block_hash
 
-			await self._sync_block_batch_with_dirty_state(
-				batch_rows, epoch_adjustment_seconds, native_mosaic_info)
+				batch.set_range(batch_rows[0]['height'], batch_rows[-1]['height'])
+				await self._sync_block_batch_with_dirty_state(
+					batch_rows, epoch_adjustment_seconds, native_mosaic_info, batch)
+				self._active_performance.complete_batch(batch)
+				self._log_performance_event(
+					batch, 'symbol_sync_batch_completed', 'completed')
+			except Exception as exception:
+				self._active_performance.fail_batch(batch)
+				self._log_performance_event(
+					batch, 'symbol_sync_batch_failed', 'failed', exception)
+				raise
 
 		return last_synced_height, last_synced_block_hash
 
-	async def _sync_block_batch_with_dirty_state(  # pylint: disable=too-many-locals
+	async def _sync_block_batch_with_dirty_state(  # pylint: disable=too-many-locals,too-many-statements
 		self,
 		batch_rows,
 		epoch_adjustment_seconds,
-		native_mosaic_info
+		native_mosaic_info,
+		batch
 	):
-		transaction_rows_by_height = await self._get_transaction_rows_by_height(
-			batch_rows[0]['height'],
-			batch_rows[-1]['height'],
-			epoch_adjustment_seconds
-		)
-		receipt_rows_by_height = await self._get_receipt_rows_by_height(batch_rows[0]['height'], batch_rows[-1]['height'])
-		await self._resolve_transaction_rows_for_batch(transaction_rows_by_height)
+		with batch.measure('transaction_fetch_ms', 'transaction_fetch'):
+			transaction_rows_by_height = await self._get_transaction_rows_by_height(
+				batch_rows[0]['height'],
+				batch_rows[-1]['height'],
+				epoch_adjustment_seconds
+			)
+			batch.set_count('transaction_count', sum(len(rows) for rows in transaction_rows_by_height.values()))
+		with batch.measure('receipt_fetch_ms', 'receipt_fetch'):
+			receipt_rows_by_height = await self._get_receipt_rows_by_height(
+				batch_rows[0]['height'], batch_rows[-1]['height'])
+			batch.set_count('receipt_count', sum(len(rows) for rows in receipt_rows_by_height.values()))
+		with batch.measure('resolution_fetch_ms', 'resolution_fetch'):
+			await self._resolve_transaction_rows_for_batch(transaction_rows_by_height)
+		batch.set_phase('dirty_key_collection')
 		dirty_addresses = self._collect_dirty_addresses_for_batch(
 			batch_rows,
 			transaction_rows_by_height,
 			receipt_rows_by_height)
+		batch.set_count('dirty_account_count', len(dirty_addresses))
 		observed_height = max(row['height'] for row in batch_rows)
-		dirty_account_rows = await self._fetch_dirty_accounts_for_batch(
-			dirty_addresses,
-			observed_height,
-			native_mosaic_info)
+		with batch.measure('account_fetch_ms', 'account_fetch'):
+			dirty_account_rows = await self._fetch_dirty_accounts_for_batch(
+				dirty_addresses,
+				observed_height,
+				native_mosaic_info)
 		dirty_namespace_ids = self._expand_dirty_namespace_ids(
 			self._collect_dirty_namespace_ids_for_batch(transaction_rows_by_height, receipt_rows_by_height))
-		dirty_namespace_entries = await self._fetch_dirty_namespaces(dirty_namespace_ids, observed_height)
+		batch.set_count('dirty_namespace_count', len(dirty_namespace_ids))
+		with batch.measure('namespace_fetch_ms', 'namespace_fetch'):
+			dirty_namespace_entries = await self._fetch_dirty_namespaces(dirty_namespace_ids, observed_height)
 		dirty_mosaic_ids = self._collect_dirty_mosaic_ids_for_batch(transaction_rows_by_height, receipt_rows_by_height)
-		dirty_mosaic_entries = await self._fetch_dirty_mosaics(dirty_mosaic_ids, observed_height)
+		batch.set_count('dirty_mosaic_count', len(dirty_mosaic_ids))
+		with batch.measure('mosaic_fetch_ms', 'mosaic_fetch'):
+			dirty_mosaic_entries = await self._fetch_dirty_mosaics(dirty_mosaic_ids, observed_height)
 		dirty_metadata_keys = self._collect_dirty_metadata_keys_for_batch(transaction_rows_by_height)
-		dirty_metadata_entries = await self._fetch_dirty_metadata(dirty_metadata_keys, observed_height)
+		batch.set_count('dirty_metadata_count', len(dirty_metadata_keys))
+		with batch.measure('metadata_fetch_ms', 'metadata_fetch'):
+			dirty_metadata_entries = await self._fetch_dirty_metadata(dirty_metadata_keys, observed_height)
 		dirty_lock_keys = self._collect_dirty_lock_keys_for_batch(transaction_rows_by_height)
-		dirty_hash_lock_entries = await self._fetch_dirty_hash_locks(
-			list(dirty_lock_keys.hash_keys), observed_height)
-		dirty_secret_lock_entries = await self._fetch_dirty_secret_locks(
-			list(dirty_lock_keys.secret_keys), observed_height)
+		batch.set_count('dirty_hash_lock_count', len(dirty_lock_keys.hash_keys))
+		batch.set_count('dirty_secret_lock_count', len(dirty_lock_keys.secret_keys))
+		with batch.measure('hash_lock_fetch_ms', 'hash_lock_fetch'):
+			dirty_hash_lock_entries = await self._fetch_dirty_hash_locks(
+				list(dirty_lock_keys.hash_keys), observed_height)
+		with batch.measure('secret_lock_fetch_ms', 'secret_lock_fetch'):
+			dirty_secret_lock_entries = await self._fetch_dirty_secret_locks(
+				list(dirty_lock_keys.secret_keys), observed_height)
 		dirty_mosaic_restriction_keys = self._collect_dirty_mosaic_restriction_keys_for_batch(
 			transaction_rows_by_height)
-		dirty_mosaic_restriction_entries = await self._fetch_dirty_mosaic_restrictions(
-			list(dirty_mosaic_restriction_keys), observed_height)
-		self.symbol_db.mark_sync_write_intent(batch_rows[0]['height'])
-		self._sync_block_batch(batch_rows, transaction_rows_by_height, receipt_rows_by_height)
-		self._write_dirty_accounts_for_batch(dirty_account_rows)
-		self.symbol_db.apply_namespace_entries(dirty_namespace_entries)
-		self._write_dirty_mosaics(dirty_mosaic_entries)
-		self._write_dirty_metadata(dirty_metadata_entries)
-		self._write_dirty_hash_locks(dirty_hash_lock_entries)
-		self._write_dirty_secret_locks(dirty_secret_lock_entries)
-		self._write_dirty_mosaic_restrictions(dirty_mosaic_restriction_entries)
+		batch.set_count('dirty_mosaic_restriction_count', len(dirty_mosaic_restriction_keys))
+		with batch.measure('mosaic_restriction_fetch_ms', 'mosaic_restriction_fetch'):
+			dirty_mosaic_restriction_entries = await self._fetch_dirty_mosaic_restrictions(
+				list(dirty_mosaic_restriction_keys), observed_height)
+		with batch.measure('db_write_total_ms', 'db_write'):
+			self.symbol_db.mark_sync_write_intent(batch_rows[0]['height'])
+			with batch.measure('block_transaction_receipt_write_ms', 'db_write'):
+				self._sync_block_batch(batch_rows, transaction_rows_by_height, receipt_rows_by_height)
+			with batch.measure('account_multisig_write_ms', 'db_write'):
+				self._write_dirty_accounts_for_batch(dirty_account_rows)
+			with batch.measure('current_state_write_ms', 'db_write'):
+				self.symbol_db.apply_namespace_entries(dirty_namespace_entries)
+				self._write_dirty_mosaics(dirty_mosaic_entries)
+				self._write_dirty_metadata(dirty_metadata_entries)
+				self._write_dirty_hash_locks(dirty_hash_lock_entries)
+				self._write_dirty_secret_locks(dirty_secret_lock_entries)
+				self._write_dirty_mosaic_restrictions(dirty_mosaic_restriction_entries)
 
 	async def _sync_finalization_lock_cleanup(self, finalized_height):
 		"""Reconciles all current Lock rows whose end height has reached finalization."""
@@ -562,6 +680,7 @@ class SymbolPuller:
 			for item in items:
 				row = create_transaction_row(item, self.symbol_facade.network, epoch_adjustment_seconds)
 				rows_by_height.setdefault(row['height'], []).append(row)
+				self._record_performance('add_count', 'transaction_count', 1)
 
 			if len(items) < MAX_PAGE_SIZE:
 				return rows_by_height

--- a/explorer/puller/puller/facade/SymbolSyncPerformance.py
+++ b/explorer/puller/puller/facade/SymbolSyncPerformance.py
@@ -1,0 +1,382 @@
+"""Per-run performance state for Symbol block synchronization."""
+
+from contextlib import contextmanager
+
+HTTP_CATEGORIES = (
+	'block',
+	'confirmed_transaction',
+	'transaction_statement',
+	'address_resolution',
+	'mosaic_resolution',
+	'account_batch',
+	'account_multisig',
+	'namespace_detail',
+	'namespace_name',
+	'mosaic_batch',
+	'metadata_search',
+	'hash_lock',
+	'secret_lock',
+	'mosaic_restriction',
+	'chain_or_network',
+	'other'
+)
+
+PHASE_FIELDS = (
+	'block_fetch_ms',
+	'transaction_fetch_ms',
+	'receipt_fetch_ms',
+	'resolution_fetch_ms',
+	'account_fetch_ms',
+	'namespace_fetch_ms',
+	'mosaic_fetch_ms',
+	'metadata_fetch_ms',
+	'hash_lock_fetch_ms',
+	'secret_lock_fetch_ms',
+	'mosaic_restriction_fetch_ms'
+)
+
+DIRTY_FIELDS = (
+	'dirty_account_count',
+	'dirty_namespace_count',
+	'dirty_mosaic_count',
+	'dirty_metadata_count',
+	'dirty_hash_lock_count',
+	'dirty_secret_lock_count',
+	'dirty_mosaic_restriction_count'
+)
+
+COUNT_FIELDS = (
+	'block_count',
+	'transaction_count',
+	'receipt_count',
+	'http_attempt_count',
+	'http_success_count',
+	'http_retry_count',
+	'http_get_attempt_count',
+	'http_post_attempt_count',
+	'rate_limit_wait_ms',
+	'db_commit_count',
+	'db_commit_attempt_count'
+)
+
+DB_FIELDS = (
+	'block_transaction_receipt_write_ms',
+	'account_multisig_write_ms',
+	'current_state_write_ms',
+	'db_write_total_ms',
+	'db_commit_ms'
+)
+
+WORKFLOW_FIELDS = (
+	'http_attempt_count',
+	'http_success_count',
+	'http_retry_count',
+	'http_get_attempt_count',
+	'http_post_attempt_count',
+	'rate_limit_wait_ms',
+	'db_commit_count',
+	'db_commit_attempt_count',
+	'db_commit_ms'
+)
+
+
+def _milliseconds(seconds):
+	return round(max(0, seconds) * 1000, 3)
+
+
+def request_category(method, url_path):  # pylint: disable=too-many-return-statements,too-many-branches
+	"""Returns a low-cardinality category for a Symbol node request path."""
+
+	path = url_path.split('?', 1)[0].lstrip('/')
+	if path in ('chain/info', 'network/properties'):
+		return 'chain_or_network'
+	if path == 'blocks' or path.startswith('blocks/'):
+		return 'block'
+	if path == 'transactions/confirmed':
+		return 'confirmed_transaction'
+	if path == 'statements/transaction':
+		return 'transaction_statement'
+	if path.startswith('statements/resolutions/address'):
+		return 'address_resolution'
+	if path.startswith('statements/resolutions/mosaic'):
+		return 'mosaic_resolution'
+	if method == 'POST' and path == 'accounts':
+		return 'account_batch'
+	if path.startswith('account/') and path.endswith('/multisig'):
+		return 'account_multisig'
+	if path.startswith('namespaces/'):
+		return 'namespace_name' if path.endswith('/names') else 'namespace_detail'
+	if method == 'POST' and path == 'mosaics':
+		return 'mosaic_batch'
+	if path.startswith('mosaics/'):
+		return 'mosaic_batch'
+	if path == 'metadata':
+		return 'metadata_search'
+	if path == 'lock/hash' or path.startswith('lock/hash/'):
+		return 'hash_lock'
+	if path == 'lock/secret':
+		return 'secret_lock'
+	if path == 'restrictions/mosaic':
+		return 'mosaic_restriction'
+	return 'other'
+
+
+class BatchPerformance:  # pylint: disable=too-many-instance-attributes
+	"""Collects counters and durations for one internal block batch."""
+
+	def __init__(self, time_source, start_height, end_height):
+		self._time_source = time_source
+		self._started_at = self._read_time()
+		self.start_height = start_height
+		self.end_height = end_height
+		self.failed_phase = None
+		self._phase = None
+		self._fields = {field: 0 for field in COUNT_FIELDS + PHASE_FIELDS + DIRTY_FIELDS + DB_FIELDS}
+		self._get_attempts_by_category = {category: 0 for category in HTTP_CATEGORIES}
+		self._post_attempts_by_category = {category: 0 for category in HTTP_CATEGORIES}
+
+	def _read_time(self):
+		try:
+			return self._time_source()
+		except Exception:  # pylint: disable=broad-exception-caught
+			return None
+
+	def _elapsed_seconds(self, started_at):
+		ended_at = self._read_time()
+		if started_at is None or ended_at is None:
+			return 0
+
+		return ended_at - started_at
+
+	@contextmanager
+	def measure(self, field, phase):
+		"""Measures one phase and preserves the phase name if its body fails."""
+
+		self._phase = phase
+		started_at = self._read_time()
+		try:
+			yield
+		finally:
+			self._fields[field] += _milliseconds(self._elapsed_seconds(started_at))
+
+	def set_range(self, start_height, end_height):
+		"""Sets the actual first and last block heights represented by the batch."""
+
+		self.start_height = start_height
+		self.end_height = end_height
+
+	def set_phase(self, phase):
+		"""Sets the current non-timed batch phase for failure reporting."""
+
+		self._phase = phase
+
+	def set_count(self, field, value):
+		"""Sets an in-memory row or deduplicated-key count."""
+
+		self._fields[field] = value
+
+	def add_count(self, field, value):
+		"""Adds rows that were created before a later fetch failure."""
+
+		self._fields[field] += value
+
+	def record_request_attempt(self, method, category):
+		"""Records one actual GET or POST node invocation attempt."""
+
+		category = category if category in HTTP_CATEGORIES else 'other'
+		self._fields['http_attempt_count'] += 1
+		field = 'http_get_attempt_count' if 'GET' == method else 'http_post_attempt_count'
+		self._fields[field] += 1
+		attempts_by_category = self._get_attempts_by_category if 'GET' == method else self._post_attempts_by_category
+		attempts_by_category[category] += 1
+
+	def record_request_success(self):
+		"""Records one node invocation that returned a non-error response."""
+
+		self._fields['http_success_count'] += 1
+
+	def record_retry(self):
+		"""Records one retry after an initial failed node invocation."""
+
+		self._fields['http_retry_count'] += 1
+
+	def record_rate_limit_wait(self, wait_seconds):
+		"""Adds one RequestRateLimiter wait duration in seconds."""
+
+		self._fields['rate_limit_wait_ms'] += _milliseconds(wait_seconds)
+
+	def record_commit(self, elapsed_seconds, succeeded):
+		"""Records one actual commit attempt and its result."""
+
+		self._fields['db_commit_attempt_count'] += 1
+		self._fields['db_commit_ms'] += _milliseconds(elapsed_seconds)
+		if succeeded:
+			self._fields['db_commit_count'] += 1
+
+	def set_failed_phase(self):
+		"""Captures the phase active when the batch failed."""
+
+		self.failed_phase = self._phase
+
+	def event(self, event_name, status, exception=None):
+		"""Builds a JSON-serializable structured event mapping."""
+
+		fields = {
+			'event': event_name,
+			'status': status,
+			'start_height': self.start_height,
+			'end_height': self.end_height,
+			'elapsed_ms': _milliseconds(self._elapsed_seconds(self._started_at)),
+			'failed_phase': self.failed_phase,
+			'exception_class': type(exception).__name__ if exception is not None else None,
+			'http_get_attempts_by_category': dict(self._get_attempts_by_category),
+			'http_post_attempts_by_category': dict(self._post_attempts_by_category),
+		}
+		fields.update(self._fields)
+		return fields
+
+
+class SyncPerformance:  # pylint: disable=too-many-instance-attributes
+	"""Owns performance state for exactly one ``sync-block`` execution."""
+
+	def __init__(self, time_source):
+		self._time_source = time_source
+		self._started_at = self._read_time()
+		self.start_height = None
+		self.target_height = None
+		self.last_completed_height = None
+		self._phase = None
+		self.failed_phase = None
+		self._batches = []
+		self._active_batch = None
+		self._workflow_counters = BatchPerformance(time_source, None, None)
+
+	def _read_time(self):
+		try:
+			return self._time_source()
+		except Exception:  # pylint: disable=broad-exception-caught
+			return None
+
+	def _elapsed_seconds(self):
+		ended_at = self._read_time()
+		if self._started_at is None or ended_at is None:
+			return 0
+
+		return ended_at - self._started_at
+
+	def set_bounds(self, start_height, target_height):
+		"""Sets the requested synchronization range."""
+
+		self.start_height = start_height
+		self.target_height = target_height
+
+	def set_phase(self, phase):
+		"""Sets the current workflow phase used when a non-batch operation fails."""
+
+		self._phase = phase
+
+	def set_failed_phase(self):
+		"""Captures the current workflow phase after a workflow failure."""
+
+		if self.failed_phase is None:
+			self.failed_phase = self._phase
+
+	def set_last_completed_height(self, height):
+		"""Sets the last persisted height when no new internal batch was needed."""
+
+		self.last_completed_height = height
+
+	def start_batch(self, start_height, end_height):
+		"""Starts and activates one internal block batch."""
+
+		batch = BatchPerformance(self._time_source, start_height, end_height)
+		self._batches.append(batch)
+		self._active_batch = batch
+		return batch
+
+	def complete_batch(self, batch):
+		"""Marks one batch complete and advances the last completed height."""
+
+		self.last_completed_height = batch.end_height
+		self._active_batch = None
+
+	def fail_batch(self, batch):
+		"""Captures a failed batch while preserving partial counters."""
+
+		batch.set_failed_phase()
+		self.failed_phase = batch.failed_phase
+		self._active_batch = None
+
+	def record_request_attempt(self, method, category):
+		"""Records an HTTP attempt for the workflow and active batch."""
+
+		self._workflow_counters.record_request_attempt(method, category)
+		if self._active_batch is not None:
+			self._active_batch.record_request_attempt(method, category)
+
+	def add_count(self, field, value):
+		"""Adds partial in-memory rows to the active batch, if one exists."""
+
+		if self._active_batch is not None:
+			self._active_batch.add_count(field, value)
+
+	def record_request_success(self):
+		"""Records an HTTP success for the workflow and active batch."""
+
+		self._workflow_counters.record_request_success()
+		if self._active_batch is not None:
+			self._active_batch.record_request_success()
+
+	def record_retry(self):
+		"""Records an HTTP retry for the workflow and active batch."""
+
+		self._workflow_counters.record_retry()
+		if self._active_batch is not None:
+			self._active_batch.record_retry()
+
+	def record_rate_limit_wait(self, wait_seconds):
+		"""Records rate-limiter wait time for the workflow and active batch."""
+
+		self._workflow_counters.record_rate_limit_wait(wait_seconds)
+		if self._active_batch is not None:
+			self._active_batch.record_rate_limit_wait(wait_seconds)
+
+	def record_commit(self, elapsed_seconds, succeeded):
+		"""Records a database commit for the workflow and active batch."""
+
+		self._workflow_counters.record_commit(elapsed_seconds, succeeded)
+		if self._active_batch is not None:
+			self._active_batch.record_commit(elapsed_seconds, succeeded)
+
+	def _aggregate(self):
+		fields = {field: 0 for field in COUNT_FIELDS + PHASE_FIELDS + DIRTY_FIELDS + DB_FIELDS}
+		for batch in self._batches:
+			event = batch.event('', '')
+			for field in fields:
+				if field not in WORKFLOW_FIELDS:
+					fields[field] += event[field]
+
+		workflow_event = self._workflow_counters.event('', '')
+		for field in WORKFLOW_FIELDS:
+			fields[field] = workflow_event[field]
+
+		return fields, workflow_event['http_get_attempts_by_category'], workflow_event['http_post_attempts_by_category']
+
+	def event(self, event_name, status, exception=None):
+		"""Builds a structured workflow completion or failure event mapping."""
+
+		fields, get_attempts_by_category, post_attempts_by_category = self._aggregate()
+		return {
+			'event': event_name,
+			'status': status,
+			'start_height': self.start_height,
+			'target_height': self.target_height,
+			'last_completed_height': self.last_completed_height,
+			'elapsed_ms': _milliseconds(self._elapsed_seconds()),
+			'batch_count': len(self._batches),
+			'failed_phase': self.failed_phase,
+			'exception_class': type(exception).__name__ if exception is not None else None,
+			'http_get_attempts_by_category': get_attempts_by_category,
+			'http_post_attempts_by_category': post_attempts_by_category,
+			**fields
+		}

--- a/explorer/puller/tests/db/test_SymbolDatabase.py
+++ b/explorer/puller/tests/db/test_SymbolDatabase.py
@@ -66,11 +66,14 @@ RESTRICTION_MOSAIC_ID = '72C0212E67A08BCE'
 
 
 class FailingCommitConnection:
+	def __init__(self, connection):
+		self._connection = connection
+
 	def commit(self):  # pylint: disable=no-self-use
 		raise RuntimeError('commit failed')
 
-	def close(self):  # pylint: disable=no-self-use
-		return None
+	def __getattr__(self, name):
+		return getattr(self._connection, name)
 
 
 class FailingCommitObserver:
@@ -92,6 +95,20 @@ class DeterministicClock:
 		self.call_count += 1
 		value = next(self._values, None)
 		assert value is not None, 'commit clock value sequence was exhausted'
+		return value
+
+
+class ScriptedClock:
+	def __init__(self, values):
+		self._values = iter(values)
+		self.call_count = 0
+
+	def __call__(self):
+		self.call_count += 1
+		value = next(self._values)
+		if isinstance(value, Exception):
+			raise value
+
 		return value
 
 
@@ -319,7 +336,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		self.assertEqual([(0.25, True), (0.50, True)], commit_notifications)
 		self.assertEqual(4, clock.call_count)
 
-	def test_public_symbol_database_api_ignores_commit_observer_failure(self):
+	def test_create_tables_and_upsert_sync_state_ignore_commit_observer_failure(self):
 		# Arrange:
 		database = self.exit_stack.enter_context(
 			SymbolDatabase(self.db_config, commit_observer=FailingCommitObserver()))
@@ -336,21 +353,7 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 		actual_sync_state['last_synced_block_hash'] = bytes(actual_sync_state['last_synced_block_hash'])
 		self.assertEqual(_create_sync_state(), actual_sync_state)
 
-	def test_symbol_database_without_commit_observer_preserves_existing_public_api(self):
-		# Arrange:
-		database = self._create_database()
-		expected_sync_state = _create_sync_state()
-
-		# Act:
-		database.upsert_sync_state(expected_sync_state)
-
-		# Assert:
-		actual_sync_state = database.get_sync_state()
-		actual_sync_state['finalized_hash'] = bytes(actual_sync_state['finalized_hash'])
-		actual_sync_state['last_synced_block_hash'] = bytes(actual_sync_state['last_synced_block_hash'])
-		self.assertEqual(expected_sync_state, actual_sync_state)
-
-	def test_public_symbol_database_api_tolerates_clock_failure_without_observer(self):
+	def test_create_tables_succeeds_when_commit_clock_fails_without_observer(self):
 		# Arrange:
 		database = self.exit_stack.enter_context(SymbolDatabase(self.db_config, time_source=FailingClock()))
 		drop_symbol_block_tables_if_present(database)
@@ -365,22 +368,117 @@ class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
 	def test_commit_failure_notifies_observer_as_failed_attempt(self):
 		# Arrange:
 		commit_notifications = []
+		clock = DeterministicClock([1.0, 1.25, 2.0, 2.75])
 		database = self.exit_stack.enter_context(
 			SymbolDatabase(
 				self.db_config,
 				commit_observer=lambda elapsed_seconds, succeeded: commit_notifications.append(
 					(elapsed_seconds, succeeded)),
-				time_source=lambda: 0))
+				time_source=clock))
+		drop_symbol_block_tables_if_present(database)
+		self.addCleanup(drop_symbol_block_tables_if_present, database)
+		database.create_tables()
 		original_connection = database.connection
-		self.addCleanup(original_connection.close)
-		database.connection = FailingCommitConnection()
+		database.connection = FailingCommitConnection(original_connection)
 
 		# Act:
-		with self.assertRaisesRegex(RuntimeError, 'commit failed'):
-			database._commit()  # pylint: disable=protected-access
+		try:
+			with self.assertRaisesRegex(RuntimeError, 'commit failed') as exception_context:
+				database.upsert_sync_state(_create_sync_state())
+		finally:
+			try:
+				database.connection.rollback()
+			finally:
+				database.connection = original_connection
 
 		# Assert:
-		self.assertEqual([(0, False)], commit_notifications)
+		self.assertEqual('commit failed', str(exception_context.exception))
+		self.assertEqual([(0.25, True), (0.75, False)], commit_notifications)
+		self.assertEqual(1, commit_notifications.count((0.75, False)))
+		self.assertEqual(4, clock.call_count)
+		self.assertIsNone(database.get_sync_state())
+
+	def test_create_tables_succeeds_when_commit_clock_start_read_fails_with_observer(self):
+		# Arrange:
+		commit_notifications = []
+		clock = ScriptedClock([RuntimeError('clock start failed'), 1.0])
+		database = self.exit_stack.enter_context(SymbolDatabase(
+			self.db_config,
+			commit_observer=lambda elapsed_seconds, succeeded: commit_notifications.append(
+				(elapsed_seconds, succeeded)),
+			time_source=clock))
+		drop_symbol_block_tables_if_present(database)
+		self.addCleanup(drop_symbol_block_tables_if_present, database)
+
+		# Act:
+		database.create_tables()
+
+		# Assert:
+		self.assertEqual([(0, True)], commit_notifications)
+		self.assertEqual(2, clock.call_count)
+
+	def test_create_tables_succeeds_when_commit_clock_end_read_fails_with_observer(self):
+		# Arrange:
+		commit_notifications = []
+		clock = ScriptedClock([1.0, RuntimeError('clock end failed')])
+		database = self.exit_stack.enter_context(SymbolDatabase(
+			self.db_config,
+			commit_observer=lambda elapsed_seconds, succeeded: commit_notifications.append(
+				(elapsed_seconds, succeeded)),
+			time_source=clock))
+		drop_symbol_block_tables_if_present(database)
+		self.addCleanup(drop_symbol_block_tables_if_present, database)
+
+		# Act:
+		database.create_tables()
+
+		# Assert:
+		self.assertEqual([(0, True)], commit_notifications)
+		self.assertEqual(2, clock.call_count)
+
+	def test_create_tables_clamps_reverse_commit_clock_to_zero_with_observer(self):
+		# Arrange:
+		commit_notifications = []
+		clock = DeterministicClock([2.0, 1.0])
+		database = self.exit_stack.enter_context(SymbolDatabase(
+			self.db_config,
+			commit_observer=lambda elapsed_seconds, succeeded: commit_notifications.append(
+				(elapsed_seconds, succeeded)),
+			time_source=clock))
+		drop_symbol_block_tables_if_present(database)
+		self.addCleanup(drop_symbol_block_tables_if_present, database)
+
+		# Act:
+		database.create_tables()
+
+		# Assert:
+		self.assertEqual([(0, True)], commit_notifications)
+		self.assertEqual(2, clock.call_count)
+
+	def test_upsert_sync_state_preserves_commit_exception_when_commit_observer_also_fails(self):
+		# Arrange:
+		database = self.exit_stack.enter_context(SymbolDatabase(
+			self.db_config,
+			commit_observer=FailingCommitObserver(),
+			time_source=lambda: 0))
+		drop_symbol_block_tables_if_present(database)
+		self.addCleanup(drop_symbol_block_tables_if_present, database)
+		database.create_tables()
+		original_connection = database.connection
+		database.connection = FailingCommitConnection(original_connection)
+
+		# Act:
+		try:
+			with self.assertRaisesRegex(RuntimeError, 'commit failed') as exception_context:
+				database.upsert_sync_state(_create_sync_state())
+		finally:
+			try:
+				database.connection.rollback()
+			finally:
+				database.connection = original_connection
+
+		# Assert:
+		self.assertEqual('commit failed', str(exception_context.exception))
 
 	def test_create_tables_creates_symbol_namespace_columns(self):
 		# Arrange:

--- a/explorer/puller/tests/db/test_SymbolDatabase.py
+++ b/explorer/puller/tests/db/test_SymbolDatabase.py
@@ -65,6 +65,36 @@ RESTRICTION_HASH_2 = bytes.fromhex('F2' * 32)
 RESTRICTION_MOSAIC_ID = '72C0212E67A08BCE'
 
 
+class FailingCommitConnection:
+	def commit(self):  # pylint: disable=no-self-use
+		raise RuntimeError('commit failed')
+
+	def close(self):  # pylint: disable=no-self-use
+		return None
+
+
+class FailingCommitObserver:
+	def __call__(self, elapsed_seconds, succeeded):  # pylint: disable=unused-argument
+		raise RuntimeError('observer failed')
+
+
+class FailingClock:
+	def __call__(self):  # pylint: disable=no-self-use
+		raise RuntimeError('clock failed')
+
+
+class DeterministicClock:
+	def __init__(self, values):
+		self._values = iter(values)
+		self.call_count = 0
+
+	def __call__(self):
+		self.call_count += 1
+		value = next(self._values, None)
+		assert value is not None, 'commit clock value sequence was exhausted'
+		return value
+
+
 def _create_mosaic_restriction_row(
 	entry_type=MosaicRestrictionEntryType.ADDRESS,
 	target_address=LOCK_RECIPIENT,
@@ -268,6 +298,90 @@ def _create_alias_name_rows(namespace_row):
 
 
 class SymbolDatabaseTest(TestCase):  # pylint: disable=too-many-public-methods
+	def test_public_symbol_database_api_reports_exact_commit_elapsed_time_for_real_postgresql_commits(self):
+		# Arrange:
+		commit_notifications = []
+		clock = DeterministicClock([1.00, 1.25, 2.00, 2.50])
+		database = self.exit_stack.enter_context(
+			SymbolDatabase(
+				self.db_config,
+				time_source=clock,
+				commit_observer=lambda elapsed_seconds, succeeded: commit_notifications.append(
+					(elapsed_seconds, succeeded))))
+		drop_symbol_block_tables_if_present(database)
+		self.addCleanup(drop_symbol_block_tables_if_present, database)
+
+		# Act:
+		database.create_tables()
+		database.upsert_sync_state(_create_sync_state())
+
+		# Assert:
+		self.assertEqual([(0.25, True), (0.50, True)], commit_notifications)
+		self.assertEqual(4, clock.call_count)
+
+	def test_public_symbol_database_api_ignores_commit_observer_failure(self):
+		# Arrange:
+		database = self.exit_stack.enter_context(
+			SymbolDatabase(self.db_config, commit_observer=FailingCommitObserver()))
+		drop_symbol_block_tables_if_present(database)
+		self.addCleanup(drop_symbol_block_tables_if_present, database)
+
+		# Act:
+		database.create_tables()
+		database.upsert_sync_state(_create_sync_state())
+
+		# Assert:
+		actual_sync_state = database.get_sync_state()
+		actual_sync_state['finalized_hash'] = bytes(actual_sync_state['finalized_hash'])
+		actual_sync_state['last_synced_block_hash'] = bytes(actual_sync_state['last_synced_block_hash'])
+		self.assertEqual(_create_sync_state(), actual_sync_state)
+
+	def test_symbol_database_without_commit_observer_preserves_existing_public_api(self):
+		# Arrange:
+		database = self._create_database()
+		expected_sync_state = _create_sync_state()
+
+		# Act:
+		database.upsert_sync_state(expected_sync_state)
+
+		# Assert:
+		actual_sync_state = database.get_sync_state()
+		actual_sync_state['finalized_hash'] = bytes(actual_sync_state['finalized_hash'])
+		actual_sync_state['last_synced_block_hash'] = bytes(actual_sync_state['last_synced_block_hash'])
+		self.assertEqual(expected_sync_state, actual_sync_state)
+
+	def test_public_symbol_database_api_tolerates_clock_failure_without_observer(self):
+		# Arrange:
+		database = self.exit_stack.enter_context(SymbolDatabase(self.db_config, time_source=FailingClock()))
+		drop_symbol_block_tables_if_present(database)
+		self.addCleanup(drop_symbol_block_tables_if_present, database)
+
+		# Act:
+		database.create_tables()
+
+		# Assert:
+		self.assertEqual(None, database.get_sync_state())
+
+	def test_commit_failure_notifies_observer_as_failed_attempt(self):
+		# Arrange:
+		commit_notifications = []
+		database = self.exit_stack.enter_context(
+			SymbolDatabase(
+				self.db_config,
+				commit_observer=lambda elapsed_seconds, succeeded: commit_notifications.append(
+					(elapsed_seconds, succeeded)),
+				time_source=lambda: 0))
+		original_connection = database.connection
+		self.addCleanup(original_connection.close)
+		database.connection = FailingCommitConnection()
+
+		# Act:
+		with self.assertRaisesRegex(RuntimeError, 'commit failed'):
+			database._commit()  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual([(0, False)], commit_notifications)
+
 	def test_create_tables_creates_symbol_namespace_columns(self):
 		# Arrange:
 		database = self._create_uninitialized_database()

--- a/explorer/puller/tests/facade/symbol/puller_test_utils.py
+++ b/explorer/puller/tests/facade/symbol/puller_test_utils.py
@@ -178,6 +178,16 @@ def create_node_block(
 	return node_block
 
 
+def create_multi_batch_block_pages(chain_height=1001):
+	"""Creates fresh block pages that exercise the puller's internal batch boundary."""
+
+	blocks = [create_node_block(height) for height in range(1, chain_height + 1)]
+	return {
+		offset: blocks[offset:offset + MAX_PAGE_SIZE]
+		for offset in range(0, chain_height, MAX_PAGE_SIZE)
+	}
+
+
 def create_node_transaction(height, transaction_hash=None, transaction_id=None, block_index=0, **transaction_overrides):
 	transaction_hash = transaction_hash or f'{height:064X}'
 	transaction = {

--- a/explorer/puller/tests/facade/symbol/puller_test_utils.py
+++ b/explorer/puller/tests/facade/symbol/puller_test_utils.py
@@ -63,13 +63,21 @@ def create_symbol_puller(  # pylint: disable=too-many-arguments,too-many-positio
 	request_timeout_seconds=10,
 	node_url=NODE_URL,
 	connector=None,
-	rate_limiter=None
+	rate_limiter=None,
+	time_source=None,
+	performance_logger=None
 ):
 	node_config = SymbolNodeConfiguration.from_url(
 		node_url,
 		allow_loopback=True,
 		timeout_seconds=request_timeout_seconds
 	)
+
+	puller_kwargs = {}
+	if time_source is not None:
+		puller_kwargs['time_source'] = time_source
+	if performance_logger is not None:
+		puller_kwargs['performance_logger'] = performance_logger
 
 	puller = SymbolPuller(
 		node_url,
@@ -78,7 +86,8 @@ def create_symbol_puller(  # pylint: disable=too-many-arguments,too-many-positio
 		node_config,
 		connector,
 		max_requests_per_second=1_000_000,
-		rate_limiter=rate_limiter
+		rate_limiter=rate_limiter,
+		**puller_kwargs
 	)
 	puller._retry_delay = 0  # pylint: disable=protected-access
 
@@ -86,11 +95,13 @@ def create_symbol_puller(  # pylint: disable=too-many-arguments,too-many-positio
 
 
 @contextmanager
-def temporary_symbol_puller(
+def temporary_symbol_puller(  # pylint: disable=too-many-arguments,too-many-positional-arguments
 	network_type='mainnet',
 	request_timeout_seconds=10,
 	connector=None,
-	rate_limiter=None
+	rate_limiter=None,
+	time_source=None,
+	performance_logger=None
 ):
 	with tempfile.TemporaryDirectory() as temp_directory:
 		db_config_path = create_db_config(temp_directory)
@@ -100,7 +111,9 @@ def temporary_symbol_puller(
 			network_type,
 			request_timeout_seconds,
 			connector=connector,
-			rate_limiter=rate_limiter
+			rate_limiter=rate_limiter,
+			time_source=time_source,
+			performance_logger=performance_logger
 		)
 
 

--- a/explorer/puller/tests/facade/symbol/test_PullerPerformance.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerPerformance.py
@@ -1,0 +1,467 @@
+import asyncio
+import json
+
+from symbolchain.sc import ReceiptType
+from symbollightapi.model.Exceptions import NodeException
+
+from puller.facade.SymbolPuller import SymbolRollbackError
+
+from .puller_test_utils import (
+	FakeConnector,
+	NoOpRateLimiter,
+	SymbolPullerTestBase,
+	create_amount_statement_item,
+	create_complete_aggregate_pair,
+	create_node_block,
+	create_sync_state,
+	set_symbol_connector,
+	set_symbol_rate_limiter,
+	statement_path,
+	transaction_path
+)
+
+
+class RecordingLogger:
+	def __init__(self):
+		self.messages = []
+
+	def info(self, message):
+		self.messages.append(message)
+
+
+class FailingLogger:
+	def info(self, message):  # pylint: disable=unused-argument,no-self-use
+		raise RuntimeError('performance logger failed')
+
+
+class RetryOnceTransactionConnector(FakeConnector):
+	def __init__(self, *args, **kwargs):
+		super().__init__(*args, **kwargs)
+		self.transaction_attempt_count = 0
+
+	async def get(self, url_path, *args):
+		if url_path.startswith('transactions/confirmed?'):
+			self.transaction_attempt_count += 1
+			if 1 == self.transaction_attempt_count:
+				self.paths.append(url_path)
+				raise NodeException('retry-only test error')
+
+		return await super().get(url_path, *args)
+
+
+class FailingSecondBatchConnector(FakeConnector):
+	async def get(self, url_path, *args):
+		if url_path.startswith('blocks?pageSize=100&offset=1000'):
+			self.paths.append(url_path)
+			raise ValueError('second batch block fetch failed')
+
+		return await super().get(url_path, *args)
+
+
+class FailingChainInfoConnector(FakeConnector):
+	def __init__(self, *args, **kwargs):
+		super().__init__(*args, **kwargs)
+		self.failure = ValueError('chain info fetch failed')
+
+	async def get(self, url_path, *args):
+		if 'chain/info' == url_path:
+			self.paths.append(url_path)
+			raise self.failure
+
+		return await super().get(url_path, *args)
+
+
+class FailingSyncStateDatabase:
+	def __init__(self, database, failure):
+		self.database = database
+		self.failure = failure
+
+	def __getattr__(self, name):
+		return getattr(self.database, name)
+
+	def upsert_sync_state(self, sync_state):
+		if 'healthy' == sync_state['status']:
+			raise self.failure
+
+		return self.database.upsert_sync_state(sync_state)
+
+
+class FailingFinalizationDatabase:
+	def __init__(self, database, failure):
+		self.database = database
+		self.failure = failure
+
+	def __getattr__(self, name):
+		return getattr(self.database, name)
+
+	def apply_finalization_lock_entries(self, hash_lock_entries, secret_lock_entries):  # pylint: disable=unused-argument
+		raise self.failure
+
+
+class FailingPerformance:
+	def __init__(self):
+		self.call_count = 0
+
+	def record_request_attempt(self, method, category):  # pylint: disable=unused-argument
+		self.call_count += 1
+		raise RuntimeError('performance recorder failed')
+
+
+class FailingEventPerformance:
+	def __init__(self):
+		self.call_count = 0
+
+	def event(self, event_name, status, exception=None):  # pylint: disable=unused-argument
+		self.call_count += 1
+		raise RuntimeError('performance event failed')
+
+
+class SymbolPullerPerformanceTest(SymbolPullerTestBase):
+	def _run_sync(self, connector, performance_logger=None):
+		# Arrange:
+		logger = performance_logger or RecordingLogger()
+		self.puller._performance_logger = logger  # pylint: disable=protected-access
+		set_symbol_connector(self.puller, connector)
+		set_symbol_rate_limiter(self.puller, NoOpRateLimiter())
+
+		# Act:
+		asyncio.run(self.puller.sync_block_headers())
+
+		# Assert:
+		return [json.loads(message) for message in logger.messages]
+
+	def test_sync_block_headers_logs_one_completed_batch_and_workflow_event(self):
+		# Arrange:
+		connector = FakeConnector(1, {0: [create_node_block(1)]})
+
+		# Act:
+		events = self._run_sync(connector)
+
+		# Assert:
+		self.assertEqual(2, len(events))
+		batch_event, workflow_event = events
+		self.assertEqual('symbol_sync_batch_completed', batch_event['event'])
+		self.assertEqual('completed', batch_event['status'])
+		self.assertEqual(1, batch_event['start_height'])
+		self.assertEqual(1, batch_event['end_height'])
+		self.assertEqual(1, batch_event['block_count'])
+		self.assertEqual(0, batch_event['transaction_count'])
+		self.assertEqual(0, batch_event['receipt_count'])
+		self.assertEqual(1, batch_event['dirty_account_count'])
+		self.assertEqual(0, batch_event['dirty_namespace_count'])
+		self.assertEqual(0, batch_event['dirty_mosaic_count'])
+		self.assertEqual(0, batch_event['dirty_metadata_count'])
+		self.assertEqual(0, batch_event['dirty_hash_lock_count'])
+		self.assertEqual(0, batch_event['dirty_secret_lock_count'])
+		self.assertEqual(0, batch_event['dirty_mosaic_restriction_count'])
+		self.assertEqual(4, batch_event['http_get_attempt_count'])
+		self.assertEqual(1, batch_event['http_post_attempt_count'])
+		self.assertEqual(5, batch_event['http_attempt_count'])
+		self.assertEqual(4, batch_event['http_success_count'])
+		self.assertEqual(0, batch_event['http_retry_count'])
+		self.assertEqual(0, batch_event['rate_limit_wait_ms'])
+		self.assertEqual(7, batch_event['db_commit_count'])
+		self.assertEqual(7, batch_event['db_commit_attempt_count'])
+		self.assertIsNone(batch_event['failed_phase'])
+		self.assertEqual('completed', workflow_event['status'])
+		self.assertEqual(1, workflow_event['batch_count'])
+		self.assertEqual(1, workflow_event['block_count'])
+		self.assertEqual(8, workflow_event['http_attempt_count'])
+		self.assertEqual(9, workflow_event['db_commit_count'])
+		self.assertIsNone(workflow_event['failed_phase'])
+		self.assertEqual(batch_event['http_attempt_count'] + 3, workflow_event['http_attempt_count'])
+		self.assertEqual(batch_event['db_commit_count'] + 2, workflow_event['db_commit_count'])
+		self.assertGreater(workflow_event['http_attempt_count'], batch_event['http_attempt_count'])
+		self.assertGreater(workflow_event['db_commit_count'], batch_event['db_commit_count'])
+
+	def test_sync_block_headers_logs_actual_range_for_partial_final_batch(self):
+		# Arrange:
+		connector = FakeConnector(2, {
+			0: [create_node_block(1), create_node_block(2)]
+		})
+
+		# Act:
+		batch_event = self._run_sync(connector)[0]
+
+		# Assert:
+		self.assertEqual(1, batch_event['start_height'])
+		self.assertEqual(2, batch_event['end_height'])
+		self.assertEqual(2, batch_event['block_count'])
+
+	def test_sync_block_headers_reports_existing_height_when_no_new_batch_is_needed(self):
+		# Arrange:
+		self._seed_blocks(self.puller.symbol_db, [1])
+		self.puller.symbol_db.upsert_sync_state(create_sync_state(chain_height=1, last_synced_height=1))
+		connector = FakeConnector(1, {})
+
+		# Act:
+		events = self._run_sync(connector)
+
+		# Assert:
+		self.assertEqual(1, len(events))
+		self.assertEqual('symbol_sync_completed', events[0]['event'])
+		self.assertEqual(0, events[0]['batch_count'])
+		self.assertEqual(1, events[0]['last_completed_height'])
+		self.assertEqual(3, events[0]['http_attempt_count'])
+		self.assertEqual(2, events[0]['db_commit_count'])
+		self.assertIsNone(events[0]['failed_phase'])
+
+	def test_sync_block_headers_counts_embedded_transactions_and_receipt_rows(self):
+		# Arrange:
+		transactions = create_complete_aggregate_pair(1, 'A' * 64, 0)
+		connector = FakeConnector(
+			1,
+			{0: [create_node_block(1)]},
+			transactions_by_path={transaction_path(1, 1): {'data': transactions}},
+			statement_pages={statement_path(1, 1): {
+				'data': [create_amount_statement_item(1, 11, ReceiptType.INFLATION.value, 'receipt-1')]
+			}}
+		)
+
+		# Act:
+		batch_event = self._run_sync(connector)[0]
+
+		# Assert:
+		self.assertEqual(2, batch_event['transaction_count'])
+		self.assertEqual(1, batch_event['receipt_count'])
+
+	def test_sync_block_headers_counts_retry_as_an_attempt_without_counting_initial_try_as_retry(self):
+		# Arrange:
+		connector = RetryOnceTransactionConnector(1, {0: [create_node_block(1)]})
+		self.puller._retry_delay = 0  # pylint: disable=protected-access
+
+		# Act:
+		batch_event = self._run_sync(connector)[0]
+
+		# Assert:
+		self.assertEqual(6, batch_event['http_attempt_count'])
+		self.assertEqual(5, batch_event['http_get_attempt_count'])
+		self.assertEqual(1, batch_event['http_post_attempt_count'])
+		self.assertEqual(1, batch_event['http_retry_count'])
+		self.assertEqual(4, batch_event['http_success_count'])
+		self.assertEqual(2, batch_event['http_get_attempts_by_category']['confirmed_transaction'])
+		self.assertEqual(0, batch_event['rate_limit_wait_ms'])
+
+	def test_sync_block_headers_sums_multiple_batch_events_in_workflow_event(self):
+		# Arrange:
+		blocks = [create_node_block(height) for height in range(1, 1002)]
+		pages = {offset: blocks[offset:offset + 100] for offset in range(0, 1001, 100)}
+		connector = FakeConnector(1001, pages)
+
+		# Act:
+		events = self._run_sync(connector)
+
+		# Assert:
+		batch_events = events[:2]
+		workflow_event = events[2]
+		self.assertEqual(2, len(batch_events))
+		self.assertEqual(1000, batch_events[0]['block_count'])
+		self.assertEqual(1, batch_events[1]['block_count'])
+		self.assertEqual(2, workflow_event['batch_count'])
+		self.assertEqual(1001, workflow_event['block_count'])
+		self.assertEqual(
+			sum(event['http_attempt_count'] for event in batch_events),
+			workflow_event['http_attempt_count'] - 3)
+		self.assertEqual(
+			sum(event['db_commit_count'] for event in batch_events),
+			workflow_event['db_commit_count'] - 2)
+		self.assertEqual(22, workflow_event['http_attempt_count'])
+		self.assertEqual(2014, workflow_event['db_commit_count'])
+		self.assertIsNone(workflow_event['failed_phase'])
+		self.assertEqual(1001, workflow_event['last_completed_height'])
+
+	def test_sync_block_headers_records_last_completed_height_when_a_later_batch_fails(self):
+		# Arrange:
+		blocks = [create_node_block(height) for height in range(1, 1002)]
+		pages = {offset: blocks[offset:offset + 100] for offset in range(0, 1001, 100)}
+		connector = FailingSecondBatchConnector(1001, pages)
+		logger = RecordingLogger()
+		set_symbol_connector(self.puller, connector)
+		set_symbol_rate_limiter(self.puller, NoOpRateLimiter())
+		self.puller._performance_logger = logger  # pylint: disable=protected-access
+
+		# Act:
+		with self.assertRaisesRegex(ValueError, 'second batch block fetch failed'):
+			asyncio.run(self.puller.sync_block_headers())
+
+		# Assert:
+		events = [json.loads(message) for message in logger.messages]
+		self.assertEqual(3, len(events))
+		self.assertEqual('symbol_sync_batch_completed', events[0]['event'])
+		self.assertEqual('symbol_sync_batch_failed', events[1]['event'])
+		self.assertEqual('block_fetch', events[1]['failed_phase'])
+		self.assertIsNone(events[0]['failed_phase'])
+		self.assertEqual('symbol_sync_failed', events[2]['event'])
+		self.assertEqual(1000, events[2]['last_completed_height'])
+		self.assertEqual('block_fetch', events[2]['failed_phase'])
+		self.assertEqual(
+			sum(event['http_attempt_count'] for event in events[:2]) + 3,
+			events[2]['http_attempt_count'])
+		self.assertEqual(
+			sum(event['db_commit_count'] for event in events[:2]) + 1,
+			events[2]['db_commit_count'])
+
+	def test_sync_block_headers_logs_failed_phase_and_preserves_original_exception(self):
+		# Arrange:
+		expected_exception = ValueError('transaction fetch failed')
+		connector = FakeConnector(
+			1,
+			{0: [create_node_block(1)]},
+			transactions_by_path={transaction_path(1, 1): expected_exception})
+		logger = RecordingLogger()
+
+		# Act:
+		set_symbol_connector(self.puller, connector)
+		set_symbol_rate_limiter(self.puller, NoOpRateLimiter())
+		self.puller._performance_logger = logger  # pylint: disable=protected-access
+		with self.assertRaisesRegex(ValueError, 'transaction fetch failed') as exception_context:
+			asyncio.run(self.puller.sync_block_headers())
+
+		# Assert:
+		self.assertIs(expected_exception, exception_context.exception)
+		events = [json.loads(message) for message in logger.messages]
+		self.assertEqual(2, len(events))
+		self.assertEqual('symbol_sync_batch_failed', events[0]['event'])
+		self.assertEqual('failed', events[0]['status'])
+		self.assertEqual('transaction_fetch', events[0]['failed_phase'])
+		self.assertEqual('ValueError', events[0]['exception_class'])
+		self.assertEqual(1, events[0]['block_count'])
+		self.assertEqual('symbol_sync_failed', events[1]['event'])
+		self.assertIsNone(events[1]['last_completed_height'])
+		self.assertEqual('transaction_fetch', events[1]['failed_phase'])
+
+	def test_sync_block_headers_does_not_replace_original_exception_when_logging_fails(self):
+		# Arrange:
+		expected_exception = ValueError('transaction fetch failed')
+		connector = FakeConnector(
+			1,
+			{0: [create_node_block(1)]},
+			transactions_by_path={transaction_path(1, 1): expected_exception})
+		set_symbol_connector(self.puller, connector)
+		set_symbol_rate_limiter(self.puller, NoOpRateLimiter())
+		self.puller._performance_logger = FailingLogger()  # pylint: disable=protected-access
+
+		# Act:
+		with self.assertRaisesRegex(ValueError, 'transaction fetch failed') as exception_context:
+			asyncio.run(self.puller.sync_block_headers())
+
+		# Assert:
+		self.assertIs(expected_exception, exception_context.exception)
+
+	def test_sync_block_headers_reports_chain_info_failure_phase_without_batch(self):
+		# Arrange:
+		expected_exception = ValueError('chain info fetch failed')
+		connector = FailingChainInfoConnector(1, {})
+		connector.failure = expected_exception
+		logger = RecordingLogger()
+		set_symbol_connector(self.puller, connector)
+		set_symbol_rate_limiter(self.puller, NoOpRateLimiter())
+		self.puller._performance_logger = logger  # pylint: disable=protected-access
+
+		# Act:
+		with self.assertRaisesRegex(ValueError, 'chain info fetch failed') as exception_context:
+			asyncio.run(self.puller.sync_block_headers())
+
+		# Assert:
+		self.assertIs(expected_exception, exception_context.exception)
+		event = json.loads(logger.messages[0])
+		self.assertEqual('symbol_sync_failed', event['event'])
+		self.assertEqual('failed', event['status'])
+		self.assertEqual(0, event['batch_count'])
+		self.assertEqual(1, event['http_attempt_count'])
+		self.assertEqual('chain_info_fetch', event['failed_phase'])
+		self.assertEqual('ValueError', event['exception_class'])
+
+	def test_sync_block_headers_reports_rollback_failure_phase_without_batch(self):
+		# Arrange:
+		connector = FakeConnector(1, {})
+		logger = RecordingLogger()
+		set_symbol_connector(self.puller, connector)
+		set_symbol_rate_limiter(self.puller, NoOpRateLimiter())
+		self.puller._performance_logger = logger  # pylint: disable=protected-access
+		self.puller.symbol_db.upsert_sync_state(create_sync_state())
+
+		# Act:
+		with self.assertRaisesRegex(SymbolRollbackError, 'Finalized block is missing from local database') as exception_context:
+			asyncio.run(self.puller.sync_block_headers())
+
+		# Assert:
+		self.assertEqual('Finalized block is missing from local database', str(exception_context.exception))
+		event = json.loads(logger.messages[0])
+		self.assertEqual('symbol_sync_failed', event['event'])
+		self.assertEqual(0, event['batch_count'])
+		self.assertEqual(3, event['http_attempt_count'])
+		self.assertEqual(1, event['db_commit_count'])
+		self.assertEqual('rollback_repair', event['failed_phase'])
+
+	def test_sync_block_headers_reports_finalization_cleanup_failure_phase_without_batch(self):
+		# Arrange:
+		expected_exception = ValueError('finalization cleanup failed')
+		connector = FakeConnector(1, {})
+		logger = RecordingLogger()
+		set_symbol_connector(self.puller, connector)
+		set_symbol_rate_limiter(self.puller, NoOpRateLimiter())
+		self.puller._performance_logger = logger  # pylint: disable=protected-access
+		self._seed_blocks(self.puller.symbol_db, [1])
+		self.puller.symbol_db.upsert_sync_state(create_sync_state(chain_height=1, last_synced_height=1))
+		self.puller.symbol_db = FailingFinalizationDatabase(self.puller.symbol_db, expected_exception)
+
+		# Act:
+		with self.assertRaisesRegex(ValueError, 'finalization cleanup failed') as exception_context:
+			asyncio.run(self.puller.sync_block_headers())
+
+		# Assert:
+		self.assertIs(expected_exception, exception_context.exception)
+		event = json.loads(logger.messages[0])
+		self.assertEqual('symbol_sync_failed', event['event'])
+		self.assertEqual(0, event['batch_count'])
+		self.assertEqual(3, event['http_attempt_count'])
+		self.assertEqual(0, event['db_commit_count'])
+		self.assertEqual('finalization_lock_cleanup', event['failed_phase'])
+
+	def test_sync_block_headers_reports_sync_state_write_failure_phase_after_batch(self):
+		# Arrange:
+		expected_exception = ValueError('sync state write failed')
+		connector = FakeConnector(1, {0: [create_node_block(1)]})
+		logger = RecordingLogger()
+		set_symbol_connector(self.puller, connector)
+		set_symbol_rate_limiter(self.puller, NoOpRateLimiter())
+		self.puller._performance_logger = logger  # pylint: disable=protected-access
+		self.puller.symbol_db = FailingSyncStateDatabase(self.puller.symbol_db, expected_exception)
+
+		# Act:
+		with self.assertRaisesRegex(ValueError, 'sync state write failed') as exception_context:
+			asyncio.run(self.puller.sync_block_headers())
+
+		# Assert:
+		self.assertIs(expected_exception, exception_context.exception)
+		events = [json.loads(message) for message in logger.messages]
+		self.assertEqual(2, len(events))
+		self.assertEqual('symbol_sync_batch_completed', events[0]['event'])
+		self.assertIsNone(events[0]['failed_phase'])
+		self.assertEqual('symbol_sync_failed', events[1]['event'])
+		self.assertEqual('sync_state_write', events[1]['failed_phase'])
+		self.assertEqual(1, events[1]['last_completed_height'])
+
+	def test_performance_recording_failure_does_not_raise(self):
+		# Arrange:
+		performance = FailingPerformance()
+		self.puller._active_performance = performance  # pylint: disable=protected-access
+
+		# Act:
+		self.puller._record_performance('record_request_attempt', 'GET', 'block')  # pylint: disable=protected-access
+
+		# Assert:
+		self.assertEqual(1, performance.call_count)
+
+	def test_performance_event_generation_failure_does_not_raise(self):
+		# Arrange:
+		performance = FailingEventPerformance()
+		self.puller._performance_logger = FailingLogger()  # pylint: disable=protected-access
+
+		# Act:
+		self.puller._log_performance_event(  # pylint: disable=protected-access
+			performance, 'symbol_sync_failed', 'failed', ValueError('original'))
+
+		# Assert:
+		self.assertEqual(1, performance.call_count)

--- a/explorer/puller/tests/facade/symbol/test_PullerPerformance.py
+++ b/explorer/puller/tests/facade/symbol/test_PullerPerformance.py
@@ -1,24 +1,64 @@
 import asyncio
 import json
 
-from symbolchain.sc import ReceiptType
+from symbolchain.sc import ReceiptType, TransactionType
+from symbolchain.symbol.Network import Address
 from symbollightapi.model.Exceptions import NodeException
 
 from puller.facade.SymbolPuller import SymbolRollbackError
+from tests.test.SymbolLockTestUtils import create_secret_lock_item
+from tests.test.SymbolMetadataTestUtils import SCOPED_METADATA_KEY, create_metadata_item, metadata_path
+from tests.test.SymbolMosaicTestUtils import MOSAIC_ID, create_mosaic_item
+from tests.test.SymbolNamespaceTestUtils import NAMESPACE_ROOT_ID, create_namespace_item
+from tests.test.SymbolTestConstants import RECIPIENT_ADDRESS, SIGNER_ADDRESS
 
 from .puller_test_utils import (
+	DelegatingSymbolDatabase,
 	FakeConnector,
 	NoOpRateLimiter,
 	SymbolPullerTestBase,
 	create_amount_statement_item,
 	create_complete_aggregate_pair,
+	create_multi_batch_block_pages,
 	create_node_block,
+	create_node_transaction,
 	create_sync_state,
 	set_symbol_connector,
 	set_symbol_rate_limiter,
 	statement_path,
 	transaction_path
 )
+
+BATCH_EVENT_KEYS = {
+	'event', 'status', 'start_height', 'end_height', 'elapsed_ms', 'failed_phase', 'exception_class',
+	'block_count', 'transaction_count', 'receipt_count', 'http_attempt_count', 'http_success_count',
+	'http_retry_count', 'http_get_attempt_count', 'http_post_attempt_count', 'rate_limit_wait_ms',
+	'db_commit_count', 'db_commit_attempt_count', 'block_fetch_ms', 'transaction_fetch_ms', 'receipt_fetch_ms',
+	'resolution_fetch_ms', 'account_fetch_ms', 'namespace_fetch_ms', 'mosaic_fetch_ms', 'metadata_fetch_ms',
+	'hash_lock_fetch_ms', 'secret_lock_fetch_ms', 'mosaic_restriction_fetch_ms', 'dirty_account_count',
+	'dirty_namespace_count', 'dirty_mosaic_count', 'dirty_metadata_count', 'dirty_hash_lock_count',
+	'dirty_secret_lock_count', 'dirty_mosaic_restriction_count', 'block_transaction_receipt_write_ms',
+	'account_multisig_write_ms', 'current_state_write_ms', 'db_write_total_ms', 'db_commit_ms',
+	'http_get_attempts_by_category', 'http_post_attempts_by_category'
+}
+WORKFLOW_EVENT_KEYS = {
+	'event', 'status', 'start_height', 'target_height', 'last_completed_height', 'elapsed_ms', 'batch_count',
+	'failed_phase', 'exception_class', 'block_count', 'transaction_count', 'receipt_count', 'http_attempt_count',
+	'http_success_count', 'http_retry_count', 'http_get_attempt_count', 'http_post_attempt_count',
+	'rate_limit_wait_ms', 'db_commit_count', 'db_commit_attempt_count', 'block_fetch_ms', 'transaction_fetch_ms',
+	'receipt_fetch_ms', 'resolution_fetch_ms', 'account_fetch_ms', 'namespace_fetch_ms', 'mosaic_fetch_ms',
+	'metadata_fetch_ms', 'hash_lock_fetch_ms', 'secret_lock_fetch_ms', 'mosaic_restriction_fetch_ms',
+	'dirty_account_count', 'dirty_namespace_count', 'dirty_mosaic_count', 'dirty_metadata_count',
+	'dirty_hash_lock_count', 'dirty_secret_lock_count', 'dirty_mosaic_restriction_count',
+	'block_transaction_receipt_write_ms', 'account_multisig_write_ms', 'current_state_write_ms',
+	'db_write_total_ms', 'db_commit_ms', 'http_get_attempts_by_category', 'http_post_attempts_by_category'
+}
+TIMING_FIELDS = {
+	'elapsed_ms', 'block_fetch_ms', 'transaction_fetch_ms', 'receipt_fetch_ms', 'resolution_fetch_ms',
+	'account_fetch_ms', 'namespace_fetch_ms', 'mosaic_fetch_ms', 'metadata_fetch_ms', 'hash_lock_fetch_ms',
+	'secret_lock_fetch_ms', 'mosaic_restriction_fetch_ms', 'block_transaction_receipt_write_ms',
+	'account_multisig_write_ms', 'current_state_write_ms', 'db_write_total_ms', 'db_commit_ms'
+}
 
 
 class RecordingLogger:
@@ -27,6 +67,10 @@ class RecordingLogger:
 
 	def info(self, message):
 		self.messages.append(message)
+
+	@property
+	def events(self):
+		return [json.loads(message) for message in self.messages]
 
 
 class FailingLogger:
@@ -71,13 +115,10 @@ class FailingChainInfoConnector(FakeConnector):
 		return await super().get(url_path, *args)
 
 
-class FailingSyncStateDatabase:
+class FailingSyncStateDatabase(DelegatingSymbolDatabase):
 	def __init__(self, database, failure):
-		self.database = database
+		super().__init__(database)
 		self.failure = failure
-
-	def __getattr__(self, name):
-		return getattr(self.database, name)
 
 	def upsert_sync_state(self, sync_state):
 		if 'healthy' == sync_state['status']:
@@ -86,16 +127,86 @@ class FailingSyncStateDatabase:
 		return self.database.upsert_sync_state(sync_state)
 
 
-class FailingFinalizationDatabase:
+class FailingFinalizationDatabase(DelegatingSymbolDatabase):
 	def __init__(self, database, failure):
-		self.database = database
+		super().__init__(database)
 		self.failure = failure
-
-	def __getattr__(self, name):
-		return getattr(self.database, name)
 
 	def apply_finalization_lock_entries(self, hash_lock_entries, secret_lock_entries):  # pylint: disable=unused-argument
 		raise self.failure
+
+
+class FailingSyncStateReadDatabase(DelegatingSymbolDatabase):
+	def __init__(self, database, failure):
+		super().__init__(database)
+		self.failure = failure
+
+	def get_sync_state(self):
+		raise self.failure
+
+
+class RetryOnceChainInfoConnector(FakeConnector):
+	def __init__(self, *args, **kwargs):
+		super().__init__(*args, **kwargs)
+		self.chain_info_attempt_count = 0
+
+	async def get(self, url_path, *args):
+		if 'chain/info' == url_path:
+			self.chain_info_attempt_count += 1
+			if 1 == self.chain_info_attempt_count:
+				self.paths.append(url_path)
+				raise NodeException('chain info retry')
+
+		return await super().get(url_path, *args)
+
+
+class FailingPhaseConnector(FakeConnector):
+	def __init__(self, failing_path, failure, *args, **kwargs):
+		super().__init__(*args, **kwargs)
+		self.failing_path = failing_path
+		self.failure = failure
+
+	async def get(self, url_path, *args):
+		if self.failing_path == url_path:
+			self.paths.append(url_path)
+			raise self.failure
+
+		return await super().get(url_path, *args)
+
+
+class FixedRateLimiter:
+	def __init__(self, first_wait_seconds, later_wait_seconds):
+		self.first_wait_seconds = first_wait_seconds
+		self.later_wait_seconds = later_wait_seconds
+		self.call_count = 0
+
+	async def wait_for_turn(self):
+		self.call_count += 1
+		return self.first_wait_seconds if 1 == self.call_count else self.later_wait_seconds
+
+
+class ExtraResponseConnector(FakeConnector):
+	def __init__(self, *args, responses=None, **kwargs):
+		super().__init__(*args, **kwargs)
+		self.responses = responses or {}
+
+	async def get(self, url_path, *args):
+		if url_path in self.responses:
+			self.paths.append(url_path)
+			return self.responses[url_path]
+
+		return await super().get(url_path, *args)
+
+
+class IncrementingClock:
+	def __init__(self, step_seconds=0.001):
+		self.value = 0
+		self.step_seconds = step_seconds
+
+	def __call__(self):
+		value = self.value
+		self.value += self.step_seconds
+		return value
 
 
 class FailingPerformance:
@@ -116,19 +227,68 @@ class FailingEventPerformance:
 		raise RuntimeError('performance event failed')
 
 
+# pylint: disable=duplicate-code,too-many-lines,too-many-public-methods
 class SymbolPullerPerformanceTest(SymbolPullerTestBase):
-	def _run_sync(self, connector, performance_logger=None):
+	def _run_sync(self, connector, performance_logger=None, rate_limiter=None):
 		# Arrange:
 		logger = performance_logger or RecordingLogger()
 		self.puller._performance_logger = logger  # pylint: disable=protected-access
 		set_symbol_connector(self.puller, connector)
-		set_symbol_rate_limiter(self.puller, NoOpRateLimiter())
+		set_symbol_rate_limiter(self.puller, rate_limiter or NoOpRateLimiter())
 
 		# Act:
 		asyncio.run(self.puller.sync_block_headers())
 
+		return logger.events
+
+	def _assert_dirty_count(self, transaction, field, connector_class=FakeConnector, **connector_kwargs):
+		# Arrange:
+		connector = connector_class(
+			1,
+			{0: [create_node_block(1)]},
+			transactions_by_path={transaction_path(1, 1): {'data': [transaction]}},
+			**connector_kwargs)
+
+		# Act:
+		batch_event, workflow_event = self._run_sync(connector)[:2]
+
 		# Assert:
-		return [json.loads(message) for message in logger.messages]
+		self.assertEqual(1, batch_event[field])
+		self.assertEqual(1, workflow_event[field])
+
+	def _assert_event_key_contract(self, event, expected_keys):
+		# Act:
+		actual_keys = set(event)
+
+		# Assert:
+		self.assertEqual(expected_keys, actual_keys)
+
+	@staticmethod
+	def _without_timing_fields(event):
+		return {key: value for key, value in event.items() if key not in TIMING_FIELDS}
+
+	@staticmethod
+	def _expected_http_categories(**overrides):
+		categories = {
+			'block': 0,
+			'confirmed_transaction': 0,
+			'transaction_statement': 0,
+			'address_resolution': 0,
+			'mosaic_resolution': 0,
+			'account_batch': 0,
+			'account_multisig': 0,
+			'namespace_detail': 0,
+			'namespace_name': 0,
+			'mosaic_batch': 0,
+			'metadata_search': 0,
+			'hash_lock': 0,
+			'secret_lock': 0,
+			'mosaic_restriction': 0,
+			'chain_or_network': 0,
+			'other': 0
+		}
+		categories.update(overrides)
+		return categories
 
 	def test_sync_block_headers_logs_one_completed_batch_and_workflow_event(self):
 		# Arrange:
@@ -140,35 +300,70 @@ class SymbolPullerPerformanceTest(SymbolPullerTestBase):
 		# Assert:
 		self.assertEqual(2, len(events))
 		batch_event, workflow_event = events
-		self.assertEqual('symbol_sync_batch_completed', batch_event['event'])
-		self.assertEqual('completed', batch_event['status'])
-		self.assertEqual(1, batch_event['start_height'])
-		self.assertEqual(1, batch_event['end_height'])
-		self.assertEqual(1, batch_event['block_count'])
-		self.assertEqual(0, batch_event['transaction_count'])
-		self.assertEqual(0, batch_event['receipt_count'])
-		self.assertEqual(1, batch_event['dirty_account_count'])
-		self.assertEqual(0, batch_event['dirty_namespace_count'])
-		self.assertEqual(0, batch_event['dirty_mosaic_count'])
-		self.assertEqual(0, batch_event['dirty_metadata_count'])
-		self.assertEqual(0, batch_event['dirty_hash_lock_count'])
-		self.assertEqual(0, batch_event['dirty_secret_lock_count'])
-		self.assertEqual(0, batch_event['dirty_mosaic_restriction_count'])
-		self.assertEqual(4, batch_event['http_get_attempt_count'])
-		self.assertEqual(1, batch_event['http_post_attempt_count'])
-		self.assertEqual(5, batch_event['http_attempt_count'])
-		self.assertEqual(4, batch_event['http_success_count'])
-		self.assertEqual(0, batch_event['http_retry_count'])
-		self.assertEqual(0, batch_event['rate_limit_wait_ms'])
-		self.assertEqual(7, batch_event['db_commit_count'])
-		self.assertEqual(7, batch_event['db_commit_attempt_count'])
-		self.assertIsNone(batch_event['failed_phase'])
-		self.assertEqual('completed', workflow_event['status'])
-		self.assertEqual(1, workflow_event['batch_count'])
-		self.assertEqual(1, workflow_event['block_count'])
-		self.assertEqual(8, workflow_event['http_attempt_count'])
-		self.assertEqual(9, workflow_event['db_commit_count'])
-		self.assertIsNone(workflow_event['failed_phase'])
+		self._assert_event_key_contract(batch_event, BATCH_EVENT_KEYS)
+		self._assert_event_key_contract(workflow_event, WORKFLOW_EVENT_KEYS)
+		self.assertEqual({
+			'event': 'symbol_sync_batch_completed',
+			'status': 'completed',
+			'start_height': 1,
+			'end_height': 1,
+			'failed_phase': None,
+			'exception_class': None,
+			'block_count': 1,
+			'transaction_count': 0,
+			'receipt_count': 0,
+			'http_attempt_count': 5,
+			'http_success_count': 4,
+			'http_retry_count': 0,
+			'http_get_attempt_count': 4,
+			'http_post_attempt_count': 1,
+			'rate_limit_wait_ms': 0,
+			'db_commit_count': 7,
+			'db_commit_attempt_count': 7,
+			'dirty_account_count': 1,
+			'dirty_namespace_count': 0,
+			'dirty_mosaic_count': 0,
+			'dirty_metadata_count': 0,
+			'dirty_hash_lock_count': 0,
+			'dirty_secret_lock_count': 0,
+			'dirty_mosaic_restriction_count': 0,
+			'http_get_attempts_by_category': self._expected_http_categories(
+				block=1, confirmed_transaction=1, transaction_statement=1, account_multisig=1),
+			'http_post_attempts_by_category': self._expected_http_categories(account_batch=1),
+		}, self._without_timing_fields(batch_event))
+		self.assertEqual({
+			'event': 'symbol_sync_completed',
+			'status': 'completed',
+			'start_height': 1,
+			'target_height': 1,
+			'last_completed_height': 1,
+			'batch_count': 1,
+			'failed_phase': None,
+			'exception_class': None,
+			'block_count': 1,
+			'transaction_count': 0,
+			'receipt_count': 0,
+			'http_attempt_count': 8,
+			'http_success_count': 7,
+			'http_retry_count': 0,
+			'http_get_attempt_count': 7,
+			'http_post_attempt_count': 1,
+			'rate_limit_wait_ms': 0,
+			'db_commit_count': 9,
+			'db_commit_attempt_count': 9,
+			'dirty_account_count': 1,
+			'dirty_namespace_count': 0,
+			'dirty_mosaic_count': 0,
+			'dirty_metadata_count': 0,
+			'dirty_hash_lock_count': 0,
+			'dirty_secret_lock_count': 0,
+			'dirty_mosaic_restriction_count': 0,
+			'http_get_attempts_by_category': self._expected_http_categories(
+				block=1, confirmed_transaction=1, transaction_statement=1, account_multisig=1,
+				mosaic_batch=1, chain_or_network=2),
+			'http_post_attempts_by_category': self._expected_http_categories(account_batch=1),
+		}, self._without_timing_fields(workflow_event))
+
 		self.assertEqual(batch_event['http_attempt_count'] + 3, workflow_event['http_attempt_count'])
 		self.assertEqual(batch_event['db_commit_count'] + 2, workflow_event['db_commit_count'])
 		self.assertGreater(workflow_event['http_attempt_count'], batch_event['http_attempt_count'])
@@ -244,9 +439,7 @@ class SymbolPullerPerformanceTest(SymbolPullerTestBase):
 
 	def test_sync_block_headers_sums_multiple_batch_events_in_workflow_event(self):
 		# Arrange:
-		blocks = [create_node_block(height) for height in range(1, 1002)]
-		pages = {offset: blocks[offset:offset + 100] for offset in range(0, 1001, 100)}
-		connector = FakeConnector(1001, pages)
+		connector = FakeConnector(1001, create_multi_batch_block_pages())
 
 		# Act:
 		events = self._run_sync(connector)
@@ -272,20 +465,15 @@ class SymbolPullerPerformanceTest(SymbolPullerTestBase):
 
 	def test_sync_block_headers_records_last_completed_height_when_a_later_batch_fails(self):
 		# Arrange:
-		blocks = [create_node_block(height) for height in range(1, 1002)]
-		pages = {offset: blocks[offset:offset + 100] for offset in range(0, 1001, 100)}
-		connector = FailingSecondBatchConnector(1001, pages)
+		connector = FailingSecondBatchConnector(1001, create_multi_batch_block_pages())
 		logger = RecordingLogger()
-		set_symbol_connector(self.puller, connector)
-		set_symbol_rate_limiter(self.puller, NoOpRateLimiter())
-		self.puller._performance_logger = logger  # pylint: disable=protected-access
 
 		# Act:
 		with self.assertRaisesRegex(ValueError, 'second batch block fetch failed'):
-			asyncio.run(self.puller.sync_block_headers())
+			self._run_sync(connector, logger)
 
 		# Assert:
-		events = [json.loads(message) for message in logger.messages]
+		events = logger.events
 		self.assertEqual(3, len(events))
 		self.assertEqual('symbol_sync_batch_completed', events[0]['event'])
 		self.assertEqual('symbol_sync_batch_failed', events[1]['event'])
@@ -311,15 +499,12 @@ class SymbolPullerPerformanceTest(SymbolPullerTestBase):
 		logger = RecordingLogger()
 
 		# Act:
-		set_symbol_connector(self.puller, connector)
-		set_symbol_rate_limiter(self.puller, NoOpRateLimiter())
-		self.puller._performance_logger = logger  # pylint: disable=protected-access
 		with self.assertRaisesRegex(ValueError, 'transaction fetch failed') as exception_context:
-			asyncio.run(self.puller.sync_block_headers())
+			self._run_sync(connector, logger)
 
 		# Assert:
 		self.assertIs(expected_exception, exception_context.exception)
-		events = [json.loads(message) for message in logger.messages]
+		events = logger.events
 		self.assertEqual(2, len(events))
 		self.assertEqual('symbol_sync_batch_failed', events[0]['event'])
 		self.assertEqual('failed', events[0]['status'])
@@ -337,13 +522,10 @@ class SymbolPullerPerformanceTest(SymbolPullerTestBase):
 			1,
 			{0: [create_node_block(1)]},
 			transactions_by_path={transaction_path(1, 1): expected_exception})
-		set_symbol_connector(self.puller, connector)
-		set_symbol_rate_limiter(self.puller, NoOpRateLimiter())
-		self.puller._performance_logger = FailingLogger()  # pylint: disable=protected-access
 
 		# Act:
 		with self.assertRaisesRegex(ValueError, 'transaction fetch failed') as exception_context:
-			asyncio.run(self.puller.sync_block_headers())
+			self._run_sync(connector, FailingLogger())
 
 		# Assert:
 		self.assertIs(expected_exception, exception_context.exception)
@@ -354,17 +536,14 @@ class SymbolPullerPerformanceTest(SymbolPullerTestBase):
 		connector = FailingChainInfoConnector(1, {})
 		connector.failure = expected_exception
 		logger = RecordingLogger()
-		set_symbol_connector(self.puller, connector)
-		set_symbol_rate_limiter(self.puller, NoOpRateLimiter())
-		self.puller._performance_logger = logger  # pylint: disable=protected-access
 
 		# Act:
 		with self.assertRaisesRegex(ValueError, 'chain info fetch failed') as exception_context:
-			asyncio.run(self.puller.sync_block_headers())
+			self._run_sync(connector, logger)
 
 		# Assert:
 		self.assertIs(expected_exception, exception_context.exception)
-		event = json.loads(logger.messages[0])
+		event = logger.events[0]
 		self.assertEqual('symbol_sync_failed', event['event'])
 		self.assertEqual('failed', event['status'])
 		self.assertEqual(0, event['batch_count'])
@@ -372,22 +551,348 @@ class SymbolPullerPerformanceTest(SymbolPullerTestBase):
 		self.assertEqual('chain_info_fetch', event['failed_phase'])
 		self.assertEqual('ValueError', event['exception_class'])
 
+	def test_sync_block_headers_counts_batch_external_chain_info_retry_only_in_workflow(self):
+		# Arrange:
+		connector = RetryOnceChainInfoConnector(1, {0: [create_node_block(1)]})
+
+		# Act:
+		events = self._run_sync(connector)
+
+		# Assert:
+		batch_event, workflow_event = events
+		self.assertEqual(5, batch_event['http_attempt_count'])
+		self.assertEqual(4, batch_event['http_success_count'])
+		self.assertEqual(0, batch_event['http_retry_count'])
+		self.assertEqual(4, batch_event['http_get_attempt_count'])
+		self.assertEqual(1, batch_event['http_post_attempt_count'])
+		self.assertEqual(9, workflow_event['http_attempt_count'])
+		self.assertEqual(7, workflow_event['http_success_count'])
+		self.assertEqual(1, workflow_event['http_retry_count'])
+		self.assertEqual(8, workflow_event['http_get_attempt_count'])
+		self.assertEqual(1, workflow_event['http_post_attempt_count'])
+		self.assertEqual(3, workflow_event['http_get_attempts_by_category']['chain_or_network'])
+
+	def test_sync_block_headers_counts_batch_external_rate_limit_wait_only_in_workflow(self):
+		# Arrange:
+		connector = FakeConnector(1, {0: [create_node_block(1)]})
+		rate_limiter = FixedRateLimiter(0.125, 0.25)
+
+		# Act:
+		batch_event, workflow_event = self._run_sync(connector, rate_limiter=rate_limiter)[:2]
+
+		# Assert:
+		self.assertEqual(8, rate_limiter.call_count)
+		self.assertEqual(1250, batch_event['rate_limit_wait_ms'])
+		self.assertEqual(1875, workflow_event['rate_limit_wait_ms'])
+		self.assertEqual(625, workflow_event['rate_limit_wait_ms'] - batch_event['rate_limit_wait_ms'])
+		self.assertEqual(0, batch_event['http_retry_count'])
+
+	def test_sync_block_headers_records_positive_deduplicated_account_dirty_count(self):
+		# Arrange:
+		connector = FakeConnector(2, {
+			0: [create_node_block(1), create_node_block(2)]
+		})
+
+		# Act:
+		batch_event, workflow_event = self._run_sync(connector)[:2]
+
+		# Assert:
+		self.assertEqual(1, batch_event['dirty_account_count'])
+		self.assertEqual(1, workflow_event['dirty_account_count'])
+
+	def test_sync_block_headers_records_positive_namespace_dirty_count(self):
+		# Arrange:
+		transaction = create_node_transaction(
+			1,
+			transaction_hash='A' * 64,
+			transaction_id='namespace-registration',
+			type=TransactionType.NAMESPACE_REGISTRATION.value,
+			id=NAMESPACE_ROOT_ID,
+			name='root',
+			registrationType=0)
+
+		# The helper performs the shared Act and Assert.
+		self._assert_dirty_count(
+			transaction,
+			'dirty_namespace_count',
+			namespace_by_id={NAMESPACE_ROOT_ID: create_namespace_item()},
+			namespace_names={NAMESPACE_ROOT_ID: 'root'})
+
+	def test_sync_block_headers_records_positive_mosaic_dirty_count(self):
+		# Arrange:
+		transaction = create_node_transaction(
+			1,
+			transaction_hash='A' * 64,
+			transaction_id='mosaic-definition',
+			type=TransactionType.MOSAIC_DEFINITION.value,
+			id=MOSAIC_ID,
+			duration='0',
+			flags=2,
+			divisibility=6)
+
+		# The helper performs the shared Act and Assert.
+		self._assert_dirty_count(
+			transaction,
+			'dirty_mosaic_count',
+			mosaics_by_id={MOSAIC_ID: create_mosaic_item()})
+
+	def test_sync_block_headers_records_positive_metadata_dirty_count(self):
+		# Arrange:
+		transaction = create_node_transaction(
+			1,
+			transaction_hash='A' * 64,
+			transaction_id='account-metadata',
+			type=TransactionType.ACCOUNT_METADATA.value,
+			targetAddress=RECIPIENT_ADDRESS,
+			scopedMetadataKey=SCOPED_METADATA_KEY,
+			valueSizeDelta=5,
+			value='68656C6C6F')
+		transaction['transaction'].pop('recipientAddress')
+		transaction['transaction'].pop('mosaics')
+		metadata_response_path = metadata_path(
+			0,
+			source_address=SIGNER_ADDRESS,
+			target_address=RECIPIENT_ADDRESS,
+			scoped_metadata_key=SCOPED_METADATA_KEY)
+
+		# The helper performs the shared Act and Assert.
+		self._assert_dirty_count(
+			transaction,
+			'dirty_metadata_count',
+			metadata_by_query={metadata_response_path: {
+				'data': [create_metadata_item(
+					metadata_type=0,
+					target_id='0000000000000000',
+					source_address=SIGNER_ADDRESS,
+					target_address=RECIPIENT_ADDRESS)
+				]}})
+
+	def test_sync_block_headers_records_positive_hash_lock_dirty_count(self):
+		# Arrange:
+		lock_hash = 'AA' * 32
+		transaction = create_node_transaction(
+			1,
+			transaction_hash='A' * 64,
+			transaction_id='hash-lock',
+			type=TransactionType.HASH_LOCK.value,
+			hash=lock_hash,
+			mosaicId=MOSAIC_ID,
+			amount='1234')
+
+		# The helper performs the shared Act and Assert.
+		self._assert_dirty_count(
+			transaction,
+			'dirty_hash_lock_count',
+			connector_class=ExtraResponseConnector,
+			responses={
+				f'lock/hash/{lock_hash}': {
+					'lock': {
+						'hash': lock_hash,
+						'ownerAddress': SIGNER_ADDRESS,
+						'mosaicId': MOSAIC_ID,
+						'amount': '1234',
+						'endHeight': '100',
+						'status': 0
+					},
+					'id': 'hash-lock'
+				}
+			})
+
+	def test_sync_block_headers_records_positive_secret_lock_dirty_count(self):
+		# Arrange:
+		secret = 'CC' * 32
+		transaction = create_node_transaction(
+			1,
+			transaction_hash='A' * 64,
+			transaction_id='secret-lock',
+			type=TransactionType.SECRET_LOCK.value,
+			secret=secret,
+			hashAlgorithm=1,
+			mosaicId=MOSAIC_ID,
+			amount='1234')
+		secret_path = (
+			f'lock/secret?address={Address(bytes.fromhex(SIGNER_ADDRESS))}&secret={secret}'
+			'&pageSize=100&pageNumber=1')
+
+		# The helper performs the shared Act and Assert.
+		self._assert_dirty_count(
+			transaction,
+			'dirty_secret_lock_count',
+			connector_class=ExtraResponseConnector,
+			responses={secret_path: {'data': [create_secret_lock_item(
+				owner_address=SIGNER_ADDRESS,
+				recipient_address=RECIPIENT_ADDRESS,
+				secret=secret,
+				mosaic_id=MOSAIC_ID)]}})
+
+	def test_sync_block_headers_records_positive_mosaic_restriction_dirty_count(self):
+		# Arrange:
+		transaction = create_node_transaction(
+			1,
+			transaction_hash='A' * 64,
+			transaction_id='mosaic-address-restriction',
+			type=TransactionType.MOSAIC_ADDRESS_RESTRICTION.value,
+			mosaicId=MOSAIC_ID,
+			targetAddress=RECIPIENT_ADDRESS)
+		restriction_path = (
+			f'restrictions/mosaic?mosaicId={MOSAIC_ID}&entryType=0&pageSize=100&pageNumber=1'
+			f'&targetAddress={Address(bytes.fromhex(RECIPIENT_ADDRESS))}')
+
+		# The helper performs the shared Act and Assert.
+		self._assert_dirty_count(
+			transaction,
+			'dirty_mosaic_restriction_count',
+			connector_class=ExtraResponseConnector,
+			responses={restriction_path: {
+				'pagination': {'pageNumber': 1, 'pageSize': 100},
+				'data': [{
+					'id': 'BB' * 12,
+					'mosaicRestrictionEntry': {
+						'version': 1,
+						'compositeHash': 'AA' * 32,
+						'entryType': 0,
+						'mosaicId': MOSAIC_ID,
+						'targetAddress': RECIPIENT_ADDRESS,
+						'restrictions': [{'key': '1', 'value': '2'}]
+					}
+				}]
+			}})
+
+	def test_sync_block_headers_connects_fetch_and_db_measurements_to_batch_and_workflow_events(self):
+		# Arrange:
+		clock = IncrementingClock()
+		self.puller._time_source = clock  # pylint: disable=protected-access
+		self.puller.symbol_db._time_source = clock  # pylint: disable=protected-access
+		connector = FakeConnector(1, {0: [create_node_block(1)]})
+
+		# Act:
+		batch_event, workflow_event = self._run_sync(connector)[:2]
+
+		# Assert:
+		expected_batch_fetch_times = {
+			'block_fetch_ms': 1,
+			'transaction_fetch_ms': 1,
+			'receipt_fetch_ms': 1,
+			'resolution_fetch_ms': 1,
+			'account_fetch_ms': 1,
+			'namespace_fetch_ms': 1,
+			'mosaic_fetch_ms': 1,
+			'metadata_fetch_ms': 1,
+			'hash_lock_fetch_ms': 1,
+			'secret_lock_fetch_ms': 1,
+			'mosaic_restriction_fetch_ms': 1
+		}
+		expected_workflow_fetch_times = {
+			'block_fetch_ms': 1,
+			'transaction_fetch_ms': 1,
+			'receipt_fetch_ms': 1,
+			'resolution_fetch_ms': 1,
+			'account_fetch_ms': 1,
+			'namespace_fetch_ms': 1,
+			'mosaic_fetch_ms': 1,
+			'metadata_fetch_ms': 1,
+			'hash_lock_fetch_ms': 1,
+			'secret_lock_fetch_ms': 1,
+			'mosaic_restriction_fetch_ms': 1
+		}
+		self.assertEqual(expected_batch_fetch_times, {field: batch_event[field] for field in (
+			'block_fetch_ms', 'transaction_fetch_ms', 'receipt_fetch_ms', 'resolution_fetch_ms', 'account_fetch_ms',
+			'namespace_fetch_ms', 'mosaic_fetch_ms', 'metadata_fetch_ms', 'hash_lock_fetch_ms',
+			'secret_lock_fetch_ms', 'mosaic_restriction_fetch_ms')})
+		self.assertEqual(expected_workflow_fetch_times, {field: workflow_event[field] for field in (
+			'block_fetch_ms', 'transaction_fetch_ms', 'receipt_fetch_ms', 'resolution_fetch_ms', 'account_fetch_ms',
+			'namespace_fetch_ms', 'mosaic_fetch_ms', 'metadata_fetch_ms', 'hash_lock_fetch_ms',
+			'secret_lock_fetch_ms', 'mosaic_restriction_fetch_ms')})
+		self.assertEqual(7, batch_event['db_commit_ms'])
+		self.assertEqual(7, batch_event['db_commit_count'])
+		self.assertEqual(9, workflow_event['db_commit_ms'])
+		self.assertEqual(9, workflow_event['db_commit_count'])
+		self.assertEqual(2, workflow_event['db_commit_ms'] - batch_event['db_commit_ms'])
+		self.assertEqual(2, workflow_event['db_commit_count'] - batch_event['db_commit_count'])
+		expected_batch_db_write_times = {
+			'block_transaction_receipt_write_ms': 7,
+			'account_multisig_write_ms': 5,
+			'current_state_write_ms': 3,
+			'db_write_total_ms': 21
+		}
+		expected_workflow_db_write_times = {
+			'block_transaction_receipt_write_ms': 7,
+			'account_multisig_write_ms': 5,
+			'current_state_write_ms': 3,
+			'db_write_total_ms': 21
+		}
+		self.assertEqual(expected_batch_db_write_times, {field: batch_event[field] for field in (
+			'block_transaction_receipt_write_ms', 'account_multisig_write_ms', 'current_state_write_ms', 'db_write_total_ms')})
+		self.assertEqual(expected_workflow_db_write_times, {field: workflow_event[field] for field in (
+			'block_transaction_receipt_write_ms', 'account_multisig_write_ms', 'current_state_write_ms', 'db_write_total_ms')})
+
+	def test_sync_block_headers_reports_sync_state_read_failure_without_batch(self):
+		# Arrange:
+		expected_exception = RuntimeError('sync state read failed')
+		connector = FakeConnector(1, {})
+		logger = RecordingLogger()
+		self.puller.symbol_db = FailingSyncStateReadDatabase(self.puller.symbol_db, expected_exception)
+
+		# Act:
+		with self.assertRaisesRegex(RuntimeError, 'sync state read failed') as exception_context:
+			self._run_sync(connector, logger)
+
+		# Assert:
+		self.assertIs(expected_exception, exception_context.exception)
+		self.assertEqual(1, len(logger.events))
+		event = logger.events[0]
+		self._assert_event_key_contract(event, WORKFLOW_EVENT_KEYS)
+		self.assertEqual('symbol_sync_failed', event['event'])
+		self.assertEqual('sync_state_read', event['failed_phase'])
+		self.assertEqual('RuntimeError', event['exception_class'])
+		self.assertEqual(0, event['batch_count'])
+		self.assertEqual(0, event['block_count'])
+		self.assertEqual(0, event['db_commit_count'])
+
+	def test_sync_block_headers_reports_network_properties_fetch_failure_phase_without_batch(self):
+		# Arrange:
+		expected_exception = ValueError('network properties fetch failed')
+		connector = FailingPhaseConnector('network/properties', expected_exception, 1, {})
+		logger = RecordingLogger()
+
+		# Act:
+		with self.assertRaisesRegex(ValueError, 'network properties fetch failed'):
+			self._run_sync(connector, logger)
+
+		# Assert:
+		event = logger.events[0]
+		self.assertEqual('network_properties_fetch', event['failed_phase'])
+		self.assertEqual(0, event['batch_count'])
+
+	def test_sync_block_headers_reports_native_mosaic_fetch_failure_phase_without_batch(self):
+		# Arrange:
+		expected_exception = ValueError('native mosaic fetch failed')
+		connector = FailingPhaseConnector(
+			'mosaics/72C0212E67A08BCE', expected_exception, 1, {})
+		logger = RecordingLogger()
+
+		# Act:
+		with self.assertRaisesRegex(ValueError, 'native mosaic fetch failed'):
+			self._run_sync(connector, logger)
+
+		# Assert:
+		event = logger.events[0]
+		self.assertEqual('native_mosaic_fetch', event['failed_phase'])
+		self.assertEqual(0, event['batch_count'])
+
 	def test_sync_block_headers_reports_rollback_failure_phase_without_batch(self):
 		# Arrange:
 		connector = FakeConnector(1, {})
 		logger = RecordingLogger()
-		set_symbol_connector(self.puller, connector)
-		set_symbol_rate_limiter(self.puller, NoOpRateLimiter())
-		self.puller._performance_logger = logger  # pylint: disable=protected-access
 		self.puller.symbol_db.upsert_sync_state(create_sync_state())
 
 		# Act:
 		with self.assertRaisesRegex(SymbolRollbackError, 'Finalized block is missing from local database') as exception_context:
-			asyncio.run(self.puller.sync_block_headers())
+			self._run_sync(connector, logger)
 
 		# Assert:
 		self.assertEqual('Finalized block is missing from local database', str(exception_context.exception))
-		event = json.loads(logger.messages[0])
+		event = logger.events[0]
 		self.assertEqual('symbol_sync_failed', event['event'])
 		self.assertEqual(0, event['batch_count'])
 		self.assertEqual(3, event['http_attempt_count'])
@@ -399,20 +904,17 @@ class SymbolPullerPerformanceTest(SymbolPullerTestBase):
 		expected_exception = ValueError('finalization cleanup failed')
 		connector = FakeConnector(1, {})
 		logger = RecordingLogger()
-		set_symbol_connector(self.puller, connector)
-		set_symbol_rate_limiter(self.puller, NoOpRateLimiter())
-		self.puller._performance_logger = logger  # pylint: disable=protected-access
 		self._seed_blocks(self.puller.symbol_db, [1])
 		self.puller.symbol_db.upsert_sync_state(create_sync_state(chain_height=1, last_synced_height=1))
 		self.puller.symbol_db = FailingFinalizationDatabase(self.puller.symbol_db, expected_exception)
 
 		# Act:
 		with self.assertRaisesRegex(ValueError, 'finalization cleanup failed') as exception_context:
-			asyncio.run(self.puller.sync_block_headers())
+			self._run_sync(connector, logger)
 
 		# Assert:
 		self.assertIs(expected_exception, exception_context.exception)
-		event = json.loads(logger.messages[0])
+		event = logger.events[0]
 		self.assertEqual('symbol_sync_failed', event['event'])
 		self.assertEqual(0, event['batch_count'])
 		self.assertEqual(3, event['http_attempt_count'])
@@ -424,18 +926,15 @@ class SymbolPullerPerformanceTest(SymbolPullerTestBase):
 		expected_exception = ValueError('sync state write failed')
 		connector = FakeConnector(1, {0: [create_node_block(1)]})
 		logger = RecordingLogger()
-		set_symbol_connector(self.puller, connector)
-		set_symbol_rate_limiter(self.puller, NoOpRateLimiter())
-		self.puller._performance_logger = logger  # pylint: disable=protected-access
 		self.puller.symbol_db = FailingSyncStateDatabase(self.puller.symbol_db, expected_exception)
 
 		# Act:
 		with self.assertRaisesRegex(ValueError, 'sync state write failed') as exception_context:
-			asyncio.run(self.puller.sync_block_headers())
+			self._run_sync(connector, logger)
 
 		# Assert:
 		self.assertIs(expected_exception, exception_context.exception)
-		events = [json.loads(message) for message in logger.messages]
+		events = logger.events
 		self.assertEqual(2, len(events))
 		self.assertEqual('symbol_sync_batch_completed', events[0]['event'])
 		self.assertIsNone(events[0]['failed_phase'])
@@ -454,10 +953,11 @@ class SymbolPullerPerformanceTest(SymbolPullerTestBase):
 		# Assert:
 		self.assertEqual(1, performance.call_count)
 
-	def test_performance_event_generation_failure_does_not_raise(self):
+	def test_performance_event_generation_failure_does_not_log_or_raise(self):
 		# Arrange:
 		performance = FailingEventPerformance()
-		self.puller._performance_logger = FailingLogger()  # pylint: disable=protected-access
+		logger = RecordingLogger()
+		self.puller._performance_logger = logger  # pylint: disable=protected-access
 
 		# Act:
 		self.puller._log_performance_event(  # pylint: disable=protected-access
@@ -465,3 +965,4 @@ class SymbolPullerPerformanceTest(SymbolPullerTestBase):
 
 		# Assert:
 		self.assertEqual(1, performance.call_count)
+		self.assertEqual([], logger.events)

--- a/explorer/puller/tests/facade/symbol/test_SymbolSyncPerformance.py
+++ b/explorer/puller/tests/facade/symbol/test_SymbolSyncPerformance.py
@@ -1,0 +1,105 @@
+import json
+from unittest import TestCase
+
+from puller.facade.SymbolSyncPerformance import BatchPerformance, SyncPerformance, request_category
+
+
+class MutableClock:
+	def __init__(self):
+		self.value = 0
+
+	def __call__(self):
+		return self.value
+
+
+class FailingClock:
+	def __call__(self):  # pylint: disable=no-self-use
+		raise RuntimeError('clock failed')
+
+
+class SymbolSyncPerformanceTest(TestCase):
+	def test_batch_event_uses_injected_clock_for_phase_commit_and_wait_durations(self):
+		# Arrange:
+		clock = MutableClock()
+		clock.value = 1
+		batch = BatchPerformance(clock, 10, 12)
+		with batch.measure('block_fetch_ms', 'block_fetch'):
+			clock.value = 1.25
+		batch.record_rate_limit_wait(0.4)
+		batch.record_commit(0.05, True)
+		batch.record_commit(0.07, False)
+		batch.set_count('receipt_count', 3)
+		clock.value = 2
+
+		# Act:
+		event = batch.event('symbol_sync_batch_failed', 'failed', RuntimeError('not logged'))
+
+		# Assert:
+		self.assertEqual(1000, event['elapsed_ms'])
+		self.assertEqual(250, event['block_fetch_ms'])
+		self.assertEqual(400, event['rate_limit_wait_ms'])
+		self.assertEqual(3, event['receipt_count'])
+		self.assertEqual(1, event['db_commit_count'])
+		self.assertEqual(2, event['db_commit_attempt_count'])
+		self.assertEqual(120, event['db_commit_ms'])
+		self.assertEqual('RuntimeError', event['exception_class'])
+
+	def test_request_category_masks_dynamic_path_values(self):
+		# Arrange:
+		sensitive_path = '/lock/hash/' + 'DEADBEEF' * 8 + '?secret=SECRET_VALUE'
+
+		# Act:
+		category = request_category('GET', sensitive_path)
+
+		# Assert:
+		self.assertEqual('hash_lock', category)
+		self.assertEqual('{"category": "hash_lock"}', json.dumps({'category': category}))
+		self.assertEqual(False, 'DEADBEEF' in json.dumps({'category': category}))
+		self.assertEqual(False, 'SECRET_VALUE' in json.dumps({'category': category}))
+
+	def test_sync_performance_state_is_not_shared_between_instances(self):
+		# Arrange:
+		clock = MutableClock()
+		first = SyncPerformance(clock)
+		second = SyncPerformance(clock)
+		first_batch = first.start_batch(1, 1)
+		first.record_request_attempt('GET', 'block')
+		first.complete_batch(first_batch)
+
+		# Act:
+		first_event = first.event('symbol_sync_completed', 'completed')
+		second_event = second.event('symbol_sync_completed', 'completed')
+
+		# Assert:
+		self.assertEqual(1, first_event['http_attempt_count'])
+		self.assertEqual(0, second_event['http_attempt_count'])
+		self.assertEqual(1, first_event['batch_count'])
+		self.assertEqual(0, second_event['batch_count'])
+
+	def test_workflow_phase_is_only_published_as_failed_phase_after_failure(self):
+		# Arrange:
+		sync = SyncPerformance(MutableClock())
+		sync.set_phase('sync_state_write')
+
+		# Act:
+		completed_event = sync.event('symbol_sync_completed', 'completed')
+		sync.set_failed_phase()
+		failed_event = sync.event('symbol_sync_failed', 'failed', ValueError('failure'))
+
+		# Assert:
+		self.assertEqual(None, completed_event['failed_phase'])
+		self.assertEqual('sync_state_write', failed_event['failed_phase'])
+
+	def test_batch_and_workflow_measurements_fall_back_when_clock_fails(self):
+		# Arrange:
+		clock = FailingClock()
+		batch = BatchPerformance(clock, 10, 12)
+		sync = SyncPerformance(clock)
+
+		# Act:
+		batch_event = batch.event('symbol_sync_batch_completed', 'completed')
+		sync_event = sync.event('symbol_sync_completed', 'completed')
+
+		# Assert:
+		self.assertEqual(0, batch_event['elapsed_ms'])
+		self.assertEqual(0, sync_event['elapsed_ms'])

--- a/explorer/puller/tests/facade/symbol/test_SymbolSyncPerformance.py
+++ b/explorer/puller/tests/facade/symbol/test_SymbolSyncPerformance.py
@@ -17,7 +17,84 @@ class FailingClock:
 		raise RuntimeError('clock failed')
 
 
+# pylint: disable=duplicate-code,too-many-public-methods
 class SymbolSyncPerformanceTest(TestCase):
+	def _assert_request_category(self, method, path, expected_category):
+		# Act:
+		category = request_category(method, path)
+
+		# Assert:
+		self.assertEqual(expected_category, category)
+
+	def test_request_category_classifies_chain_info_as_chain_or_network(self):
+		self._assert_request_category('GET', 'chain/info', 'chain_or_network')
+
+	def test_request_category_classifies_network_properties_as_chain_or_network(self):
+		self._assert_request_category('GET', 'network/properties', 'chain_or_network')
+
+	def test_request_category_classifies_block_list_as_block(self):
+		self._assert_request_category('GET', 'blocks?pageSize=100&offset=0', 'block')
+
+	def test_request_category_classifies_block_detail_as_block(self):
+		self._assert_request_category('GET', 'blocks/123', 'block')
+
+	def test_request_category_classifies_confirmed_transactions(self):
+		self._assert_request_category('GET', 'transactions/confirmed', 'confirmed_transaction')
+
+	def test_request_category_classifies_transaction_statements(self):
+		self._assert_request_category('GET', 'statements/transaction', 'transaction_statement')
+
+	def test_request_category_classifies_address_resolution(self):
+		self._assert_request_category('GET', 'statements/resolutions/address', 'address_resolution')
+
+	def test_request_category_classifies_mosaic_resolution(self):
+		self._assert_request_category('GET', 'statements/resolutions/mosaic', 'mosaic_resolution')
+
+	def test_request_category_classifies_account_batch_only_for_post(self):
+		self._assert_request_category('POST', 'accounts', 'account_batch')
+
+	def test_request_category_classifies_account_list_get_as_other(self):
+		self._assert_request_category('GET', 'accounts', 'other')
+
+	def test_request_category_classifies_account_multisig_detail(self):
+		self._assert_request_category('GET', 'account/98ABC/multisig', 'account_multisig')
+
+	def test_request_category_classifies_namespace_detail(self):
+		self._assert_request_category('GET', 'namespaces/A95F1F8A96159516', 'namespace_detail')
+
+	def test_request_category_classifies_namespace_names(self):
+		self._assert_request_category('POST', 'namespaces/names', 'namespace_name')
+
+	def test_request_category_classifies_mosaic_batch_only_for_post(self):
+		self._assert_request_category('POST', 'mosaics', 'mosaic_batch')
+
+	def test_request_category_classifies_mosaic_list_get_as_other(self):
+		self._assert_request_category('GET', 'mosaics', 'other')
+
+	def test_request_category_classifies_mosaic_detail_using_mosaic_batch_category(self):
+		self._assert_request_category('GET', 'mosaics/72C0212E67A08BCE', 'mosaic_batch')
+
+	def test_request_category_classifies_metadata_search(self):
+		self._assert_request_category('GET', 'metadata', 'metadata_search')
+
+	def test_request_category_classifies_hash_lock_detail(self):
+		self._assert_request_category('GET', 'lock/hash/' + 'AA' * 32, 'hash_lock')
+
+	def test_request_category_classifies_secret_lock_search(self):
+		self._assert_request_category('GET', 'lock/secret', 'secret_lock')
+
+	def test_request_category_classifies_mosaic_restriction_search(self):
+		self._assert_request_category('GET', 'restrictions/mosaic', 'mosaic_restriction')
+
+	def test_request_category_classifies_unknown_path_as_other(self):
+		self._assert_request_category('GET', 'unrelated/path', 'other')
+
+	def test_request_category_ignores_query_values_when_classifying(self):
+		self._assert_request_category('GET', 'lock/hash/' + 'AA' * 32 + '?secret=SECRET_VALUE', 'hash_lock')
+
+	def test_request_category_strips_leading_slash_before_classifying(self):
+		self._assert_request_category('GET', '/network/properties', 'chain_or_network')
+
 	def test_batch_event_uses_injected_clock_for_phase_commit_and_wait_durations(self):
 		# Arrange:
 		clock = MutableClock()
@@ -47,15 +124,30 @@ class SymbolSyncPerformanceTest(TestCase):
 	def test_request_category_masks_dynamic_path_values(self):
 		# Arrange:
 		sensitive_path = '/lock/hash/' + 'DEADBEEF' * 8 + '?secret=SECRET_VALUE'
+		batch = BatchPerformance(MutableClock(), 1, 1)
+		batch.record_request_attempt('GET', request_category('GET', sensitive_path))
 
 		# Act:
-		category = request_category('GET', sensitive_path)
+		event = batch.event('symbol_sync_batch_completed', 'completed')
+		serialized_event = json.dumps(event)
 
 		# Assert:
-		self.assertEqual('hash_lock', category)
-		self.assertEqual('{"category": "hash_lock"}', json.dumps({'category': category}))
-		self.assertEqual(False, 'DEADBEEF' in json.dumps({'category': category}))
-		self.assertEqual(False, 'SECRET_VALUE' in json.dumps({'category': category}))
+		self.assertEqual(1, event['http_get_attempts_by_category']['hash_lock'])
+		self.assertEqual(False, 'DEADBEEF' in serialized_event)
+		self.assertEqual(False, 'SECRET_VALUE' in serialized_event)
+		self.assertEqual(False, sensitive_path in serialized_event)
+		self.assertEqual({
+			'event', 'status', 'start_height', 'end_height', 'elapsed_ms', 'failed_phase', 'exception_class',
+			'block_count', 'transaction_count', 'receipt_count', 'http_attempt_count', 'http_success_count',
+			'http_retry_count', 'http_get_attempt_count', 'http_post_attempt_count', 'rate_limit_wait_ms',
+			'db_commit_count', 'db_commit_attempt_count', 'block_fetch_ms', 'transaction_fetch_ms', 'receipt_fetch_ms',
+			'resolution_fetch_ms', 'account_fetch_ms', 'namespace_fetch_ms', 'mosaic_fetch_ms', 'metadata_fetch_ms',
+			'hash_lock_fetch_ms', 'secret_lock_fetch_ms', 'mosaic_restriction_fetch_ms', 'dirty_account_count',
+			'dirty_namespace_count', 'dirty_mosaic_count', 'dirty_metadata_count', 'dirty_hash_lock_count',
+			'dirty_secret_lock_count', 'dirty_mosaic_restriction_count', 'block_transaction_receipt_write_ms',
+			'account_multisig_write_ms', 'current_state_write_ms', 'db_write_total_ms', 'db_commit_ms',
+			'http_get_attempts_by_category', 'http_post_attempts_by_category'
+		}, set(event))
 
 	def test_sync_performance_state_is_not_shared_between_instances(self):
 		# Arrange:
@@ -90,16 +182,53 @@ class SymbolSyncPerformanceTest(TestCase):
 		self.assertEqual(None, completed_event['failed_phase'])
 		self.assertEqual('sync_state_write', failed_event['failed_phase'])
 
-	def test_batch_and_workflow_measurements_fall_back_when_clock_fails(self):
+	def test_batch_performance_elapsed_falls_back_when_clock_fails(self):
 		# Arrange:
 		clock = FailingClock()
 		batch = BatchPerformance(clock, 10, 12)
-		sync = SyncPerformance(clock)
 
 		# Act:
 		batch_event = batch.event('symbol_sync_batch_completed', 'completed')
-		sync_event = sync.event('symbol_sync_completed', 'completed')
 
 		# Assert:
 		self.assertEqual(0, batch_event['elapsed_ms'])
+
+	def test_sync_performance_elapsed_falls_back_when_clock_fails(self):
+		# Arrange:
+		clock = FailingClock()
+		sync = SyncPerformance(clock)
+
+		# Act:
+		sync_event = sync.event('symbol_sync_completed', 'completed')
+
+		# Assert:
+		self.assertEqual(0, sync_event['elapsed_ms'])
+
+	def test_batch_performance_clamps_reverse_clock_elapsed_and_phase_to_zero(self):
+		# Arrange:
+		clock = MutableClock()
+		clock.value = 2
+		batch = BatchPerformance(clock, 10, 12)
+
+		# Act:
+		clock.value = 2
+		with batch.measure('block_fetch_ms', 'block_fetch'):
+			clock.value = 1
+		batch_event = batch.event('symbol_sync_batch_completed', 'completed')
+
+		# Assert:
+		self.assertEqual(0, batch_event['elapsed_ms'])
+		self.assertEqual(0, batch_event['block_fetch_ms'])
+
+	def test_sync_performance_clamps_reverse_clock_elapsed_to_zero(self):
+		# Arrange:
+		clock = MutableClock()
+		clock.value = 2
+		sync = SyncPerformance(clock)
+
+		# Act:
+		clock.value = 1
+		sync_event = sync.event('symbol_sync_completed', 'completed')
+
+		# Assert:
 		self.assertEqual(0, sync_event['elapsed_ms'])

--- a/explorer/puller/tests/facade/test_RequestRateLimiter.py
+++ b/explorer/puller/tests/facade/test_RequestRateLimiter.py
@@ -13,13 +13,49 @@ class FakeClock:
 
 
 class RecordingSleep:
-	def __init__(self, clock):
+	def __init__(self, clock, extra_seconds=0):
 		self.wait_seconds = []
 		self._clock = clock
+		self._extra_seconds = extra_seconds
+
+	async def __call__(self, wait_seconds):
+		self.wait_seconds.append(wait_seconds)
+		self._clock.value += wait_seconds + self._extra_seconds
+
+
+class BlockingSleep(RecordingSleep):
+	def __init__(self, clock):
+		super().__init__(clock)
+		self.started = asyncio.Event()
+		self.release = asyncio.Event()
 
 	async def __call__(self, wait_seconds):
 		self.wait_seconds.append(wait_seconds)
 		self._clock.value += wait_seconds
+		self.started.set()
+		await self.release.wait()
+
+
+class ConcurrentClock(FakeClock):
+	def __init__(self):
+		super().__init__()
+		self.call_count = 0
+		self.second_caller_started = asyncio.Event()
+
+	def __call__(self):
+		self.call_count += 1
+		if 5 == self.call_count:
+			self.second_caller_started.set()
+
+		return super().__call__()
+
+
+class SequenceClock:
+	def __init__(self, values):
+		self._values = iter(values)
+
+	def __call__(self):
+		return next(self._values)
 
 
 class RequestRateLimiterTest(TestCase):
@@ -30,10 +66,11 @@ class RequestRateLimiterTest(TestCase):
 		limiter = RequestRateLimiter(10, clock, sleep)
 
 		# Act:
-		asyncio.run(limiter.wait_for_turn())
+		wait_duration = asyncio.run(limiter.wait_for_turn())
 
 		# Assert:
 		self.assertEqual([], sleep.wait_seconds)
+		self.assertEqual(0, wait_duration)
 
 	def test_wait_for_turn_sleeps_for_remaining_interval_on_immediate_second_call(self):
 		# Arrange:
@@ -43,13 +80,13 @@ class RequestRateLimiterTest(TestCase):
 
 		# Act:
 		async def wait_twice():
-			await limiter.wait_for_turn()
-			await limiter.wait_for_turn()
+			return [await limiter.wait_for_turn(), await limiter.wait_for_turn()]
 
-		asyncio.run(wait_twice())
+		wait_durations = asyncio.run(wait_twice())
 
 		# Assert:
 		self.assertEqual([0.1], sleep.wait_seconds)
+		self.assertEqual([0, 0.1], wait_durations)
 
 	def test_wait_for_turn_does_not_sleep_when_enough_time_already_elapsed(self):
 		# Arrange:
@@ -60,13 +97,30 @@ class RequestRateLimiterTest(TestCase):
 		async def wait_with_elapsed_time():
 			await limiter.wait_for_turn()
 			clock.value += 0.2
-			await limiter.wait_for_turn()
+			return await limiter.wait_for_turn()
 
 		# Act:
-		asyncio.run(wait_with_elapsed_time())
+		wait_duration = asyncio.run(wait_with_elapsed_time())
 
 		# Assert:
 		self.assertEqual([], sleep.wait_seconds)
+		self.assertEqual(0, wait_duration)
+
+	def test_wait_for_turn_returns_actual_sleep_elapsed_time(self):
+		# Arrange:
+		clock = FakeClock()
+		sleep = RecordingSleep(clock, extra_seconds=0.05)
+		limiter = RequestRateLimiter(10, clock, sleep)
+
+		# Act:
+		async def wait_twice():
+			return [await limiter.wait_for_turn(), await limiter.wait_for_turn()]
+
+		wait_durations = asyncio.run(wait_twice())
+
+		# Assert:
+		self.assertEqual([0, 0.15], [round(duration, 2) for duration in wait_durations])
+		self.assertEqual([0.1], sleep.wait_seconds)
 
 	def test_wait_for_turn_serializes_concurrent_callers(self):
 		# Arrange:
@@ -82,3 +136,36 @@ class RequestRateLimiterTest(TestCase):
 
 		# Assert:
 		self.assertEqual(3, len(sleep.wait_seconds))
+
+	def test_wait_for_turn_includes_lock_wait_in_actual_elapsed_time(self):
+		# Arrange:
+		clock = ConcurrentClock()
+		sleep = BlockingSleep(clock)
+		limiter = RequestRateLimiter(10, clock, sleep)
+
+		# Act:
+		async def wait_concurrently():
+			await limiter.wait_for_turn()
+			first_task = asyncio.create_task(limiter.wait_for_turn())
+			await sleep.started.wait()
+			second_task = asyncio.create_task(limiter.wait_for_turn())
+			await clock.second_caller_started.wait()
+			clock.value += 0.25
+			sleep.release.set()
+			return await asyncio.gather(first_task, second_task)
+
+		wait_durations = asyncio.run(wait_concurrently())
+
+		# Assert:
+		self.assertEqual([0.35, 0.35], wait_durations)
+
+	def test_wait_for_turn_clamps_negative_clock_elapsed_time_to_zero(self):
+		# Arrange:
+		clock = SequenceClock([1, 0])
+		limiter = RequestRateLimiter(10, clock, RecordingSleep(FakeClock()))
+
+		# Act:
+		wait_duration = asyncio.run(limiter.wait_for_turn())
+
+		# Assert:
+		self.assertEqual(0, wait_duration)


### PR DESCRIPTION
## What is the current behavior?

Symbol Puller does not expose enough metrics to identify `sync-block` bottlenecks.

## What's the issue?

It is not possible to quantitatively determine whether internal batches are bottlenecked by HTTP requests, fetch operations, rate limiting, or database processing.

## How have you changed the behavior?

Added structured JSON events for batch and workflow completion/failure:

- Data and dirty-key counts
- HTTP attempts, retries, methods, and rate-limit wait time
- Fetch-phase and DB write durations
- DB commit counts and duration
- Total elapsed time and failed phase

Measurements use an injectable monotonic clock. Logging and observer failures do not affect synchronization or exception propagation. Sensitive and high-cardinality values are excluded.

Synchronization behavior, HTTP requests, retry policy, batch boundaries, SQL, and transaction boundaries are unchanged. HTTP connection reuse is not included.
